### PR TITLE
ci: add Dependabot config (#132)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      dev-deps:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+      prod-deps:
+        dependency-type: "production"
+        update-types: ["patch"]
+    ignore:
+      # Majors below have dedicated wave issues — let those PRs land first.
+      - dependency-name: "zod"                       # #153 Wave 5
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"                # #152 Wave 4
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "stylelint"                 # #152 Wave 4
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "stylelint-config-standard" # #152 Wave 4
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "i18next"                   # #151 Wave 3
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "electron"                  # #151 Wave 3
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "discord-rpc"               # #150 Wave 2 replacement
+      - dependency-name: "husky"                     # #150 Wave 2 major bump
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

OpenSSF Scorecard "Dependency-Update-Tool" finding. The repo had no Dependabot or Renovate config, so security advisories surfaced as drift instead of automated PRs.

Adds \`.github/dependabot.yml\` covering both **npm** and **github-actions** ecosystems on a weekly Monday schedule.

## Key choices

- **Grouped routine bumps**: `dev-deps` group bundles all dev minor+patch updates; `prod-deps` group bundles prod patch updates. Cuts PR noise from one-per-dep to ~2/week.
- **Ignored majors** that already have dedicated wave issues:
  - zod ([#153](https://github.com/MaddisonM79/unknown_game/issues/153) Wave 5)
  - typescript, stylelint, stylelint-config-standard ([#152](https://github.com/MaddisonM79/unknown_game/issues/152) Wave 4)
  - i18next, electron ([#151](https://github.com/MaddisonM79/unknown_game/issues/151) Wave 3)
  - discord-rpc (ignored entirely — [#150](https://github.com/MaddisonM79/unknown_game/issues/150) Wave 2 replacement)
  - husky (ignored entirely — [#150](https://github.com/MaddisonM79/unknown_game/issues/150) Wave 2 major bump)
- **github-actions ecosystem**: complements [#157](https://github.com/MaddisonM79/unknown_game/pull/157)'s SHA pins — Dependabot understands SHA-pinning and will bump pinned SHAs when their underlying tag refs move.

## Test plan
- [ ] After merge, repo Settings → Code security → Dependabot should list both ecosystems and show "last checked" populating
- [ ] Within ~24h expect 1-2 initial PRs (most likely github-actions tag bumps, since several actions are pinned to current SHAs already)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)