### PR TITLE
security: add baseline Content-Security-Policy meta tag (#18; supersedes #21)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
+    <!--
+      Content-Security-Policy: baseline. Loosely permissive because (a) ~728 inline
+      style="..." attributes still ship with the page and (b) some runtime-injected
+      handlers exist (see audit #115/#107). Both are tracked as separate refactors;
+      once they're gone, 'unsafe-inline' can be dropped from script-src and style-src
+      and replaced with nonces. Until then, this policy still blocks the big targets
+      (remote scripts other than Turnstile, <object>/<embed>, base-uri override).
+      frame-ancestors and form-action work via HTTP header, not meta — add those at
+      the origin server or via Cloudflare worker.
+    -->
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com;
+      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+      font-src 'self' https://fonts.gstatic.com;
+      img-src 'self' data:;
+      connect-src 'self' https://synergism.cc wss://synergism.cc https://challenges.cloudflare.com;
+      frame-src https://challenges.cloudflare.com;
+      worker-src 'self' blob:;
+      object-src 'none';
+      base-uri 'self';
+    ">
     <meta property="og:title" content="Synergism">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://pseudo-corp.github.io/SynergismOfficial">


### PR DESCRIPTION
## Summary

CWE-1021. The page had **no Content-Security-Policy** at all (no meta tag, no response header). Every XSS finding ([#8](https://github.com/MaddisonM79/unknown_game/issues/8), [#14](https://github.com/MaddisonM79/unknown_game/issues/14), [#21](https://github.com/MaddisonM79/unknown_game/issues/21)) is partially mitigated by a strict CSP, so this is the missing defense-in-depth layer.

Ships a baseline CSP via \`<meta http-equiv="Content-Security-Policy">\` in \`index.html\`. The policy is permissive in two places it has to be, and strict everywhere it can be.

## Why this PR supersedes [#21](https://github.com/MaddisonM79/unknown_game/issues/21) ("SRI for external fonts + Turnstile")

That issue's own body confirms: "Both endpoints don't publish stable SRI hashes (dynamic content), so SRI isn't viable here. Mitigation is via CSP \`script-src\` and \`style-src\` allow-lists (depends on #S11)." That dependency is [#18](https://github.com/MaddisonM79/unknown_game/issues/18), which this PR closes. So [#21](https://github.com/MaddisonM79/unknown_game/issues/21) → close as "superseded by [#18](https://github.com/MaddisonM79/unknown_game/issues/18)" when this PR merges.

## Policy

\`\`\`
default-src 'self';
script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com;
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
font-src 'self' https://fonts.gstatic.com;
img-src 'self' data:;
connect-src 'self' https://synergism.cc wss://synergism.cc https://challenges.cloudflare.com;
frame-src https://challenges.cloudflare.com;
worker-src 'self' blob:;
object-src 'none';
base-uri 'self';
\`\`\`

### Why each directive looks this way

| Directive | Why |
|---|---|
| \`script-src ... 'unsafe-inline'\` | Runtime-injected handlers (audit [#107](https://github.com/MaddisonM79/unknown_game/issues/107), \`Messages.ts:197\` \`onmouseover\`). Can drop \`'unsafe-inline'\` once those refactor. |
| \`script-src ... https://challenges.cloudflare.com\` | Turnstile loads its JS from here. |
| \`style-src ... 'unsafe-inline'\` | ~728 inline \`style="..."\` attributes ship with the page (audit [#113](https://github.com/MaddisonM79/unknown_game/issues/113)/[#114](https://github.com/MaddisonM79/unknown_game/issues/114)). Same trajectory: refactor → drop. |
| \`style-src ... https://fonts.googleapis.com\` | Google Fonts CSS. |
| \`font-src ... https://fonts.gstatic.com\` | Google Fonts font files. |
| \`connect-src ... wss://synergism.cc\` | The pseudo-coin WebSocket at \`wss://synergism.cc/consumables/connect\`. |
| \`worker-src 'self' blob:\` | \`worker-timers\` spawns workers via \`blob:\` URLs; MSW service worker lives at \`'self'\`. |
| \`img-src 'self' data:\` | No remote image hot-loading; \`data:\` URIs kept available for any base64-encoded UI assets. |
| \`object-src 'none'\` | No \`<object>\`/\`<embed>\`/\`<applet>\` — strict. |
| \`base-uri 'self'\` | Prevent \`<base>\` hijack of relative URL resolution. |

### Caveats noted inline

\`frame-ancestors\` and \`form-action\` are **ignored** in a meta CSP — they only work as HTTP headers. Documented inline as a TODO for the origin server / Cloudflare worker.

## Test plan
- [x] \`npm run check:tsc\` clean
- [x] \`npm run htmllint\` clean
- [ ] Load the page locally — no CSP-violation errors in the console for legitimate functionality (font loading, Turnstile widget, WebSocket connect, etc.)
- [ ] Try fetching an off-origin image via \`fetch('https://example.com/x.png')\` from devtools → should be blocked by \`connect-src\`
- [ ] Confirm the inline-style-heavy parts of the UI (every cube/upgrade/notification) still render with color and layout — \`'unsafe-inline'\` on style-src is what keeps these working today

Closes #18
Supersedes #21 — close that one as "covered by this PR" since SRI isn't viable for the dynamic CDN endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)