### PR TITLE
fix(ci): trigger kong-release on tag push, not branch push (closes #130)

### DIFF
--- a/.github/workflows/kong-release.yml
+++ b/.github/workflows/kong-release.yml
@@ -1,8 +1,9 @@
 name: Create a release for Kongregate
 on:
   push:
-    branches: master
-    
+    tags:
+      - 'v*.*.*'
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -23,9 +24,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install deps
-        run: |
-          npm ci
-          sudo apt install -y jq
+        run: npm ci
       - name: Build
         run: |
           node ./scripts/update-last-updated.js
@@ -39,10 +38,6 @@ jobs:
           files: dist/ Pictures/Splash/ Pictures/Default/ Pictures/logo.png Pictures/logoLight.png Pictures/MISSINGIMAGE.png translations/ index.html Synergism.css favicon.ico
           dest: Kong.zip
           recursive: false
-      - name: Retrieve version
-        run: |
-          echo "VERSION=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
-        id: version
       - name: Attest Kong.zip
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
@@ -51,7 +46,7 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: v${{ steps.version.outputs.VERSION }}
-          name: Kongregate Build ${{ github.event.repository.updated_at }}
+          tag_name: ${{ github.ref_name }}
+          name: Kongregate Build ${{ github.ref_name }}
           files: |
             Kong.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,3 +116,18 @@ node --run preview:cf
 ```
 
 Builds + stages + serves `build/` via `wrangler pages dev` on port 3000. Use this to verify the CSP / HSTS / cache rules behave as expected before pushing.
+
+## Releases (Kongregate build)
+
+[`.github/workflows/kong-release.yml`](.github/workflows/kong-release.yml) builds `Kong.zip`, generates a Sigstore build-provenance attestation, and creates a GitHub Release. It triggers **only on tag push** matching `v*.*.*` — pushing to `main` does not release. This keeps version bumps explicit and prevents tag overwrites.
+
+To cut a release:
+
+```sh
+# bump package.json version, commit, merge to main, then:
+git checkout main && git pull
+git tag v4.1.2
+git push origin v4.1.2
+```
+
+The tag name (`github.ref_name`) is the release tag and title; `package.json` version is not consulted at release time, so the two can drift if you forget the bump — keep them in sync as a matter of habit.


### PR DESCRIPTION
## Summary

- Switch `kong-release.yml` trigger from `push: branches: master` (dormant — default is `main`) to `push: tags: 'v*.*.*'` so version bumps are explicit and tags never overwrite.
- Use `${{ github.ref_name }}` directly for `tag_name`/release `name`; drop the `Retrieve version` step + the `jq` install it required.
- Document the new tag-push release flow in `CONTRIBUTING.md` (new "Releases (Kongregate build)" section).

## Why

[#130](https://github.com/MaddisonM79/unknown_game/issues/130) — SemVer §3 violation: pushing twice without a `package.json` bump caused `softprops/action-gh-release` to delete-and-recreate the same `v$VERSION` tag, mutating release history. SemVer §5 violation: every push to `master` was effectively a release with no intentional cut. Both go away when tag push is the trigger.

## Test plan

- [ ] CI passes on this PR (the workflow itself won't run — its trigger is tag-push only).
- [ ] Post-merge, cut a test release by tagging `v4.1.2-test` and pushing; confirm the workflow runs, packages `Kong.zip`, signs attestation, creates the GitHub release with the right title and asset.
- [ ] Re-push the same tag (force) — confirm the existing release is the one updated (or that the tag-push doesn't even retrigger, depending on git behavior), not silently recreated under the wrong name.
- [ ] Confirm no path-push to `main` triggers a release.

Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)