### PR TITLE
security: enable Electron sandbox + deny permission requests (#15)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -84,6 +84,8 @@ function createWindow (): void {
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
       preload: path.join(app.getAppPath(), 'electron', 'preload.js'),
       enableWebSQL: false,
       backgroundThrottling: false
@@ -160,6 +162,13 @@ app.on('open-url', (event, url) => {
 
 app.whenReady().then(async () => {
   const distPath = path.join(app.getAppPath(), 'dist')
+
+  // Deny all Chromium permission requests by default (geolocation, notifications,
+  // media, etc.) — Synergism doesn't need any of them. A compromised renderer
+  // shouldn't be able to silently request them either.
+  session.defaultSession.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    callback(false)
+  })
 
   session.defaultSession.protocol.handle('https', async (request) => {
     const url = new URL(request.url)


### PR DESCRIPTION
## Summary

CWE-1188. The renderer's \`webPreferences\` had \`nodeIntegration: false\` and \`contextIsolation: true\` (good) but **missing \`sandbox: true\`**. Without the sandbox, a renderer compromise (e.g. via the translation XSS path tracked in [#14](https://github.com/MaddisonM79/unknown_game/issues/14)) can still reach Node-backed APIs by abusing channels exposed through the preload bridge.

### Changes ([electron/main.ts](electron/main.ts))

- **\`sandbox: true\`** — renderer process runs sandboxed at the OS level (Chromium's seccomp/AppContainer). Even a fully RCE'd renderer can't \`require()\` Node modules or escape via shared workers.
- **\`webSecurity: true\`** — explicit (was Electron's default, but documenting it).
- **\`setPermissionRequestHandler\` denying everything** — Synergism doesn't need geolocation / notifications / camera / mic / clipboard-write / etc. A compromised renderer shouldn't be able to silently request them either.

### Preload compatibility

\`electron/preload.js\` uses \`contextBridge\` + \`ipcRenderer\`. Both are still available to sandboxed preloads via Electron's special compat layer (no \`fs\`, \`path\`, etc. needed there). No preload changes required.

## Test plan
- [ ] Build the Electron app (\`npm run electron:build:mac\` or whichever platform) — verify no preload errors at startup
- [ ] Launch the built app — game loads at \`https://synergism.cc/\`, can sign in, can save/load
- [ ] Open DevTools (dev builds) — \`window.steam\`, \`window.windowControls\`, \`window.auth\`, \`window.discord\` are present (preload bridges still work)
- [ ] If anything in the game ever calls \`navigator.geolocation\` / \`Notification.requestPermission()\` etc., the request will now silently fail; check console for any unexpected denied permissions

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)