### PR TITLE
chore: clear 29 oxlint warnings (refs #155, partial)

### DIFF
--- a/src/Achievements.ts
+++ b/src/Achievements.ts
@@ -3156,7 +3156,7 @@ const achievementsByGroup: Record<AchievementGroups, number[]> = achievements
       if (!groups[achievement.group]) {
         groups[achievement.group] = []
       }
-      groups[achievement.group].push(Number(index))
+      groups[achievement.group].push(index)
     }
     return groups
   }, {} as Record<AchievementGroups, number[]>)
@@ -3170,7 +3170,7 @@ const achievementsByReward: Record<AchievementRewards, number[]> = achievements
         if (!rewards[rewardType]) {
           rewards[rewardType] = []
         }
-        rewards[rewardType].push(Number(index))
+        rewards[rewardType].push(index)
       }
     }
     return rewards

--- a/src/CubeExperimental.ts
+++ b/src/CubeExperimental.ts
@@ -187,7 +187,7 @@ export class WowCubes extends Cube {
     player.cubeOpenedDaily += toSpend
 
     const quarkMult = getShopUpgradeEffects('cubeToQuark', 'cubeQuarkMult')
-    const gainQuarks = Number(this.checkQuarkGain(5, quarkMult, player.cubeOpenedDaily))
+    const gainQuarks = this.checkQuarkGain(5, quarkMult, player.cubeOpenedDaily)
     const actualQuarksGain = Math.max(0, gainQuarks - player.cubeQuarkDaily)
     player.cubeQuarkDaily += actualQuarksGain
     player.worlds.add(actualQuarksGain, false, true)
@@ -262,7 +262,7 @@ export class WowTesseracts extends Cube {
     player.tesseractOpenedDaily += toSpend
 
     const quarkMult = getShopUpgradeEffects('tesseractToQuark', 'tesseractQuarkMult')
-    const gainQuarks = Number(this.checkQuarkGain(7, quarkMult, player.tesseractOpenedDaily))
+    const gainQuarks = this.checkQuarkGain(7, quarkMult, player.tesseractOpenedDaily)
     const actualQuarksGain = Math.max(0, gainQuarks - player.tesseractQuarkDaily)
     player.tesseractQuarkDaily += actualQuarksGain
     player.worlds.add(actualQuarksGain, false, true)

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -202,6 +202,27 @@ import {
 import { isMobile } from './Utility'
 import { Globals as G } from './Variables'
 
+const saveStringTooltipHtml = () =>
+  [
+    i18next.t('settings.saveString.version'),
+    i18next.t('settings.saveString.time'),
+    i18next.t('settings.saveString.year'),
+    i18next.t('settings.saveString.day'),
+    i18next.t('settings.saveString.min'),
+    i18next.t('settings.saveString.period'),
+    i18next.t('settings.saveString.date'),
+    i18next.t('settings.saveString.times'),
+    i18next.t('settings.saveString.sing'),
+    i18next.t('settings.saveString.quarks'),
+    i18next.t('settings.saveString.gq'),
+    i18next.t('settings.saveString.stage')
+  ].join('<br>')
+
+function visitConsumableTab () {
+  changeTab(Tabs.Purchase)
+  changeSubTab(Tabs.Purchase, { page: 3 })
+}
+
 export const generateEventHandlers = () => {
   const ordinals = [
     'first',
@@ -1139,26 +1160,10 @@ export const generateEventHandlers = () => {
   DOMCacheGetOrSet('iconSet').addEventListener('click', () => toggleIconSet(player.iconSet + 1))
   DOMCacheGetOrSet('statSymbols').addEventListener('click', () => toggleStatSymbol())
 
-  const html = () =>
-    [
-      i18next.t('settings.saveString.version'),
-      i18next.t('settings.saveString.time'),
-      i18next.t('settings.saveString.year'),
-      i18next.t('settings.saveString.day'),
-      i18next.t('settings.saveString.min'),
-      i18next.t('settings.saveString.period'),
-      i18next.t('settings.saveString.date'),
-      i18next.t('settings.saveString.times'),
-      i18next.t('settings.saveString.sing'),
-      i18next.t('settings.saveString.quarks'),
-      i18next.t('settings.saveString.gq'),
-      i18next.t('settings.saveString.stage')
-    ].join('<br>')
-
-  saveStringInput.addEventListener('mousemove', (e) => Modal(() => html(), e.clientX, e.clientY))
+  saveStringInput.addEventListener('mousemove', (e) => Modal(saveStringTooltipHtml, e.clientX, e.clientY))
   saveStringInput.addEventListener('focus', () => {
     const elmRect = saveStringInput.getBoundingClientRect()
-    Modal(() => html(), elmRect.x, elmRect.y + elmRect.height / 2)
+    Modal(saveStringTooltipHtml, elmRect.x, elmRect.y + elmRect.height / 2)
   })
   saveStringInput.addEventListener('mouseout', CloseModal)
 
@@ -1625,11 +1630,6 @@ TODO: Fix this entire tab it's utter shit
   }
 
   // EVENT TAB
-  function visitConsumableTab () {
-    changeTab(Tabs.Purchase)
-    changeSubTab(Tabs.Purchase, { page: 3 })
-  }
-
   document.querySelector('#consumableEvents > .consumableButton')?.addEventListener('click', visitConsumableTab)
   document.querySelector('#lotusButtons > .consumableButton')?.addEventListener('click', visitConsumableTab)
 

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -447,7 +447,7 @@ export const craftHepteracts = async (hept: HepteractKeys, max = false) => {
 
   for (const item of (Object.keys(hepteracts[hept].OTHER_CONVERSIONS) as (keyof Player)[])) {
     if (typeof player[item] === 'number') {
-      // eslint-disable-next-line typescript/no-unnecessary-type-assertion: false positive
+      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion -- false positive: indexed access needs the assertion
       ;(player[item] as number) -= amountToCraft * craftCostMulti
         * hepteracts[hept].OTHER_CONVERSIONS[item]
     }

--- a/src/Login.ts
+++ b/src/Login.ts
@@ -1044,6 +1044,22 @@ const buyLotusNotification = (amount: number) => {
   }
 }
 
+async function decodeSave (save: string) {
+  const decoded = atob(save)
+  const bytes = new Uint8Array(decoded.length)
+  for (let i = 0; i < decoded.length; i++) {
+    bytes[i] = decoded.charCodeAt(i)
+  }
+
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'))
+  const textBody = await new Response(stream).text()
+  const encoder = new TextEncoder()
+  const jsonBytes = encoder.encode(textBody)
+  const final = btoa(isomorphicDecode(jsonBytes))
+
+  return final
+}
+
 function handleCloudSaves () {
   const subtabElement = document.querySelector('#accountSubTab div#right.scrollbarX')!
   const table = subtabElement.querySelector('#table > #dataGrid')!
@@ -1171,22 +1187,6 @@ function handleCloudSaves () {
           table.appendChild(rowDiv)
           table.appendChild(detailsRow)
         })
-
-        async function decodeSave (save: string) {
-          const decoded = atob(save)
-          const bytes = new Uint8Array(decoded.length)
-          for (let i = 0; i < decoded.length; i++) {
-            bytes[i] = decoded.charCodeAt(i)
-          }
-
-          const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'))
-          const textBody = await new Response(stream).text()
-          const encoder = new TextEncoder()
-          const jsonBytes = encoder.encode(textBody)
-          const final = btoa(isomorphicDecode(jsonBytes))
-
-          return final
-        }
 
         async function handleDownload (saveId: number) {
           const save = cloudSaves.find((s) => saveId === s.id)

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -102,7 +102,7 @@ export enum AntSacrificeTiers {
 
 export const resetrepeat = (input: resetNames) => {
   clearInterval(repeatreset)
-  repeatreset = +setInterval(() => resetdetails(input), 50)
+  repeatreset = setInterval(() => resetdetails(input), 50)
 }
 
 const resetdetails = (input: resetNames) => {
@@ -1189,7 +1189,6 @@ export const singularity = (setSingNumber = -1) => {
 
   if (!getSingularityChallengeEffect('limitedTime', 'preserveQuarks')) {
     player.worlds.reset()
-    hold.worlds = Number(hold.worlds)
   } else {
     hold.worlds = Number(player.worlds)
   }

--- a/src/SingularityChallenges.ts
+++ b/src/SingularityChallenges.ts
@@ -333,7 +333,7 @@ export class SingularityChallenge {
   scaleString (): string {
     let text = ''
     for (let i = 1; i <= this.scalingrewardcount; i++) {
-      const list = i18next.t(`singularityChallenge.data.${String(this.HTMLTag)}.ScalingReward${i}`)
+      const list = i18next.t(`singularityChallenge.data.${this.HTMLTag}.ScalingReward${i}`)
       text += i > 1 ? `\n${list}` : list
     }
     return text
@@ -343,7 +343,7 @@ export class SingularityChallenge {
   uniqueString (): string {
     let text = ''
     for (let i = 1; i <= this.uniquerewardcount; i++) {
-      const list = i18next.t(`singularityChallenge.data.${String(this.HTMLTag)}.UniqueReward${i}`)
+      const list = i18next.t(`singularityChallenge.data.${this.HTMLTag}.UniqueReward${i}`)
       text += i > 1 ? `\n${list}` : list
     }
     return text

--- a/src/Themes.ts
+++ b/src/Themes.ts
@@ -284,7 +284,7 @@ enum Notations {
 
 export const toggleAnnotation = (setting = true) => {
   const notationButton = DOMCacheGetOrSet('notation')
-  const current = player.notation
+  const current = player.notation as Notations
   let newNotation: Notations
 
   switch (current) {
@@ -309,7 +309,7 @@ export const toggleAnnotation = (setting = true) => {
 export const settingAnnotation = () => {
   const notationButton = DOMCacheGetOrSet('notation')
 
-  switch (player.notation) {
+  switch (player.notation as Notations) {
     case Notations.PURE_SCIENTIFIC:
       notationButton.textContent = i18next.t('settings.notation.pureScientific')
       break

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -1351,8 +1351,8 @@ export const Prompt = (text: string, defaultValue?: string): Promise<string | nu
     return p.promise
   })
 
-let closeNotification: number
-let closedNotification: number
+let closeNotification: ReturnType<typeof setTimeout> | 0
+let closedNotification: ReturnType<typeof setTimeout> | 0
 
 export const Notification = (text: string, time = 30000): Promise<void> => {
   const notification = DOMCacheGetOrSet('notification')
@@ -1378,7 +1378,7 @@ export const Notification = (text: string, time = 30000): Promise<void> => {
 
     closeNotification = 0
     x.removeEventListener('click', close)
-    closedNotification = +setTimeout(closed, 1000)
+    closedNotification = setTimeout(closed, 1000)
     p.resolve()
   }
 
@@ -1389,7 +1389,7 @@ export const Notification = (text: string, time = 30000): Promise<void> => {
   clearTimeout(closedNotification)
 
   // automatically close out after <time> ms
-  closeNotification = +setTimeout(close, time)
+  closeNotification = setTimeout(close, time)
 
   return p.promise
 }

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -858,37 +858,29 @@ export const visualUpdateCubes = () => {
   const platonicMult = 1.5
 
   const toNextQuark: cubeNames = {
-    cube: Number(
-      player.wowCubes.checkCubesToNextQuark(
-        5,
-        cubeMult,
-        player.cubeQuarkDaily,
-        player.cubeOpenedDaily
-      )
+    cube: player.wowCubes.checkCubesToNextQuark(
+      5,
+      cubeMult,
+      player.cubeQuarkDaily,
+      player.cubeOpenedDaily
     ),
-    tesseract: Number(
-      player.wowTesseracts.checkCubesToNextQuark(
-        7,
-        tesseractMult,
-        player.tesseractQuarkDaily,
-        player.tesseractOpenedDaily
-      )
+    tesseract: player.wowTesseracts.checkCubesToNextQuark(
+      7,
+      tesseractMult,
+      player.tesseractQuarkDaily,
+      player.tesseractOpenedDaily
     ),
-    hypercube: Number(
-      player.wowHypercubes.checkCubesToNextQuark(
-        10,
-        hypercubeMult,
-        player.hypercubeQuarkDaily,
-        player.hypercubeOpenedDaily
-      )
+    hypercube: player.wowHypercubes.checkCubesToNextQuark(
+      10,
+      hypercubeMult,
+      player.hypercubeQuarkDaily,
+      player.hypercubeOpenedDaily
     ),
-    platonicCube: Number(
-      player.wowPlatonicCubes.checkCubesToNextQuark(
-        15,
-        platonicMult,
-        player.platonicCubeQuarkDaily,
-        player.platonicCubeOpenedDaily
-      )
+    platonicCube: player.wowPlatonicCubes.checkCubesToNextQuark(
+      15,
+      platonicMult,
+      player.platonicCubeQuarkDaily,
+      player.platonicCubeOpenedDaily
     )
   }
 

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -98,6 +98,7 @@ export const sortDecimalWithIndices = (toSort: DecimalSource[]) => {
  * Identical to @see {DOMCacheGetOrSet} but casts the type.
  * @param id {string}
  */
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- T is the function's documented contract: callers specify the expected element type
 export const getElementById = <T extends HTMLElement>(id: string) => DOMCacheGetOrSet(id) as T
 
 /**

--- a/src/mock/websocket.ts
+++ b/src/mock/websocket.ts
@@ -4,7 +4,13 @@ import { sleep } from './util/util'
 
 const consumable = ws.link('wss://synergism.cc/consumables/connect')
 let tips = 1000
-const lotus = {
+const lotus: {
+  inventory: number
+  used: number
+  active: number
+  activeUntil: number
+  timer: ReturnType<typeof setTimeout> | 0
+} = {
   inventory: 0,
   used: 0,
   active: 0,
@@ -81,7 +87,7 @@ export const consumeHandlers = [
             clearTimeout(lotus.timer)
           }
 
-          lotus.timer = +setTimeout(() => {
+          lotus.timer = setTimeout(() => {
             lotus.active -= data.amount
             client.send(messages.lotusEnded())
           }, lotus.activeUntil - Date.now())

--- a/src/purchases/CartTab.ts
+++ b/src/purchases/CartTab.ts
@@ -185,7 +185,6 @@ const onInit = memoize(() => {
 export const initializeCart = () => {
   onInit()
 
-  // TODO(@KhafraDev):
-  // eslint-disable-next-line no-new:
-  new CartTab()
+  // TODO(@KhafraDev): refactor CartTab to expose an init() instead of side-effects in constructor
+  void new CartTab()
 }

--- a/src/saves/PlayerSchema.ts
+++ b/src/saves/PlayerSchema.ts
@@ -531,7 +531,7 @@ export const playerSchema = z.object({
     return Object.fromEntries(
       Object.keys(blankSave.unlocks).map((key) => {
         const value = object[key] ?? blankSave.unlocks[key as keyof typeof blankSave['unlocks']]
-        return value === null ? [key, false] : [key, Boolean(value)]
+        return value === null ? [key, false] : [key, value]
       })
     )
   }).default(() => ({ ...blankSave.unlocks })),
@@ -542,7 +542,7 @@ export const playerSchema = z.object({
         Object.keys(blankSave.progressiveAchievements).map((key) => {
           const value = object[key]
             ?? blankSave.progressiveAchievements[key as keyof typeof blankSave['progressiveAchievements']]
-          return value === null ? [key, 0] : [key, Number(value)]
+          return value === null ? [key, 0] : [key, value]
         })
       )
     }
@@ -1029,7 +1029,7 @@ export const playerSchema = z.object({
         Object.keys(blankSave.redAmbrosiaUpgrades).map((key) => {
           const value = object[key]
             ?? blankSave.redAmbrosiaUpgrades[key as keyof typeof blankSave['redAmbrosiaUpgrades']]
-          return value === null ? [key, 0] : [key, Number(value)]
+          return value === null ? [key, 0] : [key, value]
         })
       )
     }


### PR DESCRIPTION
## Summary

[#155](https://github.com/MaddisonM79/unknown_game/issues/155) tracks 52 warnings emitted after the wave-1 oxlint-tsgolint bump. This PR clears 29 of them by fully closing every category except \`typescript(consistent-return)\`. **Refs (not closes) #155** — remaining 23 consistent-return warnings need per-site analysis and ship in a follow-up.

### Cleared

| Category | Sites cleared |
|---|---|
| typescript(no-unnecessary-type-conversion) | 18 |
| typescript(no-unsafe-enum-comparison) | 5 |
| unicorn(consistent-function-scoping) | 3 |
| typescript(no-unnecessary-type-assertion) | 1 |
| typescript(no-unnecessary-type-parameters) | 1 |
| eslint(no-new) | 1 |

### Notable choices

- **setTimeout/setInterval typing**: three sites needed \`+setTimeout(...)\` because their variable was typed \`number\` while \`setTimeout\` returns Node's \`Timeout\`. Widened the variable type to \`ReturnType<typeof setTimeout> | 0\` so the \`+\` is no longer needed. Cleaner than the unary-plus coercion.
- **Enum comparison in Themes.ts**: \`player.notation\` is typed as the string literal union \`'Pure Scientific' | 'Pure Engineering' | 'Default'\` but the switch compares against the \`Notations\` enum. Added \`as Notations\` cast at the switch predicate. The Player interface field could be retyped to use \`Notations\` directly, but that would need to be a separate change since the enum currently lives in Themes.ts.
- **Function hoisting**: \`decodeSave\` (Login.ts), \`html\`→\`saveStringTooltipHtml\` (EventListeners.ts), and \`visitConsumableTab\` (EventListeners.ts) didn't capture outer scope, so they're now defined at module scope. \`html\` was renamed for clarity since it's now a top-level identifier.
- **Broken disable comments**: three sites had \`// eslint-disable-next-line rule: text\` with a \`:\` separator that oxlint doesn't parse. Updated to \`// oxlint-disable-next-line rule -- text\` (standard \`--\` separator).
- **\`new CartTab()\` for side effects** → \`void new CartTab()\` to make the discard explicit (oxlint accepts the void form).
- **Reset.ts:1192** \`hold.worlds = Number(hold.worlds)\` was a self-assigning no-op (the else branch does real coercion of a QuarkHandler instance; the if-branch was redundant). Removed the line.

## Follow-up

23 \`typescript(consistent-return)\` warnings remain in: Achievements (1), BlueberryUpgrades (2), Campaign (1), Challenges (3), Corruptions (1), Event (2), EventListeners (1), Features/Ants RebornELO threshold (1), Hotkeys (4), Login (1), mock/messages (1), PseudoCoinUpgrades (2), purchases/SubscriptionsSubtab (1), Synergism (2). Each needs to be examined to decide whether the missing return is a bug or an intentional implicit-undefined path — a separate PR.

## Test plan
- [x] \`npm run check:tsc\` clean
- [x] \`npm run lint\` — 0 errors, 23 warnings (down from 52)
- [x] \`npm run build:esbuild\` clean (1.6mb output)
- [ ] Trigger Notification close/reopen flow in the running game — verifies \`closeNotification\`/\`closedNotification\` typing change didn't break the timer logic
- [ ] Toggle notation in settings — verifies the \`as Notations\` cast in Themes.ts
- [ ] Open the save-string field — verifies the hoisted \`saveStringTooltipHtml\` still renders the tooltip

Refs #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)