### PR TITLE
Save-boundary hardening + dev unblock + prod bundle shrink

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "synergism-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 *.js
 !scripts/*.js
+!mockServiceWorker.js
 dist
 !.eslintrc.js
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist/dist/
 
 # wrangler local state
 .wrangler/
+
+# Claude Code local-only settings (per-user permission allowlist, etc.)
+.claude/settings.local.json

--- a/mockServiceWorker.js
+++ b/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
   "msw": {
     "workerDirectory": [
       "build",
-      "dist"
+      "dist",
+      ""
     ]
   }
 }

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -50,6 +50,12 @@ export const corruptionsSchema = z.object({
   hyperchallenge: z.number().default(0)
 })
 
+// Default Corruptions (all zeros). Safe to share across CorruptionLoadout /
+// CorruptionSaves consumers because their constructors copy fields into
+// private state rather than retaining the reference. Frozen to prevent any
+// accidental mutation if a future caller forgets that contract.
+export const defaultCorruptions: Readonly<Corruptions> = Object.freeze(corruptionsSchema.parse({}))
+
 export type Corruptions = {
   viscosity: number
   drought: number

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -57,7 +57,7 @@ export const eventCheck = async () => {
   const response = await fetch(`${apiBaseUrl}/events/get`)
 
   if (!response.ok) {
-    throw new Error('God fucking dammit')
+    throw new Error(`Failed to fetch events: HTTP ${response.status} ${response.statusText}`.trim())
   }
 
   const apiEvents = await response.json() as GameEvent

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -22,6 +22,8 @@ import { resetRuneBlessings } from './RuneBlessings'
 import { resetRunes } from './Runes'
 import { resetRuneSpirits } from './RuneSpirits'
 import { playerJsonSchema } from './saves/PlayerJsonSchema'
+import { reportSaveError } from './saves/reportSaveError'
+import { SaveDecodeError } from './saves/SaveErrors'
 import { getShopUpgradeEffects } from './Shop'
 import { getGQUpgradeEffect, goldenQuarkUpgrades } from './singularity'
 import { getSingularityChallengeEffect } from './SingularityChallenges'
@@ -368,8 +370,7 @@ export const importSynergism = (input: string | null, reset = false) => {
   try {
     f = d ? JSON.parse(d) : JSON.parse(atob(input))
   } catch (e) {
-    console.error(e)
-    Alert(i18next.t('importexport.unableImport'))
+    void reportSaveError(new SaveDecodeError(e))
     return
   }
 

--- a/src/Summary.ts
+++ b/src/Summary.ts
@@ -3,6 +3,7 @@
 import ClipboardJS from 'clipboard'
 import i18next from 'i18next'
 import { achievementPoints, maxAchievementPoints } from './Achievements'
+import { DOMCacheGetOrSet } from './Cache/DOM'
 import { type AmbrosiaUpgradeNames, ambrosiaUpgrades } from './BlueberryUpgrades'
 import {
   calculateAscensionSpeedMult,
@@ -592,7 +593,7 @@ export const generateExportSummary = async (): Promise<void> => {
     }
 
     clipboard.on('success', () => {
-      document.getElementById('exportinfo')!.textContent = 'Copied save to clipboard!'
+      DOMCacheGetOrSet('exportinfo').textContent = 'Copied save to clipboard!'
       cleanup()
     })
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -72,8 +72,8 @@ import {
   corruptionLoadoutTableCreate,
   corruptionLoadoutTableUpdate,
   CorruptionSaves,
-  corruptionsSchema,
   corruptionStatsUpdate,
+  defaultCorruptions,
   updateCorruptionLoadoutNames,
   updateUndefinedLoadouts
 } from './Corruptions'
@@ -990,11 +990,11 @@ export const player: Player = {
   },
 
   corruptions: {
-    next: new CorruptionLoadout(corruptionsSchema.parse({})),
-    used: new CorruptionLoadout(corruptionsSchema.parse({})),
+    next: new CorruptionLoadout(defaultCorruptions),
+    used: new CorruptionLoadout(defaultCorruptions),
     saves: new CorruptionSaves(
       Object.fromEntries(
-        Array.from({ length: 16 }, (_, i) => [`Loadout ${i + 1}`, corruptionsSchema.parse({})])
+        Array.from({ length: 16 }, (_, i) => [`Loadout ${i + 1}`, defaultCorruptions])
       )
     ),
     showStats: true

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -236,6 +236,8 @@ import {
 } from './RuneSpirits'
 import { playerJsonSchema } from './saves/PlayerJsonSchema'
 import { playerUpdateVarSchema } from './saves/PlayerUpdateVarSchema'
+import { logSaveError, reportSaveError } from './saves/reportSaveError'
+import { SaveDecodeError, SchemaValidationError } from './saves/SaveErrors'
 import { getShopUpgradeEffects, updateShopLevels } from './Shop'
 import {
   blankGQLevelObject,
@@ -1304,15 +1306,20 @@ async function syncToSteamCloud (saveData: string) {
 
     if (cloudSave) {
       try {
-        const parsed = playerUpdateVarSchema.parse(JSON.parse(atob(cloudSave)))
-        const cloudPoints = computeAchievementPoints(parsed.achievements, parsed.progressiveAchievements)
-        if (dev) console.log('[SteamCloud] achievementPoints:', achievementPoints, 'cloudPoints:', cloudPoints)
-        if (achievementPoints < cloudPoints) {
-          if (dev) console.log('[SteamCloud] skipping upload, cloud has higher points')
-          return
+        const raw = JSON.parse(atob(cloudSave)) as unknown
+        const decoded = playerUpdateVarSchema.safeParse(raw)
+        if (!decoded.success) {
+          logSaveError(SchemaValidationError.fromZodError(decoded.error))
+        } else {
+          const cloudPoints = computeAchievementPoints(decoded.data.achievements, decoded.data.progressiveAchievements)
+          if (dev) console.log('[SteamCloud] achievementPoints:', achievementPoints, 'cloudPoints:', cloudPoints)
+          if (achievementPoints < cloudPoints) {
+            if (dev) console.log('[SteamCloud] skipping upload, cloud has higher points')
+            return
+          }
         }
       } catch (e) {
-        console.error('[SteamCloud] failed to parse cloud save:', e)
+        logSaveError(new SaveDecodeError(e))
       }
     }
   }
@@ -1353,8 +1360,7 @@ const loadSynergy = () => {
     if (validatedPlayer.success) {
       Object.assign(player, validatedPlayer.data)
     } else {
-      console.log(validatedPlayer.error)
-      console.log(data)
+      void reportSaveError(SchemaValidationError.fromZodError(validatedPlayer.error))
       clearTimers()
       return
     }

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -5216,7 +5216,15 @@ export const reloadShit = (ignoreOfflineProgress = false) => {
 }
 
 window.addEventListener('load', async () => {
-  if (dev || testing) {
+  // Gate on import.meta.env.DEV directly rather than the `dev` re-export from
+  // Config.ts — Vite substitutes the macro to a literal at build time, so the
+  // whole ./mock/browser graph (msw + handlers + websocket, ≈415 KB / 109 KB
+  // gzipped) tree-shakes out of the prod bundle. With the variable binding,
+  // Vite can't const-fold across modules and still ships the chunk. `testing`
+  // is hardcoded false in Config.ts, so dropping it from this gate is a no-op
+  // for runtime behavior; if you flip it locally for dev work, you'll also
+  // already be running in DEV. Closes #81 (T8).
+  if (import.meta.env.DEV) {
     const { worker } = await import('./mock/browser')
     await worker.start({
       serviceWorker: {

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -3,13 +3,16 @@ import DOMPurify from 'dompurify'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import { format } from './Synergism'
 
-export const isDecimal = (o: unknown): o is Decimal =>
-  o instanceof Decimal
-  || (typeof o === 'object'
-    && o !== null
-    && Object.keys(o).length === 2
-    && 'mantissa' in o
-    && 'exponent' in o)
+// True iff `o` is a real Decimal instance. We used to accept the structural
+// shape `{ mantissa, exponent }` as a fallback so freshly-deserialized saves
+// (where Decimal fields hadn't yet been hydrated) would test true, but the
+// save-loader (PlayerSchema.ts decimalSchema) now constructs `new Decimal(src)`
+// inside the schema transform — every `player.<decimalField>` is a real instance
+// by the time anything outside the schema sees it. The duck-test fallback was
+// also the trust-boundary concern called out by #83 (T10): a hostile save with
+// `{mantissa: <evil>, exponent: <evil>}` would pass the structural check and
+// flow into Decimal-arithmetic call sites. instanceof-only closes that gap.
+export const isDecimal = (o: unknown): o is Decimal => o instanceof Decimal
 
 /**
  * This function calculates the smallest integer increment/decrement that can be applied to a number that is

--- a/src/purchases/CartTab.ts
+++ b/src/purchases/CartTab.ts
@@ -1,3 +1,4 @@
+import { DOMCacheGetOrSet } from '../Cache/DOM'
 import { apiBaseUrl, prod } from '../Config'
 import { changeSubTab, getActiveSubTab, Tabs } from '../Tabs'
 import { assert, createDeferredPromise, type DeferredPromise, memoize, retry } from '../Utility'
@@ -44,7 +45,7 @@ const cartSubTabs = {
   Merch: 5
 } as const
 
-const tab = document.getElementById('pseudoCoins')!
+const tab = DOMCacheGetOrSet('pseudoCoins')
 
 function* yieldQuerySelectorAll (selector: string) {
   const elements = tab.querySelectorAll(selector)

--- a/src/purchases/CartUtil.ts
+++ b/src/purchases/CartUtil.ts
@@ -1,3 +1,4 @@
+import { DOMCacheGetOrSet } from '../Cache/DOM'
 import type { Product } from './CartTab'
 
 /** A map of all products in the cart. */
@@ -7,7 +8,7 @@ const cartMap = new Map<string, { quantity: number; price: number; rest: Omit<Pr
 let inCart = 0
 
 const updateInCartCount = () => {
-  const counter = document.getElementById('notification-count')!
+  const counter = DOMCacheGetOrSet('notification-count')
 
   if (inCart === 0) {
     counter.style.display = 'none'

--- a/src/purchases/CheckoutTab.ts
+++ b/src/purchases/CheckoutTab.ts
@@ -1,5 +1,6 @@
 import { type FUNDING_SOURCE, loadScript } from '@paypal/paypal-js'
 import i18next from 'i18next'
+import { DOMCacheGetOrSet } from '../Cache/DOM'
 import { apiBaseUrl, isCanonicalHost, platform, prod } from '../Config'
 import { Alert, Notification } from '../UpdateHTML'
 import { assert, memoize } from '../Utility'
@@ -16,7 +17,7 @@ import {
 import { initializePayPal_Subscription } from './SubscriptionsSubtab'
 import { updatePseudoCoins } from './UpgradesSubtab'
 
-const tab = document.querySelector<HTMLElement>('#pseudoCoins > #cartContainer')!
+const tab = DOMCacheGetOrSet('cartContainer')
 const form = tab.querySelector('div.cartList')!
 
 const checkoutStripe = form.querySelector<HTMLElement>('button#checkout')

--- a/src/purchases/ConsumablesTab.ts
+++ b/src/purchases/ConsumablesTab.ts
@@ -17,7 +17,7 @@ interface ConsumableListItems {
 
 type TimeSkipCategories = 'GLOBAL' | 'ASCENSION' | 'AMBROSIA'
 
-const tab = document.querySelector<HTMLElement>('#pseudoCoins > #consumablesSection')!
+const tab = DOMCacheGetOrSet('consumablesSection')
 
 const initializeConsumablesTab = memoize(() => {
   fetch(`${apiBaseUrl}/consumables/list`)

--- a/src/purchases/MerchTab.ts
+++ b/src/purchases/MerchTab.ts
@@ -1,3 +1,4 @@
+import { DOMCacheGetOrSet } from '../Cache/DOM'
 import { apiBaseUrl } from '../Config'
 import { memoize } from '../Utility'
 
@@ -47,7 +48,7 @@ interface Merch {
   updatedAt: string
 }
 
-const tab = document.querySelector<HTMLElement>('#pseudoCoins > #merchContainer')!
+const tab = DOMCacheGetOrSet('merchContainer')
 
 const initializeMerchSubtab = memoize(() => {
   ;(async () => {

--- a/src/purchases/SubscriptionsSubtab.ts
+++ b/src/purchases/SubscriptionsSubtab.ts
@@ -1,5 +1,6 @@
 import { type FUNDING_SOURCE, loadScript } from '@paypal/paypal-js'
 import i18next from 'i18next'
+import { DOMCacheGetOrSet } from '../Cache/DOM'
 import { apiBaseUrl, isCanonicalHost, platform, prod } from '../Config'
 import { getSubMetadata, type SubscriptionMetadata, type SubscriptionProvider } from '../Login'
 import { Alert, Confirm, Notification } from '../UpdateHTML'
@@ -7,9 +8,9 @@ import { assert, memoize } from '../Utility'
 import { type SubscriptionProduct, subscriptionProducts } from './CartTab'
 import { addToCart, getQuantity } from './CartUtil'
 
-const subscriptionsContainer = document.querySelector<HTMLElement>('#pseudoCoins > #subscriptionsContainer')!
-const subscriptionSectionHolder = subscriptionsContainer.querySelector<HTMLElement>('#sub-section-holder')!
-const manageSubscriptionHolder = subscriptionsContainer.querySelector<HTMLElement>('#manage-subscription-holder')!
+const subscriptionsContainer = DOMCacheGetOrSet('subscriptionsContainer')
+const subscriptionSectionHolder = DOMCacheGetOrSet('sub-section-holder')
+const manageSubscriptionHolder = DOMCacheGetOrSet('manage-subscription-holder')
 
 type Actions = 'manage' | 'upgrade' | 'downgrade' | 'cancel'
 type RouteLinks = Record<Actions, string>

--- a/src/purchases/UpgradesSubtab.ts
+++ b/src/purchases/UpgradesSubtab.ts
@@ -44,7 +44,7 @@ interface CoinsResponse {
   coins: number
 }
 
-const tab = document.querySelector<HTMLElement>('#pseudoCoins > #upgradesContainer')!
+const tab = DOMCacheGetOrSet('upgradesContainer')
 let activeUpgrade: UpgradesList | undefined
 
 const buyUpgradeSchema = z.object({

--- a/src/saves/PlayerJsonSchema.ts
+++ b/src/saves/PlayerJsonSchema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
-import type { Corruptions } from '../Corruptions'
+import { CampaignManager } from '../Campaign'
+import { type Corruptions, CorruptionLoadout, CorruptionSaves } from '../Corruptions'
+import { WowCubes, WowHypercubes, WowPlatonicCubes, WowTesseracts } from '../CubeExperimental'
+import { QuarkHandler } from '../Quark'
+import { SingularityChallenge } from '../SingularityChallenges'
 import type { Player } from '../types/Synergism'
 import { playerSchema } from './PlayerSchema'
 
@@ -16,17 +20,40 @@ export const convertArrayToCorruption = (array: number[]): Corruptions => {
   }
 }
 
-export const playerJsonSchema = playerSchema.extend({
-  codes: z.any().transform((codes: Player['codes']) => Array.from(codes)),
-  worlds: z.any().transform((worlds: Player['worlds']) => Number(worlds)),
-  wowCubes: z.any().transform((cubes: Player['wowCubes']) => Number(cubes)),
-  wowTesseracts: z.any().transform((tesseracts: Player['wowTesseracts']) => Number(tesseracts)),
-  wowHypercubes: z.any().transform((hypercubes: Player['wowHypercubes']) => Number(hypercubes)),
-  wowPlatonicCubes: z.any().transform((cubes: Player['wowPlatonicCubes']) => Number(cubes)),
+// Save-direction (serialize) schema: extends the base playerSchema and
+// overrides the runtime-shaped fields with serializers that convert class
+// instances back into JSON-safe primitives.
+//
+// Each override uses z.custom<X>(v => v instanceof X) — not the previous
+// z.any() — so a runtime save of an unexpected shape (e.g. a partially-
+// restored player after a botched migration) surfaces a structured schema
+// error instead of silently coercing whatever was passed in. Closes #9 (S2).
+//
+// We use z.custom rather than z.instanceof because PlayerJsonSchema sits
+// inside the existing circular import cluster (#76 / T3). z.instanceof(X)
+// evaluates X eagerly as a function argument at module load and hits the
+// TDZ for classes whose modules are still resolving. The z.custom form puts
+// the class reference inside the validator closure, which is only invoked
+// once safeParse runs and the cycle has settled.
+const isCampaignManager = (v: unknown): v is CampaignManager => v instanceof CampaignManager
+const isCorruptionLoadout = (v: unknown): v is CorruptionLoadout => v instanceof CorruptionLoadout
+const isCorruptionSaves = (v: unknown): v is CorruptionSaves => v instanceof CorruptionSaves
+const isQuarkHandler = (v: unknown): v is QuarkHandler => v instanceof QuarkHandler
+const isSingularityChallenge = (v: unknown): v is SingularityChallenge => v instanceof SingularityChallenge
+const isWowCubes = (v: unknown): v is WowCubes => v instanceof WowCubes
+const isWowHypercubes = (v: unknown): v is WowHypercubes => v instanceof WowHypercubes
+const isWowPlatonicCubes = (v: unknown): v is WowPlatonicCubes => v instanceof WowPlatonicCubes
+const isWowTesseracts = (v: unknown): v is WowTesseracts => v instanceof WowTesseracts
 
-  campaigns: z.any().transform((campaigns: Player['campaigns']) => {
-    return campaigns.campaignManagerData
-  }),
+export const playerJsonSchema = playerSchema.extend({
+  codes: z.custom<Player['codes']>((v) => v instanceof Map).transform((codes) => Array.from(codes)),
+  worlds: z.custom<QuarkHandler>(isQuarkHandler).transform((worlds) => Number(worlds)),
+  wowCubes: z.custom<WowCubes>(isWowCubes).transform((cubes) => Number(cubes)),
+  wowTesseracts: z.custom<WowTesseracts>(isWowTesseracts).transform((tesseracts) => Number(tesseracts)),
+  wowHypercubes: z.custom<WowHypercubes>(isWowHypercubes).transform((hypercubes) => Number(hypercubes)),
+  wowPlatonicCubes: z.custom<WowPlatonicCubes>(isWowPlatonicCubes).transform((cubes) => Number(cubes)),
+
+  campaigns: z.custom<CampaignManager>(isCampaignManager).transform((campaigns) => campaigns.campaignManagerData),
   /*campaigns: playerCampaignSchema.transform((campaignManager: Player['campaigns']) => {
     return {
       currentCampaign: campaignManager.current,
@@ -36,29 +63,35 @@ export const playerJsonSchema = playerSchema.extend({
 
   // Platonic (or somebody I'm so tired): Figure out why the hell using `playerCorruptionsSchema` does not work for saves
   // But it does work for the other three fields.
-  corruptions: z.any().transform((stuff: Player['corruptions']) => {
-    return {
-      used: stuff.used.loadout,
-      next: stuff.next.loadout,
-      saves: stuff.saves.corrSaveData, // TODO: This is the correct typing, but see above comment
-      showStats: stuff.showStats
-    }
-  }),
+  corruptions: z.object({
+    used: z.custom<CorruptionLoadout>(isCorruptionLoadout),
+    next: z.custom<CorruptionLoadout>(isCorruptionLoadout),
+    saves: z.custom<CorruptionSaves>(isCorruptionSaves),
+    showStats: z.boolean()
+  }).transform((stuff) => ({
+    used: stuff.used.loadout,
+    next: stuff.next.loadout,
+    saves: stuff.saves.corrSaveData,
+    showStats: stuff.showStats
+  })),
 
-  singularityChallenges: z.any().transform((challenges: Player['singularityChallenges']) =>
+  singularityChallenges: z.record(
+    z.string(),
+    z.custom<SingularityChallenge>(isSingularityChallenge)
+  ).transform((challenges) =>
     Object.fromEntries(
-      Object.entries(challenges).map(([key, value]) => {
-        return [
-          key,
-          {
-            completions: value.completions,
-            highestSingularityCompleted: value.highestSingularityCompleted,
-            enabled: value.enabled
-          }
-        ]
-      })
+      Object.entries(challenges).map(([key, value]) => [
+        key,
+        {
+          completions: value.completions,
+          highestSingularityCompleted: value.highestSingularityCompleted,
+          enabled: value.enabled
+        }
+      ])
     )
   ),
 
-  dayCheck: z.any().transform((dayCheck: Player['dayCheck']) => dayCheck?.toISOString() ?? null)
+  dayCheck: z.custom<Date | null>((v) => v === null || v instanceof Date).transform((dayCheck) =>
+    dayCheck?.toISOString() ?? null
+  )
 })

--- a/src/saves/SaveErrors.ts
+++ b/src/saves/SaveErrors.ts
@@ -1,0 +1,42 @@
+import type { ZodError, ZodIssue } from 'zod'
+
+export class SaveLoadError extends Error {
+  readonly userMessageKey: string
+
+  constructor (userMessageKey: string, message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'SaveLoadError'
+    this.userMessageKey = userMessageKey
+  }
+}
+
+export class SchemaValidationError extends SaveLoadError {
+  readonly issues: ReadonlyArray<ZodIssue>
+
+  constructor (issues: ReadonlyArray<ZodIssue>, userMessageKey = 'save.loadFailed') {
+    const n = issues.length
+    super(userMessageKey, `Save schema validation failed (${n} issue${n === 1 ? '' : 's'})`)
+    this.name = 'SchemaValidationError'
+    this.issues = issues
+  }
+
+  static fromZodError (error: ZodError, userMessageKey?: string): SchemaValidationError {
+    return new SchemaValidationError(error.issues, userMessageKey)
+  }
+
+  // PII-safe issue summary. Excludes the rejected value — only path + code + zod's canonical message.
+  toSafeJSON (): { path: string; code: string; message: string }[] {
+    return this.issues.map((issue) => ({
+      path: issue.path.join('.'),
+      code: issue.code,
+      message: issue.message
+    }))
+  }
+}
+
+export class SaveDecodeError extends SaveLoadError {
+  constructor (cause: unknown, userMessageKey = 'importexport.unableImport') {
+    super(userMessageKey, 'Save decode failed', { cause })
+    this.name = 'SaveDecodeError'
+  }
+}

--- a/src/saves/reportSaveError.ts
+++ b/src/saves/reportSaveError.ts
@@ -1,0 +1,29 @@
+import i18next from 'i18next'
+import { Alert } from '../UpdateHTML'
+import { type SaveLoadError, SchemaValidationError } from './SaveErrors'
+
+interface ReportOptions {
+  // If true, also show a user-facing Alert with the error's i18n message.
+  // Set to false for background paths (e.g. Steam Cloud sync) where the user did not initiate the action.
+  alert?: boolean
+}
+
+export const logSaveError = (error: SaveLoadError): void => {
+  if (error instanceof SchemaValidationError) {
+    console.warn('[Save] schema validation failed:', error.toSafeJSON())
+  } else if (error.cause !== undefined) {
+    console.warn(`[Save] ${error.name}: ${error.message}`, { cause: error.cause })
+  } else {
+    console.warn(`[Save] ${error.name}: ${error.message}`)
+  }
+}
+
+export const reportSaveError = async (
+  error: SaveLoadError,
+  options: ReportOptions = { alert: true }
+): Promise<void> => {
+  logSaveError(error)
+  if (options.alert) {
+    await Alert(i18next.t(error.userMessageKey))
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,12 @@ export default defineConfig(({ mode }) => {
       viteStaticCopy({
         targets: [
           { src: 'Pictures', dest: '' },
-          { src: 'translations', dest: '' }
+          { src: 'translations', dest: '' },
+          // MSW service worker must be served at the site root in dev so that
+          // src/Synergism.ts's worker.start({ url: './mockServiceWorker.js' })
+          // can register it. publicDir is disabled (see above), so we copy via
+          // this plugin instead.
+          { src: 'mockServiceWorker.js', dest: '' }
         ]
       })
     ]


### PR DESCRIPTION
## Summary

Nine commits cleaning up the save-file trust boundary, fixing a dev-server regression from the Vite migration, and shrinking the production bundle by 415 KB. Each commit is independently reviewable and ordered for sane bisect — the dev fix lands first because nothing else could be verified in the browser until it did.

**Trust-boundary cluster (Block 1 + Block 3 from the plan):**
- `815d58e3` — domain error classes (`SaveLoadError`, `SchemaValidationError`, `SaveDecodeError`) and a single reporter; closes **#86 (T13)**, **#24 (S17 — PII leak)**, **#78 (T5 — three diverging load postures)**
- `943e6be2` — replaces 10 `z.any().transform()` "validation theater" sites in `PlayerJsonSchema.ts` with `z.custom<X>(v => v instanceof X)` narrowed validators; closes **#9 (S2)**. Uses the closure form rather than `z.instanceof` because `PlayerJsonSchema` sits inside the circular-import cluster (#76/T3) and `z.instanceof(X)` evaluates `X` eagerly at module load — TDZ for any class whose module is still resolving.
- `6471614d` — hoists 18 redundant `corruptionsSchema.parse({})` calls in `Synergism.ts` to a single frozen `defaultCorruptions` constant; closes **#91 (T18)**
- `4b4456fd` — tightens `isDecimal` to `instanceof Decimal`-only, dropping the structural `{mantissa, exponent}` duck-test fallback (the trust-boundary concern the issue called out); partial close on **#83 (T10)**

**Dev unblock and bundle:**
- `62a15374` — Vite 8 migration left `mockServiceWorker.js` unserved (`publicDir: false` + not in `viteStaticCopy` targets); the failed MSW registration blocked the boot sequence at `await worker.start(...)`. Generate the worker at the repo root, wire through `viteStaticCopy`, exception in `.gitignore`. Without this nothing else here could be browser-verified.
- `46fc5237` — gate the MSW dynamic import on `import.meta.env.DEV` directly rather than the `dev` re-export from `Config.ts`. Vite can't const-fold across the variable binding; switching to the macro lets the entire `./mock/browser` graph tree-shake out of prod. Removes a `browser-*.js` chunk of **415 KB / 109 KB gzipped**. Closes **#81 (T8)**.
- `0a1a29f5` — routes 10 module-scope non-null-asserted DOM lookups (`Summary.ts`, all of `src/purchases/`) through `DOMCacheGetOrSet`; partial close on **#85 (T12)**

**Misc:**
- `56d16e2f` — `eventCheck()` was throwing `new Error('God fucking dammit')` on `!response.ok`; replaced with `\`Failed to fetch events: HTTP \${status} \${statusText}\`` so the log line actually identifies the failure
- `a8929742` — `.claude/launch.json` for teammates using Claude Preview; gitignore `.claude/settings.local.json` (per-user permission allowlist)

## Deferred (called out for tracking)

- **#143 (R20 — fuzz harness)** and **#153 (DEP-W5 — zod 3→4)** — both blocked on #76 (T3 circular imports). `vitest` doesn't tolerate the cycle the way Vite's bundle does; the schema can't be imported in tests cleanly until #76 lands.
- **#82, #75, #74, #87, #77** — multi-day architectural items. #87 and #77 are partially subsumed by #82 (ordinal-fields migration).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run csslint` / `npm run htmllint` clean
- [x] `npm run build` clean; prod bundle 415 KB smaller (no `browser-*.js` chunk)
- [x] Dev boot: background → offline-progress box → game UI; verified in browser
- [x] Save round-trip: manual save → reload → loadSynergy preserves all class instances (Map, QuarkHandler, WowCubes, CampaignManager, CorruptionLoadout, CorruptionSaves, SingularityChallenge, Date)
- [x] Corrupt-save smoke: inject `{}` save → schema fail → user sees "Unable to load save." Alert + structured `[Save] schema validation failed: [{path, code, message}…]` console.warn (no payload leak)
- [x] All 10 DOM-cache target IDs resolve at runtime post-boot
- [x] `isDecimal(player.coins) === true`, `isDecimal({mantissa, exponent}) === false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)