### PR TITLE
chore: add repo metadata files (#133, #134, #141)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+* @MaddisonM79

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report a bug or unexpected behavior in Synergism
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+      placeholder: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: How can someone else reliably trigger this?
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual behavior
+      placeholder: |
+        Expected: ...
+        Actual:   ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Web (synergism.cc)
+        - Steam
+        - Electron (local build)
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: For the Web platform only. e.g. "Firefox 130", "Chrome 128".
+      placeholder: e.g. Firefox 130
+
+  - type: input
+    id: save-version
+    attributes:
+      label: Save file version
+      description: Visible in Settings or Stats. Helps with migration-related bugs.
+      placeholder: e.g. 4.1.1
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console output
+      description: Open DevTools (F12) and paste any errors. Optional but very helpful.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new feature or improvement to Synergism
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem you're trying to solve
+      description: What's the current pain point or missing capability?
+      placeholder: e.g. "Late-game cube management is tedious because ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What change would address the problem?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?
+
+  - type: dropdown
+    id: save-impact
+    attributes:
+      label: Save format impact
+      description: Would this require adding or modifying fields on the `player` object?
+      options:
+        - "No — UI / display only"
+        - "Yes — new fields needed"
+        - "Yes — existing fields changed"
+        - "Unsure"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thanks for the PR! Please keep these sections so reviewers can move quickly.
+-->
+
+## Summary
+
+<!-- One or two sentences on what this PR changes and why. -->
+
+## Linked issue
+
+<!-- e.g. Closes #123. Use "Refs #123" for partial work. -->
+
+## Test plan
+
+- [ ] `npm run check:tsc` clean
+- [ ] `npm run lint && npm run csslint` clean
+- [ ] `npm run build:esbuild` succeeds
+- [ ] Manually verified in the running game (describe what you checked):
+
+## Save format impact
+
+<!-- Check one. See CLAUDE.md / CONTRIBUTING.md for why this matters. -->
+
+- [ ] No save format impact
+- [ ] Adds field(s) to `player` (list them; describe default value and migration)
+- [ ] Modifies existing `player` field (describe migration plan)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct. Please review the canonical text at that link.
+
+## Reporting
+
+To report a concern, open a confidential report via GitHub's private security advisories at:
+
+**https://github.com/MaddisonM79/unknown_game/security/advisories/new**
+
+Reports are reviewed by the repo maintainer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+## Prerequisites
+
+Before running any of the commands below, make sure you have installed:
+
+- NodeJS >= 24.0.0 — https://nodejs.org/en/
+- git — https://git-scm.com/downloads
+
+## Recommended
+
+- VSCode — https://code.visualstudio.com/Download
+
+## Workflow
+
+1. Fork this repository.
+2. Clone your fork:
+   ```sh
+   git clone https://github.com/<USERNAME>/unknown_game
+   cd unknown_game
+   ```
+3. Install dependencies:
+   ```sh
+   npm install
+   ```
+4. Switch to a new branch:
+   ```sh
+   git checkout -b my-branch-name
+   ```
+5. Start the dev server:
+   ```sh
+   node --run dev
+   ```
+6. Make your changes and verify them in the browser.
+7. Type-check:
+   ```sh
+   node --run check:tsc
+   ```
+8. Lint:
+   ```sh
+   node --run lint
+   node --run csslint
+   ```
+9. Stage and commit:
+   ```sh
+   git add <files>
+   git commit -m "short description"
+   ```
+10. Push and open a pull request against this repository.
+
+## Save format changes
+
+Changes that add or modify fields on the `player` object affect every player's savefile size and migration path. **Before making such a change, please open an issue first** to discuss the schema impact.
+
+See also [CLAUDE.md](CLAUDE.md) for the agent-facing contribution rules (i18n, DOM caching, Steam/Electron gating, etc.).

--- a/README.md
+++ b/README.md
@@ -1,29 +1,13 @@
 # Synergism - the game
 
 ## Contributing
-Before running any of these commands below, make sure to have installed:
 
-NodeJS >= 24.0.0 - https://nodejs.org/en/
-git - https://git-scm.com/downloads
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Recommended Software
+## Code of conduct
 
-VSCode - https://code.visualstudio.com/Download
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
----
-1. Fork this repository at https://github.com/Pseudo-Corp/SynergismOfficial/fork
-2. Clone the repository you forked with `git clone https://github.com/<USERNAME>/SynergismOfficial` (make sure to change `<USERNAME>` with your own GitHub username).
-3. cd SynergismOfficial
-4. Install the project dependencies, running `npm install` (or `make install` - If you intend to use `make` from here and on, make sure it is installed first)
-5. Switch to a new branch with `git checkout -b "my-branch-name"`
-6. Run `node --run dev` (or `make dev`)
-7. Make your desired changes and test them.
-8. Typecheck all your TypeScript files by running `node --run check:tsc` (or `make check`).
-9. Lint the code by running `node --run lint` (or `make lintcode`).
-10. Lint the CSS by running `node --run csslint` (or `make lintcss`).
-11. Run `git add /path/to/file` for every file updated or created (or `git add -A` for every file).
-12. If everything is good to go, commit your changes with `git commit -m "title of my commit"`
-13. Push your changes to your personal Github Repository with `git push -u origin my-branch-name`
-14. Open a Pull Request (PR) on the Official Synergism Repository at https://github.com/Pseudo-Corp/SynergismOfficial/pulls (make sure you click on `compare across forks` to select your fork and branch)
----
-To get a list of available commands in the Makefile, run `make help` or just `make`
+## Security
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Use GitHub's Private Vulnerability Reporting to report security issues:
+
+**https://github.com/MaddisonM79/unknown_game/security/advisories/new**
+
+Please do **not** open a public issue for security vulnerabilities.
+
+You can expect an acknowledgement within 7 days. Fixes are released as soon as they are tested.
+
+## Supported Versions
+
+Only the latest version (`main` branch) is supported.


### PR DESCRIPTION
## Summary

GitHub Community Standards cluster. All net-new files except a trimmed README contributing section.

- **#133 (P1) — SECURITY.md**: Direct reporters to GitHub Private Vulnerability Reporting (no email exposed).
- **#134 (P1) — CODEOWNERS + CONTRIBUTING + CODE_OF_CONDUCT**:
  - `.github/CODEOWNERS` — single owner (`* @MaddisonM79`)
  - `CONTRIBUTING.md` — extracts the inline contributing guide from README; README now links to it
  - `CODE_OF_CONDUCT.md` — adopts Contributor Covenant v2.1 **by reference** (link-only — no embedded behavior list). Enforcement contact uses the GitHub private security advisory URL, not an email.
- **#141 (P2) — Issue + PR templates**:
  - `bug_report.yml` — Synergism-specific fields (platform dropdown, browser, save file version, console output textarea)
  - `feature_request.yml` — standard form with explicit "save format impact" dropdown matching the CLAUDE.md policy on \`player\` field changes
  - `PULL_REQUEST_TEMPLATE.md` — summary / linked issue / test plan / save format impact checklist

## Follow-up

Enable GitHub Private Vulnerability Reporting in repo Settings → Security → Code security and analysis (one click). The links in SECURITY.md and CODE_OF_CONDUCT.md assume PVR is on.

## Test plan
- [ ] Repo Insights → Community panel should show all four standards files green after merge
- [ ] Open a draft issue — confirm both templates appear in the chooser
- [ ] Open a draft PR — confirm template content renders
- [ ] Try @-mentioning a path-owned file in a PR — CODEOWNERS routes review to @MaddisonM79 (will only activate after branch protection adds "require review from code owners")

Closes #133
Closes #134
Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)