### PR TITLE
ux: rename i18n-aria-label → data-i18n-aria-label (closes #120)

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,51 +754,51 @@
                       <!-- Basic Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Basic Upgrades</th>
-                          <td><button id="upg1" class="upgrade-button" i18n-aria-label="upgrades.descriptions.1"><img src="/Pictures/Default/Coin1.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg2" class="upgrade-button" i18n-aria-label="upgrades.descriptions.2"><img src="/Pictures/Default/Coin2.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg3" class="upgrade-button" i18n-aria-label="upgrades.descriptions.3"><img src="/Pictures/Default/Coin3.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg4" class="upgrade-button" i18n-aria-label="upgrades.descriptions.4"><img src="/Pictures/Default/Coin4.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg5" class="upgrade-button" i18n-aria-label="upgrades.descriptions.5"><img src="/Pictures/Default/Coin5.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg1" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.1"><img src="/Pictures/Default/Coin1.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg2" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.2"><img src="/Pictures/Default/Coin2.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg3" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.3"><img src="/Pictures/Default/Coin3.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg4" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.4"><img src="/Pictures/Default/Coin4.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg5" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.5"><img src="/Pictures/Default/Coin5.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Prestige Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Prestige Upgrades</th>
-                          <td><button id="upg6" class="upgrade-button prestigeunlock" i18n-aria-label="upgrades.descriptions.6"><img src="/Pictures/Default/Coin6.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg7" class="upgrade-button prestigeunlock" i18n-aria-label="upgrades.descriptions.7"><img src="/Pictures/Default/Coin7.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg8" class="upgrade-button prestigeunlock" i18n-aria-label="upgrades.descriptions.8"><img src="/Pictures/Default/Coin8.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg11" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.11"><img src="/Pictures/Default/Coin11.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg9" class="upgrade-button prestigeunlock" i18n-aria-label="upgrades.descriptions.9"><img src="/Pictures/Default/Coin9.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg6" class="upgrade-button prestigeunlock" data-i18n-aria-label="upgrades.descriptions.6"><img src="/Pictures/Default/Coin6.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg7" class="upgrade-button prestigeunlock" data-i18n-aria-label="upgrades.descriptions.7"><img src="/Pictures/Default/Coin7.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg8" class="upgrade-button prestigeunlock" data-i18n-aria-label="upgrades.descriptions.8"><img src="/Pictures/Default/Coin8.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg11" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.11"><img src="/Pictures/Default/Coin11.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg9" class="upgrade-button prestigeunlock" data-i18n-aria-label="upgrades.descriptions.9"><img src="/Pictures/Default/Coin9.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Generation Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Generation Upgrades</th>
-                          <td><button id="upg12" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.12"><img src="/Pictures/Default/Coin12.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg10" class="upgrade-button prestigeunlock" i18n-aria-label="upgrades.descriptions.10"><img src="/Pictures/Default/Coin10.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg13" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.13"><img src="/Pictures/Default/Coin13.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg14" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.14"><img src="/Pictures/Default/Coin14.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg15" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.15"><img src="/Pictures/Default/Coin15.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg12" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.12"><img src="/Pictures/Default/Coin12.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg10" class="upgrade-button prestigeunlock" data-i18n-aria-label="upgrades.descriptions.10"><img src="/Pictures/Default/Coin10.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg13" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.13"><img src="/Pictures/Default/Coin13.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg14" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.14"><img src="/Pictures/Default/Coin14.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg15" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.15"><img src="/Pictures/Default/Coin15.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Transcend Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Transcend Upgrades</th>
-                          <td><button id="upg16" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.16"><img src="/Pictures/Default/Coin16.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg17" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.17"><img src="/Pictures/Default/Coin17.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg18" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.18"><img src="/Pictures/Default/Coin18.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg19" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.19"><img src="/Pictures/Default/Coin19.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg20" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.20"><img src="/Pictures/Default/Coin20.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg16" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.16"><img src="/Pictures/Default/Coin16.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg17" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.17"><img src="/Pictures/Default/Coin17.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg18" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.18"><img src="/Pictures/Default/Coin18.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg19" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.19"><img src="/Pictures/Default/Coin19.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg20" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.20"><img src="/Pictures/Default/Coin20.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Cube Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Cube Upgrades</th>
-                          <td><button id="upg121" class="upgrade-button cubeUpgrade19" i18n-aria-label="upgrades.descriptions.121"><img src="/Pictures/Default/Coin21.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg122" class="upgrade-button cubeUpgrade19" i18n-aria-label="upgrades.descriptions.122"><img src="/Pictures/Default/Coin22.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg123" class="upgrade-button cubeUpgrade19" i18n-aria-label="upgrades.descriptions.123"><img src="/Pictures/Default/Coin23.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg124" class="upgrade-button cubeUpgrade19" i18n-aria-label="upgrades.descriptions.124"><img src="/Pictures/Default/Coin24.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg125" class="upgrade-button cubeUpgrade19" i18n-aria-label="upgrades.descriptions.125"><img src="/Pictures/Default/Coin25.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg121" class="upgrade-button cubeUpgrade19" data-i18n-aria-label="upgrades.descriptions.121"><img src="/Pictures/Default/Coin21.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg122" class="upgrade-button cubeUpgrade19" data-i18n-aria-label="upgrades.descriptions.122"><img src="/Pictures/Default/Coin22.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg123" class="upgrade-button cubeUpgrade19" data-i18n-aria-label="upgrades.descriptions.123"><img src="/Pictures/Default/Coin23.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg124" class="upgrade-button cubeUpgrade19" data-i18n-aria-label="upgrades.descriptions.124"><img src="/Pictures/Default/Coin24.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg125" class="upgrade-button cubeUpgrade19" data-i18n-aria-label="upgrades.descriptions.125"><img src="/Pictures/Default/Coin25.png" alt="" loading="lazy"></button></td>
                       </tr>
                   </tbody>
               </table>
@@ -823,41 +823,41 @@
                       <!-- Basic Diamond Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Basic Diamond Upgrades</th>
-                          <td><button id="upg21" class="upgrade-button" i18n-aria-label="upgrades.descriptions.21"><img src="/Pictures/Default/Diamond1.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg22" class="upgrade-button" i18n-aria-label="upgrades.descriptions.22"><img src="/Pictures/Default/Diamond2.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg23" class="upgrade-button" i18n-aria-label="upgrades.descriptions.23"><img src="/Pictures/Default/Diamond3.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg24" class="upgrade-button" i18n-aria-label="upgrades.descriptions.24"><img src="/Pictures/Default/Diamond4.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg25" class="upgrade-button" i18n-aria-label="upgrades.descriptions.25"><img src="/Pictures/Default/Diamond5.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg21" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.21"><img src="/Pictures/Default/Diamond1.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg22" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.22"><img src="/Pictures/Default/Diamond2.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg23" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.23"><img src="/Pictures/Default/Diamond3.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg24" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.24"><img src="/Pictures/Default/Diamond4.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg25" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.25"><img src="/Pictures/Default/Diamond5.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Advanced Diamond Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Advanced Diamond Upgrades</th>
-                          <td><button id="upg26" class="upgrade-button" i18n-aria-label="upgrades.descriptions.26"><img src="/Pictures/Default/Diamond6.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg27" class="upgrade-button" i18n-aria-label="upgrades.descriptions.27"><img src="/Pictures/Default/Diamond7.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg28" class="upgrade-button" i18n-aria-label="upgrades.descriptions.28"><img src="/Pictures/Default/Diamond8.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg29" class="upgrade-button" i18n-aria-label="upgrades.descriptions.29"><img src="/Pictures/Default/Diamond9.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg30" class="upgrade-button" i18n-aria-label="upgrades.descriptions.30"><img src="/Pictures/Default/Diamond10.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg26" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.26"><img src="/Pictures/Default/Diamond6.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg27" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.27"><img src="/Pictures/Default/Diamond7.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg28" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.28"><img src="/Pictures/Default/Diamond8.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg29" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.29"><img src="/Pictures/Default/Diamond9.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg30" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.30"><img src="/Pictures/Default/Diamond10.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Transcend Diamond Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Transcend Diamond Upgrades</th>
-                          <td><button id="upg31" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.31"><img src="/Pictures/Default/Diamond11.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg32" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.32"><img src="/Pictures/Default/Diamond12.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg33" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.33"><img src="/Pictures/Default/Diamond13.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg34" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.34"><img src="/Pictures/Default/Diamond14.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg35" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.35"><img src="/Pictures/Default/Diamond15.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg31" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.31"><img src="/Pictures/Default/Diamond11.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg32" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.32"><img src="/Pictures/Default/Diamond12.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg33" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.33"><img src="/Pictures/Default/Diamond13.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg34" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.34"><img src="/Pictures/Default/Diamond14.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg35" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.35"><img src="/Pictures/Default/Diamond15.png" alt="" loading="lazy"></button></td>
                       </tr>
                       
                       <!-- Challenge Diamond Upgrades Row -->
                       <tr>
                           <th scope="row" class="sr-only">Challenge Diamond Upgrades</th>
-                          <td><button id="upg36" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.36"><img src="/Pictures/Default/Diamond16.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg37" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.37"><img src="/Pictures/Default/Diamond17.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg38" class="upgrade-button chal7" i18n-aria-label="upgrades.descriptions.38"><img src="/Pictures/Default/Diamond18.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg39" class="upgrade-button chal8" i18n-aria-label="upgrades.descriptions.39"><img src="/Pictures/Default/Diamond19.png" alt="" loading="lazy"></button></td>
-                          <td><button id="upg40" class="upgrade-button chal9" i18n-aria-label="upgrades.descriptions.40"><img src="/Pictures/Default/Diamond20.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg36" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.36"><img src="/Pictures/Default/Diamond16.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg37" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.37"><img src="/Pictures/Default/Diamond17.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg38" class="upgrade-button chal7" data-i18n-aria-label="upgrades.descriptions.38"><img src="/Pictures/Default/Diamond18.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg39" class="upgrade-button chal8" data-i18n-aria-label="upgrades.descriptions.39"><img src="/Pictures/Default/Diamond19.png" alt="" loading="lazy"></button></td>
+                          <td><button id="upg40" class="upgrade-button chal9" data-i18n-aria-label="upgrades.descriptions.40"><img src="/Pictures/Default/Diamond20.png" alt="" loading="lazy"></button></td>
                       </tr>
                   </tbody>
               </table>
@@ -876,34 +876,34 @@
                 </button>
                 <h3 class="transcendunlock" id="transcendtext" style="color: plum" i18n="upgrades.shopTitles.mythos"></h3>
               </header>
-              <table class="transcendunlock" id="transcendupgradestable" i18n-aria-label="upgrades.shopTitles.mythos">
+              <table class="transcendunlock" id="transcendupgradestable" data-i18n-aria-label="upgrades.shopTitles.mythos">
                   <tr>
-                      <td><button id="upg41" class="upgrade-button" i18n-aria-label="upgrades.descriptions.41"><img src="/Pictures/Default/Mythos1.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg42" class="upgrade-button" i18n-aria-label="upgrades.descriptions.42"><img src="/Pictures/Default/Mythos2.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg43" class="upgrade-button" i18n-aria-label="upgrades.descriptions.43"><img src="/Pictures/Default/Mythos3.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg44" class="upgrade-button" i18n-aria-label="upgrades.descriptions.44"><img src="/Pictures/Default/Mythos4.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg45" class="upgrade-button" i18n-aria-label="upgrades.descriptions.45"><img src="/Pictures/Default/Mythos5.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg41" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.41"><img src="/Pictures/Default/Mythos1.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg42" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.42"><img src="/Pictures/Default/Mythos2.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg43" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.43"><img src="/Pictures/Default/Mythos3.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg44" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.44"><img src="/Pictures/Default/Mythos4.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg45" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.45"><img src="/Pictures/Default/Mythos5.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg46" class="upgrade-button" i18n-aria-label="upgrades.descriptions.46"><img src="/Pictures/Default/Mythos6.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg47" class="upgrade-button" i18n-aria-label="upgrades.descriptions.47"><img src="/Pictures/Default/Mythos7.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg48" class="upgrade-button" i18n-aria-label="upgrades.descriptions.48"><img src="/Pictures/Default/Mythos8.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg49" class="upgrade-button" i18n-aria-label="upgrades.descriptions.49"><img src="/Pictures/Default/Mythos9.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg50" class="upgrade-button" i18n-aria-label="upgrades.descriptions.50"><img src="/Pictures/Default/Mythos10.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg46" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.46"><img src="/Pictures/Default/Mythos6.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg47" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.47"><img src="/Pictures/Default/Mythos7.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg48" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.48"><img src="/Pictures/Default/Mythos8.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg49" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.49"><img src="/Pictures/Default/Mythos9.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg50" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.50"><img src="/Pictures/Default/Mythos10.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg51" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.51"><img src="/Pictures/Default/Mythos11.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg52" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.52"><img src="/Pictures/Default/Mythos12.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg53" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.53"><img src="/Pictures/Default/Mythos13.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg54" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.54"><img src="/Pictures/Default/Mythos14.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg55" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.55"><img src="/Pictures/Default/Mythos15.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg51" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.51"><img src="/Pictures/Default/Mythos11.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg52" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.52"><img src="/Pictures/Default/Mythos12.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg53" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.53"><img src="/Pictures/Default/Mythos13.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg54" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.54"><img src="/Pictures/Default/Mythos14.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg55" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.55"><img src="/Pictures/Default/Mythos15.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg56" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.56"><img src="/Pictures/Default/Mythos16.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg57" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.57"><img src="/Pictures/Default/Mythos17.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg58" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.58"><img src="/Pictures/Default/Mythos18.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg59" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.59"><img src="/Pictures/Default/Mythos19.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg60" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.60"><img src="/Pictures/Default/Mythos20.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg56" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.56"><img src="/Pictures/Default/Mythos16.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg57" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.57"><img src="/Pictures/Default/Mythos17.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg58" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.58"><img src="/Pictures/Default/Mythos18.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg59" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.59"><img src="/Pictures/Default/Mythos19.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg60" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.60"><img src="/Pictures/Default/Mythos20.png" alt="" loading="lazy"></button></td>
                   </tr>
               </table>
               <button class="autobuyerToggleButton" id="transcendAutoUpgrade" aria-pressed="true" style="border:2px solid green">Auto: ON</button>
@@ -917,32 +917,32 @@
               </header>
               <table class="prestigeunlock" id="generatortable" aria-label="Generator Upgrades">
                   <tr>
-                      <td><button id="upg101" class="upgrade-button" i18n-aria-label="upgrades.descriptions.101"><img src="/Pictures/Default/Generator1.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg102" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.102"><img src="/Pictures/Default/Generator2.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg103" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.103"><img src="/Pictures/Default/Generator3.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg104" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.104"><img src="/Pictures/Default/Generator4.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg105" class="upgrade-button generationunlock" i18n-aria-label="upgrades.descriptions.105"><img src="/Pictures/Default/Generator5.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg101" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.101"><img src="/Pictures/Default/Generator1.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg102" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.102"><img src="/Pictures/Default/Generator2.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg103" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.103"><img src="/Pictures/Default/Generator3.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg104" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.104"><img src="/Pictures/Default/Generator4.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg105" class="upgrade-button generationunlock" data-i18n-aria-label="upgrades.descriptions.105"><img src="/Pictures/Default/Generator5.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg106" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.106"><img src="/Pictures/Default/Generator6.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg107" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.107"><img src="/Pictures/Default/Generator7.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg108" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.108"><img src="/Pictures/Default/Generator8.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg109" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.109"><img src="/Pictures/Default/Generator9.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg110" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.110"><img src="/Pictures/Default/Generator10.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg106" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.106"><img src="/Pictures/Default/Generator6.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg107" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.107"><img src="/Pictures/Default/Generator7.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg108" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.108"><img src="/Pictures/Default/Generator8.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg109" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.109"><img src="/Pictures/Default/Generator9.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg110" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.110"><img src="/Pictures/Default/Generator10.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg111" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.111"><img src="/Pictures/Default/Generator11.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg112" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.112"><img src="/Pictures/Default/Generator12.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg113" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.113"><img src="/Pictures/Default/Generator13.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg114" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.114"><img src="/Pictures/Default/Generator14.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg115" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.115"><img src="/Pictures/Default/Generator15.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg111" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.111"><img src="/Pictures/Default/Generator11.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg112" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.112"><img src="/Pictures/Default/Generator12.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg113" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.113"><img src="/Pictures/Default/Generator13.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg114" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.114"><img src="/Pictures/Default/Generator14.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg115" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.115"><img src="/Pictures/Default/Generator15.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg116" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.116"><img src="/Pictures/Default/Generator16.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg117" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.117"><img src="/Pictures/Default/Generator17.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg118" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.118"><img src="/Pictures/Default/Generator18.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg119" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.119"><img src="/Pictures/Default/Generator19.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg120" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.120"><img src="/Pictures/Default/Generator20.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg116" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.116"><img src="/Pictures/Default/Generator16.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg117" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.117"><img src="/Pictures/Default/Generator17.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg118" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.118"><img src="/Pictures/Default/Generator18.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg119" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.119"><img src="/Pictures/Default/Generator19.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg120" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.120"><img src="/Pictures/Default/Generator20.png" alt="" loading="lazy"></button></td>
                   </tr>
               </table>
               <button class="autobuyerToggleButton" id="generatorsAutoUpgrade" aria-pressed="true" style="border:2px solid green"></button>
@@ -956,73 +956,73 @@
               <h3 class="prestigeunlock crimsonText" id="automationtext" i18n="upgrades.shopTitles.automation"></h3>
               <table class="prestigeunlock" id="automationtable" aria-label="Automation Upgrades">
                   <tr>
-                      <td><button id="upg81" class="upgrade-button" i18n-aria-label="upgrades.descriptions.81"><img src="/Pictures/Default/Automation1.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg82" class="upgrade-button" i18n-aria-label="upgrades.descriptions.82"><img src="/Pictures/Default/Automation2.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg83" class="upgrade-button" i18n-aria-label="upgrades.descriptions.83"><img src="/Pictures/Default/Automation3.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg84" class="upgrade-button" i18n-aria-label="upgrades.descriptions.84"><img src="/Pictures/Default/Automation4.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg85" class="upgrade-button" i18n-aria-label="upgrades.descriptions.85"><img src="/Pictures/Default/Automation5.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg81" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.81"><img src="/Pictures/Default/Automation1.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg82" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.82"><img src="/Pictures/Default/Automation2.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg83" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.83"><img src="/Pictures/Default/Automation3.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg84" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.84"><img src="/Pictures/Default/Automation4.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg85" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.85"><img src="/Pictures/Default/Automation5.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg86" class="upgrade-button" i18n-aria-label="upgrades.descriptions.86"><img src="/Pictures/Default/Automation6.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg87" class="upgrade-button" i18n-aria-label="upgrades.descriptions.87"><img src="/Pictures/Default/Automation7.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg88" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.88"><img src="/Pictures/Default/Automation8.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg89" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.89"><img src="/Pictures/Default/Automation9.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg90" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.90"><img src="/Pictures/Default/Automation10.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg86" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.86"><img src="/Pictures/Default/Automation6.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg87" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.87"><img src="/Pictures/Default/Automation7.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg88" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.88"><img src="/Pictures/Default/Automation8.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg89" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.89"><img src="/Pictures/Default/Automation9.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg90" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.90"><img src="/Pictures/Default/Automation10.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg91" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.91"><img src="/Pictures/Default/Automation11.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg92" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.92"><img src="/Pictures/Default/Automation12.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg93" class="upgrade-button transcendunlock" i18n-aria-label="upgrades.descriptions.93"><img src="/Pictures/Default/Automation13.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg94" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.94"><img src="/Pictures/Default/Automation14.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg95" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.95"><img src="/Pictures/Default/Automation15.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg91" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.91"><img src="/Pictures/Default/Automation11.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg92" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.92"><img src="/Pictures/Default/Automation12.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg93" class="upgrade-button transcendunlock" data-i18n-aria-label="upgrades.descriptions.93"><img src="/Pictures/Default/Automation13.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg94" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.94"><img src="/Pictures/Default/Automation14.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg95" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.95"><img src="/Pictures/Default/Automation15.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg96" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.96"><img src="/Pictures/Default/Automation16.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg97" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.97"><img src="/Pictures/Default/Automation17.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg98" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.98"><img src="/Pictures/Default/Automation18.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg99" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.99"><img src="/Pictures/Default/Automation19.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg100" class="upgrade-button reincarnationunlock" i18n-aria-label="upgrades.descriptions.100"><img src="/Pictures/Default/Automation20.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg96" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.96"><img src="/Pictures/Default/Automation16.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg97" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.97"><img src="/Pictures/Default/Automation17.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg98" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.98"><img src="/Pictures/Default/Automation18.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg99" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.99"><img src="/Pictures/Default/Automation19.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg100" class="upgrade-button reincarnationunlock" data-i18n-aria-label="upgrades.descriptions.100"><img src="/Pictures/Default/Automation20.png" alt="" loading="lazy"></button></td>
                   </tr>
               </table>
             </section>
             <section class="shop-section reincarnationunlock" aria-labelledby="reincarnationtext">
               <header>
-                <button class="currency-icon particleUpgradeResearch" i18n-aria-label="upgrades.descriptions.currency">
+                <button class="currency-icon particleUpgradeResearch" data-i18n-aria-label="upgrades.descriptions.currency">
                     <img id="upgrades6" src="/Pictures/Default/Particle.png" alt="" loading="lazy">
                 </button>
                 <h3 class="particleUpgradeResearch" id="reincarnationtext" style="color: limegreen" i18n="upgrades.shopTitles.particles"></h3>
               </header>
-              <table class="reincarnationunlock" id="reincarnationupgradestable" i18n-aria-label="upgrades.shopTitles.particles">
+              <table class="reincarnationunlock" id="reincarnationupgradestable" data-i18n-aria-label="upgrades.shopTitles.particles">
                   <tr>
-                      <td><button id="upg61" class="upgrade-button reinrow1" i18n-aria-label="upgrades.descriptions.61"><img src="/Pictures/Default/Particle1.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg62" class="upgrade-button reinrow1" i18n-aria-label="upgrades.descriptions.62"><img src="/Pictures/Default/Particle2.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg63" class="upgrade-button reinrow1" i18n-aria-label="upgrades.descriptions.63"><img src="/Pictures/Default/Particle3.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg64" class="upgrade-button reinrow1" i18n-aria-label="upgrades.descriptions.64"><img src="/Pictures/Default/Particle4.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg65" class="upgrade-button reinrow1" i18n-aria-label="upgrades.descriptions.65"><img src="/Pictures/Default/Particle5.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg61" class="upgrade-button reinrow1" data-i18n-aria-label="upgrades.descriptions.61"><img src="/Pictures/Default/Particle1.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg62" class="upgrade-button reinrow1" data-i18n-aria-label="upgrades.descriptions.62"><img src="/Pictures/Default/Particle2.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg63" class="upgrade-button reinrow1" data-i18n-aria-label="upgrades.descriptions.63"><img src="/Pictures/Default/Particle3.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg64" class="upgrade-button reinrow1" data-i18n-aria-label="upgrades.descriptions.64"><img src="/Pictures/Default/Particle4.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg65" class="upgrade-button reinrow1" data-i18n-aria-label="upgrades.descriptions.65"><img src="/Pictures/Default/Particle5.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg66" class="upgrade-button reinrow2" i18n-aria-label="upgrades.descriptions.66"><img src="/Pictures/Default/Particle6.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg67" class="upgrade-button reinrow2" i18n-aria-label="upgrades.descriptions.67"><img src="/Pictures/Default/Particle7.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg68" class="upgrade-button reinrow2" i18n-aria-label="upgrades.descriptions.68"><img src="/Pictures/Default/Particle8.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg69" class="upgrade-button reinrow2" i18n-aria-label="upgrades.descriptions.69"><img src="/Pictures/Default/Particle9.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg70" class="upgrade-button reinrow2" i18n-aria-label="upgrades.descriptions.70"><img src="/Pictures/Default/Particle10.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg66" class="upgrade-button reinrow2" data-i18n-aria-label="upgrades.descriptions.66"><img src="/Pictures/Default/Particle6.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg67" class="upgrade-button reinrow2" data-i18n-aria-label="upgrades.descriptions.67"><img src="/Pictures/Default/Particle7.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg68" class="upgrade-button reinrow2" data-i18n-aria-label="upgrades.descriptions.68"><img src="/Pictures/Default/Particle8.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg69" class="upgrade-button reinrow2" data-i18n-aria-label="upgrades.descriptions.69"><img src="/Pictures/Default/Particle9.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg70" class="upgrade-button reinrow2" data-i18n-aria-label="upgrades.descriptions.70"><img src="/Pictures/Default/Particle10.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg71" class="upgrade-button reinrow3" i18n-aria-label="upgrades.descriptions.71"><img src="/Pictures/Default/Particle11.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg72" class="upgrade-button reinrow3" i18n-aria-label="upgrades.descriptions.72"><img src="/Pictures/Default/Particle12.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg73" class="upgrade-button reinrow3" i18n-aria-label="upgrades.descriptions.73"><img src="/Pictures/Default/Particle13.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg74" class="upgrade-button reinrow3" i18n-aria-label="upgrades.descriptions.74"><img src="/Pictures/Default/Particle14.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg75" class="upgrade-button reinrow3" i18n-aria-label="upgrades.descriptions.75"><img src="/Pictures/Default/Particle15.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg71" class="upgrade-button reinrow3" data-i18n-aria-label="upgrades.descriptions.71"><img src="/Pictures/Default/Particle11.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg72" class="upgrade-button reinrow3" data-i18n-aria-label="upgrades.descriptions.72"><img src="/Pictures/Default/Particle12.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg73" class="upgrade-button reinrow3" data-i18n-aria-label="upgrades.descriptions.73"><img src="/Pictures/Default/Particle13.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg74" class="upgrade-button reinrow3" data-i18n-aria-label="upgrades.descriptions.74"><img src="/Pictures/Default/Particle14.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg75" class="upgrade-button reinrow3" data-i18n-aria-label="upgrades.descriptions.75"><img src="/Pictures/Default/Particle15.png" alt="" loading="lazy"></button></td>
                   </tr>
                   <tr>
-                      <td><button id="upg76" class="upgrade-button reinrow4" i18n-aria-label="upgrades.descriptions.76"><img src="/Pictures/Default/Particle16.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg77" class="upgrade-button reinrow4" i18n-aria-label="upgrades.descriptions.77"><img src="/Pictures/Default/Particle17.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg78" class="upgrade-button reinrow4" i18n-aria-label="upgrades.descriptions.78"><img src="/Pictures/Default/Particle18.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg79" class="upgrade-button reinrow4" i18n-aria-label="upgrades.descriptions.79"><img src="/Pictures/Default/Particle19.png" alt="" loading="lazy"></button></td>
-                      <td><button id="upg80" class="upgrade-button reinrow4" i18n-aria-label="upgrades.descriptions.80"><img src="/Pictures/Default/Particle20.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg76" class="upgrade-button reinrow4" data-i18n-aria-label="upgrades.descriptions.76"><img src="/Pictures/Default/Particle16.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg77" class="upgrade-button reinrow4" data-i18n-aria-label="upgrades.descriptions.77"><img src="/Pictures/Default/Particle17.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg78" class="upgrade-button reinrow4" data-i18n-aria-label="upgrades.descriptions.78"><img src="/Pictures/Default/Particle18.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg79" class="upgrade-button reinrow4" data-i18n-aria-label="upgrades.descriptions.79"><img src="/Pictures/Default/Particle19.png" alt="" loading="lazy"></button></td>
+                      <td><button id="upg80" class="upgrade-button reinrow4" data-i18n-aria-label="upgrades.descriptions.80"><img src="/Pictures/Default/Particle20.png" alt="" loading="lazy"></button></td>
                   </tr>
               </table>
-              <button class="autobuyerToggleButton particleUpgradeResearch" id="reincarnateAutoUpgrade" i18n-aria-label="upgrades.descriptions.autobuyer" aria-pressed="true" style="border: 2px solid green"></button>
+              <button class="autobuyerToggleButton particleUpgradeResearch" id="reincarnateAutoUpgrade" data-i18n-aria-label="upgrades.descriptions.autobuyer" aria-pressed="true" style="border: 2px solid green"></button>
             </section>
         </div>
 
@@ -1455,220 +1455,220 @@
             <div class="scrollbarX">
                 <table id="researchtable">
                     <tr>
-                        <td><button id="res1" i18n-aria-label="researches.descriptions.1"><img src="/Pictures/Default/Research1.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res2" i18n-aria-label="researches.descriptions.2"><img src="/Pictures/Default/Research2.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res3" i18n-aria-label="researches.descriptions.3"><img src="/Pictures/Default/Research3.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res4" i18n-aria-label="researches.descriptions.4"><img src="/Pictures/Default/Research4.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res5" i18n-aria-label="researches.descriptions.5"><img src="/Pictures/Default/Research5.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res6" i18n-aria-label="researches.descriptions.6"><img src="/Pictures/Default/Research6.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res7" i18n-aria-label="researches.descriptions.7"><img src="/Pictures/Default/Research7.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res8" i18n-aria-label="researches.descriptions.8"><img src="/Pictures/Default/Research8.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res9" i18n-aria-label="researches.descriptions.9"><img src="/Pictures/Default/Research9.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res10" i18n-aria-label="researches.descriptions.10"><img src="/Pictures/Default/Research10.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res11" i18n-aria-label="researches.descriptions.11"><img src="/Pictures/Default/Research11.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res12" i18n-aria-label="researches.descriptions.12"><img src="/Pictures/Default/Research12.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res13" i18n-aria-label="researches.descriptions.13"><img src="/Pictures/Default/Research13.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res14" i18n-aria-label="researches.descriptions.14"><img src="/Pictures/Default/Research14.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res15" i18n-aria-label="researches.descriptions.15"><img src="/Pictures/Default/Research15.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res16" i18n-aria-label="researches.descriptions.16"><img src="/Pictures/Default/Research16.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res17" i18n-aria-label="researches.descriptions.17"><img src="/Pictures/Default/Research17.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res18" i18n-aria-label="researches.descriptions.18"><img src="/Pictures/Default/Research18.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res19" i18n-aria-label="researches.descriptions.19"><img src="/Pictures/Default/Research19.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res20" i18n-aria-label="researches.descriptions.20"><img src="/Pictures/Default/Research20.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res21" i18n-aria-label="researches.descriptions.21"><img src="/Pictures/Default/Research21.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res22" i18n-aria-label="researches.descriptions.22"><img src="/Pictures/Default/Research22.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res23" i18n-aria-label="researches.descriptions.23"><img src="/Pictures/Default/Research23.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res24" i18n-aria-label="researches.descriptions.24"><img src="/Pictures/Default/Research24.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res25" i18n-aria-label="researches.descriptions.25"><img src="/Pictures/Default/Research25.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res1" data-i18n-aria-label="researches.descriptions.1"><img src="/Pictures/Default/Research1.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res2" data-i18n-aria-label="researches.descriptions.2"><img src="/Pictures/Default/Research2.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res3" data-i18n-aria-label="researches.descriptions.3"><img src="/Pictures/Default/Research3.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res4" data-i18n-aria-label="researches.descriptions.4"><img src="/Pictures/Default/Research4.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res5" data-i18n-aria-label="researches.descriptions.5"><img src="/Pictures/Default/Research5.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res6" data-i18n-aria-label="researches.descriptions.6"><img src="/Pictures/Default/Research6.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res7" data-i18n-aria-label="researches.descriptions.7"><img src="/Pictures/Default/Research7.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res8" data-i18n-aria-label="researches.descriptions.8"><img src="/Pictures/Default/Research8.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res9" data-i18n-aria-label="researches.descriptions.9"><img src="/Pictures/Default/Research9.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res10" data-i18n-aria-label="researches.descriptions.10"><img src="/Pictures/Default/Research10.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res11" data-i18n-aria-label="researches.descriptions.11"><img src="/Pictures/Default/Research11.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res12" data-i18n-aria-label="researches.descriptions.12"><img src="/Pictures/Default/Research12.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res13" data-i18n-aria-label="researches.descriptions.13"><img src="/Pictures/Default/Research13.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res14" data-i18n-aria-label="researches.descriptions.14"><img src="/Pictures/Default/Research14.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res15" data-i18n-aria-label="researches.descriptions.15"><img src="/Pictures/Default/Research15.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res16" data-i18n-aria-label="researches.descriptions.16"><img src="/Pictures/Default/Research16.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res17" data-i18n-aria-label="researches.descriptions.17"><img src="/Pictures/Default/Research17.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res18" data-i18n-aria-label="researches.descriptions.18"><img src="/Pictures/Default/Research18.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res19" data-i18n-aria-label="researches.descriptions.19"><img src="/Pictures/Default/Research19.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res20" data-i18n-aria-label="researches.descriptions.20"><img src="/Pictures/Default/Research20.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res21" data-i18n-aria-label="researches.descriptions.21"><img src="/Pictures/Default/Research21.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res22" data-i18n-aria-label="researches.descriptions.22"><img src="/Pictures/Default/Research22.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res23" data-i18n-aria-label="researches.descriptions.23"><img src="/Pictures/Default/Research23.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res24" data-i18n-aria-label="researches.descriptions.24"><img src="/Pictures/Default/Research24.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res25" data-i18n-aria-label="researches.descriptions.25"><img src="/Pictures/Default/Research25.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res26" i18n-aria-label="researches.descriptions.26"><img src="/Pictures/Default/Research26.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res27" i18n-aria-label="researches.descriptions.27"><img src="/Pictures/Default/Research27.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res28" i18n-aria-label="researches.descriptions.28"><img src="/Pictures/Default/Research28.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res29" i18n-aria-label="researches.descriptions.29"><img src="/Pictures/Default/Research29.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res30" i18n-aria-label="researches.descriptions.30"><img src="/Pictures/Default/Research30.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res31" i18n-aria-label="researches.descriptions.31"><img src="/Pictures/Default/Research31.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res32" i18n-aria-label="researches.descriptions.32"><img src="/Pictures/Default/Research32.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res33" i18n-aria-label="researches.descriptions.33"><img src="/Pictures/Default/Research33.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res34" i18n-aria-label="researches.descriptions.34"><img src="/Pictures/Default/Research34.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res35" i18n-aria-label="researches.descriptions.35"><img src="/Pictures/Default/Research35.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res36" i18n-aria-label="researches.descriptions.36"><img src="/Pictures/Default/Research36.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res37" i18n-aria-label="researches.descriptions.37"><img src="/Pictures/Default/Research37.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res38" i18n-aria-label="researches.descriptions.38"><img src="/Pictures/Default/Research38.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res39" i18n-aria-label="researches.descriptions.39"><img src="/Pictures/Default/Research39.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res40" i18n-aria-label="researches.descriptions.40"><img src="/Pictures/Default/Research40.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res41" i18n-aria-label="researches.descriptions.41"><img src="/Pictures/Default/Research41.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res42" i18n-aria-label="researches.descriptions.42"><img src="/Pictures/Default/Research42.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res43" i18n-aria-label="researches.descriptions.43"><img src="/Pictures/Default/Research43.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res44" i18n-aria-label="researches.descriptions.44"><img src="/Pictures/Default/Research44.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res45" i18n-aria-label="researches.descriptions.45"><img src="/Pictures/Default/Research45.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res46" i18n-aria-label="researches.descriptions.46"><img src="/Pictures/Default/Research46.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res47" i18n-aria-label="researches.descriptions.47"><img src="/Pictures/Default/Research47.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res48" i18n-aria-label="researches.descriptions.48"><img src="/Pictures/Default/Research48.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res49" i18n-aria-label="researches.descriptions.49"><img src="/Pictures/Default/Research49.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res50" i18n-aria-label="researches.descriptions.50"><img src="/Pictures/Default/Research50.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res26" data-i18n-aria-label="researches.descriptions.26"><img src="/Pictures/Default/Research26.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res27" data-i18n-aria-label="researches.descriptions.27"><img src="/Pictures/Default/Research27.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res28" data-i18n-aria-label="researches.descriptions.28"><img src="/Pictures/Default/Research28.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res29" data-i18n-aria-label="researches.descriptions.29"><img src="/Pictures/Default/Research29.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res30" data-i18n-aria-label="researches.descriptions.30"><img src="/Pictures/Default/Research30.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res31" data-i18n-aria-label="researches.descriptions.31"><img src="/Pictures/Default/Research31.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res32" data-i18n-aria-label="researches.descriptions.32"><img src="/Pictures/Default/Research32.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res33" data-i18n-aria-label="researches.descriptions.33"><img src="/Pictures/Default/Research33.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res34" data-i18n-aria-label="researches.descriptions.34"><img src="/Pictures/Default/Research34.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res35" data-i18n-aria-label="researches.descriptions.35"><img src="/Pictures/Default/Research35.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res36" data-i18n-aria-label="researches.descriptions.36"><img src="/Pictures/Default/Research36.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res37" data-i18n-aria-label="researches.descriptions.37"><img src="/Pictures/Default/Research37.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res38" data-i18n-aria-label="researches.descriptions.38"><img src="/Pictures/Default/Research38.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res39" data-i18n-aria-label="researches.descriptions.39"><img src="/Pictures/Default/Research39.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res40" data-i18n-aria-label="researches.descriptions.40"><img src="/Pictures/Default/Research40.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res41" data-i18n-aria-label="researches.descriptions.41"><img src="/Pictures/Default/Research41.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res42" data-i18n-aria-label="researches.descriptions.42"><img src="/Pictures/Default/Research42.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res43" data-i18n-aria-label="researches.descriptions.43"><img src="/Pictures/Default/Research43.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res44" data-i18n-aria-label="researches.descriptions.44"><img src="/Pictures/Default/Research44.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res45" data-i18n-aria-label="researches.descriptions.45"><img src="/Pictures/Default/Research45.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res46" data-i18n-aria-label="researches.descriptions.46"><img src="/Pictures/Default/Research46.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res47" data-i18n-aria-label="researches.descriptions.47"><img src="/Pictures/Default/Research47.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res48" data-i18n-aria-label="researches.descriptions.48"><img src="/Pictures/Default/Research48.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res49" data-i18n-aria-label="researches.descriptions.49"><img src="/Pictures/Default/Research49.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res50" data-i18n-aria-label="researches.descriptions.50"><img src="/Pictures/Default/Research50.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res51" i18n-aria-label="researches.descriptions.51"><img src="/Pictures/Default/Research51.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res52" i18n-aria-label="researches.descriptions.52"><img src="/Pictures/Default/Research52.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res53" i18n-aria-label="researches.descriptions.53"><img src="/Pictures/Default/Research53.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res54" i18n-aria-label="researches.descriptions.54"><img src="/Pictures/Default/Research54.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res55" i18n-aria-label="researches.descriptions.55"><img src="/Pictures/Default/Research55.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res56" i18n-aria-label="researches.descriptions.56"><img src="/Pictures/Default/Research56.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res57" i18n-aria-label="researches.descriptions.57"><img src="/Pictures/Default/Research57.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res58" i18n-aria-label="researches.descriptions.58"><img src="/Pictures/Default/Research58.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res59" i18n-aria-label="researches.descriptions.59"><img src="/Pictures/Default/Research59.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res60" i18n-aria-label="researches.descriptions.60"><img src="/Pictures/Default/Research60.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res61" i18n-aria-label="researches.descriptions.61"><img src="/Pictures/Default/Research61.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res62" i18n-aria-label="researches.descriptions.62"><img src="/Pictures/Default/Research62.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res63" i18n-aria-label="researches.descriptions.63"><img src="/Pictures/Default/Research63.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res64" i18n-aria-label="researches.descriptions.64"><img src="/Pictures/Default/Research64.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res65" i18n-aria-label="researches.descriptions.65"><img src="/Pictures/Default/Research65.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res66" i18n-aria-label="researches.descriptions.66"><img src="/Pictures/Default/Research66.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res67" i18n-aria-label="researches.descriptions.67"><img src="/Pictures/Default/Research67.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res68" i18n-aria-label="researches.descriptions.68"><img src="/Pictures/Default/Research68.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res69" i18n-aria-label="researches.descriptions.69"><img src="/Pictures/Default/Research69.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res70" i18n-aria-label="researches.descriptions.70"><img src="/Pictures/Default/Research70.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res71" i18n-aria-label="researches.descriptions.71"><img src="/Pictures/Default/Research71.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res72" i18n-aria-label="researches.descriptions.72"><img src="/Pictures/Default/Research72.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res73" i18n-aria-label="researches.descriptions.73"><img src="/Pictures/Default/Research73.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res74" i18n-aria-label="researches.descriptions.74"><img src="/Pictures/Default/Research74.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res75" i18n-aria-label="researches.descriptions.75"><img src="/Pictures/Default/Research75.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res51" data-i18n-aria-label="researches.descriptions.51"><img src="/Pictures/Default/Research51.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res52" data-i18n-aria-label="researches.descriptions.52"><img src="/Pictures/Default/Research52.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res53" data-i18n-aria-label="researches.descriptions.53"><img src="/Pictures/Default/Research53.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res54" data-i18n-aria-label="researches.descriptions.54"><img src="/Pictures/Default/Research54.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res55" data-i18n-aria-label="researches.descriptions.55"><img src="/Pictures/Default/Research55.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res56" data-i18n-aria-label="researches.descriptions.56"><img src="/Pictures/Default/Research56.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res57" data-i18n-aria-label="researches.descriptions.57"><img src="/Pictures/Default/Research57.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res58" data-i18n-aria-label="researches.descriptions.58"><img src="/Pictures/Default/Research58.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res59" data-i18n-aria-label="researches.descriptions.59"><img src="/Pictures/Default/Research59.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res60" data-i18n-aria-label="researches.descriptions.60"><img src="/Pictures/Default/Research60.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res61" data-i18n-aria-label="researches.descriptions.61"><img src="/Pictures/Default/Research61.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res62" data-i18n-aria-label="researches.descriptions.62"><img src="/Pictures/Default/Research62.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res63" data-i18n-aria-label="researches.descriptions.63"><img src="/Pictures/Default/Research63.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res64" data-i18n-aria-label="researches.descriptions.64"><img src="/Pictures/Default/Research64.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res65" data-i18n-aria-label="researches.descriptions.65"><img src="/Pictures/Default/Research65.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res66" data-i18n-aria-label="researches.descriptions.66"><img src="/Pictures/Default/Research66.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res67" data-i18n-aria-label="researches.descriptions.67"><img src="/Pictures/Default/Research67.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res68" data-i18n-aria-label="researches.descriptions.68"><img src="/Pictures/Default/Research68.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res69" data-i18n-aria-label="researches.descriptions.69"><img src="/Pictures/Default/Research69.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res70" data-i18n-aria-label="researches.descriptions.70"><img src="/Pictures/Default/Research70.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res71" data-i18n-aria-label="researches.descriptions.71"><img src="/Pictures/Default/Research71.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res72" data-i18n-aria-label="researches.descriptions.72"><img src="/Pictures/Default/Research72.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res73" data-i18n-aria-label="researches.descriptions.73"><img src="/Pictures/Default/Research73.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res74" data-i18n-aria-label="researches.descriptions.74"><img src="/Pictures/Default/Research74.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res75" data-i18n-aria-label="researches.descriptions.75"><img src="/Pictures/Default/Research75.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res76" i18n-aria-label="researches.descriptions.76"><img src="/Pictures/Default/Research76.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res77" i18n-aria-label="researches.descriptions.77"><img src="/Pictures/Default/Research77.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res78" i18n-aria-label="researches.descriptions.78"><img src="/Pictures/Default/Research78.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res79" i18n-aria-label="researches.descriptions.79"><img src="/Pictures/Default/Research79.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res80" i18n-aria-label="researches.descriptions.80"><img src="/Pictures/Default/Research80.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res81" i18n-aria-label="researches.descriptions.81"><img src="/Pictures/Default/Research81.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res82" i18n-aria-label="researches.descriptions.82"><img src="/Pictures/Default/Research82.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res83" i18n-aria-label="researches.descriptions.83"><img src="/Pictures/Default/Research83.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res84" i18n-aria-label="researches.descriptions.84"><img src="/Pictures/Default/Research84.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res85" i18n-aria-label="researches.descriptions.85"><img src="/Pictures/Default/Research85.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res86" i18n-aria-label="researches.descriptions.86"><img src="/Pictures/Default/Research86.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res87" i18n-aria-label="researches.descriptions.87"><img src="/Pictures/Default/Research87.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res88" i18n-aria-label="researches.descriptions.88"><img src="/Pictures/Default/Research88.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res89" i18n-aria-label="researches.descriptions.89"><img src="/Pictures/Default/Research89.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res90" i18n-aria-label="researches.descriptions.90"><img src="/Pictures/Default/Research90.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res91" i18n-aria-label="researches.descriptions.91"><img src="/Pictures/Default/Research91.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res92" i18n-aria-label="researches.descriptions.92"><img src="/Pictures/Default/Research92.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res93" i18n-aria-label="researches.descriptions.93"><img src="/Pictures/Default/Research93.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res94" i18n-aria-label="researches.descriptions.94"><img src="/Pictures/Default/Research94.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res95" i18n-aria-label="researches.descriptions.95"><img src="/Pictures/Default/Research95.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res96" i18n-aria-label="researches.descriptions.96"><img src="/Pictures/Default/Research96.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res97" i18n-aria-label="researches.descriptions.97"><img src="/Pictures/Default/Research97.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res98" i18n-aria-label="researches.descriptions.98"><img src="/Pictures/Default/Research98.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res99" i18n-aria-label="researches.descriptions.99"><img src="/Pictures/Default/Research99.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res100" i18n-aria-label="researches.descriptions.100"><img src="/Pictures/Default/Research100.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res76" data-i18n-aria-label="researches.descriptions.76"><img src="/Pictures/Default/Research76.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res77" data-i18n-aria-label="researches.descriptions.77"><img src="/Pictures/Default/Research77.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res78" data-i18n-aria-label="researches.descriptions.78"><img src="/Pictures/Default/Research78.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res79" data-i18n-aria-label="researches.descriptions.79"><img src="/Pictures/Default/Research79.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res80" data-i18n-aria-label="researches.descriptions.80"><img src="/Pictures/Default/Research80.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res81" data-i18n-aria-label="researches.descriptions.81"><img src="/Pictures/Default/Research81.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res82" data-i18n-aria-label="researches.descriptions.82"><img src="/Pictures/Default/Research82.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res83" data-i18n-aria-label="researches.descriptions.83"><img src="/Pictures/Default/Research83.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res84" data-i18n-aria-label="researches.descriptions.84"><img src="/Pictures/Default/Research84.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res85" data-i18n-aria-label="researches.descriptions.85"><img src="/Pictures/Default/Research85.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res86" data-i18n-aria-label="researches.descriptions.86"><img src="/Pictures/Default/Research86.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res87" data-i18n-aria-label="researches.descriptions.87"><img src="/Pictures/Default/Research87.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res88" data-i18n-aria-label="researches.descriptions.88"><img src="/Pictures/Default/Research88.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res89" data-i18n-aria-label="researches.descriptions.89"><img src="/Pictures/Default/Research89.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res90" data-i18n-aria-label="researches.descriptions.90"><img src="/Pictures/Default/Research90.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res91" data-i18n-aria-label="researches.descriptions.91"><img src="/Pictures/Default/Research91.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res92" data-i18n-aria-label="researches.descriptions.92"><img src="/Pictures/Default/Research92.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res93" data-i18n-aria-label="researches.descriptions.93"><img src="/Pictures/Default/Research93.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res94" data-i18n-aria-label="researches.descriptions.94"><img src="/Pictures/Default/Research94.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res95" data-i18n-aria-label="researches.descriptions.95"><img src="/Pictures/Default/Research95.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res96" data-i18n-aria-label="researches.descriptions.96"><img src="/Pictures/Default/Research96.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res97" data-i18n-aria-label="researches.descriptions.97"><img src="/Pictures/Default/Research97.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res98" data-i18n-aria-label="researches.descriptions.98"><img src="/Pictures/Default/Research98.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res99" data-i18n-aria-label="researches.descriptions.99"><img src="/Pictures/Default/Research99.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res100" data-i18n-aria-label="researches.descriptions.100"><img src="/Pictures/Default/Research100.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res101" i18n-aria-label="researches.descriptions.101"><img src="/Pictures/Default/Research101.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res102" i18n-aria-label="researches.descriptions.102"><img src="/Pictures/Default/Research102.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res103" i18n-aria-label="researches.descriptions.103"><img src="/Pictures/Default/Research103.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res104" i18n-aria-label="researches.descriptions.104"><img src="/Pictures/Default/Research104.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res105" i18n-aria-label="researches.descriptions.105"><img src="/Pictures/Default/Research105.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res106" i18n-aria-label="researches.descriptions.106"><img src="/Pictures/Default/Research106.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res107" i18n-aria-label="researches.descriptions.107"><img src="/Pictures/Default/Research107.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res108" i18n-aria-label="researches.descriptions.108"><img src="/Pictures/Default/Research108.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res109" i18n-aria-label="researches.descriptions.109"><img src="/Pictures/Default/Research109.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res110" i18n-aria-label="researches.descriptions.110"><img src="/Pictures/Default/Research110.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res111" i18n-aria-label="researches.descriptions.111"><img src="/Pictures/Default/Research111.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res112" i18n-aria-label="researches.descriptions.112"><img src="/Pictures/Default/Research112.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res113" i18n-aria-label="researches.descriptions.113"><img src="/Pictures/Default/Research113.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res114" i18n-aria-label="researches.descriptions.114"><img src="/Pictures/Default/Research114.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res115" i18n-aria-label="researches.descriptions.115"><img src="/Pictures/Default/Research115.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res116" i18n-aria-label="researches.descriptions.116"><img src="/Pictures/Default/Research116.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res117" i18n-aria-label="researches.descriptions.117"><img src="/Pictures/Default/Research117.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res118" i18n-aria-label="researches.descriptions.118"><img src="/Pictures/Default/Research118.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res119" i18n-aria-label="researches.descriptions.119"><img src="/Pictures/Default/Research119.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res120" i18n-aria-label="researches.descriptions.120"><img src="/Pictures/Default/Research120.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res121" i18n-aria-label="researches.descriptions.121"><img src="/Pictures/Default/Research121.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res122" i18n-aria-label="researches.descriptions.122"><img src="/Pictures/Default/Research122.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res123" i18n-aria-label="researches.descriptions.123"><img src="/Pictures/Default/Research123.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res124" i18n-aria-label="researches.descriptions.124"><img src="/Pictures/Default/Research124.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res125" i18n-aria-label="researches.descriptions.125"><img src="/Pictures/Default/Research125.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res101" data-i18n-aria-label="researches.descriptions.101"><img src="/Pictures/Default/Research101.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res102" data-i18n-aria-label="researches.descriptions.102"><img src="/Pictures/Default/Research102.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res103" data-i18n-aria-label="researches.descriptions.103"><img src="/Pictures/Default/Research103.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res104" data-i18n-aria-label="researches.descriptions.104"><img src="/Pictures/Default/Research104.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res105" data-i18n-aria-label="researches.descriptions.105"><img src="/Pictures/Default/Research105.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res106" data-i18n-aria-label="researches.descriptions.106"><img src="/Pictures/Default/Research106.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res107" data-i18n-aria-label="researches.descriptions.107"><img src="/Pictures/Default/Research107.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res108" data-i18n-aria-label="researches.descriptions.108"><img src="/Pictures/Default/Research108.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res109" data-i18n-aria-label="researches.descriptions.109"><img src="/Pictures/Default/Research109.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res110" data-i18n-aria-label="researches.descriptions.110"><img src="/Pictures/Default/Research110.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res111" data-i18n-aria-label="researches.descriptions.111"><img src="/Pictures/Default/Research111.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res112" data-i18n-aria-label="researches.descriptions.112"><img src="/Pictures/Default/Research112.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res113" data-i18n-aria-label="researches.descriptions.113"><img src="/Pictures/Default/Research113.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res114" data-i18n-aria-label="researches.descriptions.114"><img src="/Pictures/Default/Research114.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res115" data-i18n-aria-label="researches.descriptions.115"><img src="/Pictures/Default/Research115.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res116" data-i18n-aria-label="researches.descriptions.116"><img src="/Pictures/Default/Research116.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res117" data-i18n-aria-label="researches.descriptions.117"><img src="/Pictures/Default/Research117.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res118" data-i18n-aria-label="researches.descriptions.118"><img src="/Pictures/Default/Research118.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res119" data-i18n-aria-label="researches.descriptions.119"><img src="/Pictures/Default/Research119.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res120" data-i18n-aria-label="researches.descriptions.120"><img src="/Pictures/Default/Research120.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res121" data-i18n-aria-label="researches.descriptions.121"><img src="/Pictures/Default/Research121.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res122" data-i18n-aria-label="researches.descriptions.122"><img src="/Pictures/Default/Research122.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res123" data-i18n-aria-label="researches.descriptions.123"><img src="/Pictures/Default/Research123.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res124" data-i18n-aria-label="researches.descriptions.124"><img src="/Pictures/Default/Research124.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res125" data-i18n-aria-label="researches.descriptions.125"><img src="/Pictures/Default/Research125.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res126" i18n-aria-label="researches.descriptions.126"><img src="/Pictures/Default/Research126.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res127" i18n-aria-label="researches.descriptions.127"><img src="/Pictures/Default/Research127.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res128" i18n-aria-label="researches.descriptions.128"><img src="/Pictures/Default/Research128.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res129" i18n-aria-label="researches.descriptions.129"><img src="/Pictures/Default/Research129.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res130" i18n-aria-label="researches.descriptions.130"><img src="/Pictures/Default/Research130.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res131" i18n-aria-label="researches.descriptions.131"><img src="/Pictures/Default/Research131.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res132" i18n-aria-label="researches.descriptions.132"><img src="/Pictures/Default/Research132.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res133" i18n-aria-label="researches.descriptions.133"><img src="/Pictures/Default/Research133.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res134" i18n-aria-label="researches.descriptions.134"><img src="/Pictures/Default/Research134.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res135" i18n-aria-label="researches.descriptions.135"><img src="/Pictures/Default/Research135.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res136" i18n-aria-label="researches.descriptions.136"><img src="/Pictures/Default/Research136.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res137" i18n-aria-label="researches.descriptions.137"><img src="/Pictures/Default/Research137.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res138" i18n-aria-label="researches.descriptions.138"><img src="/Pictures/Default/Research138.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res139" i18n-aria-label="researches.descriptions.139"><img src="/Pictures/Default/Research139.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res140" i18n-aria-label="researches.descriptions.140"><img src="/Pictures/Default/Research140.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res141" i18n-aria-label="researches.descriptions.141"><img src="/Pictures/Default/Research141.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res142" i18n-aria-label="researches.descriptions.142"><img src="/Pictures/Default/Research142.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res143" i18n-aria-label="researches.descriptions.143"><img src="/Pictures/Default/Research143.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res144" i18n-aria-label="researches.descriptions.144"><img src="/Pictures/Default/Research144.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res145" i18n-aria-label="researches.descriptions.145"><img src="/Pictures/Default/Research145.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res146" i18n-aria-label="researches.descriptions.146"><img src="/Pictures/Default/Research146.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res147" i18n-aria-label="researches.descriptions.147"><img src="/Pictures/Default/Research147.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res148" i18n-aria-label="researches.descriptions.148"><img src="/Pictures/Default/Research148.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res149" i18n-aria-label="researches.descriptions.149"><img src="/Pictures/Default/Research149.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res150" i18n-aria-label="researches.descriptions.150"><img src="/Pictures/Default/Research150.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res126" data-i18n-aria-label="researches.descriptions.126"><img src="/Pictures/Default/Research126.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res127" data-i18n-aria-label="researches.descriptions.127"><img src="/Pictures/Default/Research127.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res128" data-i18n-aria-label="researches.descriptions.128"><img src="/Pictures/Default/Research128.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res129" data-i18n-aria-label="researches.descriptions.129"><img src="/Pictures/Default/Research129.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res130" data-i18n-aria-label="researches.descriptions.130"><img src="/Pictures/Default/Research130.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res131" data-i18n-aria-label="researches.descriptions.131"><img src="/Pictures/Default/Research131.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res132" data-i18n-aria-label="researches.descriptions.132"><img src="/Pictures/Default/Research132.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res133" data-i18n-aria-label="researches.descriptions.133"><img src="/Pictures/Default/Research133.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res134" data-i18n-aria-label="researches.descriptions.134"><img src="/Pictures/Default/Research134.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res135" data-i18n-aria-label="researches.descriptions.135"><img src="/Pictures/Default/Research135.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res136" data-i18n-aria-label="researches.descriptions.136"><img src="/Pictures/Default/Research136.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res137" data-i18n-aria-label="researches.descriptions.137"><img src="/Pictures/Default/Research137.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res138" data-i18n-aria-label="researches.descriptions.138"><img src="/Pictures/Default/Research138.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res139" data-i18n-aria-label="researches.descriptions.139"><img src="/Pictures/Default/Research139.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res140" data-i18n-aria-label="researches.descriptions.140"><img src="/Pictures/Default/Research140.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res141" data-i18n-aria-label="researches.descriptions.141"><img src="/Pictures/Default/Research141.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res142" data-i18n-aria-label="researches.descriptions.142"><img src="/Pictures/Default/Research142.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res143" data-i18n-aria-label="researches.descriptions.143"><img src="/Pictures/Default/Research143.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res144" data-i18n-aria-label="researches.descriptions.144"><img src="/Pictures/Default/Research144.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res145" data-i18n-aria-label="researches.descriptions.145"><img src="/Pictures/Default/Research145.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res146" data-i18n-aria-label="researches.descriptions.146"><img src="/Pictures/Default/Research146.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res147" data-i18n-aria-label="researches.descriptions.147"><img src="/Pictures/Default/Research147.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res148" data-i18n-aria-label="researches.descriptions.148"><img src="/Pictures/Default/Research148.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res149" data-i18n-aria-label="researches.descriptions.149"><img src="/Pictures/Default/Research149.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res150" data-i18n-aria-label="researches.descriptions.150"><img src="/Pictures/Default/Research150.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res151" i18n-aria-label="researches.descriptions.151"><img src="/Pictures/Default/Research151.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res152" i18n-aria-label="researches.descriptions.152"><img src="/Pictures/Default/Research152.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res153" i18n-aria-label="researches.descriptions.153"><img src="/Pictures/Default/Research153.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res154" i18n-aria-label="researches.descriptions.154"><img src="/Pictures/Default/Research154.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res155" i18n-aria-label="researches.descriptions.155"><img src="/Pictures/Default/Research155.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res156" i18n-aria-label="researches.descriptions.156"><img src="/Pictures/Default/Research156.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res157" i18n-aria-label="researches.descriptions.157"><img src="/Pictures/Default/Research157.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res158" i18n-aria-label="researches.descriptions.158"><img src="/Pictures/Default/Research158.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res159" i18n-aria-label="researches.descriptions.159"><img src="/Pictures/Default/Research159.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res160" i18n-aria-label="researches.descriptions.160"><img src="/Pictures/Default/Research160.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res161" i18n-aria-label="researches.descriptions.161"><img src="/Pictures/Default/Research161.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res162" i18n-aria-label="researches.descriptions.162"><img src="/Pictures/Default/Research162.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res163" i18n-aria-label="researches.descriptions.163"><img src="/Pictures/Default/Research163.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res164" i18n-aria-label="researches.descriptions.164"><img src="/Pictures/Default/Research164.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res165" i18n-aria-label="researches.descriptions.165"><img src="/Pictures/Default/Research165.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res166" i18n-aria-label="researches.descriptions.166"><img src="/Pictures/Default/Research166.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res167" i18n-aria-label="researches.descriptions.167"><img src="/Pictures/Default/Research167.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res168" i18n-aria-label="researches.descriptions.168"><img src="/Pictures/Default/Research168.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res169" i18n-aria-label="researches.descriptions.169"><img src="/Pictures/Default/Research169.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res170" i18n-aria-label="researches.descriptions.170"><img src="/Pictures/Default/Research170.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res171" i18n-aria-label="researches.descriptions.171"><img src="/Pictures/Default/Research171.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res172" i18n-aria-label="researches.descriptions.172"><img src="/Pictures/Default/Research172.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res173" i18n-aria-label="researches.descriptions.173"><img src="/Pictures/Default/Research173.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res174" i18n-aria-label="researches.descriptions.174"><img src="/Pictures/Default/Research174.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res175" i18n-aria-label="researches.descriptions.175"><img src="/Pictures/Default/Research175.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res151" data-i18n-aria-label="researches.descriptions.151"><img src="/Pictures/Default/Research151.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res152" data-i18n-aria-label="researches.descriptions.152"><img src="/Pictures/Default/Research152.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res153" data-i18n-aria-label="researches.descriptions.153"><img src="/Pictures/Default/Research153.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res154" data-i18n-aria-label="researches.descriptions.154"><img src="/Pictures/Default/Research154.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res155" data-i18n-aria-label="researches.descriptions.155"><img src="/Pictures/Default/Research155.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res156" data-i18n-aria-label="researches.descriptions.156"><img src="/Pictures/Default/Research156.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res157" data-i18n-aria-label="researches.descriptions.157"><img src="/Pictures/Default/Research157.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res158" data-i18n-aria-label="researches.descriptions.158"><img src="/Pictures/Default/Research158.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res159" data-i18n-aria-label="researches.descriptions.159"><img src="/Pictures/Default/Research159.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res160" data-i18n-aria-label="researches.descriptions.160"><img src="/Pictures/Default/Research160.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res161" data-i18n-aria-label="researches.descriptions.161"><img src="/Pictures/Default/Research161.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res162" data-i18n-aria-label="researches.descriptions.162"><img src="/Pictures/Default/Research162.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res163" data-i18n-aria-label="researches.descriptions.163"><img src="/Pictures/Default/Research163.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res164" data-i18n-aria-label="researches.descriptions.164"><img src="/Pictures/Default/Research164.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res165" data-i18n-aria-label="researches.descriptions.165"><img src="/Pictures/Default/Research165.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res166" data-i18n-aria-label="researches.descriptions.166"><img src="/Pictures/Default/Research166.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res167" data-i18n-aria-label="researches.descriptions.167"><img src="/Pictures/Default/Research167.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res168" data-i18n-aria-label="researches.descriptions.168"><img src="/Pictures/Default/Research168.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res169" data-i18n-aria-label="researches.descriptions.169"><img src="/Pictures/Default/Research169.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res170" data-i18n-aria-label="researches.descriptions.170"><img src="/Pictures/Default/Research170.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res171" data-i18n-aria-label="researches.descriptions.171"><img src="/Pictures/Default/Research171.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res172" data-i18n-aria-label="researches.descriptions.172"><img src="/Pictures/Default/Research172.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res173" data-i18n-aria-label="researches.descriptions.173"><img src="/Pictures/Default/Research173.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res174" data-i18n-aria-label="researches.descriptions.174"><img src="/Pictures/Default/Research174.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res175" data-i18n-aria-label="researches.descriptions.175"><img src="/Pictures/Default/Research175.png" alt="" loading="lazy"></button></td>
                     </tr>
                     <tr>
-                        <td><button id="res176" i18n-aria-label="researches.descriptions.176"><img src="/Pictures/Default/Research176.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res177" i18n-aria-label="researches.descriptions.177"><img src="/Pictures/Default/Research177.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res178" i18n-aria-label="researches.descriptions.178"><img src="/Pictures/Default/Research178.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res179" i18n-aria-label="researches.descriptions.179"><img src="/Pictures/Default/Research179.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res180" i18n-aria-label="researches.descriptions.180"><img src="/Pictures/Default/Research180.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res181" i18n-aria-label="researches.descriptions.181"><img src="/Pictures/Default/Research181.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res182" i18n-aria-label="researches.descriptions.182"><img src="/Pictures/Default/Research182.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res183" i18n-aria-label="researches.descriptions.183"><img src="/Pictures/Default/Research183.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res184" i18n-aria-label="researches.descriptions.184"><img src="/Pictures/Default/Research184.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res185" i18n-aria-label="researches.descriptions.185"><img src="/Pictures/Default/Research185.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res186" i18n-aria-label="researches.descriptions.186"><img src="/Pictures/Default/Research186.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res187" i18n-aria-label="researches.descriptions.187"><img src="/Pictures/Default/Research187.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res188" i18n-aria-label="researches.descriptions.188"><img src="/Pictures/Default/Research188.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res189" i18n-aria-label="researches.descriptions.189"><img src="/Pictures/Default/Research189.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res190" i18n-aria-label="researches.descriptions.190"><img src="/Pictures/Default/Research190.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res191" i18n-aria-label="researches.descriptions.191"><img src="/Pictures/Default/Research191.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res192" i18n-aria-label="researches.descriptions.192"><img src="/Pictures/Default/Research192.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res193" i18n-aria-label="researches.descriptions.193"><img src="/Pictures/Default/Research193.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res194" i18n-aria-label="researches.descriptions.194"><img src="/Pictures/Default/Research194.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res195" i18n-aria-label="researches.descriptions.195"><img src="/Pictures/Default/Research195.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res196" i18n-aria-label="researches.descriptions.196"><img src="/Pictures/Default/Research196.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res197" i18n-aria-label="researches.descriptions.197"><img src="/Pictures/Default/Research197.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res198" i18n-aria-label="researches.descriptions.198"><img src="/Pictures/Default/Research198.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res199" i18n-aria-label="researches.descriptions.199"><img src="/Pictures/Default/Research199.png" alt="" loading="lazy"></button></td>
-                        <td><button id="res200" i18n-aria-label="researches.descriptions.200"><img src="/Pictures/Default/Research200.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res176" data-i18n-aria-label="researches.descriptions.176"><img src="/Pictures/Default/Research176.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res177" data-i18n-aria-label="researches.descriptions.177"><img src="/Pictures/Default/Research177.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res178" data-i18n-aria-label="researches.descriptions.178"><img src="/Pictures/Default/Research178.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res179" data-i18n-aria-label="researches.descriptions.179"><img src="/Pictures/Default/Research179.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res180" data-i18n-aria-label="researches.descriptions.180"><img src="/Pictures/Default/Research180.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res181" data-i18n-aria-label="researches.descriptions.181"><img src="/Pictures/Default/Research181.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res182" data-i18n-aria-label="researches.descriptions.182"><img src="/Pictures/Default/Research182.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res183" data-i18n-aria-label="researches.descriptions.183"><img src="/Pictures/Default/Research183.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res184" data-i18n-aria-label="researches.descriptions.184"><img src="/Pictures/Default/Research184.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res185" data-i18n-aria-label="researches.descriptions.185"><img src="/Pictures/Default/Research185.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res186" data-i18n-aria-label="researches.descriptions.186"><img src="/Pictures/Default/Research186.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res187" data-i18n-aria-label="researches.descriptions.187"><img src="/Pictures/Default/Research187.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res188" data-i18n-aria-label="researches.descriptions.188"><img src="/Pictures/Default/Research188.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res189" data-i18n-aria-label="researches.descriptions.189"><img src="/Pictures/Default/Research189.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res190" data-i18n-aria-label="researches.descriptions.190"><img src="/Pictures/Default/Research190.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res191" data-i18n-aria-label="researches.descriptions.191"><img src="/Pictures/Default/Research191.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res192" data-i18n-aria-label="researches.descriptions.192"><img src="/Pictures/Default/Research192.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res193" data-i18n-aria-label="researches.descriptions.193"><img src="/Pictures/Default/Research193.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res194" data-i18n-aria-label="researches.descriptions.194"><img src="/Pictures/Default/Research194.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res195" data-i18n-aria-label="researches.descriptions.195"><img src="/Pictures/Default/Research195.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res196" data-i18n-aria-label="researches.descriptions.196"><img src="/Pictures/Default/Research196.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res197" data-i18n-aria-label="researches.descriptions.197"><img src="/Pictures/Default/Research197.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res198" data-i18n-aria-label="researches.descriptions.198"><img src="/Pictures/Default/Research198.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res199" data-i18n-aria-label="researches.descriptions.199"><img src="/Pictures/Default/Research199.png" alt="" loading="lazy"></button></td>
+                        <td><button id="res200" data-i18n-aria-label="researches.descriptions.200"><img src="/Pictures/Default/Research200.png" alt="" loading="lazy"></button></td>
                     </tr>
                 </table>
             </div>
@@ -1708,39 +1708,39 @@
                     <button id="buyAllAntProducers" class="buyAllAntBtn" style="margin-bottom: 12px;" i18n="ants.buyAllProducers"></button>
                     <div id="antProducers">
                         <div class="antProducerColumn">
-                            <button id="anttier1" class="disable-hover-color" i18n-aria-label="ants.descriptions.1"><img alt="" class="antBtn" src="/Pictures/Default/AntTier1.png" loading="lazy"></button>
+                            <button id="anttier1" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.1"><img alt="" class="antBtn" src="/Pictures/Default/AntTier1.png" loading="lazy"></button>
                             <button id="antMastery1"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier2" class="disable-hover-color" i18n-aria-label="ants.descriptions.2"><img alt="" class="antBtn" src="/Pictures/Default/AntTier2.png" loading="lazy"></button>
+                            <button id="anttier2" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.2"><img alt="" class="antBtn" src="/Pictures/Default/AntTier2.png" loading="lazy"></button>
                             <button id="antMastery2"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier3" class="disable-hover-color" i18n-aria-label="ants.descriptions.3"><img alt="" class="antBtn" src="/Pictures/Default/AntTier3.png" loading="lazy"></button>
+                            <button id="anttier3" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.3"><img alt="" class="antBtn" src="/Pictures/Default/AntTier3.png" loading="lazy"></button>
                             <button id="antMastery3"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier4" class="disable-hover-color" i18n-aria-label="ants.descriptions.4"><img alt="" class="antBtn" src="/Pictures/Default/AntTier4.png" loading="lazy"></button>
+                            <button id="anttier4" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.4"><img alt="" class="antBtn" src="/Pictures/Default/AntTier4.png" loading="lazy"></button>
                             <button id="antMastery4"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier5" class="disable-hover-color" i18n-aria-label="ants.descriptions.5"><img alt="" class="antBtn" src="/Pictures/Default/AntTier5.png" loading="lazy"></button>
+                            <button id="anttier5" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.5"><img alt="" class="antBtn" src="/Pictures/Default/AntTier5.png" loading="lazy"></button>
                             <button id="antMastery5"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier6" class="disable-hover-color" i18n-aria-label="ants.descriptions.6"><img alt="" class="antBtn" src="/Pictures/Default/AntTier6.png" loading="lazy"></button>
+                            <button id="anttier6" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.6"><img alt="" class="antBtn" src="/Pictures/Default/AntTier6.png" loading="lazy"></button>
                             <button id="antMastery6"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier7" class="disable-hover-color" i18n-aria-label="ants.descriptions.7"><img alt="" class="antBtn" src="/Pictures/Default/AntTier7.png" loading="lazy"></button>
+                            <button id="anttier7" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.7"><img alt="" class="antBtn" src="/Pictures/Default/AntTier7.png" loading="lazy"></button>
                             <button id="antMastery7"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier8" class="disable-hover-color" i18n-aria-label="ants.descriptions.8"><img alt="" class="antBtn" src="/Pictures/Default/AntTier8.png" loading="lazy"></button>
+                            <button id="anttier8" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.8"><img alt="" class="antBtn" src="/Pictures/Default/AntTier8.png" loading="lazy"></button>
                             <button id="antMastery8"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                         <div class="antProducerColumn">
-                            <button id="anttier9" class="disable-hover-color" i18n-aria-label="ants.descriptions.9"><img alt="" class="antBtn" src="/Pictures/Default/AntTier9.png" loading="lazy"></button>
+                            <button id="anttier9" class="disable-hover-color" data-i18n-aria-label="ants.descriptions.9"><img alt="" class="antBtn" src="/Pictures/Default/AntTier9.png" loading="lazy"></button>
                             <button id="antMastery9"><img class="antBtn" src="/Pictures/Default/Particle5.png"></button>
                         </div>
                     </div>
@@ -1749,24 +1749,24 @@
                 <div id="antUpgradesContainer">
                     <button id="buyAllAntUpgrades" class="buyAllAntBtn" style="margin-bottom: 12px;" i18n="ants.buyAllUpgrades"></button>
                     <div class="antUpgradeRow">
-                        <button id="antUpgrade1" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.1"><img src="/Pictures/Default/AntUpgrade1.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade2" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.2"><img src="/Pictures/Default/AntUpgrade2.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade3" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.3"><img src="/Pictures/Default/AntUpgrade3.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade4" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.4"><img src="/Pictures/Default/AntUpgrade4.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade5" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.5"><img src="/Pictures/Default/AntUpgrade5.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade6" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.6"><img src="/Pictures/Default/AntUpgrade6.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade10" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.10"><img src="/Pictures/Default/AntUpgrade10.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade12" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.12"><img src="/Pictures/Default/AntUpgrade12.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade1" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.1"><img src="/Pictures/Default/AntUpgrade1.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade2" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.2"><img src="/Pictures/Default/AntUpgrade2.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade3" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.3"><img src="/Pictures/Default/AntUpgrade3.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade4" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.4"><img src="/Pictures/Default/AntUpgrade4.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade5" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.5"><img src="/Pictures/Default/AntUpgrade5.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade6" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.6"><img src="/Pictures/Default/AntUpgrade6.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade10" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.10"><img src="/Pictures/Default/AntUpgrade10.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade12" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.12"><img src="/Pictures/Default/AntUpgrade12.png" class="antBtn" alt="" loading="lazy"></button>
                     </div>
                     <div class="antUpgradeRow">
-                        <button id="antUpgrade13" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.13"><img src="/Pictures/Default/AntUpgrade13.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade7" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.7"><img src="/Pictures/Default/AntUpgrade7.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade8" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.8"><img src="/Pictures/Default/AntUpgrade8.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade9" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.9"><img src="/Pictures/Default/AntUpgrade9.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade11" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.11"><img src="/Pictures/Default/AntUpgrade11.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade14" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.14"><img src="/Pictures/Default/AntUpgrade14.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade15" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.15"><img src="/Pictures/Default/AntUpgrade15.png" class="antBtn" alt="" loading="lazy"></button>
-                        <button id="antUpgrade16" class="disable-hover-color antUpgrade" i18n-aria-label="ants.upgrades.16"><img src="/Pictures/Default/AntUpgrade16.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade13" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.13"><img src="/Pictures/Default/AntUpgrade13.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade7" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.7"><img src="/Pictures/Default/AntUpgrade7.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade8" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.8"><img src="/Pictures/Default/AntUpgrade8.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade9" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.9"><img src="/Pictures/Default/AntUpgrade9.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade11" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.11"><img src="/Pictures/Default/AntUpgrade11.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade14" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.14"><img src="/Pictures/Default/AntUpgrade14.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade15" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.15"><img src="/Pictures/Default/AntUpgrade15.png" class="antBtn" alt="" loading="lazy"></button>
+                        <button id="antUpgrade16" class="disable-hover-color antUpgrade" data-i18n-aria-label="ants.upgrades.16"><img src="/Pictures/Default/AntUpgrade16.png" class="antBtn" alt="" loading="lazy"></button>
                     </div>
                 </div>
 
@@ -1852,7 +1852,7 @@
                     </div>
                     <div id="altar" class="sacrificeAntsContainer">
                         <p style="font-size: 1.3em" i18n="ants.altar.titles.altar"></p>
-                        <button id="antSacrifice" i18n-aria-label="ants.antSacrifice" style="display: inline-block;">
+                        <button id="antSacrifice" data-i18n-aria-label="ants.antSacrifice" style="display: inline-block;">
                         <img alt="" src="/Pictures/Default/AntSacrifice.png" style="cursor: pointer; display: block;" loading="lazy">
                         </button>
                         <p id="anthillAliveText" i18n="ants.anthillAlive"></p>
@@ -2368,100 +2368,100 @@
                     <p id="cubeAmount2" style="color: white">You have 0 Wow! Cubes</p>
                     <table id="cubeUpgradeTable">
                         <tr>
-                            <td><button id="cubeUpg1" i18n-aria-label="cubes.upgradeNames.1"><img src="/Pictures/Default/CubeUpgrade1.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg2" i18n-aria-label="cubes.upgradeNames.2"><img src="/Pictures/Default/CubeUpgrade2.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg3" i18n-aria-label="cubes.upgradeNames.3"><img src="/Pictures/Default/CubeUpgrade3.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg4" i18n-aria-label="cubes.upgradeNames.4"><img src="/Pictures/Default/CubeUpgrade4.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg5" i18n-aria-label="cubes.upgradeNames.5"><img src="/Pictures/Default/CubeUpgrade5.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg6" i18n-aria-label="cubes.upgradeNames.6"><img src="/Pictures/Default/CubeUpgrade6.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg7" i18n-aria-label="cubes.upgradeNames.7"><img src="/Pictures/Default/CubeUpgrade7.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg8" i18n-aria-label="cubes.upgradeNames.8"><img src="/Pictures/Default/CubeUpgrade8.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg9" i18n-aria-label="cubes.upgradeNames.9"><img src="/Pictures/Default/CubeUpgrade9.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg10" i18n-aria-label="cubes.upgradeNames.10"><img src="/Pictures/Default/CubeUpgrade10.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg1" data-i18n-aria-label="cubes.upgradeNames.1"><img src="/Pictures/Default/CubeUpgrade1.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg2" data-i18n-aria-label="cubes.upgradeNames.2"><img src="/Pictures/Default/CubeUpgrade2.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg3" data-i18n-aria-label="cubes.upgradeNames.3"><img src="/Pictures/Default/CubeUpgrade3.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg4" data-i18n-aria-label="cubes.upgradeNames.4"><img src="/Pictures/Default/CubeUpgrade4.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg5" data-i18n-aria-label="cubes.upgradeNames.5"><img src="/Pictures/Default/CubeUpgrade5.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg6" data-i18n-aria-label="cubes.upgradeNames.6"><img src="/Pictures/Default/CubeUpgrade6.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg7" data-i18n-aria-label="cubes.upgradeNames.7"><img src="/Pictures/Default/CubeUpgrade7.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg8" data-i18n-aria-label="cubes.upgradeNames.8"><img src="/Pictures/Default/CubeUpgrade8.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg9" data-i18n-aria-label="cubes.upgradeNames.9"><img src="/Pictures/Default/CubeUpgrade9.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg10" data-i18n-aria-label="cubes.upgradeNames.10"><img src="/Pictures/Default/CubeUpgrade10.png" class="gridImg" alt="" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg11" i18n-aria-label="cubes.upgradeNames.11"><img src="/Pictures/Default/CubeUpgrade11.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg12" i18n-aria-label="cubes.upgradeNames.12"><img src="/Pictures/Default/CubeUpgrade12.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg13" i18n-aria-label="cubes.upgradeNames.13"><img src="/Pictures/Default/CubeUpgrade13.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg14" i18n-aria-label="cubes.upgradeNames.14"><img src="/Pictures/Default/CubeUpgrade14.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg15" i18n-aria-label="cubes.upgradeNames.15"><img src="/Pictures/Default/CubeUpgrade15.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg16" i18n-aria-label="cubes.upgradeNames.16"><img src="/Pictures/Default/CubeUpgrade16.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg17" i18n-aria-label="cubes.upgradeNames.17"><img src="/Pictures/Default/CubeUpgrade17.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg18" i18n-aria-label="cubes.upgradeNames.18"><img src="/Pictures/Default/CubeUpgrade18.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg19" i18n-aria-label="cubes.upgradeNames.19"><img src="/Pictures/Default/CubeUpgrade19.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg20" i18n-aria-label="cubes.upgradeNames.20"><img src="/Pictures/Default/CubeUpgrade20.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg11" data-i18n-aria-label="cubes.upgradeNames.11"><img src="/Pictures/Default/CubeUpgrade11.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg12" data-i18n-aria-label="cubes.upgradeNames.12"><img src="/Pictures/Default/CubeUpgrade12.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg13" data-i18n-aria-label="cubes.upgradeNames.13"><img src="/Pictures/Default/CubeUpgrade13.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg14" data-i18n-aria-label="cubes.upgradeNames.14"><img src="/Pictures/Default/CubeUpgrade14.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg15" data-i18n-aria-label="cubes.upgradeNames.15"><img src="/Pictures/Default/CubeUpgrade15.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg16" data-i18n-aria-label="cubes.upgradeNames.16"><img src="/Pictures/Default/CubeUpgrade16.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg17" data-i18n-aria-label="cubes.upgradeNames.17"><img src="/Pictures/Default/CubeUpgrade17.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg18" data-i18n-aria-label="cubes.upgradeNames.18"><img src="/Pictures/Default/CubeUpgrade18.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg19" data-i18n-aria-label="cubes.upgradeNames.19"><img src="/Pictures/Default/CubeUpgrade19.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg20" data-i18n-aria-label="cubes.upgradeNames.20"><img src="/Pictures/Default/CubeUpgrade20.png" class="gridImg" alt="" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg21" i18n-aria-label="cubes.upgradeNames.21"><img src="/Pictures/Default/CubeUpgrade21.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg22" i18n-aria-label="cubes.upgradeNames.22"><img src="/Pictures/Default/CubeUpgrade22.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg23" i18n-aria-label="cubes.upgradeNames.23"><img src="/Pictures/Default/CubeUpgrade23.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg24" i18n-aria-label="cubes.upgradeNames.24"><img src="/Pictures/Default/CubeUpgrade24.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg25" i18n-aria-label="cubes.upgradeNames.25"><img src="/Pictures/Default/CubeUpgrade25.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg26" i18n-aria-label="cubes.upgradeNames.26"><img src="/Pictures/Default/CubeUpgrade26.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg27" i18n-aria-label="cubes.upgradeNames.27"><img src="/Pictures/Default/CubeUpgrade27.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg28" i18n-aria-label="cubes.upgradeNames.28"><img src="/Pictures/Default/CubeUpgrade28.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg29" i18n-aria-label="cubes.upgradeNames.29"><img src="/Pictures/Default/CubeUpgrade29.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg30" i18n-aria-label="cubes.upgradeNames.30"><img src="/Pictures/Default/CubeUpgrade30.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg21" data-i18n-aria-label="cubes.upgradeNames.21"><img src="/Pictures/Default/CubeUpgrade21.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg22" data-i18n-aria-label="cubes.upgradeNames.22"><img src="/Pictures/Default/CubeUpgrade22.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg23" data-i18n-aria-label="cubes.upgradeNames.23"><img src="/Pictures/Default/CubeUpgrade23.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg24" data-i18n-aria-label="cubes.upgradeNames.24"><img src="/Pictures/Default/CubeUpgrade24.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg25" data-i18n-aria-label="cubes.upgradeNames.25"><img src="/Pictures/Default/CubeUpgrade25.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg26" data-i18n-aria-label="cubes.upgradeNames.26"><img src="/Pictures/Default/CubeUpgrade26.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg27" data-i18n-aria-label="cubes.upgradeNames.27"><img src="/Pictures/Default/CubeUpgrade27.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg28" data-i18n-aria-label="cubes.upgradeNames.28"><img src="/Pictures/Default/CubeUpgrade28.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg29" data-i18n-aria-label="cubes.upgradeNames.29"><img src="/Pictures/Default/CubeUpgrade29.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg30" data-i18n-aria-label="cubes.upgradeNames.30"><img src="/Pictures/Default/CubeUpgrade30.png" class="gridImg" alt="" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg31" i18n-aria-label="cubes.upgradeNames.31"><img src="/Pictures/Default/CubeUpgrade31.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg32" i18n-aria-label="cubes.upgradeNames.32"><img src="/Pictures/Default/CubeUpgrade32.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg33" i18n-aria-label="cubes.upgradeNames.33"><img src="/Pictures/Default/CubeUpgrade33.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg34" i18n-aria-label="cubes.upgradeNames.34"><img src="/Pictures/Default/CubeUpgrade34.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg35" i18n-aria-label="cubes.upgradeNames.35"><img src="/Pictures/Default/CubeUpgrade35.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg36" i18n-aria-label="cubes.upgradeNames.36"><img src="/Pictures/Default/CubeUpgrade36.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg37" i18n-aria-label="cubes.upgradeNames.37"><img src="/Pictures/Default/CubeUpgrade37.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg38" i18n-aria-label="cubes.upgradeNames.38"><img src="/Pictures/Default/CubeUpgrade38.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg39" i18n-aria-label="cubes.upgradeNames.39"><img src="/Pictures/Default/CubeUpgrade39.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg40" i18n-aria-label="cubes.upgradeNames.40"><img src="/Pictures/Default/CubeUpgrade40.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg31" data-i18n-aria-label="cubes.upgradeNames.31"><img src="/Pictures/Default/CubeUpgrade31.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg32" data-i18n-aria-label="cubes.upgradeNames.32"><img src="/Pictures/Default/CubeUpgrade32.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg33" data-i18n-aria-label="cubes.upgradeNames.33"><img src="/Pictures/Default/CubeUpgrade33.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg34" data-i18n-aria-label="cubes.upgradeNames.34"><img src="/Pictures/Default/CubeUpgrade34.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg35" data-i18n-aria-label="cubes.upgradeNames.35"><img src="/Pictures/Default/CubeUpgrade35.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg36" data-i18n-aria-label="cubes.upgradeNames.36"><img src="/Pictures/Default/CubeUpgrade36.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg37" data-i18n-aria-label="cubes.upgradeNames.37"><img src="/Pictures/Default/CubeUpgrade37.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg38" data-i18n-aria-label="cubes.upgradeNames.38"><img src="/Pictures/Default/CubeUpgrade38.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg39" data-i18n-aria-label="cubes.upgradeNames.39"><img src="/Pictures/Default/CubeUpgrade39.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg40" data-i18n-aria-label="cubes.upgradeNames.40"><img src="/Pictures/Default/CubeUpgrade40.png" class="gridImg" alt="" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg41" i18n-aria-label="cubes.upgradeNames.41"><img src="/Pictures/Default/CubeUpgrade41.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg42" i18n-aria-label="cubes.upgradeNames.42"><img src="/Pictures/Default/CubeUpgrade42.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg43" i18n-aria-label="cubes.upgradeNames.43"><img src="/Pictures/Default/CubeUpgrade43.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg44" i18n-aria-label="cubes.upgradeNames.44"><img src="/Pictures/Default/CubeUpgrade44.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg45" i18n-aria-label="cubes.upgradeNames.45"><img src="/Pictures/Default/CubeUpgrade45.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg46" i18n-aria-label="cubes.upgradeNames.46"><img src="/Pictures/Default/CubeUpgrade46.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg47" i18n-aria-label="cubes.upgradeNames.47"><img src="/Pictures/Default/CubeUpgrade47.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg48" i18n-aria-label="cubes.upgradeNames.48"><img src="/Pictures/Default/CubeUpgrade48.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg49" i18n-aria-label="cubes.upgradeNames.49"><img src="/Pictures/Default/CubeUpgrade49.png" class="gridImg" alt="" loading="lazy"></button></td>
-                            <td><button id="cubeUpg50" i18n-aria-label="cubes.upgradeNames.50"><img src="/Pictures/Default/CubeUpgrade50.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg41" data-i18n-aria-label="cubes.upgradeNames.41"><img src="/Pictures/Default/CubeUpgrade41.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg42" data-i18n-aria-label="cubes.upgradeNames.42"><img src="/Pictures/Default/CubeUpgrade42.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg43" data-i18n-aria-label="cubes.upgradeNames.43"><img src="/Pictures/Default/CubeUpgrade43.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg44" data-i18n-aria-label="cubes.upgradeNames.44"><img src="/Pictures/Default/CubeUpgrade44.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg45" data-i18n-aria-label="cubes.upgradeNames.45"><img src="/Pictures/Default/CubeUpgrade45.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg46" data-i18n-aria-label="cubes.upgradeNames.46"><img src="/Pictures/Default/CubeUpgrade46.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg47" data-i18n-aria-label="cubes.upgradeNames.47"><img src="/Pictures/Default/CubeUpgrade47.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg48" data-i18n-aria-label="cubes.upgradeNames.48"><img src="/Pictures/Default/CubeUpgrade48.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg49" data-i18n-aria-label="cubes.upgradeNames.49"><img src="/Pictures/Default/CubeUpgrade49.png" class="gridImg" alt="" loading="lazy"></button></td>
+                            <td><button id="cubeUpg50" data-i18n-aria-label="cubes.upgradeNames.50"><img src="/Pictures/Default/CubeUpgrade50.png" class="gridImg" alt="" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg51" class="assortedCookies1" i18n-aria-label="cubes.upgradeNames.51"><img src="/Pictures/Default/CubeUpgrade51.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg52" class="assortedCookies1" i18n-aria-label="cubes.upgradeNames.52"><img src="/Pictures/Default/CubeUpgrade52.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg53" class="assortedCookies1" i18n-aria-label="cubes.upgradeNames.53"><img src="/Pictures/Default/CubeUpgrade53.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg54" class="assortedCookies1" i18n-aria-label="cubes.upgradeNames.54"><img src="/Pictures/Default/CubeUpgrade54.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg55" class="assortedCookies1" i18n-aria-label="cubes.upgradeNames.55"><img src="/Pictures/Default/CubeUpgrade55.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg56" class="assortedCookies2" i18n-aria-label="cubes.upgradeNames.56"><img src="/Pictures/Default/CubeUpgrade56.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg57" class="assortedCookies2" i18n-aria-label="cubes.upgradeNames.57"><img src="/Pictures/Default/CubeUpgrade57.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg58" class="assortedCookies2" i18n-aria-label="cubes.upgradeNames.58"><img src="/Pictures/Default/CubeUpgrade58.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg59" class="assortedCookies2" i18n-aria-label="cubes.upgradeNames.59"><img src="/Pictures/Default/CubeUpgrade59.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg60" class="assortedCookies2" i18n-aria-label="cubes.upgradeNames.60"><img src="/Pictures/Default/CubeUpgrade60.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg51" class="assortedCookies1" data-i18n-aria-label="cubes.upgradeNames.51"><img src="/Pictures/Default/CubeUpgrade51.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg52" class="assortedCookies1" data-i18n-aria-label="cubes.upgradeNames.52"><img src="/Pictures/Default/CubeUpgrade52.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg53" class="assortedCookies1" data-i18n-aria-label="cubes.upgradeNames.53"><img src="/Pictures/Default/CubeUpgrade53.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg54" class="assortedCookies1" data-i18n-aria-label="cubes.upgradeNames.54"><img src="/Pictures/Default/CubeUpgrade54.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg55" class="assortedCookies1" data-i18n-aria-label="cubes.upgradeNames.55"><img src="/Pictures/Default/CubeUpgrade55.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg56" class="assortedCookies2" data-i18n-aria-label="cubes.upgradeNames.56"><img src="/Pictures/Default/CubeUpgrade56.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg57" class="assortedCookies2" data-i18n-aria-label="cubes.upgradeNames.57"><img src="/Pictures/Default/CubeUpgrade57.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg58" class="assortedCookies2" data-i18n-aria-label="cubes.upgradeNames.58"><img src="/Pictures/Default/CubeUpgrade58.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg59" class="assortedCookies2" data-i18n-aria-label="cubes.upgradeNames.59"><img src="/Pictures/Default/CubeUpgrade59.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg60" class="assortedCookies2" data-i18n-aria-label="cubes.upgradeNames.60"><img src="/Pictures/Default/CubeUpgrade60.png" class="gridImg" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg61" class="assortedCookies3" i18n-aria-label="cubes.upgradeNames.61"><img src="/Pictures/Default/CubeUpgrade61.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg62" class="assortedCookies3" i18n-aria-label="cubes.upgradeNames.62"><img src="/Pictures/Default/CubeUpgrade62.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg63" class="assortedCookies3" i18n-aria-label="cubes.upgradeNames.63"><img src="/Pictures/Default/CubeUpgrade63.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg64" class="assortedCookies3" i18n-aria-label="cubes.upgradeNames.64"><img src="/Pictures/Default/CubeUpgrade64.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg65" class="assortedCookies3" i18n-aria-label="cubes.upgradeNames.65"><img src="/Pictures/Default/CubeUpgrade65.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg66" class="assortedCookies4" i18n-aria-label="cubes.upgradeNames.66"><img src="/Pictures/Default/CubeUpgrade66.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg67" class="assortedCookies4" i18n-aria-label="cubes.upgradeNames.67"><img src="/Pictures/Default/CubeUpgrade67.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg68" class="assortedCookies4" i18n-aria-label="cubes.upgradeNames.68"><img src="/Pictures/Default/CubeUpgrade68.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg69" class="assortedCookies4" i18n-aria-label="cubes.upgradeNames.69"><img src="/Pictures/Default/CubeUpgrade69.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg70" class="assortedCookies4" i18n-aria-label="cubes.upgradeNames.70"><img src="/Pictures/Default/CubeUpgrade70.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg61" class="assortedCookies3" data-i18n-aria-label="cubes.upgradeNames.61"><img src="/Pictures/Default/CubeUpgrade61.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg62" class="assortedCookies3" data-i18n-aria-label="cubes.upgradeNames.62"><img src="/Pictures/Default/CubeUpgrade62.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg63" class="assortedCookies3" data-i18n-aria-label="cubes.upgradeNames.63"><img src="/Pictures/Default/CubeUpgrade63.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg64" class="assortedCookies3" data-i18n-aria-label="cubes.upgradeNames.64"><img src="/Pictures/Default/CubeUpgrade64.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg65" class="assortedCookies3" data-i18n-aria-label="cubes.upgradeNames.65"><img src="/Pictures/Default/CubeUpgrade65.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg66" class="assortedCookies4" data-i18n-aria-label="cubes.upgradeNames.66"><img src="/Pictures/Default/CubeUpgrade66.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg67" class="assortedCookies4" data-i18n-aria-label="cubes.upgradeNames.67"><img src="/Pictures/Default/CubeUpgrade67.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg68" class="assortedCookies4" data-i18n-aria-label="cubes.upgradeNames.68"><img src="/Pictures/Default/CubeUpgrade68.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg69" class="assortedCookies4" data-i18n-aria-label="cubes.upgradeNames.69"><img src="/Pictures/Default/CubeUpgrade69.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg70" class="assortedCookies4" data-i18n-aria-label="cubes.upgradeNames.70"><img src="/Pictures/Default/CubeUpgrade70.png" class="gridImg" loading="lazy"></button></td>
                         </tr>
                         <tr>
-                            <td><button id="cubeUpg71" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.71"><img src="/Pictures/Default/CubeUpgrade71.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg72" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.72"><img src="/Pictures/Default/CubeUpgrade72.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg73" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.73"><img src="/Pictures/Default/CubeUpgrade73.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg74" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.74"><img src="/Pictures/Default/CubeUpgrade74.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg75" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.75"><img src="/Pictures/Default/CubeUpgrade75.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg76" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.76"><img src="/Pictures/Default/CubeUpgrade76.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg77" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.77"><img src="/Pictures/Default/CubeUpgrade77.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg78" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.78"><img src="/Pictures/Default/CubeUpgrade78.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg79" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.79"><img src="/Pictures/Default/CubeUpgrade79.png" class="gridImg" loading="lazy"></button></td>
-                            <td><button id="cubeUpg80" class="assortedCookies5" i18n-aria-label="cubes.upgradeNames.80"><img src="/Pictures/Default/CubeUpgrade80.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg71" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.71"><img src="/Pictures/Default/CubeUpgrade71.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg72" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.72"><img src="/Pictures/Default/CubeUpgrade72.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg73" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.73"><img src="/Pictures/Default/CubeUpgrade73.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg74" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.74"><img src="/Pictures/Default/CubeUpgrade74.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg75" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.75"><img src="/Pictures/Default/CubeUpgrade75.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg76" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.76"><img src="/Pictures/Default/CubeUpgrade76.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg77" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.77"><img src="/Pictures/Default/CubeUpgrade77.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg78" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.78"><img src="/Pictures/Default/CubeUpgrade78.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg79" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.79"><img src="/Pictures/Default/CubeUpgrade79.png" class="gridImg" loading="lazy"></button></td>
+                            <td><button id="cubeUpg80" class="assortedCookies5" data-i18n-aria-label="cubes.upgradeNames.80"><img src="/Pictures/Default/CubeUpgrade80.png" class="gridImg" loading="lazy"></button></td>
                         </tr>
                     </table>
                     <div aria-live="polite">
@@ -3855,241 +3855,241 @@
                     <p id="goldenQuarkMultiBuyText" i18n="general.multiBuyInstructions"></p>
                 </div>
                 <div class="boxColor" id="actualSingularityUpgradeContainer">
-                    <button class="singularityUpgrade" id="goldenQuarks1" i18n-aria-label="singularity.data.goldenQuarks1.description">
+                    <button class="singularityUpgrade" id="goldenQuarks1" data-i18n-aria-label="singularity.data.goldenQuarks1.description">
                         <img alt="goldenQuarks1" src="/Pictures/Default/SingularityCurrency1.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="goldenQuarks2" i18n-aria-label="singularity.data.goldenQuarks2.description">
+                    <button class="singularityUpgrade" id="goldenQuarks2" data-i18n-aria-label="singularity.data.goldenQuarks2.description">
                         <img alt="goldenQuarks2" src="/Pictures/Default/SingularityCurrency2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="goldenQuarks3" i18n-aria-label="singularity.data.goldenQuarks3.description">
+                    <button class="singularityUpgrade" id="goldenQuarks3" data-i18n-aria-label="singularity.data.goldenQuarks3.description">
                         <img alt="goldenQuarks3" src="/Pictures/Default/SingularityCurrency3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="starterPack" i18n-aria-label="singularity.data.starterPack.description">
+                    <button class="singularityUpgrade" id="starterPack" data-i18n-aria-label="singularity.data.starterPack.description">
                         <img alt="starterPack" src="/Pictures/Default/SingularityStarterPack.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="intermediatePack" i18n-aria-label="singularity.data.intermediatePack.description">
+                    <button class="singularityUpgrade" id="intermediatePack" data-i18n-aria-label="singularity.data.intermediatePack.description">
                         <img alt="intermediatePack" src="/Pictures/Default/SingularityIntermediatePack.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="favoriteUpgrade" i18n-aria-label="singularity.data.favoriteUpgrade.description">
+                    <button class="singularityUpgrade" id="favoriteUpgrade" data-i18n-aria-label="singularity.data.favoriteUpgrade.description">
                         <img alt="favoriteUpgrade" src="/Pictures/Default/SingularityFavoriteUpgrade.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="advancedPack" i18n-aria-label="singularity.data.advancedPack.description">
+                    <button class="singularityUpgrade" id="advancedPack" data-i18n-aria-label="singularity.data.advancedPack.description">
                         <img alt="advancedPack" src="/Pictures/Default/SingularityAdvancedPack.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="expertPack" i18n-aria-label="singularity.data.expertPack.description">
+                    <button class="singularityUpgrade" id="expertPack" data-i18n-aria-label="singularity.data.expertPack.description">
                         <img alt="expertPack" src="/Pictures/Default/SingularityExpertPack.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="masterPack" i18n-aria-label="singularity.data.masterPack.description">
+                    <button class="singularityUpgrade" id="masterPack" data-i18n-aria-label="singularity.data.masterPack.description">
                         <img alt="masterPack" src="/Pictures/Default/SingularityMasterPack.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="divinePack" i18n-aria-label="singularity.data.divinePack.description">
+                    <button class="singularityUpgrade" id="divinePack" data-i18n-aria-label="singularity.data.divinePack.description">
                         <img alt="divinePack" src="/Pictures/Default/SingularityDivinePack.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singTalismanBonusRunes1" i18n-aria-label="singularity.data.singTalismanBonusRunes1.description">
+                    <button class="singularityUpgrade" id="singTalismanBonusRunes1" data-i18n-aria-label="singularity.data.singTalismanBonusRunes1.description">
                         <img alt="singTalismanBonusRunes1" src="/Pictures/Default/SingularityTalismanBonusRunes1.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singTalismanBonusRunes2" i18n-aria-label="singularity.data.singTalismanBonusRunes2.description">
+                    <button class="singularityUpgrade" id="singTalismanBonusRunes2" data-i18n-aria-label="singularity.data.singTalismanBonusRunes2.description">
                         <img alt="singTalismanBonusRunes2" src="/Pictures/Default/SingularityTalismanBonusRunes2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singTalismanBonusRunes3" i18n-aria-label="singularity.data.singTalismanBonusRunes3.description">
+                    <button class="singularityUpgrade" id="singTalismanBonusRunes3" data-i18n-aria-label="singularity.data.singTalismanBonusRunes3.description">
                         <img alt="singTalismanBonusRunes3" src="/Pictures/Default/SingularityTalismanBonusRunes3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singTalismanBonusRunes4" i18n-aria-label="singularity.data.singTalismanBonusRunes4.description">
+                    <button class="singularityUpgrade" id="singTalismanBonusRunes4" data-i18n-aria-label="singularity.data.singTalismanBonusRunes4.description">
                         <img alt="singTalismanBonusRunes4" src="/Pictures/Default/SingularityTalismanBonusRunes4.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="wowPass" i18n-aria-label="singularity.data.wowPass.description">
+                    <button class="singularityUpgrade" id="wowPass" data-i18n-aria-label="singularity.data.wowPass.description">
                         <img alt="wowPass" src="/Pictures/Default/SingularityWowPass.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="wowPass2" i18n-aria-label="singularity.data.wowPass2.description">
+                    <button class="singularityUpgrade" id="wowPass2" data-i18n-aria-label="singularity.data.wowPass2.description">
                         <img alt="wowPass2" src="/Pictures/Default/SingularityWowPass2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="wowPass3" i18n-aria-label="singularity.data.wowPass3.description">
+                    <button class="singularityUpgrade" id="wowPass3" data-i18n-aria-label="singularity.data.wowPass3.description">
                         <img alt="wowPass3" src="/Pictures/Default/SingularityWowPass3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="wowPass4" i18n-aria-label="singularity.data.wowPass4.description">
+                    <button class="singularityUpgrade" id="wowPass4" data-i18n-aria-label="singularity.data.wowPass4.description">
                         <img alt="wowPass4" src="/Pictures/Default/SingularityWowPass4.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="cookies" i18n-aria-label="singularity.data.cookies.description">
+                    <button class="singularityUpgrade" id="cookies" data-i18n-aria-label="singularity.data.cookies.description">
                         <img alt="cookies" src="/Pictures/Default/SingularityCookies.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="cookies2" i18n-aria-label="singularity.data.cookies2.description">
+                    <button class="singularityUpgrade" id="cookies2" data-i18n-aria-label="singularity.data.cookies2.description">
                         <img alt="cookies2" src="/Pictures/Default/SingularityCookies2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="cookies3" i18n-aria-label="singularity.data.cookies3.description">
+                    <button class="singularityUpgrade" id="cookies3" data-i18n-aria-label="singularity.data.cookies3.description">
                         <img alt="cookies3" src="/Pictures/Default/SingularityCookies3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="cookies4" i18n-aria-label="singularity.data.cookies4.description">
+                    <button class="singularityUpgrade" id="cookies4" data-i18n-aria-label="singularity.data.cookies4.description">
                         <img alt="cookies4" src="/Pictures/Default/SingularityCookies4.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="cookies5" i18n-aria-label="singularity.data.cookies5.description">
+                    <button class="singularityUpgrade" id="cookies5" data-i18n-aria-label="singularity.data.cookies5.description">
                         <img alt="cookies5" src="/Pictures/Default/SingularityCookies5.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="ascensions" i18n-aria-label="singularity.data.ascensions.description">
+                    <button class="singularityUpgrade" id="ascensions" data-i18n-aria-label="singularity.data.ascensions.description">
                         <img alt="ascensions" src="/Pictures/Default/SingularityAscensions.png" style="cursor:pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="corruptionFourteen" i18n-aria-label="singularity.data.corruptionFourteen.description">
+                    <button class="singularityUpgrade" id="corruptionFourteen" data-i18n-aria-label="singularity.data.corruptionFourteen.description">
                         <img alt="corruptionFourteen" src="/Pictures/Default/SingularityCorruption14.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="corruptionFifteen" i18n-aria-label="singularity.data.corruptionFifteen.description">
+                    <button class="singularityUpgrade" id="corruptionFifteen" data-i18n-aria-label="singularity.data.corruptionFifteen.description">
                         <img alt="corruptionFifteen" src="/Pictures/Default/SingularityCorruption15.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="platonicTau" i18n-aria-label="singularity.data.platonicTau.description">
+                    <button class="singularityUpgrade" id="platonicTau" data-i18n-aria-label="singularity.data.platonicTau.description">
                         <img alt="platonicTau" src="/Pictures/Default/SingularityTau.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="platonicAlpha" i18n-aria-label="singularity.data.platonicAlpha.description">
+                    <button class="singularityUpgrade" id="platonicAlpha" data-i18n-aria-label="singularity.data.platonicAlpha.description">
                         <img alt="platonicAlpha" src="/Pictures/Default/SingularityAlpha.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="platonicDelta" i18n-aria-label="singularity.data.platonicDelta.description">
+                    <button class="singularityUpgrade" id="platonicDelta" data-i18n-aria-label="singularity.data.platonicDelta.description">
                         <img alt="platonicDelta" src="/Pictures/Default/SingularityDelta.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="platonicPhi" i18n-aria-label="singularity.data.platonicPhi.description">
+                    <button class="singularityUpgrade" id="platonicPhi" data-i18n-aria-label="singularity.data.platonicPhi.description">
                         <img alt="platonicPhi" src="/Pictures/Default/SingularityPhi.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOfferings1" i18n-aria-label="singularity.data.singOfferings1.description">
+                    <button class="singularityUpgrade" id="singOfferings1" data-i18n-aria-label="singularity.data.singOfferings1.description">
                         <img alt="singOfferings1" src="/Pictures/Default/SingularityOfferings1.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOfferings2" i18n-aria-label="singularity.data.singOfferings2.description">
+                    <button class="singularityUpgrade" id="singOfferings2" data-i18n-aria-label="singularity.data.singOfferings2.description">
                         <img alt="singOfferings2" src="/Pictures/Default/SingularityOfferings2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOfferings3" i18n-aria-label="singularity.data.singOfferings3.description">
+                    <button class="singularityUpgrade" id="singOfferings3" data-i18n-aria-label="singularity.data.singOfferings3.description">
                         <img alt="singOfferings3" src="/Pictures/Default/SingularityOfferings3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singObtainium1" i18n-aria-label="singularity.data.singObtainium1.description">
+                    <button class="singularityUpgrade" id="singObtainium1" data-i18n-aria-label="singularity.data.singObtainium1.description">
                         <img alt="singObtainium1" src="/Pictures/Default/SingularityObtainium1.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singObtainium2" i18n-aria-label="singularity.data.singObtainium2.description">
+                    <button class="singularityUpgrade" id="singObtainium2" data-i18n-aria-label="singularity.data.singObtainium2.description">
                         <img alt="singObtainium2" src="/Pictures/Default/SingularityObtainium2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singObtainium3" i18n-aria-label="singularity.data.singObtainium3.description">
+                    <button class="singularityUpgrade" id="singObtainium3" data-i18n-aria-label="singularity.data.singObtainium3.description">
                         <img alt="singObtainium3" src="/Pictures/Default/SingularityObtainium3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singCubes1" i18n-aria-label="singularity.data.singCubes1.description">
+                    <button class="singularityUpgrade" id="singCubes1" data-i18n-aria-label="singularity.data.singCubes1.description">
                         <img alt="singCubes1" src="/Pictures/Default/SingularityCubes1.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singCubes2" i18n-aria-label="singularity.data.singCubes2.description">
+                    <button class="singularityUpgrade" id="singCubes2" data-i18n-aria-label="singularity.data.singCubes2.description">
                         <img alt="singCubes2" src="/Pictures/Default/SingularityCubes2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singCubes3" i18n-aria-label="singularity.data.singCubes3.description">
+                    <button class="singularityUpgrade" id="singCubes3" data-i18n-aria-label="singularity.data.singCubes3.description">
                         <img alt="singCubes3" src="/Pictures/Default/SingularityCubes3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singBonusTokens1" i18n-aria-label="singularity.data.singBonusTokens1.description">
+                    <button class="singularityUpgrade" id="singBonusTokens1" data-i18n-aria-label="singularity.data.singBonusTokens1.description">
                         <img alt="singBonusTokens1" src="/Pictures/Default/SingularityBonusTokens1.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singBonusTokens2" i18n-aria-label="singularity.data.singBonusTokens2.description">
+                    <button class="singularityUpgrade" id="singBonusTokens2" data-i18n-aria-label="singularity.data.singBonusTokens2.description">
                         <img alt="singBonusTokens2" src="/Pictures/Default/SingularityBonusTokens2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singBonusTokens3" i18n-aria-label="singularity.data.singBonusTokens3.description">
+                    <button class="singularityUpgrade" id="singBonusTokens3" data-i18n-aria-label="singularity.data.singBonusTokens3.description">
                         <img alt="singBonusTokens3" src="/Pictures/Default/SingularityBonusTokens3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singBonusTokens4" i18n-aria-label="singularity.data.singBonusTokens4.description">
+                    <button class="singularityUpgrade" id="singBonusTokens4" data-i18n-aria-label="singularity.data.singBonusTokens4.description">
                         <img alt="singBonusTokens4" src="/Pictures/Default/SingularityBonusTokens4.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singCitadel" i18n-aria-label="singularity.data.singCitadel.description">
+                    <button class="singularityUpgrade" id="singCitadel" data-i18n-aria-label="singularity.data.singCitadel.description">
                         <img alt="singCitadel" src="/Pictures/Default/SingularityCitadel.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singCitadel2" i18n-aria-label="singularity.data.singCitadel2.description">
+                    <button class="singularityUpgrade" id="singCitadel2" data-i18n-aria-label="singularity.data.singCitadel2.description">
                         <img alt="singCitadel2" src="/Pictures/Default/SingularityCitadel2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="octeractUnlock" i18n-aria-label="singularity.data.octeractUnlock.description">
+                    <button class="singularityUpgrade" id="octeractUnlock" data-i18n-aria-label="singularity.data.octeractUnlock.description">
                         <img alt="octeractUnlock" src="/Pictures/Default/SingularityOcteracts.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOcteractPatreonBonus" i18n-aria-label="singularity.data.singOcteractPatreonBonus.description">
+                    <button class="singularityUpgrade" id="singOcteractPatreonBonus" data-i18n-aria-label="singularity.data.singOcteractPatreonBonus.description">
                         <img alt="singOcteractPatreonBonus" src="/Pictures/Default/SingularityPatreonOcteracts.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="potionBuff" i18n-aria-label="singularity.data.potionBuff.description">
+                    <button class="singularityUpgrade" id="potionBuff" data-i18n-aria-label="singularity.data.potionBuff.description">
                         <img alt="potionBuff" src="/Pictures/Default/SingularityPotions.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="potionBuff2" i18n-aria-label="singularity.data.potionBuff2.description">
+                    <button class="singularityUpgrade" id="potionBuff2" data-i18n-aria-label="singularity.data.potionBuff2.description">
                         <img alt="potionBuff2" src="/Pictures/Default/SingularityPotions2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="potionBuff3" i18n-aria-label="singularity.data.potionBuff3.description">
+                    <button class="singularityUpgrade" id="potionBuff3" data-i18n-aria-label="singularity.data.potionBuff3.description">
                         <img alt="potionBuff3" src="/Pictures/Default/SingularityPotions3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singChallengeExtension" i18n-aria-label="singularity.data.singChallengeExtension.description">
+                    <button class="singularityUpgrade" id="singChallengeExtension" data-i18n-aria-label="singularity.data.singChallengeExtension.description">
                         <img alt="singChallengeExtension" src="/Pictures/Default/SingularityChallenges1.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singChallengeExtension2" i18n-aria-label="singularity.data.singChallengeExtension2.description">
+                    <button class="singularityUpgrade" id="singChallengeExtension2" data-i18n-aria-label="singularity.data.singChallengeExtension2.description">
                         <img alt="singChallengeExtension2" src="/Pictures/Default/SingularityChallenges2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singChallengeExtension3" i18n-aria-label="singularity.data.singChallengeExtension3.description">
+                    <button class="singularityUpgrade" id="singChallengeExtension3" data-i18n-aria-label="singularity.data.singChallengeExtension3.description">
                         <img alt="singChallengeExtension3" src="/Pictures/Default/SingularityChallenges3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singQuarkImprover1" i18n-aria-label="singularity.data.singQuarkImprover1.description">
+                    <button class="singularityUpgrade" id="singQuarkImprover1" data-i18n-aria-label="singularity.data.singQuarkImprover1.description">
                         <img src="/Pictures/Default/SingularityQuarkImprover.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singQuarkHepteract" i18n-aria-label="singularity.data.singQuarkHepteract.description">
+                    <button class="singularityUpgrade" id="singQuarkHepteract" data-i18n-aria-label="singularity.data.singQuarkHepteract.description">
                         <img alt="singQuarkHepteract" src="/Pictures/Default/SingularityQuarkHepteract.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singQuarkHepteract2" i18n-aria-label="singularity.data.singQuarkHepteract2.description">
+                    <button class="singularityUpgrade" id="singQuarkHepteract2" data-i18n-aria-label="singularity.data.singQuarkHepteract2.description">
                         <img alt="singQuarkHepteract2" src="/Pictures/Default/SingularityQuarkHepteract2.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singQuarkHepteract3" i18n-aria-label="singularity.data.singQuarkHepteract3.description">
+                    <button class="singularityUpgrade" id="singQuarkHepteract3" data-i18n-aria-label="singularity.data.singQuarkHepteract3.description">
                         <img alt="singQuarkHepteract3" src="/Pictures/Default/SingularityQuarkHepteract3.png" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOcteractGain" i18n-aria-label="singularity.data.singOcteractGain.description">
+                    <button class="singularityUpgrade" id="singOcteractGain" data-i18n-aria-label="singularity.data.singOcteractGain.description">
                         <img src="/Pictures/Default/SingularityOcteractGain1.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOcteractGain2" i18n-aria-label="singularity.data.singOcteractGain2.description">
+                    <button class="singularityUpgrade" id="singOcteractGain2" data-i18n-aria-label="singularity.data.singOcteractGain2.description">
                         <img src="/Pictures/Default/SingularityOcteractGain2.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOcteractGain3" i18n-aria-label="singularity.data.singOcteractGain3.description">
+                    <button class="singularityUpgrade" id="singOcteractGain3" data-i18n-aria-label="singularity.data.singOcteractGain3.description">
                         <img src="/Pictures/Default/SingularityOcteractGain3.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOcteractGain4" i18n-aria-label="singularity.data.singOcteractGain4.description">
+                    <button class="singularityUpgrade" id="singOcteractGain4" data-i18n-aria-label="singularity.data.singOcteractGain4.description">
                         <img src="/Pictures/Default/SingularityOcteractGain4.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singOcteractGain5" i18n-aria-label="singularity.data.singOcteractGain5.description">
+                    <button class="singularityUpgrade" id="singOcteractGain5" data-i18n-aria-label="singularity.data.singOcteractGain5.description">
                         <img src="/Pictures/Default/SingularityOcteractGain5.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singFastForward" i18n-aria-label="singularity.data.singFastForward.description">
+                    <button class="singularityUpgrade" id="singFastForward" data-i18n-aria-label="singularity.data.singFastForward.description">
                         <img src="/Pictures/Default/SingularityFastForward.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singFastForward2" i18n-aria-label="singularity.data.singFastForward2.description">
+                    <button class="singularityUpgrade" id="singFastForward2" data-i18n-aria-label="singularity.data.singFastForward2.description">
                         <img src="/Pictures/Default/SingularityFastForward2.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAscensionSpeed" i18n-aria-label="singularity.data.singAscensionSpeed.description">
+                    <button class="singularityUpgrade" id="singAscensionSpeed" data-i18n-aria-label="singularity.data.singAscensionSpeed.description">
                         <img src="/Pictures/Default/SingularityAscensionSpeed.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAscensionSpeed2" i18n-aria-label="singularity.data.singAscensionSpeed2.description">
+                    <button class="singularityUpgrade" id="singAscensionSpeed2" data-i18n-aria-label="singularity.data.singAscensionSpeed2.description">
                         <img src="/Pictures/Default/SingularityAscensionSpeed2.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="ultimatePen" i18n-aria-label="singularity.data.ultimatePen.description">
+                    <button class="singularityUpgrade" id="ultimatePen" data-i18n-aria-label="singularity.data.ultimatePen.description">
                         <img src="/Pictures/Default/UltimatePen.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="halfMind" i18n-aria-label="singularity.data.halfMind.description">
+                    <button class="singularityUpgrade" id="halfMind" data-i18n-aria-label="singularity.data.halfMind.description">
                         <img src="/Pictures/Default/SingularityOneMind.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="oneMind" i18n-aria-label="singularity.data.oneMind.description">
+                    <button class="singularityUpgrade" id="oneMind" data-i18n-aria-label="singularity.data.oneMind.description">
                         <img src="/Pictures/Default/SingularityOneMind.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="blueberries" i18n-aria-label="singularity.data.blueberries.description">
+                    <button class="singularityUpgrade" id="blueberries" data-i18n-aria-label="singularity.data.blueberries.description">
                         <img src="/Pictures/Default/SingularityBlueBerry.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaLuck2" i18n-aria-label="singularity.data.singAmbrosiaLuck2.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaLuck2" data-i18n-aria-label="singularity.data.singAmbrosiaLuck2.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaImprover.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaLuck3" i18n-aria-label="singularity.data.singAmbrosiaLuck3.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaLuck3" data-i18n-aria-label="singularity.data.singAmbrosiaLuck3.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaImprover2.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaLuck" i18n-aria-label="singularity.data.singAmbrosiaLuck.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaLuck" data-i18n-aria-label="singularity.data.singAmbrosiaLuck.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaImprover3.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaLuck4" i18n-aria-label="singularity.data.singAmbrosiaLuck4.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaLuck4" data-i18n-aria-label="singularity.data.singAmbrosiaLuck4.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaImprover4.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaGeneration2" i18n-aria-label="singularity.data.singAmbrosiaGeneration2.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaGeneration2" data-i18n-aria-label="singularity.data.singAmbrosiaGeneration2.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaGeneration.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaGeneration3" i18n-aria-label="singularity.data.singAmbrosiaGeneration3.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaGeneration3" data-i18n-aria-label="singularity.data.singAmbrosiaGeneration3.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaGeneration2.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaGeneration" i18n-aria-label="singularity.data.singAmbrosiaGeneration.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaGeneration" data-i18n-aria-label="singularity.data.singAmbrosiaGeneration.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaGeneration3.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singAmbrosiaGeneration4" i18n-aria-label="singularity.data.singAmbrosiaGeneration4.description">
+                    <button class="singularityUpgrade" id="singAmbrosiaGeneration4" data-i18n-aria-label="singularity.data.singAmbrosiaGeneration4.description">
                         <img src="/Pictures/Default/SingularityAmbrosiaGeneration4.png" style="cursor: pointer" loading="lazy">
                     </button>
-                    <button class="singularityUpgrade" id="singInfiniteShopUpgrades" i18n-aria-label="singularity.data.singInfiniteShopUpgrades.description">
+                    <button class="singularityUpgrade" id="singInfiniteShopUpgrades" data-i18n-aria-label="singularity.data.singInfiniteShopUpgrades.description">
                         <img src="/Pictures/Default/SingularityInfiniteShopLevels.png" style="cursor: pointer" loading="lazy">
                     </button>
                 </div>
@@ -4137,145 +4137,145 @@
                     <p id="octeractMultiBuyText" i18n="general.multiBuyInstructions"></p>
                 </div>
                 <div class="boxColor" id="octeractUpgradeContainer">
-                    <button class="octeractUpgrade" id="octeractStarter" i18n-aria-label="octeract.data.octeractStarter.description">
+                    <button class="octeractUpgrade" id="octeractStarter" data-i18n-aria-label="octeract.data.octeractStarter.description">
                         <img src="/Pictures/Default/OcteractStarter.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractGain" i18n-aria-label="octeract.data.octeractGain.description">
+                    <button class="octeractUpgrade" id="octeractGain" data-i18n-aria-label="octeract.data.octeractGain.description">
                         <img src="/Pictures/Default/OcteractOcteracts.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractGain2" i18n-aria-label="octeract.data.octeractGain2.description">
+                    <button class="octeractUpgrade" id="octeractGain2" data-i18n-aria-label="octeract.data.octeractGain2.description">
                         <img src="/Pictures/Default/OcteractOcteracts2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractQuarkGain" i18n-aria-label="octeract.data.octeractQuarkGain.description">
+                    <button class="octeractUpgrade" id="octeractQuarkGain" data-i18n-aria-label="octeract.data.octeractQuarkGain.description">
                         <img src="/Pictures/Default/OcteractQuarks.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractQuarkGain2" i18n-aria-label="octeract.data.octeractQuarkGain2.description">
+                    <button class="octeractUpgrade" id="octeractQuarkGain2" data-i18n-aria-label="octeract.data.octeractQuarkGain2.description">
                         <img src="/Pictures/Default/OcteractQuarks2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractCorruption" i18n-aria-label="octeract.data.octeractCorruption.description">
+                    <button class="octeractUpgrade" id="octeractCorruption" data-i18n-aria-label="octeract.data.octeractCorruption.description">
                         <img src="/Pictures/Default/OcteractCorruptions.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractGQCostReduce" i18n-aria-label="octeract.data.octeractGQCostReduce.description">
+                    <button class="octeractUpgrade" id="octeractGQCostReduce" data-i18n-aria-label="octeract.data.octeractGQCostReduce.description">
                         <img src="/Pictures/Default/OcteractGoldenQuarkCost.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractExportQuarks" i18n-aria-label="octeract.data.octeractExportQuarks.description">
+                    <button class="octeractUpgrade" id="octeractExportQuarks" data-i18n-aria-label="octeract.data.octeractExportQuarks.description">
                         <img src="/Pictures/Default/OcteractExportQuarks.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedDaily" i18n-aria-label="octeract.data.octeractImprovedDaily.description">
+                    <button class="octeractUpgrade" id="octeractImprovedDaily" data-i18n-aria-label="octeract.data.octeractImprovedDaily.description">
                         <img src="/Pictures/Default/OcteractImprovedDaily.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedDaily2" i18n-aria-label="octeract.data.octeractImprovedDaily2.description">
+                    <button class="octeractUpgrade" id="octeractImprovedDaily2" data-i18n-aria-label="octeract.data.octeractImprovedDaily2.description">
                         <img src="/Pictures/Default/OcteractImprovedDaily2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedDaily3" i18n-aria-label="octeract.data.octeractImprovedDaily3.description">
+                    <button class="octeractUpgrade" id="octeractImprovedDaily3" data-i18n-aria-label="octeract.data.octeractImprovedDaily3.description">
                         <img src="/Pictures/Default/OcteractImprovedDaily3.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedQuarkHept" i18n-aria-label="octeract.data.octeractImprovedQuarkHepteract.description">
+                    <button class="octeractUpgrade" id="octeractImprovedQuarkHept" data-i18n-aria-label="octeract.data.octeractImprovedQuarkHepteract.description">
                         <img src="/Pictures/Default/OcteractImprovedQuarkHepteract.png" style="cursor:pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractTalismanLevelCap1" i18n-aria-label="octeract.data.octeractTalismanLevelCap1.description">
+                    <button class="octeractUpgrade" id="octeractTalismanLevelCap1" data-i18n-aria-label="octeract.data.octeractTalismanLevelCap1.description">
                         <img src="/Pictures/Default/OcteractTalismanLevelCap1.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractTalismanLevelCap2" i18n-aria-label="octeract.data.octeractTalismanLevelCap2.description">
+                    <button class="octeractUpgrade" id="octeractTalismanLevelCap2" data-i18n-aria-label="octeract.data.octeractTalismanLevelCap2.description">
                         <img src="/Pictures/Default/OcteractTalismanLevelCap2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractTalismanLevelCap3" i18n-aria-label="octeract.data.octeractTalismanLevelCap3.description">
+                    <button class="octeractUpgrade" id="octeractTalismanLevelCap3" data-i18n-aria-label="octeract.data.octeractTalismanLevelCap3.description">
                         <img src="/Pictures/Default/OcteractTalismanLevelCap3.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractTalismanLevelCap4" i18n-aria-label="octeract.data.octeractTalismanLevelCap4.description">
+                    <button class="octeractUpgrade" id="octeractTalismanLevelCap4" data-i18n-aria-label="octeract.data.octeractTalismanLevelCap4.description">
                         <img src="/Pictures/Default/OcteractTalismanLevelCap4.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedGlobalSpeed" i18n-aria-label="octeract.data.octeractImprovedGlobalSpeed.description">
+                    <button class="octeractUpgrade" id="octeractImprovedGlobalSpeed" data-i18n-aria-label="octeract.data.octeractImprovedGlobalSpeed.description">
                         <img src="/Pictures/Default/OcteractImprovedGlobalSpeed.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedAscensionSpeed" i18n-aria-label="octeract.data.octeractImprovedAscensionSpeed.description">
+                    <button class="octeractUpgrade" id="octeractImprovedAscensionSpeed" data-i18n-aria-label="octeract.data.octeractImprovedAscensionSpeed.description">
                         <img src="/Pictures/Default/OcteractImprovedAscensionSpeed.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedAscensionSpeed2" i18n-aria-label="octeract.data.octeractImprovedAscensionSpeed2.description">
+                    <button class="octeractUpgrade" id="octeractImprovedAscensionSpeed2" data-i18n-aria-label="octeract.data.octeractImprovedAscensionSpeed2.description">
                         <img src="/Pictures/Default/OcteractImprovedAscensionSpeed2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedFree" i18n-aria-label="octeract.data.octeractImprovedFree.description">
+                    <button class="octeractUpgrade" id="octeractImprovedFree" data-i18n-aria-label="octeract.data.octeractImprovedFree.description">
                         <img src="/Pictures/Default/OcteractFreeUpgradeImprovement.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedFree2" i18n-aria-label="octeract.data.octeractImprovedFree2.description">
+                    <button class="octeractUpgrade" id="octeractImprovedFree2" data-i18n-aria-label="octeract.data.octeractImprovedFree2.description">
                         <img src="/Pictures/Default/OcteractFreeUpgradeImprovement2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedFree3" i18n-aria-label="octeract.data.octeractImprovedFree3.description">
+                    <button class="octeractUpgrade" id="octeractImprovedFree3" data-i18n-aria-label="octeract.data.octeractImprovedFree3.description">
                         <img src="/Pictures/Default/OcteractFreeUpgradeImprovement3.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractImprovedFree4" i18n-aria-label="octeract.data.octeractImprovedFree4.description">
+                    <button class="octeractUpgrade" id="octeractImprovedFree4" data-i18n-aria-label="octeract.data.octeractImprovedFree4.description">
                         <img src="/Pictures/Default/OcteractFreeUpgradeImprovement4.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractBonusTokens1" i18n-aria-label="octeract.data.octeractBonusTokens1.description">
+                    <button class="octeractUpgrade" id="octeractBonusTokens1" data-i18n-aria-label="octeract.data.octeractBonusTokens1.description">
                         <img src="/Pictures/Default/OcteractBonusTokens1.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractBonusTokens2" i18n-aria-label="octeract.data.octeractBonusTokens2.description">
+                    <button class="octeractUpgrade" id="octeractBonusTokens2" data-i18n-aria-label="octeract.data.octeractBonusTokens2.description">
                         <img src="/Pictures/Default/OcteractBonusTokens2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractBonusTokens3" i18n-aria-label="octeract.data.octeractBonusTokens3.description">
+                    <button class="octeractUpgrade" id="octeractBonusTokens3" data-i18n-aria-label="octeract.data.octeractBonusTokens3.description">
                         <img src="/Pictures/Default/OcteractBonusTokens3.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractBonusTokens4" i18n-aria-label="octeract.data.octeractBonusTokens4.description">
+                    <button class="octeractUpgrade" id="octeractBonusTokens4" data-i18n-aria-label="octeract.data.octeractBonusTokens4.description">
                         <img src="/Pictures/Default/OcteractBonusTokens4.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractSingUpgradeCap" i18n-aria-label="octeract.data.octeractSingUpgradeCap.description">
+                    <button class="octeractUpgrade" id="octeractSingUpgradeCap" data-i18n-aria-label="octeract.data.octeractSingUpgradeCap.description">
                         <img src="/Pictures/Default/OcteractMaxSingularityUpgrade.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractOfferings1" i18n-aria-label="octeract.data.octeractOfferings1.description">
+                    <button class="octeractUpgrade" id="octeractOfferings1" data-i18n-aria-label="octeract.data.octeractOfferings1.description">
                         <img src="/Pictures/Default/OcteractOfferings.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractObtainium1" i18n-aria-label="octeract.data.octeractObtainium1.description">
+                    <button class="octeractUpgrade" id="octeractObtainium1" data-i18n-aria-label="octeract.data.octeractObtainium1.description">
                         <img src="/Pictures/Default/OcteractObtainium.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAscensions" i18n-aria-label="octeract.data.octeractAscensions.description">
+                    <button class="octeractUpgrade" id="octeractAscensions" data-i18n-aria-label="octeract.data.octeractAscensions.description">
                         <img src="/Pictures/Default/OcteractAscensionCount.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAscensions2" i18n-aria-label="octeract.data.octeractAscensions2.description">
+                    <button class="octeractUpgrade" id="octeractAscensions2" data-i18n-aria-label="octeract.data.octeractAscensions2.description">
                         <img src="/Pictures/Default/OcteractAscensionCount2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAscensionsOcteractGain" i18n-aria-label="octeract.data.octeractAscensionsOcteractGain.description">
+                    <button class="octeractUpgrade" id="octeractAscensionsOcteractGain" data-i18n-aria-label="octeract.data.octeractAscensionsOcteractGain.description">
                         <img src="/Pictures/Default/OcteractAscensionOcteracts.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractFastForward" i18n-aria-label="octeract.data.octeractFastForward.description">
+                    <button class="octeractUpgrade" id="octeractFastForward" data-i18n-aria-label="octeract.data.octeractFastForward.description">
                         <img src="/Pictures/Default/OcteractFastForward.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAutoPotionSpeed" i18n-aria-label="octeract.data.octeractAutoPotionSpeed.description">
+                    <button class="octeractUpgrade" id="octeractAutoPotionSpeed" data-i18n-aria-label="octeract.data.octeractAutoPotionSpeed.description">
                         <img src="/Pictures/Default/OcteractAutoPotionSpeed.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAutoPotionEfficiency" i18n-aria-label="octeract.data.octeractAutoPotionEfficiency.description">
+                    <button class="octeractUpgrade" id="octeractAutoPotionEfficiency" data-i18n-aria-label="octeract.data.octeractAutoPotionEfficiency.description">
                         <img src="/Pictures/Default/OcteractAutoPotionEfficiency.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractOneMindImprover" i18n-aria-label="octeract.data.octeractOneMindImprover.description">
+                    <button class="octeractUpgrade" id="octeractOneMindImprover" data-i18n-aria-label="octeract.data.octeractOneMindImprover.description">
                         <img src="/Pictures/Default/OcteractOneMindImprover.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck2" i18n-aria-label="octeract.data.octeractAmbrosiaLuck2.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck2" data-i18n-aria-label="octeract.data.octeractAmbrosiaLuck2.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaImprover.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck3" i18n-aria-label="octeract.data.octeractAmbrosiaLuck3.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck3" data-i18n-aria-label="octeract.data.octeractAmbrosiaLuck3.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaImprover2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck" i18n-aria-label="octeract.data.octeractAmbrosiaLuck.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck" data-i18n-aria-label="octeract.data.octeractAmbrosiaLuck.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaImprover3.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck4" i18n-aria-label="octeract.data.octeractAmbrosiaLuck4.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaLuck4" data-i18n-aria-label="octeract.data.octeractAmbrosiaLuck4.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaImprover4.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration2" i18n-aria-label="octeract.data.octeractAmbrosiaGeneration2.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration2" data-i18n-aria-label="octeract.data.octeractAmbrosiaGeneration2.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaGeneration.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration3" i18n-aria-label="octeract.data.octeractAmbrosiaGeneration3.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration3" data-i18n-aria-label="octeract.data.octeractAmbrosiaGeneration3.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaGeneration2.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration" i18n-aria-label="octeract.data.octeractAmbrosiaGeneration.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration" data-i18n-aria-label="octeract.data.octeractAmbrosiaGeneration.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaGeneration3.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration4" i18n-aria-label="octeract.data.octeractAmbrosiaGeneration4.description">
+                    <button class="octeractUpgrade" id="octeractAmbrosiaGeneration4" data-i18n-aria-label="octeract.data.octeractAmbrosiaGeneration4.description">
                         <img src="/Pictures/Default/OcteractAmbrosiaGeneration4.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractBlueberries" i18n-aria-label="octeract.data.octeractBlueberries.description">
+                    <button class="octeractUpgrade" id="octeractBlueberries" data-i18n-aria-label="octeract.data.octeractBlueberries.description">
                         <img src="/Pictures/Default/OcteractBlueberries.png" style="cursor: pointer">
                     </button>
-                    <button class="octeractUpgrade" id="octeractInfiniteShopUpgrades" i18n-aria-label="octeract.data.octeractInfiniteShopUpgrades.description">
+                    <button class="octeractUpgrade" id="octeractInfiniteShopUpgrades" data-i18n-aria-label="octeract.data.octeractInfiniteShopUpgrades.description">
                         <img src="/Pictures/Default/OcteractInfiniteShopUpgrades.png" style="cursor: pointer">
                     </button>
                 </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -118,8 +118,8 @@ function translateHTML () {
     }
   })
 
-  document.querySelectorAll('[i18n-aria-label]').forEach((element) => {
-    const key = element.getAttribute('i18n-aria-label')!
+  document.querySelectorAll('[data-i18n-aria-label]').forEach((element) => {
+    const key = element.getAttribute('data-i18n-aria-label')!
     element.setAttribute('aria-label', i18next.t(key))
   })
 }


### PR DESCRIPTION
## Summary

Mechanical rename of a non-standard custom attribute to its spec-compliant \`data-*\` form. Touches \`index.html\` (561 sites) and \`src/i18n.ts\` (2 sites — the selector and the \`getAttribute\` call).

\`\`\`diff
- <button id="upg1" class="upgrade-button" i18n-aria-label="upgrades.descriptions.1">
+ <button id="upg1" class="upgrade-button" data-i18n-aria-label="upgrades.descriptions.1">
\`\`\`

\`\`\`diff
- document.querySelectorAll('[i18n-aria-label]').forEach((element) => {
-   const key = element.getAttribute('i18n-aria-label')!
+ document.querySelectorAll('[data-i18n-aria-label]').forEach((element) => {
+   const key = element.getAttribute('data-i18n-aria-label')!
\`\`\`

## Why

[#120](https://github.com/MaddisonM79/unknown_game/issues/120) — the non-standard form is a silent-failure foot-gun: nothing in the HTML spec or any linter would catch a future contributor adding \`i18n-aria-label\` to a new element but forgetting to wire up the i18n loop. The \`data-\` prefix:

- Lives in the spec's reserved custom-attribute namespace
- Is accepted by htmlhint without rule changes
- Maps cleanly to TypeScript's \`HTMLElement.dataset.i18nAriaLabel\` (well-typed)
- Makes intent unambiguous in markup review

## No behavior change

Attribute names change; values (the i18n keys like \`upgrades.descriptions.1\`) and the runtime semantics are identical. Existing \`translations/en.json\` keys still resolve.

## Verified in dev preview

Reloaded the page, dismissed the offline modal, clicked the Upgrades tab. Inspected \`#upg1\`:

\`\`\`json
{
  "hasOld": false,
  "hasNew": true,
  "newVal": "upgrades.descriptions.1",
  "ariaLabel": "Increase production of Workers per producer bought."
}
\`\`\`

The TS handler reads the new attribute and populates \`aria-label\` correctly — same behavior as before the rename. \`tsc\` + \`oxlint\` + \`htmlhint\` all clean locally.

## Test plan

- [ ] CI passes
- [ ] Spot-check a screen reader (VoiceOver / NVDA) on the Upgrades tab — buttons should still announce their localized label
- [ ] Switch language → confirm \`aria-label\` re-renders with the new locale (same flow as before — relies on the same i18n init loop)

Closes [#120](https://github.com/MaddisonM79/unknown_game/issues/120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)