### PR TITLE
ci: harden workflow permissions and secret handling (#125, #127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:

--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/kong-release.yml
+++ b/.github/workflows/kong-release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -20,9 +20,11 @@ jobs:
         project: 'synergism'
         # Add this if you want GitHub Deployments (see below)
         githubToken: ${{ secrets.API_TOKEN_GITHUB }}
-    - run: |
+    - env:
+        CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      run: |
         curl -X POST "https://api.cloudflare.com/client/v4/zones/418cbe6ba02822b5065295e82b6b2ea9/purge_cache" \
-          -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" \
+          -H "Authorization: Bearer $CF_API_TOKEN" \
           -H "Content-Type: application/json" \
           --data "{\"purge_everything\":true}"
 


### PR DESCRIPTION
## Summary

- **#125 (P0):** 4 of 7 workflows had no `permissions:` block, falling back to the repository's broad token grant. Add a least-privilege `permissions:` at job level for each.
- **#127 (P0):** `purge-cache.yml` interpolated `secrets.CF_API_TOKEN` directly into a `run:` shell script. That renders the secret into the script source, where it can leak via shell tracing, process listings, or error output. Move to an `env:` block and reference `\$CF_API_TOKEN` from the shell.

## Permissions added

| Workflow | Permission | Reason |
|---|---|---|
| ci.yml | `contents: read` | lint/tsc/build/translation diff — read-only |
| deploy-ghpages.yml | `contents: write` | JamesIves pushes to gh-pages branch |
| electron-build.yml | `contents: read` | No publish config in electron-builder.json; `GH_TOKEN` is only consumed for rate-limited Electron binary downloads |
| kong-release.yml | `contents: write` | softprops/action-gh-release creates a GitHub release |

The other 3 workflows (`claude.yml`, `claude-auto-review.yml`, `purge-cache.yml`) already had appropriate permissions blocks.

## CF token move

```diff
-    - run: |
+    - env:
+        CF_API_TOKEN: \${{ secrets.CF_API_TOKEN }}
+      run: |
         curl -X POST "..." \\
-          -H "Authorization: Bearer \${{ secrets.CF_API_TOKEN }}" \\
+          -H "Authorization: Bearer \$CF_API_TOKEN" \\
```

Line 18 (`apiToken: \${{ secrets.CF_API_TOKEN }}` as input to WalshyDev/cf-pages-await) is untouched — that's an action input, not shell.

## Test plan
- [ ] CI green on this push (ci.yml runs with `contents: read` only)
- [ ] On merge to master, `deploy-ghpages.yml` and `purge-cache.yml` fire. Confirm gh-pages deploy succeeds and CF cache purge curl returns 200.
- [ ] Next release tag exercises `kong-release.yml` — confirm release is created.

Closes #125
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)