### PR TITLE
chore: add badges to README (#146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Synergism - the game
 
+[![CI](https://github.com/MaddisonM79/unknown_game/actions/workflows/ci.yml/badge.svg)](https://github.com/MaddisonM79/unknown_game/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/MaddisonM79/unknown_game/actions/workflows/codeql.yml/badge.svg)](https://github.com/MaddisonM79/unknown_game/actions/workflows/codeql.yml)
+[![Version](https://img.shields.io/github/package-json/v/MaddisonM79/unknown_game)](package.json)
+[![License](https://img.shields.io/github/license/MaddisonM79/unknown_game)](LICENSE)
+[![Contributors](https://img.shields.io/github/contributors/MaddisonM79/unknown_game)](https://github.com/MaddisonM79/unknown_game/graphs/contributors)
+[![Last commit](https://img.shields.io/github/last-commit/MaddisonM79/unknown_game/main)](https://github.com/MaddisonM79/unknown_game/commits/main)
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Six badges at the top of the README:

- **CI** status — links to \`ci.yml\` workflow runs
- **CodeQL** status — links to \`codeql.yml\` (added in [#173](https://github.com/MaddisonM79/unknown_game/pull/173))
- **Version** — shields.io reads from \`package.json\`
- **License** — shields.io reads from \`LICENSE\` (MIT)
- **Contributors** count
- **Last commit** on \`main\`

All badge sources are shields.io or GitHub's native action-badge endpoints — no third-party trackers.

## Test plan
- [ ] After merge, GitHub renders the README at the repo home and the six badges show — CI green, CodeQL green, version matches \`package.json\`, license shows MIT
- [ ] Tap each badge — they link to the correct destination

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)