### PR TITLE
ci: workflow consistency bundle (#136, #137, #139, #140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     paths-ignore:
       - '*.md'
-      - '*.json'
   pull_request:
     paths-ignore:
       - '*.md'
-      - '*.json'
 
 jobs:
   test:
@@ -30,7 +28,7 @@ jobs:
           node-version: lts/*
       - name: Install
         run: |
-          npm install
+          npm ci
       - name: Check
         run: |
           npm run check:tsc

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Automatic PR Review
         uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta

--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: lts/*
       - name: Install deps
         run: |
-          npm install
+          npm ci
       - name: Lint
         run: |
           npm run lint

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -2,8 +2,8 @@ name: Electron Build
 
 on:
   push:
-    paths-ignore:
-      - '*.md'
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/kong-release.yml
+++ b/.github/workflows/kong-release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: lts/*
       - name: Install deps
         run: |
-          npm install
+          npm ci
           sudo apt install -y jq
       - name: Build
         run: |

--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -11,6 +11,8 @@ jobs:
       deployments: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Wait for CF Pages
       id: cf-pages
       uses: WalshyDev/cf-pages-await@3abae9f62a7672a1701300702ce42908e16cb88a # v1


### PR DESCRIPTION
## Summary

Four workflow-policy nits from The Hand audit, batched because each is a few-line policy edit.

- **#136 (electron-build runs on every push)** — trigger changed from \`push: { paths-ignore: ['*.md'] }\` to \`push: { tags: ['v*'] }\` (keeps the existing \`workflow_dispatch\`). The win/mac/linux Electron build matrix no longer fires on every translation merge, typo fix, or rebase. To produce a build on demand: tag a release or run from the Actions UI.
- **#137 (persist-credentials: false missing on 4 workflows)** — added to \`electron-build\`, \`claude\`, \`claude-auto-review\`, \`purge-cache\`. Default persists \`GITHUB_TOKEN\` in the runner's local git config where subsequent steps can read it. Now every checkout in the repo drops the token after the action returns.
- **#139 (\`npm install\` → \`npm ci\`)** — three workflows used \`npm install\` (which can mutate \`package-lock.json\` and resolves "compatible" versions per semver ranges). Switched to \`npm ci\` in \`ci\`, \`deploy-ghpages\`, \`kong-release\` for deterministic lockfile-exact installs. \`electron-build\` already used \`npm ci\`. What passes \`ci.yml\` is now exactly what \`deploy-ghpages\` and \`kong-release\` will install.
- **#140 (\`paths-ignore: ['*.json']\` hid translation changes from CI)** — Crowdin's translation JSON merges (\`l10n_master\` PRs) **did not trigger CI**, so the github-script translation-diff check (\`ci.yml:44-68\`) only ran when a non-JSON file changed. Removed \`*.json\` from both \`push\` and \`pull_request\` paths-ignore. \`package.json\`, \`package-lock.json\`, and \`translations/*.json\` all now trigger CI.

## Test plan
- [ ] Open this PR and verify CI runs (it modifies workflows, not source — but ci.yml triggers on workflow changes regardless)
- [ ] Push a tag like \`v0.0.0-test\` to a throwaway branch, then delete — verifies \`electron-build\` still fires on tags
- [ ] After merge, no \`electron-build\` runs on subsequent regular pushes to main
- [ ] Crowdin's next l10n_master PR runs the translation diff check

Closes #136
Closes #137
Closes #139
Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)