### PR TITLE
ci: add CodeQL workflow (#142)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run on Mondays so vuln databases stay fresh even without commits.
+    - cron: '23 7 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      # Needed for workflows in private repos using "Default" or "Auto build"; harmless on public repos.
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
+        with:
+          languages: javascript-typescript
+          # Default queries cover most of the OWASP top 10 for JS/TS.
+          # Add `queries: security-extended` if you want more aggressive checks
+          # (more findings, more false positives, slower scan).
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Summary

OpenSSF Scorecard "Static-Analysis" finding. The repo had no SAST workflow; for a TypeScript SPA that processes untrusted save files (LZ-string-compressed JSON parsed client-side) this is a meaningful gap.

Adds \`.github/workflows/codeql.yml\`:
- **Language**: \`javascript-typescript\` (one CodeQL analysis covers both)
- **Triggers**: push + PR to \`main\`, plus a weekly Monday cron at 07:23 UTC so the vulnerability database stays fresh between commits
- **Pinned actions**: \`actions/checkout\` and \`github/codeql-action/{init,analyze}\` by full commit SHA — matches the pinning convention from [#157](https://github.com/MaddisonM79/unknown_game/pull/157)
- **Permissions**: \`contents: read\` + \`security-events: write\` + \`actions: read\` (the minimum needed for CodeQL upload)

The default query suite covers most of the OWASP top 10 for JS/TS. Switching to \`security-extended\` is a one-line change in this file if more aggressive checks are wanted later (more findings, more false positives, slower scan).

## Test plan
- [ ] After merge: first run of \`codeql.yml\` on the merge commit should complete in ~5–10 min
- [ ] Repo Insights → Security → Code scanning should show "javascript-typescript" results
- [ ] Any findings appear inline on PRs as code-scanning annotations

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)