### PR TITLE
chore: reconcile authorship + pin claude action (#128, #131)

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 1
 
       - name: Automatic PR Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: "60"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2019-2025 Platonic and Khafra
+Copyright (c) 2019-2025 Platonic and Khafra (original authors)
+Copyright (c) 2026-present MaddisonM79 (current maintainer, https://github.com/MaddisonM79)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -79,16 +79,10 @@
     "synergism",
     "synergismofficial"
   ],
-  "author": "Platonic (Kevin Bunn)",
-  "maintainers": [
-    {
-      "email": "pseudonian@gmail.com",
-      "name": "Kevin Bunn"
-    },
-    {
-      "email": "maitken033380023@gmail.com",
-      "name": "Matthew Aitken"
-    }
+  "author": "MaddisonM79 (https://github.com/MaddisonM79)",
+  "contributors": [
+    { "name": "Platonic" },
+    { "name": "Khafra" }
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
## Summary

- **#128 (P0 license divergence):** `LICENSE` listed "Platonic and Khafra" while `package.json`'s `author` / `maintainers` array used real-name form (Kevin Bunn / Matthew Aitken). SBOM and license-scanner tools would emit divergent attribution records. Reconciled on handle/alias form, dropping PII as a side effect.
- **#131 (P1 supply-chain):** `anthropics/claude-code-action@beta` pin deferred from #157. Resolved to commit SHA `28f83620103c48a57093dcc2837eec89e036bb9f` (current `@beta` tag) and applied to both `claude.yml` and `claude-auto-review.yml`.

## Attribution changes (handle-only)

`LICENSE` — dual copyright:
```
Copyright (c) 2019-2025 Platonic and Khafra (original authors)
Copyright (c) 2026-present MaddisonM79 (current maintainer, https://github.com/MaddisonM79)
```

`package.json`:
```diff
-  "author": "Platonic (Kevin Bunn)",
-  "maintainers": [
-    { "email": "pseudonian@gmail.com",         "name": "Kevin Bunn"      },
-    { "email": "maitken033380023@gmail.com",   "name": "Matthew Aitken"  }
-  ],
+  "author": "MaddisonM79 (https://github.com/MaddisonM79)",
+  "contributors": [
+    { "name": "Platonic" },
+    { "name": "Khafra" }
+  ],
```

**Net PII change**: -2 real names, -2 emails removed from public package metadata. Codebase grep confirms nothing reads the `maintainers` field.

## Out of scope

- `id-token: write` on `claude.yml` — the audit also suggested removing this if no OIDC use case exists. Leaving it: claude-code-action may use it internally for token exchange. Revisit if action logs show unused.
- Updating `package.json` `repository.url` / `bugs.url` / `homepage` (still point at `Pseudo-Corp/SynergismOfficial`) — separate cleanup; tangential to attribution.

## Test plan
- [x] `npm run check:tsc && npm run lint && npm run build:esbuild` clean
- [ ] Next PR or `@claude` mention triggers `claude.yml` / `claude-auto-review.yml` — confirm SHA-pinned action still runs

Closes #128
Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)