### PR TITLE
chore: small TS/repo cleanup bundle (#29, #92, #93, #94, #115)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Before running any of the commands below, make sure you have installed:
 
-- NodeJS >= 24.0.0 — https://nodejs.org/en/
+- NodeJS >= 22.21.0 — https://nodejs.org/en/
 - git — https://git-scm.com/downloads
 
 ## Recommended

--- a/src/Login.ts
+++ b/src/Login.ts
@@ -104,17 +104,16 @@ export const allDurableConsumables: Record<PseudoCoinConsumableNames, Consumable
   }
 }
 
-const messageSchema = z.preprocess(
-  (data, ctx) => {
-    if (typeof data === 'string') {
-      try {
-        return JSON.parse(data)
-      } catch {}
+const messageSchema = z.string()
+  .transform((data, ctx) => {
+    try {
+      return JSON.parse(data)
+    } catch {
+      ctx.addIssue({ code: 'custom', message: 'Invalid message received.' })
+      return z.NEVER
     }
-
-    ctx.addIssue({ code: 'custom', message: 'Invalid message received.' })
-  },
-  z.union([
+  })
+  .pipe(z.union([
     /** Received after the user connects to the websocket */
     z.object({ type: z.literal('join') }),
     z.object({ type: z.literal('error'), message: z.string() }),
@@ -1243,7 +1242,7 @@ function handleCloudSaves () {
           if (response.ok) {
             Alert(i18next.t('account.deletedSave', { name: save.name }))
           } else {
-            console.log(response)
+            console.error('[deleteSave] non-ok response:', response)
             Alert(i18next.t('account.notDeleted'))
 
             if (save.actionButtons) {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1309,19 +1309,19 @@ async function syncToSteamCloud (saveData: string) {
   const saveFileName = `synergism_${steamId}.txt`
 
   const exists = await cloudFileExists(saveFileName)
-  console.log('[SteamCloud] cloudFileExists:', exists)
+  if (dev) console.log('[SteamCloud] cloudFileExists:', exists)
 
   if (exists) {
     const cloudSave = await cloudReadFile(saveFileName)
-    console.log('[SteamCloud] cloudReadFile returned:', cloudSave ? `string(${cloudSave.length})` : cloudSave)
+    if (dev) console.log('[SteamCloud] cloudReadFile returned:', cloudSave ? `string(${cloudSave.length})` : cloudSave)
 
     if (cloudSave) {
       try {
         const parsed = playerUpdateVarSchema.parse(JSON.parse(atob(cloudSave)))
         const cloudPoints = computeAchievementPoints(parsed.achievements, parsed.progressiveAchievements)
-        console.log('[SteamCloud] achievementPoints:', achievementPoints, 'cloudPoints:', cloudPoints)
+        if (dev) console.log('[SteamCloud] achievementPoints:', achievementPoints, 'cloudPoints:', cloudPoints)
         if (achievementPoints < cloudPoints) {
-          console.log('[SteamCloud] skipping upload, cloud has higher points')
+          if (dev) console.log('[SteamCloud] skipping upload, cloud has higher points')
           return
         }
       } catch (e) {
@@ -1331,7 +1331,7 @@ async function syncToSteamCloud (saveData: string) {
   }
 
   const writeResult = await cloudWriteFile(saveFileName, saveData)
-  console.log('[SteamCloud] cloudWriteFile result:', writeResult)
+  if (dev) console.log('[SteamCloud] cloudWriteFile result:', writeResult)
 }
 
 const loadSynergy = () => {
@@ -1375,15 +1375,6 @@ const loadSynergy = () => {
 
     if (data.offerpromo24used !== undefined) {
       player.codes.set(25, false)
-    }
-
-    // sets all non-existent codes to default value false
-    if (player.codes.size < size) {
-      for (let i = player.codes.size + 1; i <= size; i++) {
-        if (!player.codes.has(i)) {
-          player.codes.set(i, false)
-        }
-      }
     }
 
     // sets all non-existent codes to default value false
@@ -2213,12 +2204,12 @@ export const format = (
   longExponent = false
 ): string => {
   if (input == null) {
-    return '0 [null]'
+    return '0'
   }
 
   // NaN check
   if (input !== input) {
-    return '0 [NaN]'
+    return '0'
   }
 
   const inputType = typeof input
@@ -2428,7 +2419,7 @@ export const format = (
     return `e${power.toExponential(2)}`
   }
 
-  return '0 [und.]'
+  return '0'
 }
 
 export const formatTimeShort = (


### PR DESCRIPTION
## Summary

Five tiny issues from the audit, bundled because each is a few-line fix and they share no scope. Total diff: +19 / -29 across 3 files.

- **#92 (P3)** — `Synergism.ts:1380-1396` had a 6-line "set missing codes to false" loop duplicated immediately after itself. Deleted the second copy.
- **#115 (P3)** — `format()` formatter (lines ~2216, 2221, 2431) shipped debug strings `'0 [null]'`, `'0 [NaN]'`, `'0 [und.]'` to players whenever input was missing. Replaced with `'0'`.
- **#29 (P3)** — SteamCloud info-level `console.log`s in `Synergism.ts:1312-1334` now gated behind the `dev` Config flag so they don't ship to production. Error-level `console.error` retained. `Login.ts:1246` debug log promoted to `console.error` with a clearer prefix.
- **#94 (P3)** — `Login.ts:107-127` `messageSchema` used `z.preprocess + ctx.addIssue`, which leaves the preprocess returning `undefined` and runs the union against it, producing two errors per bad input. Rewrote with the modern `z.string().transform(...).pipe(z.union(...))` idiom plus `z.NEVER` short-circuit.
- **#93 (P3)** — `package.json` engines floor (`>=22.21.0`) is the canonical Node version statement; CI workflows use `lts/*` or explicit `22`. The Node version line in `CONTRIBUTING.md` (which inherited the README's old "24.0.0" wording in #160) now matches the engines floor.

## Test plan
- [x] `npm run check:tsc` clean
- [x] `npm run lint` — 0 errors. Warning count dropped 52 → 51 (one of the edits incidentally cleared one); the remaining 51 are tracked in #155 and PR 8.
- [x] `npm run build:esbuild` clean (1.6mb output)
- [ ] Run the game and trigger a SteamCloud sync — verify info logs are silenced in prod build (`dist/out.js`), still appear in dev (`--define:DEV=true`)
- [ ] Send a malformed WebSocket message — verify `messageSchema` reports a single error, not two

Closes #29
Closes #92
Closes #93
Closes #94
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)