### PR TITLE
security: MSW onUnhandledRequest throws for synergism.cc (#17)

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -5231,6 +5231,16 @@ window.addEventListener('load', async () => {
     await worker.start({
       serviceWorker: {
         url: './mockServiceWorker.js'
+      },
+      // Default is 'warn', which logs and then passes the request through to
+      // the real network — so any unmocked endpoint silently hits the live
+      // synergism.cc server during local dev (polluting prod analytics, risking
+      // accidental state-changing calls, tripping rate limits). Hard-fail on
+      // synergism.cc; let third-party calls (fonts, Turnstile) pass through.
+      onUnhandledRequest: (request) => {
+        if (new URL(request.url).hostname === 'synergism.cc') {
+          throw new Error(`Unmocked synergism.cc call: ${request.method} ${request.url}`)
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary

\`worker.start()\` in \`src/Synergism.ts\` previously used MSW's default \`onUnhandledRequest: 'warn'\`. That setting logs a warning and **passes the request through to the real network**. In dev mode, any endpoint not explicitly mocked in \`src/mock/browser.ts\` silently hit live \`synergism.cc\` during local iteration:

- Polluted prod analytics/logs with dev traffic
- Risk of tripping prod rate limits during fast iteration
- Risk of accidental state-changing calls (saves, purchases) hitting live data
- Inconsistent observable behavior between mocked and unmocked endpoints

## Fix

Pass a custom \`onUnhandledRequest\` to \`worker.start()\` that hard-throws for unmocked \`synergism.cc/*\` requests, while letting third-party calls (Google Fonts, Cloudflare Turnstile, Discord avatars, etc.) pass through. The handler runs only in dev/testing — the \`worker.start()\` block is already gated behind \`if (dev || testing)\`.

\`\`\`ts
onUnhandledRequest: (request) => {
  if (new URL(request.url).hostname === 'synergism.cc') {
    throw new Error(\`Unmocked synergism.cc call: \${request.method} \${request.url}\`)
  }
}
\`\`\`

The thrown error surfaces in the console with the missing method+URL, so the next step (writing the mock) is obvious.

## Test plan
- [x] \`npm run check:tsc\` clean
- [x] \`npm run build:esbuild\` clean
- [ ] \`npm run dev\` and load the game — confirm no unmocked synergism.cc requests fire (or, if any do, the error pinpoints the missing handler)
- [ ] A third-party fetch (e.g. loading a Google font) should pass through normally

Closes #17

## Dependency note

This branch was opened from main pre-[#178](https://github.com/MaddisonM79/unknown_game/pull/178). The lint step will show the 22 consistent-return warnings + 3 redundant-type-constituent errors that #178 closes. Once #178 merges, this PR's lint goes green on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)