### PR TITLE
ci: attest release artifacts via Sigstore (#138)

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      # actions/attest-build-provenance signs an attestation via Sigstore
+      # (id-token: write) and uploads it to the GitHub attestations API
+      # (attestations: write).
+      id-token: write
+      attestations: write
 
     strategy:
       fail-fast: false
@@ -40,6 +45,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Attest Windows artifacts
+        if: matrix.platform == 'win'
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: 'release/*.exe'
+
       - name: Upload Windows artifacts
         if: matrix.platform == 'win'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -49,6 +60,12 @@ jobs:
             release/*.exe
           if-no-files-found: error
 
+      - name: Attest macOS artifacts
+        if: matrix.platform == 'mac'
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: 'release/*.zip'
+
       - name: Upload macOS artifacts
         if: matrix.platform == 'mac'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -57,6 +74,12 @@ jobs:
           path: |
             release/*.zip
           if-no-files-found: error
+
+      - name: Attest Linux artifacts
+        if: matrix.platform == 'linux'
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: 'release/linux-unpacked/**/*'
 
       - name: Upload Linux artifacts
         if: matrix.platform == 'linux'

--- a/.github/workflows/kong-release.yml
+++ b/.github/workflows/kong-release.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # actions/attest-build-provenance signs an attestation via Sigstore
+      # (id-token: write) and uploads it to the GitHub attestations API
+      # (attestations: write).
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -38,6 +43,10 @@ jobs:
         run: |
           echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
         id: version
+      - name: Attest Kong.zip
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: 'Kong.zip'
       - name: Create release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:


### PR DESCRIPTION
## Summary

SLSA L1 — The Hand audit MEDIUM. Released artifacts (Electron .exe / .zip / linux-unpacked, Kongregate \`Kong.zip\`) had **no cryptographic provenance**. Users downloading from GitHub Releases had no way to verify the artifact came from this repo's official builds vs. a supply-chain interloper.

Adds \`actions/attest-build-provenance@v3\` (pinned by SHA) at every release-producing step:

| Workflow | Artifact | Subject path |
|---|---|---|
| \`electron-build.yml\` | Windows installer | \`release/*.exe\` |
| \`electron-build.yml\` | macOS bundle | \`release/*.zip\` |
| \`electron-build.yml\` | Linux unpacked | \`release/linux-unpacked/**/*\` |
| \`kong-release.yml\` | Kongregate zip | \`Kong.zip\` |

Each step uses GitHub's OIDC token to sign a SLSA provenance attestation via Sigstore's Fulcio CA, then uploads to the GitHub attestations API (free for public repos).

## Verification

After a build, anyone can verify a downloaded artifact:

\`\`\`sh
gh attestation verify <downloaded-file> --repo MaddisonM79/unknown_game
\`\`\`

That command checks the attestation chain back to a build run in this repo, on this workflow, at the corresponding commit SHA.

## Permissions added (job-level)

| Permission | Why |
|---|---|
| \`id-token: write\` | OIDC token for Sigstore signing |
| \`attestations: write\` | Upload to GitHub attestations API |

## Out of scope

Separate workstreams that need paid certificates and secret management:

- **Apple Developer ID** code signing of \`.app\`/\`.pkg\` (macOS notarization)
- **Authenticode** signing of \`.exe\` (Windows SmartScreen trust)

Build-provenance attestations are independent of those — and arguably more valuable for a download-from-Releases threat model, since they verify *origin* rather than *vendor identity*.

## Test plan
- [ ] Push a tag (e.g. \`v0.0.0-test\` on a throwaway branch then delete) to trigger \`electron-build.yml\` — verify each platform's attestation appears in repo Settings → Code security → Attestations
- [ ] Next push to \`master\` triggers \`kong-release.yml\` — verify \`Kong.zip\` attestation appears
- [ ] Download a release artifact and run \`gh attestation verify\` — should report a valid attestation chain

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)