### PR TITLE
docs: strip Steam/Electron from CLAUDE.md + tidy index.html

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,29 +52,9 @@ translations/en.json       # Required for all new text strings
 - Match existing naming conventions
 - Maintain consistency with current architecture
 
-### Steam
-- There is a Steam version of the app that uses Electron.
-- Steam features MUST be gated by checking the `platform` variable from Config.ts
-- When using a feature only available to the Electron app, you MUST use dynamic imports. Example:
+### Desktop / Steam (deferred)
 
-```ts
-import { platform } from './Config'
-
-async function myFunction () {
-  if (platform === 'steam') {
-    const { steamOnlyFeature } = await import('./steam/steam')
-
-    await steamOnlyFeature()
-  } else {
-    // browser version
-    browserOnlyFeature()
-  }
-}
-```
-
-- The platform variable comes from Vite's `define` config (which uses esbuild under the hood for the substitution). These act as macros essentially, which removes the
-  `else` block on Steam and vice-versa on browser builds.
-- **Wrong**: `import { steamOnlyFeature } from './steam/steam'`W
+The Electron-based Steam build was removed. The plan is to reintroduce a desktop runtime via Tauri + Rust later in the roadmap, with Steam SDK integration and Discord Rich Presence reimplemented on that side. Until then, treat this as a browser-only codebase — there is no `platform === 'steam'` gate, no `PLATFORM` build-time macro, no `src/steam/` contract layer. Don't reintroduce a Steam/Electron abstraction. New desktop-only work should wait for the Tauri integration.
 
 ### Recommended Patterns
 - Objects and arrays that are constant should be hoisted to the module scope when possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Since merges are squashed, the PR title becomes the commit message on `main`. In
 
 Changes that add or modify fields on the `player` object affect every player's savefile size and migration path. **Before making such a change, please open an issue first** to discuss the schema impact.
 
-See also [CLAUDE.md](CLAUDE.md) for the agent-facing contribution rules (i18n, DOM caching, Steam/Electron gating, etc.).
+See also [CLAUDE.md](CLAUDE.md) for the agent-facing contribution rules (i18n, DOM caching, etc.).
 
 ## Build-time configuration
 

--- a/index.html
+++ b/index.html
@@ -3258,7 +3258,7 @@
                 <button id="open-forgotpassword">Forgot Password</button>
               </div>
               <div id="register">
-                <form action="%VITE_API_BASE_URL%/register" data-steam-action="%VITE_API_BASE_URL%/login/direct/steam/register" method="POST">
+                <form action="%VITE_API_BASE_URL%/register" method="POST">
                   <label for="email">Email Address</label>
                   <input type="text" id="email" name="email" placeholder="you@gmail.com">
                   <label for="password">Password</label>
@@ -3270,7 +3270,7 @@
                 </form>
               </div>
               <div id="login">
-                <form action="%VITE_API_BASE_URL%/signin" data-steam-action="%VITE_API_BASE_URL%/login/direct/steam" method="POST">
+                <form action="%VITE_API_BASE_URL%/signin" method="POST">
                   <label for="email-si">Email Address</label>
                   <input type="text" id="email-si" name="email" placeholder="you@gmail.com">
                   <label for="password-si">Password</label>
@@ -3280,7 +3280,7 @@
                 </form>
               </div>
               <div id="forgotpassword">
-                <form action="%VITE_API_BASE_URL%/forgot-password" data-steam-action="%VITE_API_BASE_URL%/forgot-password/direct/steam" method="POST">
+                <form action="%VITE_API_BASE_URL%/forgot-password" method="POST">
                   <label for="email-fp">Email Address</label>
                   <input type="text" id="email-fp" name="email" placeholder="you@gmail.com">
                   <div class="turnstile" data-sitekey="0x4AAAAAAA4kwOTMEdx48IMm"></div>


### PR DESCRIPTION
## Summary

Companion docs PR for [#199](https://github.com/MaddisonM79/unknown_game/pull/199) (the Electron + Steam + Discord RPC rip).

- **CLAUDE.md** — Replaces the "Steam" section (dynamic-import pattern guidance) with a short "Desktop / Steam (deferred)" note explaining the runtime is gone and will return via Tauri + Rust.
- **CONTRIBUTING.md** — Drops the "Steam/Electron gating" phrase from the CLAUDE.md cross-reference.
- **index.html** — Removes \`data-steam-action="..."\` attributes from the register / signin / forgot-password forms. Those were read by the Steam-mode \`renderCaptcha\` handler, which is deleted in #199.

## Order

Land **after** [#199](https://github.com/MaddisonM79/unknown_game/pull/199). The \`data-steam-action\` removal in \`index.html\` is coupled to that PR's deletion of the Steam captcha handler. Landing this first wouldn't actually break the live browser build (Steam mode was dormant on this fork), but conceptually they belong together.

## Test plan

- [ ] CI passes (no behavior change, pure markup/docs)
- [ ] Verify CLAUDE.md renders cleanly on GitHub
- [ ] After merging both PRs, do a quick auth-form smoke test (register/login/forgot-password should still submit to the right endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)