### PR TITLE
ci: drop windows/macos from matrix — browser-only build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,12 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    # Browser-only build; production deploys to Cloudflare Pages (Linux).
+    # No desktop runtime to validate. Win/macOS dropped to save ~12x CI minutes
+    # per push (GitHub bills macOS at 10x, Windows at 2x Linux minutes).
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,7 +39,7 @@ jobs:
         run: |
           npm run build:esbuild
       - name: Check translation files
-        if: matrix.os == 'ubuntu-latest' && ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: check-translation-files
         with:


### PR DESCRIPTION
## Summary

Since [#199](https://github.com/MaddisonM79/unknown_game/pull/199) ripped Electron there is no desktop runtime to validate. Production deploys to Cloudflare Pages (Linux). \`tsc\`, \`oxlint\`, \`stylelint\`, and \`vite\`/\`rolldown\` all produce identical results on every OS — the 3-OS matrix is paying ~13x Linux-equivalent CI minutes per push for ~no additional signal.

\`\`\`diff
 jobs:
   test:
-    runs-on: \${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ubuntu-latest
\`\`\`

## Cost math

GitHub bills macOS runners at 10x Linux minutes, Windows at 2x. Each push consumed ~13 "Linux-equivalent minutes" instead of 1. That's a meaningful spend cut at the typical PR push rate.

## Signal kept

The lockfile-resolves-cleanly check (which just caught the @emnapi divergence in [#207](https://github.com/MaddisonM79/unknown_game/pull/207)) still runs — on Ubuntu, the platform that matters for production.

## Signal dropped

- Win/macOS-specific path-separator or line-ending bugs. Browser-only build, no native binaries we ship, no Electron — these classes essentially don't apply here.
- Catching the @emnapi-class divergence pre-merge. Mitigated separately: contributors using \`npm install --include=optional\` (worth documenting in CONTRIBUTING.md as a follow-up).

When/if a desktop runtime returns via Tauri, that's the right time to reintroduce per-platform CI matched to the Tauri target set.

## Stacked on #207

This PR targets \`chore/sync-lockfile-emnapi\` (the lockfile-fix branch) so CI passes from the first run. Once #207 merges, GitHub will auto-retarget this PR's base to \`main\`.

## Test plan

- [ ] CI passes (single ubuntu-latest job)
- [ ] Confirm no required-status-check on the repo is pinned to \`test (windows-latest)\` or \`test (macOS-latest)\` (branch protection is on hold per #129, so likely no — but worth a glance at Settings → Branches if anything's configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)