### PR TITLE
chore: clear remaining 22 oxlint warnings + 3 errors (closes #155)

### DIFF
--- a/src/Achievements.ts
+++ b/src/Achievements.ts
@@ -3585,6 +3585,7 @@ const awardAchievement = (index: number) => {
       }
     }
   }
+  return undefined
 }
 
 export const awardUngroupedAchievement = (name: UngroupedAchievementNames) => {

--- a/src/BlueberryUpgrades.ts
+++ b/src/BlueberryUpgrades.ts
@@ -1430,7 +1430,10 @@ export const resetBlueberryTree = (giveAlert = true) => {
   }
   player.ambrosia = player.lifetimeAmbrosia
   player.spentBlueberries = 0
-  if (giveAlert) return Alert(i18next.t('ambrosia.refund'))
+  if (giveAlert) {
+    void Alert(i18next.t('ambrosia.refund'))
+    return
+  }
 }
 
 const validateBlueberryTree = (modules: BlueberryOpt) => {
@@ -1577,14 +1580,16 @@ const createBlueberryTree = (modules: BlueberryOpt) => {
 
 export const importBlueberryTree = (input: string | null) => {
   if (typeof input !== 'string') {
-    return Alert(i18next.t('importexport.unableImport'))
+    void Alert(i18next.t('importexport.unableImport'))
+    return
   } else {
     try {
       const modules = JSON.parse(input) as BlueberryOpt
       createBlueberryTree(modules)
       createLoadoutDescription(0, modules)
     } catch {
-      return Alert(i18next.t('ambrosia.importTree.error'))
+      void Alert(i18next.t('ambrosia.importTree.error'))
+      return
     }
   }
 }

--- a/src/Campaign.ts
+++ b/src/Campaign.ts
@@ -1606,7 +1606,8 @@ const campaignCorruptionStatHTMLUpdate = (key: CampaignKeys) => {
     campaignButton.textContent = i18next.t('campaigns.corruptionStats.startCampaign')
     campaignButton.addEventListener('click', () => {
       if (player.currentChallenge.ascension !== 0) {
-        return Alert(i18next.t('campaigns.errorMessages.ascensionChallenge'))
+        void Alert(i18next.t('campaigns.errorMessages.ascensionChallenge'))
+        return
       }
       reset('ascension')
       player.campaigns.campaign = key

--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -543,6 +543,9 @@ const calculateChallengeRequirementMultiplier = (
         requirementMultiplier *= Math.pow(1000, completions)
       }
       return requirementMultiplier
+    default: {
+      throw new Error(`Unhandled challenge type: ${type satisfies never}`)
+    }
   }
 }
 
@@ -566,6 +569,9 @@ export const CalcECC = (type: 'transcend' | 'reincarnation' | 'ascension', compl
       effective += Math.min(10, completions)
       effective += 1 / 2 * (Math.max(10, completions) - 10)
       return effective
+    default: {
+      throw new Error(`Unhandled challenge type: ${type satisfies never}`)
+    }
   }
 }
 
@@ -682,6 +688,9 @@ function sweepTransitionFunc (
       } else {
         return { kind: 'initial_wait' }
       }
+    default: {
+      throw new Error(`Unhandled SweepState kind: ${(state as { kind: string }).kind}`)
+    }
   }
 }
 

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -234,6 +234,9 @@ export class CorruptionLoadout {
       case 'viscosity': {
         return this.#viscosityEffect()
       }
+      default: {
+        throw new Error(`Unhandled corruption: ${corr satisfies never}`)
+      }
     }
   }
 

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -137,6 +137,9 @@ export const getEventBuff = (buff: BuffType): number => {
       return event.blueberryTime
     case BuffType.AmbrosiaLuck:
       return event.ambrosiaLuck
+    default: {
+      throw new Error(`Unhandled BuffType: ${buff}`)
+    }
   }
 }
 
@@ -179,6 +182,9 @@ export const consumableEventBuff = (buff: BuffType) => {
       return HAPPY_HOUR_BELL ? 0.1 + 0.01 * happyHourInterval : 0
     case BuffType.AmbrosiaLuck:
       return HAPPY_HOUR_BELL ? 0.1 + 0.01 * happyHourInterval : 0
+    default: {
+      throw new Error(`Unhandled BuffType: ${buff}`)
+    }
   }
 }
 

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -945,7 +945,8 @@ export const generateEventHandlers = () => {
         }
 
         if (getOwnedLotus() < 1) {
-          return Alert(i18next.t('pseudoCoins.lotus.noLotus'))
+          void Alert(i18next.t('pseudoCoins.lotus.noLotus'))
+          return
         }
 
         sendToWebsocket(

--- a/src/Features/Ants/AntSacrifice/Rewards/ELO/RebornELO/Stages/lib/threshold.ts
+++ b/src/Features/Ants/AntSacrifice/Rewards/ELO/RebornELO/Stages/lib/threshold.ts
@@ -1,5 +1,4 @@
 import { player } from '../../../../../../../../Synergism'
-import { assert } from '../../../../../../../../Utility'
 
 export const thresholdTranches = [
   { stages: 100, perStage: 100, quarkPerStage: 1 },
@@ -66,7 +65,7 @@ export const calculateToNextELOThreshold = (rebornELO: number, stage?: number) =
     stagesChecked += tranche.stages
     tempELO -= tranche.stages * tranche.perStage
   }
-  assert(false, 'Unreachable code in calculateToNextELOThreshold')
+  throw new Error('Unreachable code in calculateToNextELOThreshold')
 }
 
 export const calculateLeftoverELO = (rebornELO: number, stage?: number) => {

--- a/src/Hotkeys.ts
+++ b/src/Hotkeys.ts
@@ -156,15 +156,18 @@ const makeSlot = (key: string, descr: string) => {
     const toSet = newKey.toUpperCase()
 
     if (newKey.length === 0) {
-      return void Alert('You didn\'t enter anything, canceled!')
+      void Alert('You didn\'t enter anything, canceled!')
+      return
     }
 
     if (!isNaN(Number(newKey))) {
-      return void Alert('Number keys are currently unavailable!')
+      void Alert('Number keys are currently unavailable!')
+      return
     }
 
     if (hotkeys.has(toSet) || oldKey === toSet) {
-      return void Alert('That key is already binded to an action, use another key instead!')
+      void Alert('That key is already binded to an action, use another key instead!')
+      return
     } else if (hotkeys.has(oldKey)) {
       const old = hotkeys.get(oldKey)!
 
@@ -178,7 +181,8 @@ const makeSlot = (key: string, descr: string) => {
 
       enableHotkeys()
     } else {
-      return void Alert(`No hotkey is triggered by ${oldKey}!`)
+      void Alert(`No hotkey is triggered by ${oldKey}!`)
+      return
     }
   })
 

--- a/src/PseudoCoinUpgrades.ts
+++ b/src/PseudoCoinUpgrades.ts
@@ -200,6 +200,9 @@ export const displayPCoinEffect = (name: PseudoCoinUpgradeNames, level: number) 
       )
     case 'RED_LUCK_BUFF':
       return String(i18next.t('pseudoCoins.upgradeEffects.RED_LUCK_BUFF', { amount: 20 * level }))
+    default: {
+      throw new Error(`Unhandled PseudoCoinUpgradeNames: ${name}`)
+    }
   }
 }
 
@@ -285,5 +288,8 @@ export const showCostAndEffect = (name: PseudoCoinUpgradeNames) => {
         cost: 'Cost: 100/150/200/250/300 PseudoCoins',
         effect: 'Effect: 20/40/60/80/100 Red Luck'
       }
+    default: {
+      throw new Error(`Unhandled PseudoCoinUpgradeNames: ${name}`)
+    }
   }
 }

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1345,7 +1345,8 @@ const loadSynergy = () => {
 
   if (data) {
     if ((data.exporttest === false || data.exporttest === 'NO!') && !testing) {
-      return Alert(i18next.t('testing.saveInLive2'))
+      void Alert(i18next.t('testing.saveInLive2'))
+      return
     }
 
     // size before loading
@@ -5045,13 +5046,15 @@ export const reloadShit = (ignoreOfflineProgress = false) => {
 
     if (isLZString) {
       if (!decompress) {
-        return Alert(i18next.t('save.loadFailed'))
+        void Alert(i18next.t('save.loadFailed'))
+        return
       }
 
       const saveString = btoa(decompress)
 
       if (saveString === null) {
-        return Alert(i18next.t('save.loadFailed'))
+        void Alert(i18next.t('save.loadFailed'))
+        return
       }
 
       localStorage.clear()

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -1351,8 +1351,8 @@ export const Prompt = (text: string, defaultValue?: string): Promise<string | nu
     return p.promise
   })
 
-let closeNotification: ReturnType<typeof setTimeout> | 0
-let closedNotification: ReturnType<typeof setTimeout> | 0
+let closeNotification: ReturnType<typeof setTimeout> | undefined = undefined
+let closedNotification: ReturnType<typeof setTimeout> | undefined = undefined
 
 export const Notification = (text: string, time = 30000): Promise<void> => {
   const notification = DOMCacheGetOrSet('notification')
@@ -1369,14 +1369,14 @@ export const Notification = (text: string, time = 30000): Promise<void> => {
   const closed = () => {
     notification.style.display = 'none'
     textNode.textContent = ''
-    closedNotification = 0
+    closedNotification = undefined
   }
 
   const close = () => {
     notification.classList.add('slide-out')
     notification.classList.remove('slide-in')
 
-    closeNotification = 0
+    closeNotification = undefined
     x.removeEventListener('click', close)
     closedNotification = setTimeout(closed, 1000)
     p.resolve()

--- a/src/mock/util/messages.ts
+++ b/src/mock/util/messages.ts
@@ -114,11 +114,12 @@ export const messageSchema = z.preprocess(
         return JSON.parse(arg)
       } catch {
         ctx.addIssue({ code: 'custom', message: 'Received non-JSON message' })
-        return
+        return z.NEVER
       }
     }
 
     ctx.addIssue({ code: 'custom', message: 'Received non-string message' })
+    return z.NEVER
   },
   z.union([
     z.object({ type: z.literal('consume'), consumable: z.string() }),

--- a/src/mock/websocket.ts
+++ b/src/mock/websocket.ts
@@ -9,13 +9,13 @@ const lotus: {
   used: number
   active: number
   activeUntil: number
-  timer: ReturnType<typeof setTimeout> | 0
+  timer: ReturnType<typeof setTimeout> | undefined
 } = {
   inventory: 0,
   used: 0,
   active: 0,
   activeUntil: 0,
-  timer: 0
+  timer: undefined
 }
 
 export const consumeHandlers = [

--- a/src/purchases/SubscriptionsSubtab.ts
+++ b/src/purchases/SubscriptionsSubtab.ts
@@ -313,6 +313,7 @@ const createIndividualSubscriptionHTML = (product: SubscriptionProduct, currentS
       </section>
     `
   }
+  return undefined
 }
 
 const manageSubscriptionButtonVisibility = (sub: SubscriptionMetadata) => {


### PR DESCRIPTION
## Summary

Completes the [#155](https://github.com/MaddisonM79/unknown_game/issues/155) sweep started in [#172](https://github.com/MaddisonM79/unknown_game/pull/172). That PR cleared 29 of 52; this one clears the final 22 \`typescript(consistent-return)\` warnings **and** fixes 3 latent \`no-redundant-type-constituents\` **errors** that I introduced in #172 (the \`ReturnType<typeof setTimeout> | 0\` widening — \`0\` is subsumed by \`number\`).

After this lands, \`npm run lint\` is fully clean: 0 warnings, 0 errors.

## consistent-return — by category (22 sites)

| Category | Fix shape | Sites |
|---|---|---|
| \`return void Alert(...)\` / \`return Alert(...)\` in void/async fns | Split to \`void Alert(...); return\` | Hotkeys.ts (4), EventListeners.ts (1), Campaign.ts (1), BlueberryUpgrades.ts (3) |
| Exhaustive switch missing default | Add \`default: throw new Error(\\\`Unhandled X: \${x}\\\`)\` (with \`x satisfies never\` for closed unions) | Event.ts (2), PseudoCoinUpgrades.ts (2), Corruptions.ts (1), Challenges.ts (2) |
| Non-exhaustive discriminated union | Same — \`default: throw\` covers future \`SweepStates\` kinds | Challenges.ts \`sweepTransitionFunc\` (1) |
| Conditional return path with implicit fall-through | Explicit \`return undefined\` at tail; in \`threshold.ts\`, replaced \`assert(false, ...)\` tail with \`throw new Error(...)\` (semantically identical, doesn't widen return type) | Achievements.ts, Synergism.ts (×2), SubscriptionsSubtab.ts, threshold.ts |
| zod preprocess bare \`return\` | \`return z.NEVER\` (matches PR #171 messageSchema pattern) | mock/util/messages.ts |

## Bonus: the 3 errors from #172

\`ReturnType<typeof setTimeout> | 0\` flagged \`0 is overridden by number in this union type\`. oxlint sees \`setTimeout\` returning \`number\` (browser context); tsc sees it returning Node's \`Timeout\`. Bridged by changing the union to use \`| undefined = undefined\` — structurally distinct from \`number\`, satisfies both. Two reset sites in \`UpdateHTML.ts\` (\`= 0\` → \`= undefined\`) and one initial in \`mock/websocket.ts\`. \`clearTimeout(undefined)\` is a spec'd no-op, so reset semantics are unchanged.

## Test plan
- [x] \`npm run check:tsc\` clean
- [x] \`npm run lint\` — exit 0, 0 warnings, 0 errors
- [x] \`npm run build:esbuild\` clean (1.6mb output)
- [ ] Trigger any \`Alert\` flow in the running game (e.g. blueberry tree reset) — should pop the modal and the calling function should exit immediately
- [ ] Notification close/reopen flow — \`closeNotification\`/\`closedNotification\` type change shouldn't change behavior (\`clearTimeout(undefined)\` is a no-op per spec)

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)