### PR TITLE
ux: hygiene bundle — reduced motion, responsive, notifications, hotkeys, i18n (#95, #100, #101, #109, #117)

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -4,7 +4,6 @@ body {
 }
 
 html {
-    min-width: 1250px;
     position: relative;
     font-family:
         -apple-system,
@@ -338,12 +337,12 @@ body button:active:not(:disabled):not(.disable-hover-color) {
 }
 
 .slide-in {
-    animation: slide-in 1000ms;
+    animation: slide-in 200ms ease-out;
     animation-fill-mode: forwards;
 }
 
 .slide-out {
-    animation: slide-out 1000ms;
+    animation: slide-out 150ms ease-in;
     animation-fill-mode: forwards;
 }
 
@@ -3846,7 +3845,7 @@ header .img {
 .subHeader {
     display: flex;
     flex-direction: row;
-    min-width: 1250px;
+    min-width: min-content;
     max-width: calc((38px + 7.5em) * 4 + 40em);
     min-height: 90px;
     margin-bottom: 5px;
@@ -3888,7 +3887,7 @@ header #obtainiumDisplay { color: pink; }
 #ascensionStats {
     display: flex;
     margin: 10px 0;
-    min-width: 1250px;
+    min-width: min-content;
     justify-content: center;
     align-content: center;
     flex-wrap: wrap;
@@ -7394,5 +7393,32 @@ html[data-instant-unlock2="false"] .infiniteAscentShopUpgrade {
     #challengesAutoToggles > button {
         min-height: 44px;
         padding: 8px 12px;
+    }
+}
+
+/* ============================================
+   REDUCED MOTION
+   ============================================ */
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .rainbowText {
+        background-image: none;
+        background-clip: border-box;
+        color: gold;
+    }
+
+    .gradientText {
+        background-image: none;
+        background-clip: border-box;
+        color: var(--gradient-start, gold);
     }
 }

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
             </div>
         </div>
 
-        <button id="exitOffline" class="subtabContent">That's cool. Take me to the game!</button>
+        <button id="exitOffline" class="subtabContent" i18n="offlineProgress.exit">That's cool. Take me to the game!</button>
 
     </div>
     <div id="fastForwardContainer" style="display: none">
@@ -196,7 +196,7 @@
             </div>
         </div>
 
-        <button id="exitFastForward">Awesome!</button>
+        <button id="exitFastForward" i18n="fastForward.exit">Awesome!</button>
     </div>
     <header>
         <div id="ascensionStats">

--- a/src/Hotkeys.ts
+++ b/src/Hotkeys.ts
@@ -78,7 +78,7 @@ const eventHotkeys = (event: KeyboardEvent): void => {
     return
   }
 
-  if (document.activeElement?.localName === 'input') {
+  if (document.activeElement?.matches('input, textarea, select, [contenteditable]')) {
     // https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation
     // finally fixes the bug where hotkeys would be activated when typing in an input field
     event.stopPropagation()

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -1354,7 +1354,7 @@ export const Prompt = (text: string, defaultValue?: string): Promise<string | nu
 let closeNotification: ReturnType<typeof setTimeout> | undefined = undefined
 let closedNotification: ReturnType<typeof setTimeout> | undefined = undefined
 
-export const Notification = (text: string, time = 30000): Promise<void> => {
+export const Notification = (text: string, time = 5000): Promise<void> => {
   const notification = DOMCacheGetOrSet('notification')
   const textNode = document.querySelector<HTMLElement>('#notification > p')!
   const x = DOMCacheGetOrSet('notifx')
@@ -1378,7 +1378,7 @@ export const Notification = (text: string, time = 30000): Promise<void> => {
 
     closeNotification = undefined
     x.removeEventListener('click', close)
-    closedNotification = setTimeout(closed, 1000)
+    closedNotification = setTimeout(closed, 150)
     p.resolve()
   }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -4826,12 +4826,14 @@
     "currentAscensionTimer": "Current Ascension Timer: +<<gold|{{value}}>> seconds",
     "exportQuarks": "Export Quarks: +<<goldenrod|{{value}}>>",
     "ambrosia": "Ambrosia: +<<orange|{{value}}>> | Ambrosia Bar Points +<<lightblue|{{value2}}>>",
-    "redAmbrosia": "Red Ambrosia: +<<red|{{value}}>> | Red Bar Points +<<red|{{value2}}>>"
+    "redAmbrosia": "Red Ambrosia: +<<red|{{value}}>> | Red Bar Points +<<red|{{value2}}>>",
+    "exit": "That's cool. Take me to the game!"
   },
   "fastForward": {
     "global": "Your Global stuff fast forwarded {{time}} seconds!",
     "ascension": "Your Ascension stuff fast forwarded {{time}} seconds!",
-    "ambrosia": "Your Ambrosia stuff fast forwarded {{time}} seconds!"
+    "ambrosia": "Your Ambrosia stuff fast forwarded {{time}} seconds!",
+    "exit": "Awesome!"
   },
   "campaigns": {
     "intro": "Campaigns - <<orange | Ascensions>> but <<maroon | harder™>>",


### PR DESCRIPTION
## Summary
Five small UX/a11y findings bundled into one PR — all P1–P3, all single-spot edits.

- **#95 (U1, P1, a11y)** — Add `@media (prefers-reduced-motion: reduce)` block. Clamps all animation/transition durations to 0.01ms, sets `animation-iteration-count: 1`, and substitutes solid colors for `.rainbowText` / `.gradientText` (the two infinite-loop animations on Singularity headers etc.).
- **#100 (U6, P2)** — Remove `min-width: 1250px` from `html`, `.subHeader`, and `#ascensionStats`. Stops forcing a horizontal scrollbar on zoomed displays and 1366×768 laptops. Replaced with `min-width: min-content` on the two layout containers so flex still reflows correctly.
- **#101 (U7, P2)** — Notification slide-in 1000ms → 200ms ease-out; slide-out 1000ms → 150ms ease-in; default duration 30s → 5s. Matched the slide-out cleanup `setTimeout` (1000ms → 150ms) so the element hides as soon as the slide-out finishes.
- **#109 (U15, P3)** — Broaden `Hotkeys.ts` input guard from `localName === 'input'` to `matches('input, textarea, select, [contenteditable]')`. Future text panels won't reactivate hotkeys.
- **#117 (U23, P3)** — `exitOffline` / `exitFastForward` buttons in `index.html` are now `i18n`-keyed; added `offlineProgress.exit` and `fastForward.exit` to `translations/en.json`. First screen a returning player sees is no longer hardcoded English.

## Test plan
- [ ] `npm run lint` → clean
- [ ] `npm run check:tsc` → clean
- [ ] `npm run csslint` → clean
- [ ] `npm run htmllint` → clean
- [ ] `npm run build:esbuild` → succeeds (1.6 MB bundle, same as main)
- [ ] Manual: notification appears in ~200 ms, dismisses after ~5 s
- [ ] Manual: enable OS "Reduce Motion" → Singularity headers no longer rainbow-animate
- [ ] Manual: browser zoom to 150% on 1080p → no horizontal scrollbar in header area
- [ ] Manual: focus on a `<textarea>` (if present) → hotkeys don't fire while typing
- [ ] Manual: return after going offline → exit button text matches `offlineProgress.exit`

Closes #95, #100, #101, #109, #117.