### PR TITLE
ci: pin third-party actions by SHA (#124, #126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
       - name: Install
@@ -38,7 +38,7 @@ jobs:
           npm run csslint
       - name: Check translation files
         if: matrix.os == 'ubuntu-latest' && ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: check-translation-files
         with:
           result-encoding: string

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          persist-credentials: false 
+          persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
       - name: Install deps
@@ -32,7 +32,7 @@ jobs:
           mkdir -p targetdir
           mv dist Pictures translations index.html Synergism.css favicon.ico package.json targetdir/
       - name: Deploy with the $GME emoji for some reason 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505 # 3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload Windows artifacts
         if: matrix.platform == 'win'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: synergism-windows
           path: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload macOS artifacts
         if: matrix.platform == 'mac'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: synergism-macos
           path: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload Linux artifacts
         if: matrix.platform == 'linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: synergism-linux
           path: release/linux-unpacked/

--- a/.github/workflows/kong-release.yml
+++ b/.github/workflows/kong-release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          persist-credentials: false 
+          persist-credentials: false
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
       - name: Install deps
@@ -27,7 +27,7 @@ jobs:
         run: |
           rm -rf Kong.zip
       - name: Create .zip File
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310 # v1
         with:
           files: dist/ Pictures/Splash/ Pictures/Default/ Pictures/logo.png Pictures/logoLight.png Pictures/MISSINGIMAGE.png translations/ index.html Synergism.css favicon.ico
           dest: Kong.zip
@@ -37,10 +37,10 @@ jobs:
           echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
         id: version
       - name: Create release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: v${{ steps.version.outputs.VERSION }}
-          title: Kongregate Build ${{ github.event.repository.updated_at }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: v${{ steps.version.outputs.VERSION }}
+          name: Kongregate Build ${{ github.event.repository.updated_at }}
           files: |
             Kong.zip

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -10,10 +10,10 @@ jobs:
       contents: read
       deployments: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Wait for CF Pages
       id: cf-pages
-      uses: WalshyDev/cf-pages-await@v1
+      uses: WalshyDev/cf-pages-await@3abae9f62a7672a1701300702ce42908e16cb88a # v1
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         accountId: 'bd22ac056a23329365c8a57927490701'


### PR DESCRIPTION
## Summary
- **#126 (Pinned-Dependencies, P0):** every `uses:` across the 7 workflows referenced a mutable tag (`v4`, `@beta`, `@latest`, `3.7.1`). A single upstream takeover would inject code running against `secrets.GITHUB_TOKEN`. Pin every third-party action by full commit SHA, with the readable tag preserved in a trailing comment.
- **#124 (marvinpinto/action-automatic-releases@latest, P0):** action was last tagged v1.2.1 in 2021 on EOL Node 12 and floats `@latest`. Replaced with `softprops/action-gh-release@v2` (SHA-pinned). Input names mapped: `repo_token` → `token`, `automatic_release_tag` → `tag_name`, `title` → `name`, `files` unchanged.

## Version bumps included

- `actions/checkout` v3 → v4 (Node 16 → 20 runtime; drop-in)
- `actions/setup-node` v3 → v4 (same)

`JamesIves/github-pages-deploy-action` kept at 3.7.1 — its v4 has different input names (`BRANCH` → `branch`, `FOLDER` → `folder`, `GITHUB_TOKEN` → `token`); the major bump warrants its own PR with a test push to `gh-pages`.

## Out of scope

- `anthropics/claude-code-action@beta` (2 occurrences) is covered by #131 — left as-is here so this PR is purely about pinning.

## Pinned table

| Workflow | Action | SHA |
|---|---|---|
| ci, claude-auto-review, claude, deploy-ghpages, electron-build, kong-release, purge-cache | `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) |
| ci, deploy-ghpages, electron-build, kong-release | `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4) |
| ci | `actions/github-script` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` (v7) |
| electron-build | `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4) |
| deploy-ghpages | `JamesIves/github-pages-deploy-action` | `132898c54c57c7cc6b80eb3a89968de8fc283505` (3.7.1) |
| kong-release | `vimtor/action-zip` | `5f1c4aa587ea41db1110df6a99981dbe19cee310` (v1) |
| kong-release | `softprops/action-gh-release` (replaces marvinpinto) | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` (v2) |
| purge-cache | `WalshyDev/cf-pages-await` | `3abae9f62a7672a1701300702ce42908e16cb88a` (v1) |

## Test plan
- [x] All SHAs resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` and verified as commit refs
- [ ] CI green on this push (ci.yml will run with newly-pinned actions)
- [ ] Next push to master exercises deploy-ghpages.yml and kong-release.yml; watch for any new release on the Releases page (softprops swap)
- [ ] Next deploy triggers purge-cache.yml — Cloudflare cache purge should still succeed

Closes #124
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)