### PR TITLE
ux: explain why number keys can't be rebound to hotkeys (closes #108)

### DIFF
--- a/src/Hotkeys.ts
+++ b/src/Hotkeys.ts
@@ -161,7 +161,9 @@ const makeSlot = (key: string, descr: string) => {
     }
 
     if (!isNaN(Number(newKey))) {
-      void Alert('Number keys are currently unavailable!')
+      void Alert(
+        'Number keys (0-9) can\'t be rebound — they\'re reserved for in-tab actions (buying buildings, toggling challenges 1-10, spending offerings on runes, etc.).'
+      )
       return
     }
 


### PR DESCRIPTION
## Summary

One-line message improvement in [\`src/Hotkeys.ts\`](src/Hotkeys.ts).

The Alert when a user tries to rebind a hotkey to a number key just said:

> Number keys are currently unavailable!

…with no explanation. Verified the actual reason by reading [\`src/Synergism.ts:4864-4957\`](src/Synergism.ts:4864): number keys 0-9 are hardcoded to in-tab actions (buy buildings, toggle challenges 1-10, spend offerings/blessings/spirits on runes 1-7, buy crystal upgrades). The new message names that.

Before:
\`\`\`
Number keys are currently unavailable!
\`\`\`

After:
\`\`\`
Number keys (0-9) can't be rebound — they're reserved for in-tab actions
(buying buildings, toggling challenges 1-10, spending offerings on runes, etc.).
\`\`\`

## Why

[#108](https://github.com/MaddisonM79/unknown_game/issues/108) — "Hotkey rebinding rejects numeric keys with no explanation."

## Test plan

- [ ] CI passes
- [ ] Settings → Hotkeys → click a binding → enter "5" in the prompt → see the new message

🤖 Generated with [Claude Code](https://claude.com/claude-code)