### PR TITLE
ts: hygiene Cthulhu trio — DOM cache LRU, blankGlobals deep clone, corruption loadouts (#89, #90, #91)

### DIFF
--- a/src/Cache/DOM.ts
+++ b/src/Cache/DOM.ts
@@ -1,21 +1,13 @@
 const MAX_CACHE_SIZE = 1e4
+const PRUNE_TO = 8e3
 
-/**
- * A cache for DOM elements
- */
-let DOMCache: Record<string, HTMLElement> = {}
-let cacheSize = 0
+const DOMCache = new Map<string, HTMLElement>()
 
 export const DOMCacheGetOrSet = (id: string) => {
-  if (cacheSize > MAX_CACHE_SIZE) {
-    console.error(`Possible memory leak detected ${cacheSize} dom elements cached`)
-
-    DOMCache = {}
-    cacheSize = 0
-  }
-
-  const cachedEl = DOMCache[id]
+  const cachedEl = DOMCache.get(id)
   if (cachedEl) {
+    DOMCache.delete(id)
+    DOMCache.set(id, cachedEl)
     return cachedEl
   }
 
@@ -25,8 +17,19 @@ export const DOMCacheGetOrSet = (id: string) => {
     throw new TypeError(`Element with id "${id}" was not found on page?`)
   }
 
-  cacheSize++
-  return DOMCache[id] = el
+  DOMCache.set(id, el)
+
+  if (DOMCache.size > MAX_CACHE_SIZE) {
+    console.error(`Possible memory leak detected ${DOMCache.size} dom elements cached, pruning oldest`)
+    const iter = DOMCache.keys()
+    while (DOMCache.size > PRUNE_TO) {
+      const next = iter.next()
+      if (next.done) break
+      DOMCache.delete(next.value)
+    }
+  }
+
+  return el
 }
 
-export const DOMCacheHas = (id: string) => DOMCache[id] !== undefined
+export const DOMCacheHas = (id: string) => DOMCache.has(id)

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -17,7 +17,7 @@ import {
   tickChallengeSweep
 } from './Challenges'
 import { btoa } from './Utility'
-import { blankGlobals, Globals as G } from './Variables'
+import { freshBlankGlobals, Globals as G } from './Variables'
 
 import {
   achievementPoints,
@@ -990,24 +990,11 @@ export const player: Player = {
   corruptions: {
     next: new CorruptionLoadout(corruptionsSchema.parse({})),
     used: new CorruptionLoadout(corruptionsSchema.parse({})),
-    saves: new CorruptionSaves({
-      'Loadout 1': corruptionsSchema.parse({}),
-      'Loadout 2': corruptionsSchema.parse({}),
-      'Loadout 3': corruptionsSchema.parse({}),
-      'Loadout 4': corruptionsSchema.parse({}),
-      'Loadout 5': corruptionsSchema.parse({}),
-      'Loadout 6': corruptionsSchema.parse({}),
-      'Loadout 7': corruptionsSchema.parse({}),
-      'Loadout 8': corruptionsSchema.parse({}),
-      'Loadout 9': corruptionsSchema.parse({}),
-      'Loadout 10': corruptionsSchema.parse({}),
-      'Loadout 11': corruptionsSchema.parse({}),
-      'Loadout 12': corruptionsSchema.parse({}),
-      'Loadout 13': corruptionsSchema.parse({}),
-      'Loadout 14': corruptionsSchema.parse({}),
-      'Loadout 15': corruptionsSchema.parse({}),
-      'Loadout 16': corruptionsSchema.parse({})
-    }),
+    saves: new CorruptionSaves(
+      Object.fromEntries(
+        Array.from({ length: 16 }, (_, i) => [`Loadout ${i + 1}`, corruptionsSchema.parse({})])
+      )
+    ),
     showStats: true
   },
 
@@ -1341,7 +1328,7 @@ const loadSynergy = () => {
     data.exporttest = false
   }
 
-  Object.assign(G, { ...blankGlobals })
+  Object.assign(G, freshBlankGlobals())
 
   if (data) {
     if ((data.exporttest === false || data.exporttest === 'NO!') && !testing) {

--- a/src/Variables.ts
+++ b/src/Variables.ts
@@ -1,7 +1,16 @@
 import Decimal from 'break_infinity.js'
+import rfdc from 'rfdc'
 import { calculateSigmoid } from './Calculate'
 import { Tabs } from './Tabs'
 import type { GlobalVariables } from './types/Synergism'
+
+const cloneGlobals = rfdc({
+  proto: false,
+  circles: false,
+  constructorHandlers: [
+    [Decimal, (o: Decimal) => new Decimal(o)]
+  ]
+})
 
 export enum Upgrade {
   coin = 'coins',
@@ -545,4 +554,6 @@ export const Globals: GlobalVariables = {
   ]
 }
 
-export const blankGlobals = { ...Globals }
+export const blankGlobals = cloneGlobals(Globals)
+
+export const freshBlankGlobals = (): GlobalVariables => cloneGlobals(blankGlobals)


### PR DESCRIPTION
## Summary
Three TypeScript hygiene findings from the Cthulhu category — each a single-spot, low-risk fix.

- **#89 (T16, P3)** — `src/Cache/DOM.ts`: switched from a `Record` that flushed the entire cache on overflow to a `Map`-based LRU. On hit, the entry is moved to the end (most recently used); on overflow, the oldest entries are pruned down to 8000 instead of dropping all 10000.
- **#90 (T17, P3, Cthulhu)** — `src/Variables.ts`: `blankGlobals` was `{ ...Globals }`, a shallow spread that shared Decimal references. `Object.assign(G, { ...blankGlobals })` at reset silently failed to reset Decimal state. Now built via `rfdc` with a `Decimal` constructor handler; `freshBlankGlobals()` returns an independent deep clone per call. `src/Synergism.ts` reset path (loadSynergy:1344) updated.
- **#91 (T18, P3, Cthulhu)** — `src/Synergism.ts`: 16 hand-written `corruptionsSchema.parse({})` entries collapsed into `Array.from({ length: 16 }, ...)` + `Object.fromEntries`. Cosmetic but kills the eyesore.

Also closed [#88](https://github.com/MaddisonM79/unknown_game/issues/88) (T15 esbuild targets) as already resolved by PR #175.

## Test plan
- [x] `npm run lint` → clean
- [x] `npm run check:tsc` → clean
- [x] `npm run build:esbuild` → succeeds (1.6 MB bundle)
- [ ] Manual: trigger a reset — Decimal-typed globals in `G` should reset to defaults (e.g. `G.acceleratorEffect.toNumber() === 1` after reset)
- [ ] Manual: open many modals to test DOM cache; ensure no `Element with id "..." was not found` errors after long sessions

Closes #89, #90, #91. Also closes #88 (already resolved).