### PR TITLE
ux: move building-tier borders + active buyAmount bg to CSS classes (closes #113, #114)

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -106,6 +106,18 @@ body {
     --scrollbar-bg-color: #111;
     --transition: 0;
     --transition-extra: 0.15s;
+
+    /* Building-tier color system (used by .coinBorder / .diamondBorder / etc.
+       below and by the matching text classes). --tesseract-color lives in
+       html[data-legacyicons] so it can vary by icon theme. */
+    --coin-color: yellow;
+    --diamond-color: cyan;
+    --mythos-color: plum;
+    --particle-color: greenyellow;
+
+    /* Selected state for buy-amount selectors (1 / 10 / 100 / ...).
+       See .buyAmountActive below. */
+    --buy-amount-active-bg: green;
 }
 
 body.loading {
@@ -156,6 +168,20 @@ html[data-legacyicons="true"] {
 .wowhypercubeText { color: var(--hypercube-color); }
 .wowplatonicText { color: var(--platonic-color); }
 .wowhepteractText { color: var(--hepteract-color); }
+
+/* Building-tier border utility classes. Swap these in instead of inline
+   style="border: 2px solid yellow;" — keeps the tier signal themeable. */
+.coinBorder { border: 2px solid var(--coin-color); }
+.diamondBorder { border: 2px solid var(--diamond-color); }
+.mythosBorder { border: 2px solid var(--mythos-color); }
+.particleBorder { border: 2px solid var(--particle-color); }
+.tesseractBorder { border: 2px solid var(--tesseract-color); }
+
+/* "This buy-amount is currently selected" — applied to .buyAmountBtn elements
+   by toggleBuyAmount() in Toggles.ts. Replaces the legacy inline
+   style="background-color: green" pattern. Compound selector beats the
+   .buyAmountBtn { background-color: var(--button-color) } rule defined later. */
+.buyAmountBtn.buyAmountActive { background-color: var(--buy-amount-active-bg); }
 
 .active-subtab {
     background-color: crimson;

--- a/index.html
+++ b/index.html
@@ -325,17 +325,17 @@
 
     <div id="buildings">
         <div class="subTabWrapper">
-            <button id="switchToCoinBuilding" class="active-subtab" style="border: 2px solid yellow;" i18n="tabs.buildings.coin"></button>
-            <button class="prestigeunlock" id="switchToDiamondBuilding" style="border: 2px solid cyan" i18n="tabs.buildings.diamond"></button>
-            <button class="transcendunlock" id="switchToMythosBuilding" style="border: 2px solid plum" i18n="tabs.buildings.mythos"></button>
-            <button class="reincarnationunlock" id="switchToParticleBuilding" style="border: 2px solid greenyellow" i18n="tabs.buildings.particle"></button>
-            <button class="ascendunlock" id="switchToTesseractBuilding" style="border: 2px solid orange" i18n="tabs.buildings.tesseract"></button>
+            <button id="switchToCoinBuilding" class="active-subtab coinBorder" i18n="tabs.buildings.coin"></button>
+            <button class="prestigeunlock diamondBorder" id="switchToDiamondBuilding" i18n="tabs.buildings.diamond"></button>
+            <button class="transcendunlock mythosBorder" id="switchToMythosBuilding" i18n="tabs.buildings.mythos"></button>
+            <button class="reincarnationunlock particleBorder" id="switchToParticleBuilding" i18n="tabs.buildings.particle"></button>
+            <button class="ascendunlock tesseractBorder" id="switchToTesseractBuilding" i18n="tabs.buildings.tesseract"></button>
         </div>
         <div id="coinBuildings">
             <div id="buyamountcoin">
                 <table class="coinunlock3" id="coinbuyamount" title="Toggle amount to buy">
                     <tr>
-                    <td><img id="coinone" alt="One Coin Building" class="buyAmountBtn" src="/Pictures/Default/CoinOne.png" style="background-color: green;" loading="lazy"></td>
+                    <td><img id="coinone" alt="One Coin Building" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/CoinOne.png" loading="lazy"></td>
                     <td><img id="cointen" alt="Ten Coin buildings" class="buyAmountBtn" src="/Pictures/Default/CoinTen.png" loading="lazy"></td>
                     <td><img id="coinhundred" alt="100 Coin Buildings" class="buyAmountBtn" src="/Pictures/Default/CoinHundred.png" loading="lazy"></td>
                     <td><img id="cointhousand" alt="1000 Coin Buildings" class="buyAmountBtn" src="/Pictures/Default/CoinThousand.png" loading="lazy"></td>
@@ -424,7 +424,7 @@
             <div id="buyamountcrystal">
                 <table id="crystalbuyamount" title="Toggle amount to buy">
                     <tr>
-                    <td><img id="crystalone" alt="One Crystal Building" class="buyAmountBtn" src="/Pictures/Default/CrystalOne.png" style="background-color: green;" loading="lazy"></td>
+                    <td><img id="crystalone" alt="One Crystal Building" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/CrystalOne.png" loading="lazy"></td>
                     <td><img id="crystalten" alt="Ten Crystal Buildings" class="buyAmountBtn" src="/Pictures/Default/CrystalTen.png" loading="lazy"></td>
                     <td><img id="crystalhundred" alt="100 Crystal Buildings" class="buyAmountBtn" src="/Pictures/Default/CrystalHundred.png" loading="lazy"></td>
                     <td><img id="crystalthousand" alt="1000 Crystal Buildings" class="buyAmountBtn" src="/Pictures/Default/CrystalThousand.png" loading="lazy"></td>
@@ -504,7 +504,7 @@
             <div id="buyamountmythos">
                 <table id="mythosbuyamount" title="Toggle amount to buy">
                     <tr>
-                    <td><img id="mythosone" alt="One Mythos Building" class="buyAmountBtn" src="/Pictures/Default/MythosOne.png" style="background-color: green;" loading="lazy"></td>
+                    <td><img id="mythosone" alt="One Mythos Building" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/MythosOne.png" loading="lazy"></td>
                     <td><img id="mythosten" alt="Ten Mythos Buildings" class="buyAmountBtn" src="/Pictures/Default/MythosTen.png" loading="lazy"></td>
                     <td><img id="mythoshundred" alt="100 Mythos Buildings" class="buyAmountBtn" src="/Pictures/Default/MythosHundred.png" loading="lazy"></td>
                     <td><img id="mythosthousand" alt="1000 Mythos Buildings" class="buyAmountBtn" src="/Pictures/Default/MythosThousand.png" loading="lazy"></td>
@@ -568,7 +568,7 @@
             <div id="buyamountparticle">
                 <table id="particlebuyamount" title="Toggle amount to buy">
                     <tr>
-                    <td><img id="particleone" alt="One Particle Building" class="buyAmountBtn" src="/Pictures/Default/ParticleOne.png" style="background-color: green;" loading="lazy"></td>
+                    <td><img id="particleone" alt="One Particle Building" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/ParticleOne.png" loading="lazy"></td>
                     <td><img id="particleten" alt="Ten Particle Buildings" class="buyAmountBtn" src="/Pictures/Default/ParticleTen.png" loading="lazy"></td>
                     <td><img id="particlehundred" alt="100 Particle Buildings" class="buyAmountBtn" src="/Pictures/Default/ParticleHundred.png" loading="lazy"></td>
                     <td><img id="particlethousand" alt="1000 Particle Buildings" class="buyAmountBtn" src="/Pictures/Default/ParticleThousand.png" loading="lazy"></td>
@@ -636,7 +636,7 @@
             <div id="buyAmountTesseract">
                 <table id="buyTesseractToggles" title="Toggle amount to buy">
                     <tr>
-                        <td><img id="tesseractone" alt="One Tesseract Building" class="buyAmountBtn" src="/Pictures/Default/TesseractOne.png" style="background-color: green;" loading="lazy"></td>
+                        <td><img id="tesseractone" alt="One Tesseract Building" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/TesseractOne.png" loading="lazy"></td>
                         <td><img id="tesseractten" alt="Ten Tesseract Buildings" class="buyAmountBtn" src="/Pictures/Default/TesseractTen.png" loading="lazy"></td>
                         <td><img id="tesseracthundred" alt="100 Tesseract Buildings" class="buyAmountBtn" src="/Pictures/Default/TesseractHundred.png" loading="lazy"></td>
                         <td><img id="tesseractthousand" alt="1000 Tesseract Buildings" class="buyAmountBtn" src="/Pictures/Default/TesseractThousand.png" loading="lazy"></td>
@@ -1106,7 +1106,7 @@
             <div id="buyamountoffering">
                 <table id="offeringbuyamount" title="Toggle the number of levels to buy per sacrifice" style="font-size: 0;">
                     <tr>
-                    <td><img id="offeringone" alt="One Rune Level" class="buyAmountBtn" src="/Pictures/Default/OfferingOne.png" style="background-color: green;" loading="lazy"></td>
+                    <td><img id="offeringone" alt="One Rune Level" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/OfferingOne.png" loading="lazy"></td>
                     <td><img id="offeringten" alt="Ten Rune Levels" class="buyAmountBtn" src="/Pictures/Default/OfferingTen.png" loading="lazy"></td>
                     <td><img id="offeringhundred" alt="100 Rune Levels" class="buyAmountBtn" src="/Pictures/Default/OfferingHundred.png" loading="lazy"></td>
                     <td><img id="offeringthousand" alt="1000 Rune Levels" class="buyAmountBtn" src="/Pictures/Default/OfferingThousand.png" loading="lazy"></td>
@@ -1238,7 +1238,7 @@
                     <div id="buyTalismanLevelAmount">
                         <table style="font-size: 0;" title="Toggle percent resources used">
                             <tr>
-                                <td><img id="talismanTen" alt="Ten Percent" class="buyAmountBtn" src="/Pictures/Default/TalismanTen.png" style="background-color: green;" loading="lazy"></td>
+                                <td><img id="talismanTen" alt="Ten Percent" class="buyAmountBtn buyAmountActive" src="/Pictures/Default/TalismanTen.png" loading="lazy"></td>
                                 <td><img id="talismanTwentyFive" alt="Twenty Five Percent" class="buyAmountBtn" src="/Pictures/Default/TalismanTwentyFive.png" loading="lazy"></td>
                                 <td><img id="talismanFifty" alt="Fifty Percent" class="buyAmountBtn" src="/Pictures/Default/TalismanFifty.png" loading="lazy"></td>
                                 <td><img id="talismanHundred" alt="Hundred Percent" class="buyAmountBtn" src="/Pictures/Default/TalismanHundred.png" loading="lazy"></td>

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -129,6 +129,7 @@ import {
   autoCubeUpgradesToggle,
   autoPlatonicUpgradesToggle,
   AutoResetModes,
+  buyAmountNames,
   setAutoAscendResetActiveText,
   setAutoAscendResetModeText,
   setAutoResetModeTexts,
@@ -1410,53 +1411,12 @@ const loadSynergy = () => {
       updatePlatonicUpgradeBG(j)
     }
 
-    for (let j = 0; j <= 5; j++) {
-      for (let k = 0; k < 6; k++) {
-        let d = ''
-        if (k === 0) {
-          d = 'one'
-        }
-        if (k === 1) {
-          d = 'ten'
-        }
-        if (k === 2) {
-          d = 'hundred'
-        }
-        if (k === 3) {
-          d = 'thousand'
-        }
-        if (k === 4) {
-          d = '10k'
-        }
-        if (k === 5) {
-          d = '100k'
-        }
-        const e = `${buyAmountTypes[j]}${d}`
-        DOMCacheGetOrSet(e).style.backgroundColor = ''
+    for (const type of buyAmountTypes) {
+      const curBuyAmount = player[`${type}buyamount` as const]
+      const selected = buyAmountNames[curBuyAmount.toString().length - 1]
+      for (const name of buyAmountNames) {
+        DOMCacheGetOrSet(`${type}${name}`).classList.toggle('buyAmountActive', name === selected)
       }
-      let c = ''
-      const curBuyAmount = player[`${buyAmountTypes[j]}buyamount` as const]
-      if (curBuyAmount === 1) {
-        c = 'one'
-      }
-      if (curBuyAmount === 10) {
-        c = 'ten'
-      }
-      if (curBuyAmount === 100) {
-        c = 'hundred'
-      }
-      if (curBuyAmount === 1000) {
-        c = 'thousand'
-      }
-      if (curBuyAmount === 10000) {
-        c = '10k'
-      }
-      if (curBuyAmount === 100000) {
-        c = '100k'
-      }
-
-      const b = `${buyAmountTypes[j]}${c}`
-      DOMCacheGetOrSet(b).style.backgroundColor = 'green'
     }
 
     player.roombaResearchIndex = 0

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -20,7 +20,7 @@ import { Globals as G } from './Variables'
 
 type ToggleBuy = 'coin' | 'crystal' | 'mythos' | 'particle' | 'offering' | 'tesseract'
 
-const buyAmountNames = ['one', 'ten', 'hundred', 'thousand', '10k', '100k']
+export const buyAmountNames = ['one', 'ten', 'hundred', 'thousand', '10k', '100k']
 
 export const toggleSettings = (toggle: HTMLElement) => {
   const toggleId = toggle.getAttribute('toggleId') ?? 1
@@ -121,26 +121,10 @@ export const toggleChallenges = (i: number, auto = false) => {
 
 export const toggleBuyAmount = (quantity: BuyAmount, type: ToggleBuy) => {
   player[`${type}buyamount` as const] = quantity
-  const a = buyAmountNames[quantity.toString().length - 1]
+  const selected = buyAmountNames[quantity.toString().length - 1]
 
-  DOMCacheGetOrSet(`${type}${a}`).style.backgroundColor = 'Green'
-  if (quantity !== 1) {
-    DOMCacheGetOrSet(`${type}one`).style.backgroundColor = ''
-  }
-  if (quantity !== 10) {
-    DOMCacheGetOrSet(`${type}ten`).style.backgroundColor = ''
-  }
-  if (quantity !== 100) {
-    DOMCacheGetOrSet(`${type}hundred`).style.backgroundColor = ''
-  }
-  if (quantity !== 1000) {
-    DOMCacheGetOrSet(`${type}thousand`).style.backgroundColor = ''
-  }
-  if (quantity !== 10000) {
-    DOMCacheGetOrSet(`${type}10k`).style.backgroundColor = ''
-  }
-  if (quantity !== 100000) {
-    DOMCacheGetOrSet(`${type}100k`).style.backgroundColor = ''
+  for (const name of buyAmountNames) {
+    DOMCacheGetOrSet(`${type}${name}`).classList.toggle('buyAmountActive', name === selected)
   }
 }
 


### PR DESCRIPTION
## Summary

Two related inline-style cleanups that close a pair of UX tickets and lay theme-able groundwork for the future [#96](https://github.com/MaddisonM79/unknown_game/issues/96) colorblind theme.

**Net:** 4 files, +48 / -78 lines (Synergism.ts shed a 47-line reload-init loop).

### What moves to CSS classes

**[#114](https://github.com/MaddisonM79/unknown_game/issues/114) — building-tier borders (5 sites, 1 class system):**

| Tier | Inline before | Class after | CSS var |
|---|---|---|---|
| Coin | \`style="border: 2px solid yellow;"\` | \`.coinBorder\` | \`--coin-color\` |
| Diamond | \`style="border: 2px solid cyan"\` | \`.diamondBorder\` | \`--diamond-color\` |
| Mythos | \`style="border: 2px solid plum"\` | \`.mythosBorder\` | \`--mythos-color\` |
| Particle | \`style="border: 2px solid greenyellow"\` | \`.particleBorder\` | \`--particle-color\` |
| Tesseract | \`style="border: 2px solid orange"\` | \`.tesseractBorder\` | \`--tesseract-color\` (already existed) |

**[#113](https://github.com/MaddisonM79/unknown_game/issues/113) 🐙 — active buyAmount selector (7 HTML sites + 2 JS toggle sites):**
- HTML: \`style="background-color: green;"\` on each default-selected button → \`class="buyAmountBtn buyAmountActive"\`
- JS: \`Toggles.ts\` \`toggleBuyAmount\` and \`Synergism.ts\` reload-init loop both swap from \`el.style.backgroundColor = 'green' / ''\` to \`el.classList.toggle('buyAmountActive', name === selected)\`.

The CSS rule for the selected state is \`.buyAmountBtn.buyAmountActive { background-color: var(--buy-amount-active-bg); }\` — compound selector needed because \`.buyAmountBtn { background-color: var(--button-color) }\` is defined later in the file.

### Verified in browser preview

- Buildings tab → "Coin Buildings" subtab shows yellow 2px border ✓
- Clicking "10" in the buyAmount row swaps Active class: \`coinone\` loses \`buyAmountActive\`, \`cointen\` gains it; computed \`background-color\` flips between \`rgb(23, 23, 23)\` (\`--button-color\`) and \`rgb(0, 128, 0)\` (\`--buy-amount-active-bg\`) accordingly ✓
- Initial-state highlight after a fresh reload correctly reflects each \`player[\${type}buyamount]\` value ✓

### Scope I deliberately did NOT touch

The audit findings call out specifically (a) the building-tier color **system** and (b) the buyAmount "selected" pattern. Other inline color uses look similar but are different semantics:

- \`UpdateHTML.ts:846-906\` Crystal-autobuy display ('green' = auto-buying, 'purple' = affordable, '' = neither) — different state machine.
- \`Talismans.ts\` talisman-rarity selection — adjacent but distinct.
- \`Statistics.ts\` stat highlights ('crimson', \`#2f2f2f\`).
- \`Themes.ts\` theme overrides — legitimate per-theme inline rules.
- \`UpdateVisuals.ts:1388\` hepteract bars (already uses var(--hepteract-bar-red)).
- Misc decorative borders on settings subtabs (darkorange, darkcyan, orangered, plum) — not part of the building-tier system.

Each of those is worth its own ticket if you want it.

## Test plan

- [ ] CI passes (tsc + oxlint clean locally)
- [ ] Buildings tab: 5 tier buttons show colored borders (yellow / cyan / plum / greenyellow / orange) once unlocked
- [ ] Click through buyAmount buttons (1 / 10 / 100 / 1K / 10K / 100K) for coin / crystal / mythos / particle / tesseract / offering / talisman — active one is green, click moves Active to clicked button, save/reload preserves state
- [ ] If you bump \`--coin-color\` etc. in DevTools, the rendered border colors should follow — confirming themability

Closes [#113](https://github.com/MaddisonM79/unknown_game/issues/113), [#114](https://github.com/MaddisonM79/unknown_game/issues/114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)