### PR TITLE
TS bundle: tack() hot path, named timer registry, DOM cache sweep

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         <div id="notifx">
             <img src="/Pictures/Default/X.png" height="16" width="16">
         </div>
-        <p></p>
+        <p id="notificationText"></p>
     </div>
     <div id="modal">
         <div id="modalContent">

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
                 <div id="resetinfo"></div>
             </div>
         </div>
-        <nav class="navbar">
+        <nav id="navbar" class="navbar">
             <button id="mobileMenuToggle" class="mobile-menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">
                 <span class="hamburger-line"></span>
                 <span class="hamburger-line"></span>
@@ -1844,7 +1844,7 @@
                                 <p id="lotusStatus"></p>
                                 <div id="lotusButtons">
                                     <button id="use-lotus" i18n="pseudoCoins.lotus.useLotus"></button>
-                                    <button class="consumableButton" i18n="pseudoCoins.consumables.consumableButton"></button>
+                                    <button id="lotusConsumableButton" class="consumableButton" i18n="pseudoCoins.consumables.consumableButton"></button>
                                 </div>
                             </div>
                             <p id="lotusInformation"></p>
@@ -2915,13 +2915,13 @@
                 <div id="thirdParty">
                     <div id="discord">
                         <p style="color: gold" i18n="settings.joinDiscord"></p>
-                        <button style="background: transparent">
+                        <button id="discordJoinButton" style="background: transparent">
                             <img alt="Discord Icon" src="/Pictures/Default/icon.gif" title="Click to join the official Discord!" width="100" height="100" loading="lazy">
                         </button>
                     </div>
                     <div id="patreon">
                         <p style="color: gold" i18n="settings.joinPatreon"></p>
-                        <button href="https://www.patreon.com/synergism" style="background: transparent">
+                        <button id="patreonSupportButton" href="https://www.patreon.com/synergism" style="background: transparent">
                             <img alt="Store Icon" src="/Pictures/PseudoShop/GOLDEN_QUARK_BUFF.png" title="Click to support development!" loading="lazy">
                             <p id="currentBonus">Current Bonus: 0%</p>
                         </button>
@@ -3238,7 +3238,7 @@
             </div>
         </div>
         <div class="subtabContent subtabDisplayFlex" id="hotkeys">
-            <div class="hotkeys"></div>
+            <div id="hotkeysList" class="hotkeys"></div>
             <span style="color: lightblue;">Last enabled key: <span style="color: gold;" id="lastHotkey"></span> <span style="color: white;" id="lastHotkeyName"></span></span>
             <span id="hotkeyTooltip" i18n="hotkeys.note2"></span>
             <span class="chal11 grayText" i18n="hotkeys.note1"></span>
@@ -4701,7 +4701,7 @@
                 </div>
             </div>
             <div class="consumableSpoiler" i18n="pseudoCoins.consumables.consumableSpoiler"></div>
-            <button class="consumableButton" i18n="pseudoCoins.consumables.consumableButton"></button>
+            <button id="eventConsumableButton" class="consumableButton" i18n="pseudoCoins.consumables.consumableButton"></button>
             <button id="apply-tips" i18n="pseudoCoins.consumables.applyTips"></button>
         </div>
     </div>

--- a/src/Buildings.ts
+++ b/src/Buildings.ts
@@ -1,0 +1,74 @@
+// Precomputed key tables for the 5-building/4-resource layout.
+// Hoisted so the per-tick recompute in tack() (≈200 Hz) does not
+// allocate template-literal strings, and so the OneToFive / ZeroToFour
+// casts that previously littered the hot loops can be replaced with
+// typed indexing.
+
+import type { OneToFive, ZeroToFour } from './types/Synergism'
+
+export type BuildingResource = 'Coin' | 'Diamonds' | 'Mythos'
+
+export const buildingResources = ['Coin', 'Diamonds', 'Mythos'] as const satisfies readonly BuildingResource[]
+
+export const particleOriginalCosts = [1, 1e2, 1e4, 1e8, 1e16] as const
+
+export const ordinalsZeroToFour = [0, 1, 2, 3, 4] as const satisfies readonly ZeroToFour[]
+export const ordinalsOneToFive = [1, 2, 3, 4, 5] as const satisfies readonly OneToFive[]
+
+// First-to-fifth ordinal names as a typed tuple. GlobalVariables['ordinals']
+// is `readonly ['first', ..., 'eighth', ...string[]]`, so indexing it by a
+// `number` widens to `string` and loses the literal type. This 5-name tuple
+// keeps the narrow union for the building/particle hot paths.
+export const buildingOrdinalNames = [
+  'first',
+  'second',
+  'third',
+  'fourth',
+  'fifth'
+] as const
+
+export const ascendBuildingKeys = [
+  'ascendBuilding1',
+  'ascendBuilding2',
+  'ascendBuilding3',
+  'ascendBuilding4',
+  'ascendBuilding5'
+] as const satisfies readonly `ascendBuilding${OneToFive}`[]
+
+export const buildingCostKeys = {
+  Coin: ['firstCostCoin', 'secondCostCoin', 'thirdCostCoin', 'fourthCostCoin', 'fifthCostCoin'],
+  Diamonds: ['firstCostDiamonds', 'secondCostDiamonds', 'thirdCostDiamonds', 'fourthCostDiamonds', 'fifthCostDiamonds'],
+  Mythos: ['firstCostMythos', 'secondCostMythos', 'thirdCostMythos', 'fourthCostMythos', 'fifthCostMythos']
+} as const
+
+export const buildingOwnedKeys = {
+  Coin: ['firstOwnedCoin', 'secondOwnedCoin', 'thirdOwnedCoin', 'fourthOwnedCoin', 'fifthOwnedCoin'],
+  Diamonds: ['firstOwnedDiamonds', 'secondOwnedDiamonds', 'thirdOwnedDiamonds', 'fourthOwnedDiamonds', 'fifthOwnedDiamonds'],
+  Mythos: ['firstOwnedMythos', 'secondOwnedMythos', 'thirdOwnedMythos', 'fourthOwnedMythos', 'fifthOwnedMythos']
+} as const
+
+export const particleCostKeys = [
+  'firstCostParticles',
+  'secondCostParticles',
+  'thirdCostParticles',
+  'fourthCostParticles',
+  'fifthCostParticles'
+] as const
+
+export const particleOwnedKeys = [
+  'firstOwnedParticles',
+  'secondOwnedParticles',
+  'thirdOwnedParticles',
+  'fourthOwnedParticles',
+  'fifthOwnedParticles'
+] as const
+
+// Used by the buy-hotkey handler to map a narrowed digit case to OneToFive
+// without an unchecked cast.
+export const digitToOneToFive = {
+  '1': 1,
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5
+} as const satisfies Record<'1' | '2' | '3' | '4' | '5', OneToFive>

--- a/src/Cache/DOM.ts
+++ b/src/Cache/DOM.ts
@@ -33,3 +33,29 @@ export const DOMCacheGetOrSet = (id: string) => {
 }
 
 export const DOMCacheHas = (id: string) => DOMCache.has(id)
+
+// Non-throwing variant of DOMCacheGetOrSet — returns null when the element
+// doesn't exist (instead of throwing). Touch-on-get LRU behavior matches
+// DOMCacheGetOrSet. Misses are NOT cached, so a subsequent create() + lookup
+// works correctly (see Statistics.ts create-if-missing pattern).
+export const DOMCacheGet = (id: string): HTMLElement | null => {
+  const cachedEl = DOMCache.get(id)
+  if (cachedEl) {
+    DOMCache.delete(id)
+    DOMCache.set(id, cachedEl)
+    return cachedEl
+  }
+
+  const el = document.getElementById(id)
+  if (!el) return null
+
+  DOMCache.set(id, el)
+  return el
+}
+
+// Invalidates a cached id. Call this BEFORE detaching / replacing the
+// underlying DOM node so subsequent DOMCacheGetOrSet calls re-fetch instead
+// of returning a stale reference (see Campaign.ts createCampaignIconHTMLS).
+export const DOMCacheDelete = (id: string): void => {
+  DOMCache.delete(id)
+}

--- a/src/Campaign.ts
+++ b/src/Campaign.ts
@@ -1,6 +1,6 @@
 import i18next from 'i18next'
 import { awardAchievementGroup } from './Achievements'
-import { DOMCacheGetOrSet } from './Cache/DOM'
+import { DOMCacheDelete, DOMCacheGetOrSet } from './Cache/DOM'
 import { inheritanceTokens, singularityBonusTokenMult } from './Calculate'
 import {
   corrIcons,
@@ -1498,7 +1498,7 @@ export const campaignIconHTMLUpdates = () => {
 }
 
 export const campaignIconHTMLUpdate = (key: CampaignKeys) => {
-  const icon = document.querySelector<HTMLElement>(`#campaignIconGrid > #${key}CampaignIcon`)!
+  const icon = DOMCacheGetOrSet(`${key}CampaignIcon`)
   if (!campaignDatas[key].unlockRequirement()) {
     icon.style.display = 'none'
   } else {
@@ -1636,6 +1636,12 @@ const campaignCorruptionStatHTMLUpdate = (key: CampaignKeys) => {
 
 export const createCampaignIconHTMLS = () => {
   const campaignIconDiv = DOMCacheGetOrSet('campaignIconGrid')
+  // Invalidate any previously-cached campaign-icon entries before detaching
+  // them, so DOMCacheGetOrSet calls in campaignIconHTMLUpdate re-fetch the
+  // freshly created elements instead of pointing at the old detached nodes.
+  for (const key of Object.keys(campaignDatas) as CampaignKeys[]) {
+    DOMCacheDelete(`${key}CampaignIcon`)
+  }
   // Reset existing Icons
   campaignIconDiv.innerHTML = ''
 

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -931,7 +931,7 @@ export const generateEventHandlers = () => {
     updateOnlySacrificeMaxRebornELOToggle(player.ants.toggles.onlySacrificeMaxRebornELO)
   })
 
-  document.getElementById('use-lotus')?.addEventListener('click', () => {
+  DOMCacheGetOrSet('use-lotus').addEventListener('click', () => {
     const timeNow = Date.now()
     const lotusTime = getLotusTimeExpiresAt()
     let extraHTML = ''
@@ -1634,7 +1634,7 @@ TODO: Fix this entire tab it's utter shit
   document.querySelector('#consumableEvents > .consumableButton')?.addEventListener('click', visitConsumableTab)
   document.querySelector('#lotusButtons > .consumableButton')?.addEventListener('click', visitConsumableTab)
 
-  document.getElementById('apply-tips')?.addEventListener('click', () => {
+  DOMCacheGetOrSet('apply-tips').addEventListener('click', () => {
     Prompt(i18next.t('pseudoCoins.consumables.applyTipsPrompt', { tips: getTips() }))
       .then((amount) => {
         const n = Number(amount)
@@ -1689,11 +1689,11 @@ TODO: Fix this entire tab it's utter shit
     }
   })
 
-  document.getElementById('patchnotes')?.addEventListener(
+  DOMCacheGetOrSet('patchnotes').addEventListener(
     'click',
     openIframeOverlay.bind(null, 'https://changelog.synergism.cc/latest')
   )
-  document.getElementById('tosLink')?.addEventListener(
+  DOMCacheGetOrSet('tosLink').addEventListener(
     'click',
     openIframeOverlay.bind(null, 'https://synergism.cc/terms-of-service')
   )

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -1168,11 +1168,11 @@ export const generateEventHandlers = () => {
   })
   saveStringInput.addEventListener('mouseout', CloseModal)
 
-  document.querySelector('#thirdParty > #discord > button')?.addEventListener(
+  DOMCacheGetOrSet('discordJoinButton').addEventListener(
     'click',
     () => location.href = 'https://www.discord.gg/ameCknq' // TODO: redirect with synergism.cc
   )
-  document.querySelector('#thirdParty > #patreon > button')?.addEventListener('click', () => {
+  DOMCacheGetOrSet('patreonSupportButton').addEventListener('click', () => {
     changeTab(Tabs.Purchase)
     changeSubTab(Tabs.Purchase, { page: 1 })
   })
@@ -1631,8 +1631,8 @@ TODO: Fix this entire tab it's utter shit
   }
 
   // EVENT TAB
-  document.querySelector('#consumableEvents > .consumableButton')?.addEventListener('click', visitConsumableTab)
-  document.querySelector('#lotusButtons > .consumableButton')?.addEventListener('click', visitConsumableTab)
+  DOMCacheGetOrSet('eventConsumableButton').addEventListener('click', visitConsumableTab)
+  DOMCacheGetOrSet('lotusConsumableButton').addEventListener('click', visitConsumableTab)
 
   DOMCacheGetOrSet('apply-tips').addEventListener('click', () => {
     Prompt(i18next.t('pseudoCoins.consumables.applyTipsPrompt', { tips: getTips() }))

--- a/src/Hotkeys.ts
+++ b/src/Hotkeys.ts
@@ -201,7 +201,7 @@ export const disableHotkeys = () => hotkeysEnabled = false
 export const enableHotkeys = () => {
   changeHotkeys()
 
-  const hotkey = document.querySelector('.hotkeys')!
+  const hotkey = DOMCacheGetOrSet('hotkeysList')
 
   while (hotkey.firstChild) {
     hotkey.removeChild(hotkey.firstChild)

--- a/src/Login.ts
+++ b/src/Login.ts
@@ -299,13 +299,11 @@ async function fetchMeRoute () {
 
 export async function handleLogin () {
   generateSubtabBrowser: {
-    const subtabElement = document.querySelector('#accountSubTab div#left.scrollbarX')!
+    const subtabElement = DOMCacheGetOrSet('left')
 
-    const logoutElement = document.getElementById('logoutButton')
-    if (logoutElement !== null) {
-      logoutElement.addEventListener('click', logout, { once: true })
-      document.getElementById('accountSubTab')?.appendChild(logoutElement)
-    }
+    const logoutElement = DOMCacheGetOrSet('logoutButton')
+    logoutElement.addEventListener('click', logout, { once: true })
+    DOMCacheGetOrSet('accountSubTab').appendChild(logoutElement)
 
     const response = await fetchMeRoute()
 
@@ -1060,8 +1058,8 @@ async function decodeSave (save: string) {
 }
 
 function handleCloudSaves () {
-  const subtabElement = document.querySelector('#accountSubTab div#right.scrollbarX')!
-  const table = subtabElement.querySelector('#table > #dataGrid')!
+  const subtabElement = DOMCacheGetOrSet('right')
+  const table = DOMCacheGetOrSet('dataGrid')
 
   const uploadButton = subtabElement.querySelector<HTMLButtonElement>('button#upload')
   const transferButton = subtabElement.querySelector<HTMLButtonElement>('button#transfer')
@@ -1336,7 +1334,7 @@ async function handleSteamCloudSave () {
   if (!steamId) return
 
   const saveFileName = `synergism_${steamId}.txt`
-  const table = document.querySelector('#accountSubTab div#right.scrollbarX #table > #dataGrid')!
+  const table = DOMCacheGetOrSet('dataGrid')
 
   // Remove any existing Steam save row
   table.querySelectorAll('.steam-save-row, .steam-details-row').forEach((row) => row.remove())

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -2,7 +2,7 @@ import Decimal, { type DecimalSource } from 'break_infinity.js'
 import i18next from 'i18next'
 import { achievementLevel, getAchievementReward } from './Achievements'
 import { getAmbrosiaUpgradeEffects } from './BlueberryUpgrades'
-import { DOMCacheGetOrSet } from './Cache/DOM'
+import { DOMCacheGet, DOMCacheGetOrSet } from './Cache/DOM'
 import {
   calculateAllCubeMultiplier,
   calculateAmbrosiaAdditiveLuckMult,
@@ -3714,7 +3714,7 @@ const loadStatistics = (
   const statNumTotalHTMLName = `${statLinePrefix}NT`
 
   // Query that an element with name statTotalHTMLName Exists
-  const totalElm = document.getElementById(statTotalHTMLName)
+  const totalElm = DOMCacheGet(statTotalHTMLName)
 
   if (totalElm === null && hasSummative) {
     const statTotal = document.createElement('p')

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1457,8 +1457,7 @@ const loadSynergy = () => {
     for (let j = 1; j < player.cubeUpgrades.length; j++) {
       updateCubeUpgradeBG(j)
     }
-    const platUpg = document.querySelectorAll('button[id^="platUpg"]')
-    for (let j = 1; j <= platUpg.length; j++) {
+    for (let j = 1; j < player.platonicUpgrades.length; j++) {
       updatePlatonicUpgradeBG(j)
     }
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -142,7 +142,19 @@ import {
   updateAutoChallenge,
   updateRuneBlessingBuyAmount
 } from './Toggles'
-import type { OneToFive, Player, resetNames, ZeroToFour } from './types/Synergism'
+import type { Player, resetNames } from './types/Synergism'
+import {
+  ascendBuildingKeys,
+  buildingCostKeys,
+  buildingOrdinalNames,
+  buildingOwnedKeys,
+  buildingResources,
+  digitToOneToFive,
+  ordinalsOneToFive,
+  particleCostKeys,
+  particleOriginalCosts,
+  particleOwnedKeys
+} from './Buildings'
 import {
   Alert,
   buttoncolorchange,
@@ -263,8 +275,6 @@ const buyAmountTypes = [
   'offering',
   'tesseract'
 ] as const
-const buildingResources = ['Coin', 'Diamonds', 'Mythos'] as const
-const particleOriginalCosts = [1, 1e2, 1e4, 1e8, 1e16]
 
 export const player: Player = {
   firstPlayed: new Date().toISOString(),
@@ -3377,22 +3387,20 @@ export const resourceGain = (dt: number): void => {
     )
   }*/
 
-  for (let i = 1; i <= 5; i++) {
-    G.ascendBuildingProduction[G.ordinals[(5 - i) as ZeroToFour]] = player[
-      `ascendBuilding${(6 - i) as OneToFive}` as const
-    ].generated
-      .add(player[`ascendBuilding${(6 - i) as OneToFive}` as const].owned)
+  for (let j = 4; j >= 0; j--) {
+    const buildingKey = ascendBuildingKeys[j]
+    const ordinalName = buildingOrdinalNames[j]
+    G.ascendBuildingProduction[ordinalName] = player[buildingKey].generated
+      .add(player[buildingKey].owned)
       // 4.1.0: Removing this from player, also because I want to make the multiplier 0.05 instead of 0.01 anyway
-      // .times(player[`ascendBuilding${i as OneToFive}` as const].multiplier)
+      // .times(player[buildingKey].multiplier)
       .times(0.05)
       .times(G.globalConstantMult)
 
-    if (i !== 5) {
-      const fiveMinusI = (5 - i) as 1 | 2 | 3 | 4
-      player[`ascendBuilding${fiveMinusI}` as const].generated = player[
-        `ascendBuilding${fiveMinusI}` as const
-      ].generated.add(
-        G.ascendBuildingProduction[G.ordinals[fiveMinusI]].times(dt)
+    if (j !== 0) {
+      const prevKey = ascendBuildingKeys[j - 1]
+      player[prevKey].generated = player[prevKey].generated.add(
+        G.ascendBuildingProduction[ordinalName].times(dt)
       )
     }
   }
@@ -4341,9 +4349,9 @@ export const updateAll = (): void => {
     && player.resetToggleModes.ascension === AutoAscensionModes.amount
   ) {
     const ownedBuildings: TesseractBuildings = [null, null, null, null, null]
-    for (let i = 1; i <= 5; i++) {
-      if (player.autoTesseracts[i]) {
-        ownedBuildings[i - 1] = player[`ascendBuilding${i as OneToFive}` as const].owned
+    for (let idx = 0; idx < 5; idx++) {
+      if (player.autoTesseracts[ordinalsOneToFive[idx]]) {
+        ownedBuildings[idx] = player[ascendBuildingKeys[idx]].owned
       }
     }
     const budget = Number(player.wowTesseracts) - player.tesseractAutoBuyerAmount
@@ -4353,11 +4361,11 @@ export const updateAll = (): void => {
     )
     // Prioritise buying buildings from highest tier to lowest,
     // in case there are any off-by-ones or floating point errors.
-    for (let i = 5; i >= 1; i--) {
-      const buyFrom = ownedBuildings[i - 1]
-      const buyTo = buyToBuildings[i - 1]
+    for (let idx = 4; idx >= 0; idx--) {
+      const buyFrom = ownedBuildings[idx]
+      const buyTo = buyToBuildings[idx]
       if (buyFrom !== null && buyTo !== null && buyTo !== buyFrom) {
-        buyTesseractBuilding(i as OneToFive, buyTo - buyFrom)
+        buyTesseractBuilding(ordinalsOneToFive[idx], buyTo - buyFrom)
       }
     }
   }
@@ -4566,21 +4574,21 @@ export const updateAll = (): void => {
     G.prevReductionValue = reductionValue
     for (let res = 0; res < buildingResources.length; ++res) {
       const resource = buildingResources[res]
+      const costKeys = buildingCostKeys[resource]
+      const ownedKeys = buildingOwnedKeys[resource]
       for (let ord = 0; ord < 5; ++ord) {
-        const num = G.ordinals[ord as ZeroToFour]
-        player[`${num}Cost${resource}` as const] = getCost(
-          (ord + 1) as OneToFive,
+        player[costKeys[ord]] = getCost(
+          ordinalsOneToFive[ord],
           resource,
-          player[`${num}Owned${resource}` as const] + 1,
+          player[ownedKeys[ord]] + 1,
           reductionValue
         )
       }
     }
 
     for (let i = 0; i <= 4; i++) {
-      const num = G.ordinals[i as ZeroToFour]
-      const buyTo = player[`${num}OwnedParticles` as const] + 1
-      player[`${num}CostParticles` as const] = new Decimal(
+      const buyTo = player[particleOwnedKeys[i]] + 1
+      player[particleCostKeys[i]] = new Decimal(
         Decimal.pow(2, buyTo - 1).times(
           Decimal.pow(
             1.001,
@@ -4913,7 +4921,7 @@ export const synergismHotkeys = (event: KeyboardEvent, key: string): void => {
     case '3':
     case '4':
     case '5': {
-      const num = Number(key) as OneToFive
+      const num = digitToOneToFive[key]
 
       if (G.currentTab === Tabs.Buildings) {
         if (type === 'Particles') {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -265,7 +265,7 @@ import {
 } from './SingularityChallenges'
 import { changeSubTab, changeTab, getActiveSubTab, Tabs } from './Tabs'
 import { settingAnnotation, settingSymbols, toggleIconSet, toggleTheme } from './Themes'
-import { clearTimeout, clearTimers, setInterval, setTimeout } from './Timers'
+import { clearTimeout, clearTimers, setNamedInterval, setTimeout } from './Timers'
 
 const buyAmountTypes = [
   'coin',
@@ -4624,14 +4624,14 @@ export const slowUpdates = (): void => {
 }
 
 export const constantIntervals = (): void => {
-  setInterval(saveSynergy, 5000)
-  setInterval(slowUpdates, 200)
-  setInterval(fastUpdates, 50)
-  setInterval(campaignIconHTMLUpdates, 15000)
-  setInterval(updateAllRuneLevelsFromEXP, 25)
-  setInterval(updateTalismanRarities, 250)
-  setInterval(() => awardAchievementGroup('runeFreeLevel'), 25)
-  setInterval(() => {
+  setNamedInterval('save', saveSynergy, 5000)
+  setNamedInterval('slowUpdates', slowUpdates, 200)
+  setNamedInterval('fastUpdates', fastUpdates, 50)
+  setNamedInterval('campaignIconHTMLUpdates', campaignIconHTMLUpdates, 15000)
+  setNamedInterval('runeLevelsFromEXP', updateAllRuneLevelsFromEXP, 25)
+  setNamedInterval('talismanRarities', updateTalismanRarities, 250)
+  setNamedInterval('runeFreeLevelAchievement', () => awardAchievementGroup('runeFreeLevel'), 25)
+  setNamedInterval('progressiveAchievementsUpdate', () => {
     for (const key of Object.keys(progressiveAchievements) as ProgressiveAchievements[]) {
       updateProgressiveCache(key)
     }
@@ -4646,7 +4646,7 @@ let lastUpdate = 0
 
 export const createTimer = (): void => {
   lastUpdate = performance.now()
-  setInterval(tick, 1000 / ticksPerSecond)
+  setNamedInterval('mainTick', tick, 1000 / ticksPerSecond)
 }
 
 const dt = 5
@@ -5183,7 +5183,7 @@ export const reloadShit = (ignoreOfflineProgress = false) => {
   changeSubTab(Tabs.Settings, { page: 0 }) // set 'statistics main'
 
   dailyResetCheck()
-  setInterval(dailyResetCheck, 30000)
+  setNamedInterval('dailyResetCheck', dailyResetCheck, 30000)
 
   constantIntervals()
   changeTabColor()
@@ -5191,7 +5191,8 @@ export const reloadShit = (ignoreOfflineProgress = false) => {
   eventCheck()
     .catch(() => {})
     .finally(() => {
-      setInterval(
+      setNamedInterval(
+        'eventCheck',
         () =>
           eventCheck().catch((error: Error) => {
             console.error(error)
@@ -5264,7 +5265,7 @@ window.addEventListener('load', async () => {
 
   refreshQuarkBonus()
     .catch(console.error)
-    .finally(() => setInterval(() => refreshQuarkBonus(), 1000 * 60 * 15))
+    .finally(() => setNamedInterval('refreshQuarkBonus', () => refreshQuarkBonus(), 1000 * 60 * 15))
 
   try {
     await initializePCoinCache()

--- a/src/Tabs.ts
+++ b/src/Tabs.ts
@@ -674,10 +674,10 @@ tabRow.appendButton(
 
 // Mobile menu toggle functionality
 const mobileMenuToggle = DOMCacheGetOrSet('mobileMenuToggle')
-const navbar = document.querySelector('.navbar')
+const navbar = DOMCacheGetOrSet('navbar')
 
 const toggleMobileMenu = () => {
-  const isOpen = navbar?.classList.toggle('menu-open')
+  const isOpen = navbar.classList.toggle('menu-open')
   mobileMenuToggle.classList.toggle('menu-open', isOpen)
   mobileMenuToggle.setAttribute('aria-expanded', String(isOpen))
 }
@@ -687,7 +687,7 @@ mobileMenuToggle.addEventListener('click', toggleMobileMenu)
 // Close mobile menu when a tab is clicked
 tabRow.addEventListener('click', (e) => {
   const target = e.target as HTMLElement
-  if (target.tagName === 'BUTTON' && navbar?.classList.contains('menu-open')) {
+  if (target.tagName === 'BUTTON' && navbar.classList.contains('menu-open')) {
     toggleMobileMenu()
   }
 })

--- a/src/Timers.ts
+++ b/src/Timers.ts
@@ -6,6 +6,7 @@ interface ActiveTimer {
 }
 
 const activeTimers: ActiveTimer[] = []
+const namedIntervals = new Map<string, number>()
 
 export const setInterval: typeof workerTimers['setInterval'] = (fn, delay) => {
   const timer = workerTimers.setInterval(fn, delay)
@@ -18,8 +19,36 @@ export const clearInterval: typeof workerTimers['clearInterval'] = (timerId) => 
     if (timer.type === 'interval' && timer.id === timerId) {
       workerTimers.clearInterval(timerId)
       activeTimers.splice(activeTimers.indexOf(timer), 1)
+      // Also drop the name binding if this id is tracked there
+      for (const [name, id] of namedIntervals) {
+        if (id === timerId) {
+          namedIntervals.delete(name)
+          break
+        }
+      }
       return
     }
+  }
+}
+
+// Idempotent named interval registration: if a timer with the given name is
+// already live, clear it first. Catches the duplicate-interval bug class that
+// 54f393e5 fixed by hand: re-entry into the bootstrap path no longer doubles
+// the saveSynergy / fastUpdates / tick clocks.
+export const setNamedInterval = (name: string, fn: () => void, delay: number): number => {
+  const existing = namedIntervals.get(name)
+  if (existing !== undefined) {
+    clearInterval(existing)
+  }
+  const timer = setInterval(fn, delay)
+  namedIntervals.set(name, timer)
+  return timer
+}
+
+export const clearNamedInterval = (name: string): void => {
+  const id = namedIntervals.get(name)
+  if (id !== undefined) {
+    clearInterval(id)
   }
 }
 
@@ -52,4 +81,5 @@ export const clearTimers = (): void => {
       clearTimeout(id)
     }
   }
+  namedIntervals.clear()
 }

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -558,7 +558,7 @@ export const hideStuff = () => {
   DOMCacheGetOrSet('singularitytab').style.backgroundColor = ''
   DOMCacheGetOrSet('event').style.display = 'none'
   DOMCacheGetOrSet('eventtab').style.backgroundColor = ''
-  document.getElementById('pseudoCoins')?.style.setProperty('display', 'none')
+  DOMCacheGetOrSet('pseudoCoins').style.display = 'none'
   DOMCacheGetOrSet('pseudoCoinstab').style.backgroundColor = ''
 
   const tab = DOMCacheGetOrSet('settingstab')
@@ -652,7 +652,7 @@ export const hideStuff = () => {
   if (G.currentTab === Tabs.Purchase) {
     initializeCart()
 
-    document.getElementById('pseudoCoins')?.style.setProperty('display', 'unset')
+    DOMCacheGetOrSet('pseudoCoins').style.display = 'unset'
     DOMCacheGetOrSet('pseudoCoinstab').style.backgroundColor = 'orange'
   }
 }
@@ -1356,7 +1356,7 @@ let closedNotification: ReturnType<typeof setTimeout> | undefined = undefined
 
 export const Notification = (text: string, time = 5000): Promise<void> => {
   const notification = DOMCacheGetOrSet('notification')
-  const textNode = document.querySelector<HTMLElement>('#notification > p')!
+  const textNode = DOMCacheGetOrSet('notificationText')
   const x = DOMCacheGetOrSet('notifx')
 
   textNode.textContent = text

--- a/src/purchases/ProductSubtab.ts
+++ b/src/purchases/ProductSubtab.ts
@@ -1,10 +1,11 @@
+import { DOMCacheGetOrSet } from '../Cache/DOM'
 import { format } from '../Synergism'
 import { Alert, Notification } from '../UpdateHTML'
 import { memoize } from '../Utility'
 import { coinProducts } from './CartTab'
 import { addToCart, calculateGrossPrice } from './CartUtil'
 
-const productContainer = document.querySelector<HTMLElement>('#pseudoCoins > #productContainer')
+const productContainer = DOMCacheGetOrSet('productContainer')
 
 const formatter = Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -25,7 +26,7 @@ const clickHandler = (e: HTMLElementEventMap['click']) => {
 }
 
 const initializeProductPage = memoize(() => {
-  productContainer!.innerHTML = coinProducts.map((product) => (`
+  productContainer.innerHTML = coinProducts.map((product) => (`
     <section class="pseudoCoinContainer" key="${product.id}">
       <div>
         <img class="pseudoCoinImage" alt="${product.name}" src="./Pictures/${product.id}.png" />
@@ -39,7 +40,7 @@ const initializeProductPage = memoize(() => {
     </section>
   `)).join('')
 
-  productContainer!.style.display = 'grid'
+  productContainer.style.display = 'grid'
 
   document.querySelectorAll<HTMLButtonElement>('.pseudoCoinContainer > div > button[data-id]').forEach((element) => {
     element.addEventListener('click', clickHandler)
@@ -47,10 +48,10 @@ const initializeProductPage = memoize(() => {
 })
 
 export const clearProductPage = () => {
-  productContainer!.style.display = 'none'
+  productContainer.style.display = 'none'
 }
 
 export const toggleProductPage = () => {
   initializeProductPage()
-  productContainer!.style.display = 'grid'
+  productContainer.style.display = 'grid'
 }


### PR DESCRIPTION
## Summary

Five commits from the TypeScript category. Each commit is independently reviewable; the bundle reflects the natural rhythm of working through the area.

- **Closes [#77](https://github.com/MaddisonM79/Synergism/issues/77)** (T4 — tack() hot-path string allocation @ 200Hz)
- **Closes [#87](https://github.com/MaddisonM79/Synergism/issues/87)** (T14 — `OneToFive` / `ZeroToFour` unchecked casts in Synergism.ts)
- **Closes [#79](https://github.com/MaddisonM79/Synergism/issues/79)** (T6 — setInterval discipline / named timer registry)
- **Advances [#85](https://github.com/MaddisonM79/Synergism/issues/85)** (T12 — DOMCacheGetOrSet sweep): 20 more sites converted on top of `0a1a29f5`'s initial 10. Inherent multi-element `querySelectorAll` patterns left out of scope.
- Also issues [#90](https://github.com/MaddisonM79/Synergism/issues/90) and [#78](https://github.com/MaddisonM79/Synergism/issues/78) were closed separately as already-fixed (commit titles used `(#N)` rather than the auto-close keyword).

## Commits

| Commit | What |
|---|---|
| [`f105d14d`](https://github.com/MaddisonM79/Synergism/commit/f105d14d) | New `src/Buildings.ts` with precomputed typed key tables (`buildingCostKeys`, `buildingOwnedKeys`, `particleCostKeys`, `particleOwnedKeys`, `ascendBuildingKeys`, `buildingOrdinalNames`, `ordinalsOneToFive`, `digitToOneToFive`). `tack()` cost-recompute no longer allocates 30 template-literal strings per recompute hit. All 9 `OneToFive`/`ZeroToFour` casts in Synergism.ts removed via typed const-tuple indexing. Ascend-building production loop rewritten to iterate `j=4→0` so the `(5-i)`/`(6-i)` arithmetic disappears. |
| [`fabe31ac`](https://github.com/MaddisonM79/Synergism/commit/fabe31ac) | First DOM-cache sweep: 6 sites. UpdateHTML.ts pseudoCoins + `notificationText` (new HTML id on `#notification > p`). EventListeners.ts bootstrap listeners. |
| [`7dab1c4e`](https://github.com/MaddisonM79/Synergism/commit/7dab1c4e) | `setNamedInterval` / `clearNamedInterval` in `Timers.ts`. Idempotent re-registration: if a timer with a given name is already live, clear it before re-creating. Catches the dup-interval bug class that `54f393e5` had to fix by hand. 11 callers in Synergism.ts switched (`constantIntervals` × 8, `createTimer`, `dailyResetCheck`, `eventCheck`, `refreshQuarkBonus`). |
| [`aea88093`](https://github.com/MaddisonM79/Synergism/commit/aea88093) | Second DOM-cache sweep: 14 sites. Compound `#accountSubTab` selectors in Login.ts collapsed since `#left`/`#right`/`#dataGrid` are globally unique. EventListeners third-party buttons + consumable buttons get new ids. Tabs.ts `<nav>` gets `id="navbar"`. Hotkeys.ts `.hotkeys` inner div gets `id="hotkeysList"`. ProductSubtab module-scope lookup uses DOMCacheGetOrSet. The `platUpg` button qSA → `player.platonicUpgrades.length`. |
| [`7f87fe2b`](https://github.com/MaddisonM79/Synergism/commit/7f87fe2b) | `DOMCacheGet` (non-throwing variant — keeps null branch alive for the create-if-missing pattern) and `DOMCacheDelete` (invalidation — call before detaching a cached node) in `Cache/DOM.ts`. Statistics.ts loadStatistics uses `DOMCacheGet`. Campaign.ts `createCampaignIconHTMLS` invalidates before innerHTML reset; `campaignIconHTMLUpdate` switches to `DOMCacheGetOrSet`. |

## Verification

- `npx tsc --noEmit` clean on every commit
- `oxlint` clean on every commit
- `vite build` clean on every commit
- Browser end-to-end for [`f105d14d`](https://github.com/MaddisonM79/Synergism/commit/f105d14d): bumped first/fifth owned counts for Coin/Diamonds/Mythos/Particles, forced `G.prevReductionValue = -999`, confirmed all 4 × 5 cost values updated correctly. Separately bumped ascendBuilding[1..5].owned and confirmed the production chain propagates correctly across all 5 tiers. Browser smoke for the later commits is static-check only — a sibling worktree was holding port 3000 via vite's `strictPort`, and the auto-mode classifier (correctly) blocked spinning a second dev server on an alternate port without explicit user direction.

## Test plan

- [ ] `npm run check:tsc` clean
- [ ] `npm run lint` clean
- [ ] `npm run build:esbuild` clean
- [ ] `npm run dev` — fresh save loads, the main game tick advances, building costs update on purchase, particle costs update on purchase
- [ ] Notification path — trigger any notification; text appears in the popup with no console errors
- [ ] Settings tab — Discord + Patreon buttons clickable; hotkeys list renders
- [ ] Cloud save subtab — table renders if signed in
- [ ] Campaign tab — icons render and update visibility per unlock; trigger a regen path (language change reloads campaign HTML) and confirm icons still update
- [ ] Statistics → Quark / Cube multiplier panels — `Total` line appears once and updates each tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)