### PR TITLE
refactor: migrate 9 calculation clusters into @synergism/logic

### DIFF
--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -4,6 +4,17 @@
 // not exported from this file should be considered internal to the package.
 
 export type { CoreEvent } from './events/types'
+export { calculateSigmoid, calculateSigmoidExponential } from './math/sigmoid'
+export type {
+  CalculateCubicSumDataResult,
+  CalculateSummationNonLinearResult
+} from './math/summations'
+export {
+  calculateCubicSumData,
+  calculateSummationCubic,
+  calculateSummationNonLinear,
+  solveQuadratic
+} from './math/summations'
 export type {
   AcceleratorState,
   AscendBuildingState,
@@ -213,6 +224,97 @@ export type {
   GlobalSpeedMultInput,
   ReductionValueInput
 } from './mechanics/calculate'
+export type {
+  AmbrosiaMultInput,
+  CalculateRequiredBlueberryTimeInput,
+  CalculateRequiredRedAmbrosiaTimeInput
+} from './mechanics/ambrosia'
+export type {
+  CalculateAcceleratorMultiplierInput,
+  CalculateTotalAcceleratorBoostInput,
+  CalculateTotalAcceleratorBoostResult
+} from './mechanics/acceleratorMultipliers'
+export {
+  calculateAcceleratorMultiplier,
+  calculateTotalAcceleratorBoost
+} from './mechanics/acceleratorMultipliers'
+export type { CalculateAscensionCountInput } from './mechanics/ascensions'
+export { calculateAscensionCount } from './mechanics/ascensions'
+export type { CalculateCubeQuarkMultiplierInput } from './mechanics/overfluxBonuses'
+export {
+  calculateCubeMultFromPowder,
+  calculateCubeQuarkMultiplier,
+  calculateQuarkMultFromPowder
+} from './mechanics/overfluxBonuses'
+export {
+  calculateAmbrosiaCubeMult,
+  calculateAmbrosiaGenerationOcteractUpgrade,
+  calculateAmbrosiaGenerationSingularityUpgrade,
+  calculateAmbrosiaLuckOcteractUpgrade,
+  calculateAmbrosiaLuckSingularityUpgrade,
+  calculateAmbrosiaQuarkMult,
+  calculateNumberOfThresholds,
+  calculateRequiredBlueberryTime,
+  calculateRequiredRedAmbrosiaTime,
+  calculateSingularityMilestoneBlueberries,
+  calculateToNextThreshold
+} from './mechanics/ambrosia'
+export type {
+  CalculateExalt3PenaltyInput,
+  CalculateExalt4EffectiveSingularityMultiplierInput
+} from './mechanics/exaltPenalties'
+export type {
+  CalculatePotionValueInput,
+  PotionBonusResult
+} from './mechanics/potionBonuses'
+export {
+  calculateObtainiumPotionBaseObtainium,
+  calculateOfferingPotionBaseOfferings,
+  calculatePotionValue
+} from './mechanics/potionBonuses'
+export type {
+  CalculateCookieUpgrade29LuckInput,
+  CalculateRedAmbrosiaCubesInput,
+  CalculateRedAmbrosiaResourceInput
+} from './mechanics/redAmbrosiaBonuses'
+export {
+  calculateCookieUpgrade29Luck,
+  calculateRedAmbrosiaCubes,
+  calculateRedAmbrosiaObtainium,
+  calculateRedAmbrosiaOffering
+} from './mechanics/redAmbrosiaBonuses'
+export type {
+  CalculateTotalOcteractCubeBonusInput,
+  CalculateTotalOcteractObtainiumBonusInput,
+  CalculateTotalOcteractOfferingBonusInput,
+  CalculateTotalOcteractQuarkBonusInput
+} from './mechanics/octeractBonuses'
+export {
+  calculateTotalOcteractCubeBonus,
+  calculateTotalOcteractObtainiumBonus,
+  calculateTotalOcteractOfferingBonus,
+  calculateTotalOcteractQuarkBonus
+} from './mechanics/octeractBonuses'
+export {
+  calculateExalt3AscensionLimit,
+  calculateExalt3Penalty,
+  calculateExalt4EffectiveSingularityMultiplier,
+  calculateExalt6Penalty,
+  calculateExalt6PenaltyPerSecond,
+  calculateExalt6TimeLimit
+} from './mechanics/exaltPenalties'
+export type { CalculateBaseGoldenQuarksInput } from './mechanics/singularityMilestones'
+export {
+  calculateBaseGoldenQuarks,
+  calculateDilatedFiveLeafBonus,
+  calculateImmaculateAlchemyBonus,
+  calculateSingularityAmbrosiaLuckMilestoneBonus,
+  calculateSingularityQuarkMilestoneMultiplier,
+  derpsmithCornucopiaBonus,
+  inheritanceTokens,
+  singularityBonusTokenMult,
+  sumOfExaltCompletions
+} from './mechanics/singularityMilestones'
 export {
   calculateActualAntSpeedMult,
   calculateAllCubeMultiplier,

--- a/packages/logic/src/math/sigmoid.ts
+++ b/packages/logic/src/math/sigmoid.ts
@@ -1,0 +1,24 @@
+// Sigmoid-style curve helpers lifted from packages/web_ui/src/Calculate.ts.
+// Generic 1-line formulas that return 1 at zero progress and asymptote
+// toward `constant` as progress grows. Used by cube/quark multiplier code
+// in web_ui.
+
+/**
+ * Doubling-half sigmoid:
+ *   1 + (constant - 1) * (1 - 2 ^ (-factor / divisor))
+ * Returns 1 when factor = 0 and asymptotes to `constant` as factor → ∞.
+ * `divisor` controls how quickly the curve saturates.
+ */
+export function calculateSigmoid(constant: number, factor: number, divisor: number): number {
+  return 1 + (constant - 1) * (1 - Math.pow(2, -factor / divisor))
+}
+
+/**
+ * Natural-exponential sigmoid:
+ *   1 + (constant - 1) * (1 - e^(-coefficient))
+ * Same shape as `calculateSigmoid` but uses `e` as the base — `coefficient`
+ * is the natural-log progress rather than a halving count.
+ */
+export function calculateSigmoidExponential(constant: number, coefficient: number): number {
+  return 1 + (constant - 1) * (1 - Math.exp(-coefficient))
+}

--- a/packages/logic/src/math/summations.ts
+++ b/packages/logic/src/math/summations.ts
@@ -1,0 +1,147 @@
+// Summation / cost helpers lifted from packages/web_ui/src/Calculate.ts.
+// Generic algebraic primitives used by the upgrade-cost code in web_ui.
+//
+// Error path: the web_ui versions threw Error(i18next.t('calculate.*Error')).
+// Logic isn't allowed to call i18next, so it throws plain Errors with
+// machine-readable codes (`SUMMATIONS_QUADRATIC_IMPROPER` etc.). Callers
+// that want to surface a translated message can catch and re-throw — but
+// these guards fire only on invalid inputs (programmer error), so in
+// practice they're dev-facing.
+
+// ─── Linear non-linear-cost summation (cost = base * (1 + level * d)) ──────
+
+export interface CalculateSummationNonLinearResult {
+  levelCanBuy: number
+  cost: number
+}
+
+/**
+ * If costs grow as `base * (1 + level * diffPerLevel)` from `baseLevel`,
+ * compute how many levels can be bought with `resourceAvailable` (capped at
+ * `baseLevel + buyAmount`) and the total cost spent.
+ */
+export function calculateSummationNonLinear(
+  baseLevel: number,
+  baseCost: number,
+  resourceAvailable: number,
+  diffPerLevel: number,
+  buyAmount: number
+): CalculateSummationNonLinearResult {
+  const c = diffPerLevel / 2
+  resourceAvailable = resourceAvailable || 0
+  const alreadySpent = baseCost * (c * Math.pow(baseLevel, 2) + baseLevel * (1 - c))
+  resourceAvailable += alreadySpent
+  const v = resourceAvailable / baseCost
+  let buyToLevel = c > 0
+    ? Math.max(
+      0,
+      Math.floor(
+        (c - 1) / (2 * c)
+          + Math.pow(Math.pow(1 - c, 2) + 4 * c * v, 1 / 2) / (2 * c)
+      )
+    )
+    : Math.floor(v)
+
+  buyToLevel = Math.min(buyToLevel, buyAmount + baseLevel)
+  buyToLevel = Math.max(buyToLevel, baseLevel)
+  let totalCost = baseCost * (c * Math.pow(buyToLevel, 2) + buyToLevel * (1 - c))
+    - alreadySpent
+  if (buyToLevel === baseLevel) {
+    totalCost = baseCost * (1 + 2 * c * baseLevel)
+  }
+  return {
+    levelCanBuy: buyToLevel,
+    cost: totalCost
+  }
+}
+
+// ─── Cubic summation + quadratic solver ────────────────────────────────────
+
+/**
+ * Sum of the first `n` positive cubes — closed form `(n(n+1)/2)^2`.
+ * Returns 0 if `n === 0`, or -1 if `n` is negative / non-integer (matches
+ * the validation behavior of the original web_ui helper).
+ */
+export function calculateSummationCubic(n: number): number {
+  if (n < 0) {
+    return -1
+  }
+  if (!Number.isInteger(n)) {
+    return -1
+  }
+  return Math.pow((n * (n + 1)) / 2, 2)
+}
+
+/**
+ * Real-root solver for `a * n^2 + b * n + c = 0`. `a` must be nonneg and
+ * the discriminant must be non-negative; otherwise throws.
+ *
+ * `positive` selects which root to return: true → `(-b + sqrt(disc)) / (2a)`,
+ * false → `(-b - sqrt(disc)) / (2a)`. When the discriminant is 0 both forms
+ * collapse to `-b / (2a)`.
+ */
+export function solveQuadratic(a: number, b: number, c: number, positive: boolean): number {
+  if (a < 0) {
+    throw new Error('SUMMATIONS_QUADRATIC_IMPROPER')
+  }
+  const determinant = Math.pow(b, 2) - 4 * a * c
+  if (determinant < 0) {
+    throw new Error('SUMMATIONS_QUADRATIC_DETERMINANT')
+  }
+
+  if (determinant === 0) {
+    return -b / (2 * a)
+  }
+  const root = Math.sqrt(determinant)
+  return positive ? (-b + root) / (2 * a) : (-b - root) / (2 * a)
+}
+
+export interface CalculateCubicSumDataResult {
+  levelCanBuy: number
+  cost: number
+}
+
+/**
+ * Cubic-cost upgrade-batch solver: if level i costs `baseCost * (i+1)^3`,
+ * compute how many levels can be bought given `initialLevel` already owned
+ * and `amountToSpend` more available, capped at `maxLevel`. Returns the
+ * `{levelCanBuy, cost}` pair where `cost` is the actual amount that would
+ * be spent.
+ *
+ * Throws on negative `totalToSpend` (programmer-error guard).
+ */
+export function calculateCubicSumData(
+  initialLevel: number,
+  baseCost: number,
+  amountToSpend: number,
+  maxLevel: number
+): CalculateCubicSumDataResult {
+  if (initialLevel >= maxLevel) {
+    return {
+      levelCanBuy: maxLevel,
+      cost: 0
+    }
+  }
+  const alreadySpent = baseCost * calculateSummationCubic(initialLevel)
+  const totalToSpend = alreadySpent + amountToSpend
+
+  if (totalToSpend < 0) {
+    throw new Error('SUMMATIONS_CUBIC_SUM_NEGATIVE')
+  }
+
+  const determinantRoot = Math.pow(totalToSpend / baseCost, 0.5)
+  const solution = solveQuadratic(1, 1, -2 * determinantRoot, true)
+
+  const levelToBuy = Math.max(
+    Math.min(maxLevel, Math.floor(solution)),
+    initialLevel
+  )
+  const realCost = levelToBuy === initialLevel
+    ? baseCost * Math.pow(initialLevel + 1, 3)
+    : baseCost * calculateSummationCubic(levelToBuy) - alreadySpent
+
+  return {
+    levelCanBuy: levelToBuy,
+    cost: realCost
+  }
+}

--- a/packages/logic/src/mechanics/acceleratorMultipliers.ts
+++ b/packages/logic/src/mechanics/acceleratorMultipliers.ts
@@ -1,0 +1,186 @@
+// Total free-accelerator-boost and accelerator-multiplier formulas lifted
+// from packages/web_ui/src/Calculate.ts. Both functions read a lot of
+// player / G state; the web_ui shim collects every input field and passes
+// them in scalar form.
+//
+// G side-effect note: the old `calculateTotalAcceleratorBoost` and
+// `calculateAcceleratorMultiplier` wrote to G.freeAcceleratorBoost /
+// G.totalAcceleratorBoost / G.acceleratorMultiplier directly. Logic stays
+// pure — it returns the computed values; the web_ui shim does the G writes.
+
+import { CalcECC } from './challenges'
+
+// ─── Total accelerator boost (free + total) ────────────────────────────────
+
+export interface CalculateTotalAcceleratorBoostInput {
+  /** player.upgrades[26] — +1 free boost when > 0.5. */
+  upgrade26: number
+  /** player.upgrades[31] — adds totalCoinOwned/2000 (floored × 100 / 100) when > 0.5. */
+  upgrade31: number
+  /** Precomputed by `calculateTotalCoinOwned` in web_ui. */
+  totalCoinOwned: number
+  /**
+   * +getAchievementReward('accelBoosts') — the achievement reward already
+   * comes back as a number (the unary + is preserved by callers if needed).
+   */
+  achievementAccelBoosts: number
+  /** player.researches[93] — multiplies floor(sumOfRuneLevels/20). */
+  research93: number
+  /** sumOfRuneLevels() in web_ui. */
+  sumOfRuneLevels: number
+  /** player.researches[3]. */
+  research3: number
+  /** player.challengecompletions[14] — feeds CalcECC('ascension', cc14). */
+  challengeCompletions14: number
+  /** player.researches[16], 17. */
+  research16: number
+  research17: number
+  /** player.researches[88]. */
+  research88: number
+  /** getAntUpgradeEffect(AntUpgrades.AcceleratorBoosts).acceleratorBoostMult. */
+  antBuildingAcceleratorBoostMult: number
+  /** player.researches[127], 142, 157, 172, 187, 200. */
+  research127: number
+  research142: number
+  research157: number
+  research172: number
+  research187: number
+  research200: number
+  /** player.cubeUpgrades[50]. */
+  cubeUpgrade50: number
+  /** hepteractEffective('acceleratorBoost') in web_ui. */
+  hepteractEffectiveAcceleratorBoost: number
+  /** player.upgrades[73] — doubles boost when also in a reincarnation challenge. */
+  upgrade73: number
+  /** True when player.currentChallenge.reincarnation !== 0. */
+  inReincarnationChallenge: boolean
+  /** player.acceleratorBoostBought — added to free boost for the total. */
+  acceleratorBoostBought: number
+}
+
+export interface CalculateTotalAcceleratorBoostResult {
+  /** What web_ui assigns to G.freeAcceleratorBoost. */
+  freeAcceleratorBoost: number
+  /** What web_ui assigns to G.totalAcceleratorBoost. */
+  totalAcceleratorBoost: number
+}
+
+/**
+ * Computes the "free" accelerator-boost amount from upgrades, achievements,
+ * researches, rune levels, ant building effects, hepteract effectiveness,
+ * and various cube upgrades. The reincarnation-challenge × upgrade[73] gate
+ * doubles the result. Floored, then capped at 1e100.
+ *
+ * `totalAcceleratorBoost` = floor(bought + free × 100) / 100 — the original
+ * floor-to-1-decimal that web_ui assigned to G.totalAcceleratorBoost.
+ */
+export function calculateTotalAcceleratorBoost(
+  input: CalculateTotalAcceleratorBoostInput
+): CalculateTotalAcceleratorBoostResult {
+  let b = 0
+  if (input.upgrade26 > 0.5) {
+    b += 1
+  }
+  if (input.upgrade31 > 0.5) {
+    b += (Math.floor(input.totalCoinOwned / 2000) * 100) / 100
+  }
+  b += input.achievementAccelBoosts
+
+  b += input.research93 * Math.floor((1 / 20) * input.sumOfRuneLevels)
+  b *= 1
+    + (1 / 5)
+      * input.research3
+      * (1 + (1 / 2) * CalcECC('ascension', input.challengeCompletions14))
+  b *= 1 + (1 / 20) * input.research16 + (1 / 20) * input.research17
+  b *= 1 + (1 / 20) * input.research88
+  b *= input.antBuildingAcceleratorBoostMult
+  b *= 1 + (1 / 100) * input.research127
+  b *= 1 + (0.8 / 100) * input.research142
+  b *= 1 + (0.6 / 100) * input.research157
+  b *= 1 + (0.4 / 100) * input.research172
+  b *= 1 + (0.2 / 100) * input.research187
+  b *= 1 + (0.01 / 100) * input.research200
+  b *= 1 + (0.01 / 100) * input.cubeUpgrade50
+  b *= 1 + (1 / 1000) * input.hepteractEffectiveAcceleratorBoost
+  if (input.upgrade73 > 0.5 && input.inReincarnationChallenge) {
+    b *= 2
+  }
+  b = Math.min(1e100, Math.floor(b))
+
+  const freeAcceleratorBoost = b
+  const totalAcceleratorBoost = (Math.floor(input.acceleratorBoostBought + freeAcceleratorBoost) * 100) / 100
+  return { freeAcceleratorBoost, totalAcceleratorBoost }
+}
+
+// ─── Accelerator multiplier ────────────────────────────────────────────────
+
+export interface CalculateAcceleratorMultiplierInput {
+  /** player.researches[1]. */
+  research1: number
+  /** player.challengecompletions[14] — feeds CalcECC('ascension', cc14). */
+  challengeCompletions14: number
+  /** player.researches[6..10]. */
+  research6: number
+  research7: number
+  research8: number
+  research9: number
+  research10: number
+  /** player.researches[86], 126, 141, 156, 171, 186, 200. */
+  research86: number
+  research126: number
+  research141: number
+  research156: number
+  research171: number
+  research186: number
+  research200: number
+  /** player.cubeUpgrades[50]. */
+  cubeUpgrade50: number
+  /** player.upgrades[21..25] — sum is the exponent on 1.01. */
+  upgrade21: number
+  upgrade22: number
+  upgrade23: number
+  upgrade24: number
+  upgrade25: number
+  /** player.upgrades[50] — combined with the in-challenge gate, multiplies by 1.25. */
+  upgrade50: number
+  /**
+   * True when player.currentChallenge.transcension !== 0 OR
+   * player.currentChallenge.reincarnation !== 0.
+   */
+  inTranscensionOrReincarnationChallenge: boolean
+}
+
+/**
+ * Compounding multiplier built from research levels, cube upgrades, the
+ * 21..25 upgrade pentad (1.01^sum), and an optional 1.25× from
+ * upgrade[50] while in a transcension or reincarnation challenge.
+ */
+export function calculateAcceleratorMultiplier(input: CalculateAcceleratorMultiplierInput): number {
+  let multiplier = 1
+  multiplier *= 1
+    + (1 / 5)
+      * input.research1
+      * (1 + (1 / 2) * CalcECC('ascension', input.challengeCompletions14))
+  multiplier *= 1
+    + (1 / 20) * input.research6
+    + (1 / 25) * input.research7
+    + (1 / 40) * input.research8
+    + (3 / 200) * input.research9
+    + (1 / 200) * input.research10
+  multiplier *= 1 + (1 / 20) * input.research86
+  multiplier *= 1 + (1 / 100) * input.research126
+  multiplier *= 1 + (0.8 / 100) * input.research141
+  multiplier *= 1 + (0.6 / 100) * input.research156
+  multiplier *= 1 + (0.4 / 100) * input.research171
+  multiplier *= 1 + (0.2 / 100) * input.research186
+  multiplier *= 1 + (0.01 / 100) * input.research200
+  multiplier *= 1 + (0.01 / 100) * input.cubeUpgrade50
+  multiplier *= Math.pow(
+    1.01,
+    input.upgrade21 + input.upgrade22 + input.upgrade23 + input.upgrade24 + input.upgrade25
+  )
+  if (input.inTranscensionOrReincarnationChallenge && input.upgrade50 > 0.5) {
+    multiplier *= 1.25
+  }
+  return multiplier
+}

--- a/packages/logic/src/mechanics/ambrosia.ts
+++ b/packages/logic/src/mechanics/ambrosia.ts
@@ -1,0 +1,190 @@
+// Ambrosia-family formulas lifted from packages/web_ui/src/Calculate.ts:
+//   - threshold counters over player.lifetimeAmbrosia
+//   - blueberry / red-ambrosia time-per-tick formulas
+//   - cube / quark ambrosia multipliers
+//   - composers over the 4 singularity-GQ and 4 octeract upgrade levels
+//
+// External effect lookups (getShopUpgradeEffects, getAmbrosiaUpgradeEffects,
+// getSingularityChallengeEffect, getGQUpgradeEffect, getOcteractUpgradeEffect)
+// stay in web_ui — callers precompute them and pass scalar/array inputs in.
+
+// ─── Threshold counters ────────────────────────────────────────────────────
+
+const digitReduction = 4
+
+/**
+ * Number of crossed "digit-reduction" thresholds. The first threshold is at
+ * 10000 lifetime ambrosia, and they alternate at 10^(N+digitReduction) and
+ * 3 × 10^(N+digitReduction). Returns 0 below the first threshold.
+ */
+export function calculateNumberOfThresholds(lifetimeAmbrosia: number): number {
+  const numDigits = lifetimeAmbrosia > 0 ? 1 + Math.floor(Math.log10(lifetimeAmbrosia)) : 0
+  const matissa = Math.floor(lifetimeAmbrosia / Math.pow(10, numDigits - 1))
+  const extraReduction = matissa >= 3 ? 1 : 0
+  return Math.max(0, 2 * (numDigits - digitReduction) - 1 + extraReduction)
+}
+
+/**
+ * Distance (in lifetime ambrosia) to the next threshold. Mirrors the two
+ * alternating threshold forms — 10^N and 3 × 10^N.
+ */
+export function calculateToNextThreshold(lifetimeAmbrosia: number): number {
+  const numThresholds = calculateNumberOfThresholds(lifetimeAmbrosia)
+  if (numThresholds === 0) {
+    return 10000 - lifetimeAmbrosia
+  }
+  if (numThresholds % 2 === 0) {
+    return Math.pow(10, numThresholds / 2 + digitReduction) - lifetimeAmbrosia
+  }
+  return 3 * Math.pow(10, (numThresholds - 1) / 2 + digitReduction) - lifetimeAmbrosia
+}
+
+// ─── Required blueberry / red ambrosia times ───────────────────────────────
+
+export interface CalculateRequiredBlueberryTimeInput {
+  /** G.TIME_PER_AMBROSIA — base time-per-bar constant (currently 45). */
+  timePerAmbrosia: number
+  /** player.lifetimeAmbrosia — drives both the +1/300 linear ramp and the >=10000 power scaling. */
+  lifetimeAmbrosia: number
+  /** getShopUpgradeEffects('shopAmbrosiaAccelerator', 'ambrosiaPointRequirementMult'). */
+  acceleratorMult: number
+  /** getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'barRequirementMult'). */
+  brickOfLeadMult: number
+}
+
+/**
+ * Time (in seconds, rounded up past 10k) required to fill one ambrosia bar.
+ * Base ramps linearly by lifetime/300, multiplied by the shop accelerator
+ * and brick-of-lead, with a `(lifetime/10000)^log10(4)` power kick above
+ * 10000.
+ */
+export function calculateRequiredBlueberryTime(input: CalculateRequiredBlueberryTimeInput): number {
+  let val = input.timePerAmbrosia
+  val += Math.floor(input.lifetimeAmbrosia / 300)
+  val *= input.acceleratorMult
+  val *= input.brickOfLeadMult
+  if (input.lifetimeAmbrosia >= 10000) {
+    const extraScalingPower = Math.log10(4)
+    val *= Math.pow(input.lifetimeAmbrosia / 10000, extraScalingPower)
+    return Math.ceil(val)
+  }
+  return val
+}
+
+export interface CalculateRequiredRedAmbrosiaTimeInput {
+  /** G.TIME_PER_RED_AMBROSIA — base time-per-bar constant (currently 100,000). */
+  timePerRedAmbrosia: number
+  /** player.lifetimeRedAmbrosia — drives the +200 per linear ramp. */
+  lifetimeRedAmbrosia: number
+  /** getSingularityChallengeEffect('limitedTime', 'barRequirementMultiplier'). */
+  barRequirementMultiplier: number
+}
+
+/**
+ * Time (in seconds) required to fill one red ambrosia bar. Linear in
+ * `lifetimeRedAmbrosia` then multiplied by the limitedTime-challenge effect,
+ * capped at `1e6 * barRequirementMultiplier`.
+ */
+export function calculateRequiredRedAmbrosiaTime(input: CalculateRequiredRedAmbrosiaTimeInput): number {
+  let val = input.timePerRedAmbrosia
+  val += 200 * input.lifetimeRedAmbrosia
+  const max = 1e6 * input.barRequirementMultiplier
+  val *= input.barRequirementMultiplier
+  return Math.min(max, val)
+}
+
+// ─── Singularity milestone blueberries ─────────────────────────────────────
+
+/**
+ * Number of blueberries unlocked by all-time max singularity count.
+ * Stepwise: 64 → 1, 128 → 2, 192 → 3, 256 → 4, 270 → 5.
+ */
+export function calculateSingularityMilestoneBlueberries(highestSingularityCount: number): number {
+  if (highestSingularityCount >= 270) return 5
+  if (highestSingularityCount >= 256) return 4
+  if (highestSingularityCount >= 192) return 3
+  if (highestSingularityCount >= 128) return 2
+  if (highestSingularityCount >= 64) return 1
+  return 0
+}
+
+// ─── Ambrosia cube / quark multipliers ─────────────────────────────────────
+
+export interface AmbrosiaMultInput {
+  /** player.singularityChallenges.noAmbrosiaUpgrades.enabled — when true, effective ambrosia is 0. */
+  noAmbrosiaUpgradesEnabled: boolean
+  /** player.lifetimeAmbrosia. */
+  lifetimeAmbrosia: number
+}
+
+/**
+ * Cube multiplier from lifetime ambrosia. Three additive tiers:
+ *   - floor(eff/66)/100, capped at 1.5
+ *   - +floor(eff/666)/100 (capped 1.5), if eff >= 10000
+ *   - +floor(eff/6666)/100 (uncapped), if eff >= 100000
+ * The `noAmbrosiaUpgrades` Exalt zeros out effective ambrosia.
+ */
+export function calculateAmbrosiaCubeMult(input: AmbrosiaMultInput): number {
+  const effectiveAmbrosia = input.noAmbrosiaUpgradesEnabled ? 0 : input.lifetimeAmbrosia
+  let multiplier = 1
+  multiplier += Math.min(1.5, Math.floor(effectiveAmbrosia / 66) / 100)
+  if (effectiveAmbrosia >= 10000) {
+    multiplier += Math.min(1.5, Math.floor(effectiveAmbrosia / 666) / 100)
+  }
+  if (effectiveAmbrosia >= 100000) {
+    multiplier += Math.floor(effectiveAmbrosia / 6666) / 100
+  }
+  return multiplier
+}
+
+/**
+ * Quark multiplier from lifetime ambrosia. Same three-tier shape as the cube
+ * mult but smaller divisors and a 0.3 per-tier cap on the first two.
+ */
+export function calculateAmbrosiaQuarkMult(input: AmbrosiaMultInput): number {
+  const effectiveAmbrosia = input.noAmbrosiaUpgradesEnabled ? 0 : input.lifetimeAmbrosia
+  let multiplier = 1
+  multiplier += Math.min(0.3, Math.floor(effectiveAmbrosia / 1666) / 100)
+  if (effectiveAmbrosia >= 50000) {
+    multiplier += Math.min(0.3, Math.floor(effectiveAmbrosia / 16666) / 100)
+  }
+  if (effectiveAmbrosia >= 500000) {
+    multiplier += Math.floor(effectiveAmbrosia / 166666) / 100
+  }
+  return multiplier
+}
+
+// ─── Upgrade composers ─────────────────────────────────────────────────────
+//
+// Each composer takes the 4 precomputed effect values for the relevant
+// upgrade chain (singAmbrosiaGeneration / singAmbrosiaGeneration2/3/4 etc.)
+// and reduces them — multiplicative for generation-speed, additive for luck.
+
+/**
+ * Multiplies the four `singAmbrosiaGeneration[1..4]` `ambrosiaBarSpeedMult`
+ * effects together. Caller (web_ui) collects them via getGQUpgradeEffect.
+ */
+export function calculateAmbrosiaGenerationSingularityUpgrade(speedMults: number[]): number {
+  return speedMults.reduce((a, b) => a * b, 1)
+}
+
+/**
+ * Sums the four `singAmbrosiaLuck[1..4]` `ambrosiaLuck` effects.
+ */
+export function calculateAmbrosiaLuckSingularityUpgrade(luckValues: number[]): number {
+  return luckValues.reduce((a, b) => a + b, 0)
+}
+
+/**
+ * Multiplies the four `octeractAmbrosiaGeneration[1..4]` speed-mult effects.
+ */
+export function calculateAmbrosiaGenerationOcteractUpgrade(speedMults: number[]): number {
+  return speedMults.reduce((a, b) => a * b, 1)
+}
+
+/**
+ * Sums the four `octeractAmbrosiaLuck[1..4]` luck effects.
+ */
+export function calculateAmbrosiaLuckOcteractUpgrade(luckValues: number[]): number {
+  return luckValues.reduce((a, b) => a + b, 0)
+}

--- a/packages/logic/src/mechanics/ascensions.ts
+++ b/packages/logic/src/mechanics/ascensions.ts
@@ -1,0 +1,30 @@
+// Ascension-related formulas lifted from packages/web_ui/src/Calculate.ts.
+// Currently just the per-reset ascension count. Web_ui collects the
+// `ascensionCountMultStats` StatLine values into an array and passes them in;
+// logic reduces and floors.
+
+export interface CalculateAscensionCountInput {
+  /**
+   * player.singularityChallenges.limitedAscensions.enabled — when true the
+   * count is capped at 1 (Exalt 3 forces one ascension at a time).
+   */
+  limitedAscensionsEnabled: boolean
+  /**
+   * Precomputed multiplier contributions (web_ui:
+   *   ascensionCountMultStats.map(s => s.stat())
+   * ). Product is floored to give the final count.
+   */
+  ascensionCountMults: number[]
+}
+
+/**
+ * `1` when Exalt 3 is active; otherwise
+ * `floor(prod(ascensionCountMults))`. Multiplier contributions can include
+ * fractional and >1 boosts; flooring handles the off-by-one rounding.
+ */
+export function calculateAscensionCount(input: CalculateAscensionCountInput): number {
+  if (input.limitedAscensionsEnabled) {
+    return 1
+  }
+  return Math.floor(input.ascensionCountMults.reduce((a, b) => a * b, 1))
+}

--- a/packages/logic/src/mechanics/exaltPenalties.ts
+++ b/packages/logic/src/mechanics/exaltPenalties.ts
@@ -1,0 +1,111 @@
+// Singularity-challenge penalty math for Exalt 3 (limitedAscensions),
+// Exalt 4 (noOcteracts), and Exalt 6 (limitedTime). Lifted verbatim from
+// packages/web_ui/src/Calculate.ts. Most of these were already parameterized
+// by `comps` or `(comps, time)` and read no player state — the lifts are
+// near-identity. The two that read player state (Exalt 3 penalty, Exalt 4
+// multiplier) take their state as an input object.
+
+// ─── Exalt 3 (limitedAscensions) ───────────────────────────────────────────
+
+/**
+ * Max ascensions allowed in Exalt 3 before the doubling penalty kicks in.
+ * Drops by 2 per challenge completion, floored at 0.
+ */
+export function calculateExalt3AscensionLimit(comps: number): number {
+  return Math.max(15 - comps * 2, 0)
+}
+
+export interface CalculateExalt3PenaltyInput {
+  /** player.singularityChallenges.limitedAscensions.enabled — gates the penalty. */
+  limitedAscensionsEnabled: boolean
+  /** player.singularityChallenges.limitedAscensions.completions — feeds the ascension limit. */
+  limitedAscensionsCompletions: number
+  /** player.ascensionCount — the current run's ascension count. */
+  ascensionCount: number
+}
+
+/**
+ * Returns `2 ^ (ascensions - limit)` once the player crosses the
+ * limit, or 1 otherwise. Outside Exalt 3 the penalty is always 1.
+ */
+export function calculateExalt3Penalty(input: CalculateExalt3PenaltyInput): number {
+  if (!input.limitedAscensionsEnabled) {
+    return 1
+  }
+  const ascensionLimit = calculateExalt3AscensionLimit(input.limitedAscensionsCompletions)
+  return Math.pow(2, Math.max(input.ascensionCount - ascensionLimit, 0))
+}
+
+// ─── Exalt 4 (noOcteracts) ─────────────────────────────────────────────────
+
+export interface CalculateExalt4EffectiveSingularityMultiplierInput {
+  /** noOcteracts challenge completion count being evaluated. */
+  comps: number
+  /**
+   * Force the bonus on even outside the challenge — used by previewers /
+   * Statistics displays that show what the bonus *would* be.
+   */
+  force: boolean
+  /** player.singularityChallenges.noOcteracts.enabled — gates the bonus. */
+  inExalt4: boolean
+}
+
+/**
+ * `(comps + 1)^3` if the player is currently in Exalt 4 OR `force` is true,
+ * else 1. Used as a singularity-count multiplier when computing rewards under
+ * the no-octeracts challenge.
+ */
+export function calculateExalt4EffectiveSingularityMultiplier(
+  input: CalculateExalt4EffectiveSingularityMultiplierInput
+): number {
+  return input.inExalt4 || input.force ? Math.pow(input.comps + 1, 3) : 1
+}
+
+// ─── Exalt 6 (limitedTime) ─────────────────────────────────────────────────
+
+/**
+ * Soft time-cap (in seconds) for an Exalt 6 attempt. Goes from 600s at 0
+ * comps, drops by 60s/comp until 10 comps (at 60s base, but the formula
+ * switches), then 115s minus 5s/comp beyond 10.
+ */
+export function calculateExalt6TimeLimit(comps: number): number {
+  if (comps >= 10) {
+    return 115 - 5 * (comps - 10)
+  }
+  return 600 - 60 * comps
+}
+
+/**
+ * Per-minute penalty rate scaling with comp count. Switches to a faster
+ * scaling at 10+ comps. Internal — only consumed by
+ * `calculateExalt6PenaltyPerSecond`.
+ */
+function calculateExalt6PenaltyPerMinute(comps: number): number {
+  if (comps >= 10) {
+    return 60 + 10 * (comps - 10)
+  }
+  return 10 + 3 * comps
+}
+
+/**
+ * 60-th root of the per-minute penalty rate. Compounding base for the final
+ * `^(-displacedTime)` Exalt 6 penalty.
+ */
+export function calculateExalt6PenaltyPerSecond(comps: number): number {
+  return Math.pow(calculateExalt6PenaltyPerMinute(comps), 1 / 60)
+}
+
+/**
+ * Final Exalt 6 penalty multiplier: 1 if the player finishes within the
+ * `calculateExalt6TimeLimit`, otherwise `penaltyPerSecond ^ -displacedTime`
+ * where `displacedTime = time - timeLimit`.
+ */
+export function calculateExalt6Penalty(comps: number, time: number): number {
+  const timeLimit = calculateExalt6TimeLimit(comps)
+  const displacedTime = Math.max(0, time - timeLimit)
+  if (displacedTime === 0) {
+    return 1
+  }
+  const penaltyPerSecond = calculateExalt6PenaltyPerSecond(comps)
+  return Math.pow(penaltyPerSecond, -displacedTime)
+}

--- a/packages/logic/src/mechanics/octeractBonuses.ts
+++ b/packages/logic/src/mechanics/octeractBonuses.ts
@@ -1,0 +1,121 @@
+// Total-octeract bonuses lifted from packages/web_ui/src/Calculate.ts. Four
+// thematically-related functions gated by the noOcteracts (Exalt 4)
+// singularity challenge. All bodies are transcribed verbatim — only the
+// player / getSingularityChallengeEffect lookups are hoisted out into input
+// fields that the web_ui shim precomputes.
+//
+// Offering & Obtainium bonuses are derived from the cube bonus, so the
+// caller precomputes that and passes it in (matches the rest of the package's
+// "callers aggregate, logic transforms" convention).
+
+// ─── Total octeract cube bonus ─────────────────────────────────────────────
+
+export interface CalculateTotalOcteractCubeBonusInput {
+  /** player.singularityChallenges.noOcteracts.enabled — Exalt 4 gate. */
+  exalt4Enabled: boolean
+  /** player.totalWowOcteracts — lifetime octeract earnings. */
+  totalWowOcteracts: number
+  /**
+   * getSingularityChallengeEffect('noOcteracts', 'octeractPow') — additive
+   * exponent boost on the log10 branch. Base power is 2 + octeractPow.
+   */
+  octeractPow: number
+}
+
+/**
+ * Linear ramp from 1 to 3 across 0–1000 octeracts (with a small-value
+ * threshold to avoid noise just above 1), then a log10 power curve above
+ * 1000: `3 * (log10(N) - 2) ^ (2 + octeractPow)`. Returns 1 when inside
+ * Exalt 4 (bonus is suppressed by the challenge).
+ */
+export function calculateTotalOcteractCubeBonus(input: CalculateTotalOcteractCubeBonusInput): number {
+  if (input.exalt4Enabled) {
+    return 1
+  }
+  if (input.totalWowOcteracts < 1000) {
+    const bonus = 1 + (2 / 1000) * input.totalWowOcteracts
+    return bonus > 1.00001 ? bonus : 1
+  }
+  const power = 2 + input.octeractPow
+  return 3 * Math.pow(Math.log10(input.totalWowOcteracts) - 2, power)
+}
+
+// ─── Total octeract quark bonus ────────────────────────────────────────────
+
+export interface CalculateTotalOcteractQuarkBonusInput {
+  /** player.singularityChallenges.noOcteracts.enabled — Exalt 4 gate. */
+  exalt4Enabled: boolean
+  /** player.totalWowOcteracts — lifetime octeract earnings. */
+  totalWowOcteracts: number
+}
+
+/**
+ * Linear ramp from 1 to 1.20 across 0–1000 octeracts (with the same
+ * small-value tolerance as the cube bonus), then linear in `log10(N) - 2`
+ * above 1000: `1.1 + 0.1 * (log10(N) - 2)`. Returns 1 in Exalt 4.
+ */
+export function calculateTotalOcteractQuarkBonus(input: CalculateTotalOcteractQuarkBonusInput): number {
+  if (input.exalt4Enabled) {
+    return 1
+  }
+  if (input.totalWowOcteracts < 1000) {
+    const bonus = 1 + (0.2 / 1000) * input.totalWowOcteracts
+    return bonus > 1.00001 ? bonus : 1
+  }
+  return 1.1 + 0.1 * (Math.log10(input.totalWowOcteracts) - 2)
+}
+
+// ─── Total octeract offering bonus ─────────────────────────────────────────
+
+export interface CalculateTotalOcteractOfferingBonusInput {
+  /**
+   * Truthy when `getSingularityChallengeEffect('noOcteracts', 'offeringBonus')`
+   * is unlocked (Exalt 4 has been completed enough to grant the offering
+   * bonus). Falsy → returns 1.
+   */
+  offeringBonusEnabled: boolean
+  /**
+   * Precomputed cube bonus (caller invokes `calculateTotalOcteractCubeBonus`
+   * first). Raised to the 1.25 power.
+   */
+  cubeBonus: number
+}
+
+/**
+ * `cubeBonus ^ 1.25` once the offering reward of Exalt 4 has been unlocked;
+ * otherwise 1.
+ */
+export function calculateTotalOcteractOfferingBonus(
+  input: CalculateTotalOcteractOfferingBonusInput
+): number {
+  if (!input.offeringBonusEnabled) {
+    return 1
+  }
+  return Math.pow(input.cubeBonus, 1.25)
+}
+
+// ─── Total octeract obtainium bonus ────────────────────────────────────────
+
+export interface CalculateTotalOcteractObtainiumBonusInput {
+  /**
+   * Truthy when `getSingularityChallengeEffect('noOcteracts', 'obtainiumBonus')`
+   * is unlocked. Falsy → returns 1.
+   */
+  obtainiumBonusEnabled: boolean
+  /** Precomputed cube bonus, raised to the 1.25 power. */
+  cubeBonus: number
+}
+
+/**
+ * `cubeBonus ^ 1.25` once the obtainium reward of Exalt 4 has been unlocked;
+ * otherwise 1. Same formula as the offering bonus, gated by a different
+ * challenge effect.
+ */
+export function calculateTotalOcteractObtainiumBonus(
+  input: CalculateTotalOcteractObtainiumBonusInput
+): number {
+  if (!input.obtainiumBonusEnabled) {
+    return 1
+  }
+  return Math.pow(input.cubeBonus, 1.25)
+}

--- a/packages/logic/src/mechanics/overfluxBonuses.ts
+++ b/packages/logic/src/mechanics/overfluxBonuses.ts
@@ -1,0 +1,80 @@
+// Overflux-derived multipliers lifted from packages/web_ui/src/Calculate.ts.
+// Two pure-powder formulas plus the orbs-based cube-to-quark multiplier
+// (a 12-term sigmoid stack gated by singularity-count unlocks).
+
+import { calculateSigmoid } from '../math/sigmoid'
+
+// ─── Powder → cube / quark mults ───────────────────────────────────────────
+
+/**
+ * Cube multiplier from overflux powder. Linear in `overfluxPowder/10000`
+ * below the 10k threshold; switches to a log10² scaling above it.
+ */
+export function calculateCubeMultFromPowder(overfluxPowder: number): number {
+  return overfluxPowder > 10000
+    ? 1 + (1 / 16) * Math.pow(Math.log10(overfluxPowder), 2)
+    : 1 + (1 / 10000) * overfluxPowder
+}
+
+/**
+ * Quark multiplier from overflux powder. Same boundary as the cube version,
+ * but linear log10 above the threshold.
+ */
+export function calculateQuarkMultFromPowder(overfluxPowder: number): number {
+  return overfluxPowder > 10000
+    ? 1 + (1 / 40) * Math.log10(overfluxPowder)
+    : 1 + (1 / 100000) * overfluxPowder
+}
+
+// ─── Orbs → cube-quark multiplier ──────────────────────────────────────────
+
+export interface CalculateCubeQuarkMultiplierInput {
+  /** player.overfluxOrbs — the main scaling input for every sigmoid. */
+  overfluxOrbs: number
+  /**
+   * player.highestSingularityCount — gates the last nine sigmoid contributors
+   * at thresholds 1, 2, 5, 10, 15, 20, 25, 30, 35.
+   */
+  highestSingularityCount: number
+  /**
+   * getShopUpgradeEffects('cubeToQuarkAll', 'quarkMult') — final outer
+   * multiplier.
+   */
+  cubeToQuarkAllMult: number
+  /**
+   * player.autoWarpCheck. When true, the result is further multiplied by
+   * `1 + dailyPowderResetUses`.
+   */
+  autoWarpCheck: boolean
+  /** player.dailyPowderResetUses. */
+  dailyPowderResetUses: number
+}
+
+/**
+ * Cube → quark multiplier from overflux orbs. Sums 12 sigmoid contributors
+ * (with progressively higher constants and divisors), each of the last 9
+ * gated by a singularity-count threshold. Subtracts 11 (the all-zero sum
+ * baseline is 12 because each sigmoid returns 1 at factor=0), then
+ * multiplies by the `cubeToQuarkAll` shop effect and an optional
+ * `dailyPowderResetUses` bonus when auto-warp is on.
+ */
+export function calculateCubeQuarkMultiplier(input: CalculateCubeQuarkMultiplierInput): number {
+  const orbs = input.overfluxOrbs
+  const high = input.highestSingularityCount
+
+  const sigmoids = calculateSigmoid(2, Math.pow(orbs, 0.5), 40)
+    + calculateSigmoid(1.5, Math.pow(orbs, 0.5), 160)
+    + calculateSigmoid(1.5, Math.pow(orbs, 0.5), 640)
+    + calculateSigmoid(1.15, +(high >= 1) * Math.pow(orbs, 0.45), 2560)
+    + calculateSigmoid(1.15, +(high >= 2) * Math.pow(orbs, 0.4), 10000)
+    + calculateSigmoid(1.25, +(high >= 5) * Math.pow(orbs, 0.35), 40000)
+    + calculateSigmoid(1.25, +(high >= 10) * Math.pow(orbs, 0.32), 160000)
+    + calculateSigmoid(1.35, +(high >= 15) * Math.pow(orbs, 0.27), 640000)
+    + calculateSigmoid(1.45, +(high >= 20) * Math.pow(orbs, 0.24), 2e6)
+    + calculateSigmoid(1.55, +(high >= 25) * Math.pow(orbs, 0.21), 1e7)
+    + calculateSigmoid(1.85, +(high >= 30) * Math.pow(orbs, 0.18), 4e7)
+    + calculateSigmoid(3, +(high >= 35) * Math.pow(orbs, 0.15), 1e8)
+
+  const warpBonus = input.autoWarpCheck ? 1 + input.dailyPowderResetUses : 1
+  return (sigmoids - 11) * input.cubeToQuarkAllMult * warpBonus
+}

--- a/packages/logic/src/mechanics/potionBonuses.ts
+++ b/packages/logic/src/mechanics/potionBonuses.ts
@@ -1,0 +1,176 @@
+// Potion-consumption bonuses lifted from packages/web_ui/src/Calculate.ts.
+// Both functions count how many fixed potion-consumption thresholds the
+// player has crossed (via a binary search) and return that count plus the
+// distance to the next threshold. The threshold arrays are pure data and
+// move with the formulas.
+//
+// Also exports `calculatePotionValue` (the actual resource award a potion
+// produces), which uses the same `calculateFastForwardResourcesGlobal`
+// helper internally.
+
+import { Decimal } from '../math/bignum'
+
+// Binary search returning the insertion index for `target` into `array`
+// (assumed sorted ascending). Reproduces the behavior of web_ui's
+// `findInsertionIndex` (Utility.ts) — kept local to this module since the
+// logic package can't reach into web_ui.
+function findInsertionIndex(target: number, array: readonly number[]): number {
+  if (array.length === 0 || target < array[0]) {
+    return 0
+  }
+  if (target >= array[array.length - 1]) {
+    return array.length
+  }
+
+  let low = 0
+  let high = array.length - 1
+
+  while (low < high) {
+    const mid = Math.floor((low + high + 1) / 2)
+    if (array[mid] <= target) {
+      low = mid
+    } else {
+      high = mid - 1
+    }
+  }
+
+  return low + 1
+}
+
+const offeringPotionThresholds: readonly number[] = [
+  1,
+  10,
+  25,
+  50,
+  100,
+  500,
+  1000,
+  10000,
+  5e4,
+  1e5,
+  1e6,
+  1e7,
+  1e8,
+  1e9,
+  1e10,
+  1e11,
+  1e12,
+  1e13,
+  1e14,
+  1e15
+]
+
+const obtainiumPotionThresholds: readonly number[] = [
+  1, 20, 50, 250, 1000, 20000, 4e5, 1e7, 4e8, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15
+]
+
+export interface PotionBonusResult {
+  /** Number of crossed thresholds — drives the base offering/obtainium award. */
+  amount: number
+  /**
+   * Lifetime potions of this type still required before the next threshold,
+   * or `Number.POSITIVE_INFINITY` if all thresholds have been crossed.
+   */
+  toNext: number
+}
+
+function computePotionBonus(consumed: number, thresholds: readonly number[]): PotionBonusResult {
+  const amount = findInsertionIndex(consumed, thresholds)
+  const toNext = amount < thresholds.length
+    ? thresholds[amount] - consumed
+    : Number.POSITIVE_INFINITY
+  return { amount, toNext }
+}
+
+/**
+ * Offering potion base award. Returns the count of crossed
+ * `offeringPotionThresholds` plus the distance to the next one.
+ */
+export function calculateOfferingPotionBaseOfferings(consumed: number): PotionBonusResult {
+  return computePotionBonus(consumed, offeringPotionThresholds)
+}
+
+/**
+ * Obtainium potion base award. Same shape as the offering version with the
+ * obtainium-specific threshold table.
+ */
+export function calculateObtainiumPotionBaseObtainium(consumed: number): PotionBonusResult {
+  return computePotionBonus(consumed, obtainiumPotionThresholds)
+}
+
+// ─── Potion value ──────────────────────────────────────────────────────────
+
+interface CalculateFastForwardResourcesGlobalInput {
+  resetTime: number
+  fastForwardAmount: Decimal
+  resourceMult: Decimal
+  baseResource: number
+  /** getGQUpgradeEffect('halfMind', 'unlocked') — gates whether deltaTime uses a flat 10 or the live globalSpeedMult. */
+  halfMindUnlocked: boolean
+  /** calculateGlobalSpeedMult() — used for the alt-deltaTime branch and the dead-code correction below. */
+  globalSpeedMult: number
+  /** resetTimeThreshold() in web_ui, i.e. 10 - player.campaigns.timeThresholdReduction. */
+  resetTimeThreshold: number
+}
+
+function calculateFastForwardResourcesGlobal(input: CalculateFastForwardResourcesGlobalInput): Decimal {
+  let timeMultiplier: Decimal = new Decimal('1')
+
+  const deltaTime = input.fastForwardAmount.times(
+    input.halfMindUnlocked ? 10 : input.globalSpeedMult
+  )
+
+  // Take the min of two derivative approximations: quadratic-penalty branch
+  // (when reset time is below threshold) and linear-penalty branch (above).
+  timeMultiplier = Decimal.min(
+    deltaTime.times(2 * input.resetTime).div(input.resetTimeThreshold ** 2),
+    deltaTime.div(input.resetTimeThreshold)
+  )
+
+  // NOTE: preserved verbatim from web_ui — this `.times(...)` call discards
+  // its result (should be `timeMultiplier = timeMultiplier.times(...)`).
+  // Treated as a no-op so parity stays exact; a real fix is out of scope.
+  timeMultiplier.times(input.halfMindUnlocked ? input.globalSpeedMult / 10 : 1)
+
+  return Decimal.max(input.fastForwardAmount.times(input.baseResource), input.resourceMult.times(timeMultiplier))
+}
+
+export interface CalculatePotionValueInput {
+  /** player.{reset}counter — current run time. */
+  resetTime: number
+  /** Precomputed `calculateOfferings` or `calculateObtainium` value. */
+  resourceMult: Decimal
+  /** Precomputed `calculateBaseOfferings` / `calculateBaseObtainium`. */
+  baseResource: number
+  /** getGQUpgradeEffect('halfMind', 'unlocked'). */
+  halfMindUnlocked: boolean
+  /** calculateGlobalSpeedMult() in web_ui. */
+  globalSpeedMult: number
+  /** resetTimeThreshold() in web_ui. */
+  resetTimeThreshold: number
+  /**
+   * Product of the four potion-power multiplier effects: `potionBuff`,
+   * `potionBuff2`, `potionBuff3` (singularity GQ) and
+   * `octeractAutoPotionEfficiency` (octeract).
+   */
+  potionMultipliers: number
+}
+
+/**
+ * Resource award for activating one potion. Combines a 7200-second
+ * fast-forward (= 2h) computed against the current run time with the
+ * stacked potion-power multipliers.
+ */
+export function calculatePotionValue(input: CalculatePotionValueInput): Decimal {
+  const potionTimeValue = new Decimal(7200)
+  const fastForwardMult = calculateFastForwardResourcesGlobal({
+    resetTime: input.resetTime,
+    fastForwardAmount: potionTimeValue,
+    resourceMult: input.resourceMult,
+    baseResource: input.baseResource,
+    halfMindUnlocked: input.halfMindUnlocked,
+    globalSpeedMult: input.globalSpeedMult,
+    resetTimeThreshold: input.resetTimeThreshold
+  })
+  return fastForwardMult.times(input.potionMultipliers)
+}

--- a/packages/logic/src/mechanics/redAmbrosiaBonuses.ts
+++ b/packages/logic/src/mechanics/redAmbrosiaBonuses.ts
@@ -1,0 +1,86 @@
+// Red-ambrosia-derived bonuses lifted from packages/web_ui/src/Calculate.ts.
+// Four functions, each one read `player.lifetimeRedAmbrosia` and combine it
+// with a red-ambrosia-upgrade gate / exponent. The cookie-29 luck function
+// also reads `player.cubeUpgrades[79]` as its second gate. The
+// `getRedAmbrosiaUpgradeEffects(...)` lookups stay in web_ui — callers pass
+// scalar inputs in.
+
+// ─── Cookie upgrade 29 luck ────────────────────────────────────────────────
+
+export interface CalculateCookieUpgrade29LuckInput {
+  /** player.cubeUpgrades[79] — gates the bonus. 0 → no bonus. */
+  cubeUpgrade79: number
+  /** player.lifetimeRedAmbrosia — feeds the log10 in the formula. */
+  lifetimeRedAmbrosia: number
+}
+
+/**
+ * 10 × log10(lifetimeRedAmbrosia)^2 once both gates are non-zero, else 0.
+ */
+export function calculateCookieUpgrade29Luck(input: CalculateCookieUpgrade29LuckInput): number {
+  if (input.cubeUpgrade79 === 0 || input.lifetimeRedAmbrosia === 0) {
+    return 0
+  }
+  return 10 * Math.pow(Math.log10(input.lifetimeRedAmbrosia), 2)
+}
+
+// ─── Red ambrosia cube bonus ───────────────────────────────────────────────
+
+export interface CalculateRedAmbrosiaCubesInput {
+  /**
+   * Truthy when `getRedAmbrosiaUpgradeEffects('redAmbrosiaCube',
+   * 'unlockedRedAmbrosiaCube')` is set. Falsy → returns 1.
+   */
+  unlocked: boolean
+  /** player.lifetimeRedAmbrosia. */
+  lifetimeRedAmbrosia: number
+  /**
+   * `getRedAmbrosiaUpgradeEffects('redAmbrosiaCubeImprover',
+   * 'extraExponent')` — added to the base 0.4 exponent.
+   */
+  extraExponent: number
+}
+
+/**
+ * `1 + lifetimeRedAmbrosia ^ (0.4 + extraExponent) / 100` once the unlock is
+ * set; otherwise 1.
+ */
+export function calculateRedAmbrosiaCubes(input: CalculateRedAmbrosiaCubesInput): number {
+  if (!input.unlocked) {
+    return 1
+  }
+  const exponent = 0.4 + input.extraExponent
+  return 1 + Math.pow(input.lifetimeRedAmbrosia, exponent) / 100
+}
+
+// ─── Red ambrosia obtainium bonus ──────────────────────────────────────────
+
+export interface CalculateRedAmbrosiaResourceInput {
+  /**
+   * Truthy when the corresponding red-ambrosia upgrade is unlocked. Falsy →
+   * returns 1.
+   */
+  unlocked: boolean
+  /** player.lifetimeRedAmbrosia. */
+  lifetimeRedAmbrosia: number
+}
+
+/**
+ * `1 + lifetimeRedAmbrosia^0.6 / 100` when unlocked; else 1.
+ */
+export function calculateRedAmbrosiaObtainium(input: CalculateRedAmbrosiaResourceInput): number {
+  if (!input.unlocked) {
+    return 1
+  }
+  return 1 + Math.pow(input.lifetimeRedAmbrosia, 0.6) / 100
+}
+
+/**
+ * Same formula as the obtainium bonus, gated on the offering unlock instead.
+ */
+export function calculateRedAmbrosiaOffering(input: CalculateRedAmbrosiaResourceInput): number {
+  if (!input.unlocked) {
+    return 1
+  }
+  return 1 + Math.pow(input.lifetimeRedAmbrosia, 0.6) / 100
+}

--- a/packages/logic/src/mechanics/singularityMilestones.ts
+++ b/packages/logic/src/mechanics/singularityMilestones.ts
@@ -1,0 +1,198 @@
+// Singularity-milestone bonuses, lifted from packages/web_ui/src/Calculate.ts.
+//
+// Every function in this file follows the same shape: read a single (or two)
+// counter from the player — current `singularityCount` or all-time
+// `highestSingularityCount` — count how many entries of a hardcoded threshold
+// array have been crossed, and return a numeric bonus. The threshold arrays
+// are data (not state) and live here alongside the formulas that use them.
+
+// dprint-ignore
+const singQuarkMilestoneThresholds = [
+  5, 7, 10, 20, 35, 50, 65, 80, 90, 100, 121, 144, 150, 160, 166, 169, 170,
+  175, 180, 190, 196, 200, 201, 202, 203, 204, 205, 210, 213, 216, 219, 225,
+  228, 231, 234, 237, 240, 244, 248, 252, 256, 260, 264, 268, 272, 276, 280,
+  284, 288, 290
+]
+
+const ambrosiaLuckSingThresholds1 = [35, 42, 49, 56, 63, 70, 77]
+const ambrosiaLuckSingThresholds2 = [135, 142, 149, 156, 163, 170, 177]
+
+const derpsmithSingCounts = [
+  18,
+  38,
+  58,
+  78,
+  88,
+  98,
+  118,
+  148,
+  178,
+  188,
+  198,
+  208,
+  218,
+  228,
+  238,
+  248
+]
+
+const immaculateAlchemyThresholds = [50, 90, 130, 170, 200, 217, 235, 253, 271, 289]
+
+const inheritanceLevels = [2, 5, 10, 17, 26, 37, 50, 65, 82, 101, 220, 240, 260, 270, 277]
+const inheritanceTokenValues = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
+
+const bonusTokenLevels = [41, 58, 113, 163, 229]
+
+const dilatedFiveLeafSingThresholds = [100, 150, 200, 225, 250, 255, 260, 265, 269, 272]
+
+// ─── Quark milestone multiplier ────────────────────────────────────────────
+
+/**
+ * Compounds a 1.05× multiplier for every entry of `singQuarkMilestoneThresholds`
+ * crossed by the current `player.singularityCount`. Resets with the
+ * singularity; uses the live count, not the all-time max.
+ */
+export function calculateSingularityQuarkMilestoneMultiplier(singularityCount: number): number {
+  let multiplier = 1
+  for (const sing of singQuarkMilestoneThresholds) {
+    if (singularityCount >= sing) {
+      multiplier *= 1.05
+    }
+  }
+  return multiplier
+}
+
+// ─── Base golden quarks earned at a singularity ────────────────────────────
+
+export interface CalculateBaseGoldenQuarksInput {
+  /** The singularity count being entered — exponent base for the minimum value. */
+  singularity: number
+  /** player.quarksThisSingularity — / 1e5 contribution. */
+  quarksThisSingularity: number
+  /** player.highestSingularityCount — capped at 10 for the first-ten +10 each bonus. */
+  highestSingularityCount: number
+}
+
+/**
+ * Base GQ award before any milestone / shop / GQ-upgrade multipliers.
+ *   floor(100 * 1.04^singularity + quarksThisSingularity/1e5 + 10 * min(highest, 10))
+ */
+export function calculateBaseGoldenQuarks(input: CalculateBaseGoldenQuarksInput): number {
+  const minimumValue = 100 * Math.pow(1.04, input.singularity)
+  const contributionFromQuarks = input.quarksThisSingularity / 1e5
+  const firstTenBonus = 10 * Math.min(input.highestSingularityCount, 10)
+  return Math.floor(minimumValue + contributionFromQuarks + firstTenBonus)
+}
+
+// ─── Ambrosia luck milestone bonus ─────────────────────────────────────────
+
+/**
+ * Additive ambrosia-luck bonus from two singularity-count threshold tables:
+ * +5 per entry of ambrosiaLuckSingThresholds1 crossed, +6 per entry of
+ * ambrosiaLuckSingThresholds2 crossed. Uses the all-time max count.
+ */
+export function calculateSingularityAmbrosiaLuckMilestoneBonus(highestSingularityCount: number): number {
+  let bonus = 0
+  for (const sing of ambrosiaLuckSingThresholds1) {
+    if (highestSingularityCount >= sing) {
+      bonus += 5
+    }
+  }
+  for (const sing of ambrosiaLuckSingThresholds2) {
+    if (highestSingularityCount >= sing) {
+      bonus += 6
+    }
+  }
+  return bonus
+}
+
+// ─── Dilated Five Leaf bonus ───────────────────────────────────────────────
+
+/**
+ * Returns the fraction (0.00–0.10) representing how many of the
+ * dilatedFiveLeafSingThresholds have been crossed by the all-time max
+ * singularity count. The first un-crossed threshold's index / 100 is
+ * returned; if all thresholds are crossed, returns thresholds.length / 100.
+ */
+export function calculateDilatedFiveLeafBonus(highestSingularityCount: number): number {
+  for (let i = 0; i < dilatedFiveLeafSingThresholds.length; i++) {
+    if (highestSingularityCount < dilatedFiveLeafSingThresholds[i]) return i / 100
+  }
+  return dilatedFiveLeafSingThresholds.length / 100
+}
+
+// ─── Derpsmith Cornucopia ──────────────────────────────────────────────────
+
+/**
+ * 1 + (count_of_thresholds_crossed × highestSingularityCount) / 100. The
+ * count grows in coarse steps from derpsmithSingCounts; the per-count weight
+ * is the all-time max singularity count itself.
+ */
+export function derpsmithCornucopiaBonus(highestSingularityCount: number): number {
+  let counter = 0
+  for (const sing of derpsmithSingCounts) {
+    if (highestSingularityCount >= sing) {
+      counter += 1
+    }
+  }
+  return 1 + (counter * highestSingularityCount) / 100
+}
+
+// ─── Immaculate Alchemy ────────────────────────────────────────────────────
+
+/**
+ * 1 + 0.4 per immaculateAlchemyThreshold crossed by the current
+ * singularityCount (not the all-time max).
+ */
+export function calculateImmaculateAlchemyBonus(singularityCount: number): number {
+  let bonus = 1
+  for (let i = 0; i < immaculateAlchemyThresholds.length; i++) {
+    if (singularityCount >= immaculateAlchemyThresholds[i]) {
+      bonus += 0.4
+    }
+  }
+  return bonus
+}
+
+// ─── Inheritance Tokens ────────────────────────────────────────────────────
+
+/**
+ * Returns the inheritanceTokenValues entry for the highest
+ * inheritanceLevels[i] that the player has crossed (1 ≤ i ≤ 15). Returns 0
+ * if nothing crossed. Indexes 1..15 — index 0 is unused (matches the
+ * original web_ui loop).
+ */
+export function inheritanceTokens(highestSingularityCount: number): number {
+  for (let i = 15; i > 0; i--) {
+    if (highestSingularityCount >= inheritanceLevels[i]) {
+      return inheritanceTokenValues[i]
+    }
+  }
+  return 0
+}
+
+// ─── Sum of exalt completions ──────────────────────────────────────────────
+
+/**
+ * Sum of `.completions` across every singularity challenge. Web_ui passes
+ * the precomputed array (Object.values(player.singularityChallenges)
+ * .map(c => c.completions)) and logic reduces.
+ */
+export function sumOfExaltCompletions(completionsList: number[]): number {
+  return completionsList.reduce((a, b) => a + b, 0)
+}
+
+// ─── Singularity bonus token mult ──────────────────────────────────────────
+
+/**
+ * Returns 1 + 0.02 × i, where i is the highest index 1..5 such that the
+ * player's all-time max singularity count is ≥ bonusTokenLevels[i-1].
+ */
+export function singularityBonusTokenMult(highestSingularityCount: number): number {
+  for (let i = 5; i > 0; i--) {
+    if (highestSingularityCount >= bonusTokenLevels[i - 1]) {
+      return 1 + 0.02 * i
+    }
+  }
+  return 1
+}

--- a/packages/logic/test/parity/acceleratorMultipliers.parity.test.ts
+++ b/packages/logic/test/parity/acceleratorMultipliers.parity.test.ts
@@ -1,0 +1,276 @@
+// Parity tests for the accelerator-boost and accelerator-multiplier
+// formulas lifted from packages/web_ui/src/Calculate.ts. The old web_ui
+// versions wrote to G.freeAcceleratorBoost / G.totalAcceleratorBoost /
+// G.acceleratorMultiplier; the new versions return the values and let
+// the web_ui shim do the G writes. The `old*` impls below transcribe the
+// computation without the G side effects so the parity check is a pure
+// value compare.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateAcceleratorMultiplier as newAccelMult,
+  calculateTotalAcceleratorBoost as newAccelBoost
+} from '../../src/mechanics/acceleratorMultipliers'
+import { CalcECC } from '../../src/mechanics/challenges'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts,
+//     minus the G writes — they compute the same values) ─────────────────
+
+interface OldAccelBoostArgs {
+  upgrade26: number
+  upgrade31: number
+  totalCoinOwned: number
+  achievementAccelBoosts: number
+  research93: number
+  sumOfRuneLevels: number
+  research3: number
+  challengeCompletions14: number
+  research16: number
+  research17: number
+  research88: number
+  antBuildingAcceleratorBoostMult: number
+  research127: number
+  research142: number
+  research157: number
+  research172: number
+  research187: number
+  research200: number
+  cubeUpgrade50: number
+  hepteractEffectiveAcceleratorBoost: number
+  upgrade73: number
+  inReincarnationChallenge: boolean
+  acceleratorBoostBought: number
+}
+
+const oldAccelBoost = (a: OldAccelBoostArgs): { freeAcceleratorBoost: number; totalAcceleratorBoost: number } => {
+  let b = 0
+  if (a.upgrade26 > 0.5) b += 1
+  if (a.upgrade31 > 0.5) b += (Math.floor(a.totalCoinOwned / 2000) * 100) / 100
+  b += a.achievementAccelBoosts
+  b += a.research93 * Math.floor((1 / 20) * a.sumOfRuneLevels)
+  b *= 1
+    + (1 / 5)
+      * a.research3
+      * (1 + (1 / 2) * CalcECC('ascension', a.challengeCompletions14))
+  b *= 1 + (1 / 20) * a.research16 + (1 / 20) * a.research17
+  b *= 1 + (1 / 20) * a.research88
+  b *= a.antBuildingAcceleratorBoostMult
+  b *= 1 + (1 / 100) * a.research127
+  b *= 1 + (0.8 / 100) * a.research142
+  b *= 1 + (0.6 / 100) * a.research157
+  b *= 1 + (0.4 / 100) * a.research172
+  b *= 1 + (0.2 / 100) * a.research187
+  b *= 1 + (0.01 / 100) * a.research200
+  b *= 1 + (0.01 / 100) * a.cubeUpgrade50
+  b *= 1 + (1 / 1000) * a.hepteractEffectiveAcceleratorBoost
+  if (a.upgrade73 > 0.5 && a.inReincarnationChallenge) b *= 2
+  b = Math.min(1e100, Math.floor(b))
+  return {
+    freeAcceleratorBoost: b,
+    totalAcceleratorBoost: (Math.floor(a.acceleratorBoostBought + b) * 100) / 100
+  }
+}
+
+interface OldAccelMultArgs {
+  research1: number
+  challengeCompletions14: number
+  research6: number
+  research7: number
+  research8: number
+  research9: number
+  research10: number
+  research86: number
+  research126: number
+  research141: number
+  research156: number
+  research171: number
+  research186: number
+  research200: number
+  cubeUpgrade50: number
+  upgrade21: number
+  upgrade22: number
+  upgrade23: number
+  upgrade24: number
+  upgrade25: number
+  upgrade50: number
+  inTranscensionOrReincarnationChallenge: boolean
+}
+
+const oldAccelMult = (a: OldAccelMultArgs): number => {
+  let m = 1
+  m *= 1
+    + (1 / 5)
+      * a.research1
+      * (1 + (1 / 2) * CalcECC('ascension', a.challengeCompletions14))
+  m *= 1
+    + (1 / 20) * a.research6
+    + (1 / 25) * a.research7
+    + (1 / 40) * a.research8
+    + (3 / 200) * a.research9
+    + (1 / 200) * a.research10
+  m *= 1 + (1 / 20) * a.research86
+  m *= 1 + (1 / 100) * a.research126
+  m *= 1 + (0.8 / 100) * a.research141
+  m *= 1 + (0.6 / 100) * a.research156
+  m *= 1 + (0.4 / 100) * a.research171
+  m *= 1 + (0.2 / 100) * a.research186
+  m *= 1 + (0.01 / 100) * a.research200
+  m *= 1 + (0.01 / 100) * a.cubeUpgrade50
+  m *= Math.pow(1.01, a.upgrade21 + a.upgrade22 + a.upgrade23 + a.upgrade24 + a.upgrade25)
+  if (a.inTranscensionOrReincarnationChallenge && a.upgrade50 > 0.5) m *= 1.25
+  return m
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateTotalAcceleratorBoost', () => {
+  // Representative state slices. Bool gates × research patterns × hepteract.
+  const cases: OldAccelBoostArgs[] = [
+    // All zeros — baseline
+    {
+      upgrade26: 0, upgrade31: 0, totalCoinOwned: 0, achievementAccelBoosts: 0,
+      research93: 0, sumOfRuneLevels: 0, research3: 0, challengeCompletions14: 0,
+      research16: 0, research17: 0, research88: 0, antBuildingAcceleratorBoostMult: 1,
+      research127: 0, research142: 0, research157: 0, research172: 0,
+      research187: 0, research200: 0, cubeUpgrade50: 0,
+      hepteractEffectiveAcceleratorBoost: 0, upgrade73: 0,
+      inReincarnationChallenge: false, acceleratorBoostBought: 0
+    },
+    // upgrade26 alone
+    {
+      upgrade26: 1, upgrade31: 0, totalCoinOwned: 0, achievementAccelBoosts: 0,
+      research93: 0, sumOfRuneLevels: 0, research3: 0, challengeCompletions14: 0,
+      research16: 0, research17: 0, research88: 0, antBuildingAcceleratorBoostMult: 1,
+      research127: 0, research142: 0, research157: 0, research172: 0,
+      research187: 0, research200: 0, cubeUpgrade50: 0,
+      hepteractEffectiveAcceleratorBoost: 0, upgrade73: 0,
+      inReincarnationChallenge: false, acceleratorBoostBought: 0
+    },
+    // upgrade31 with totalCoinOwned just past 2000 boundary
+    {
+      upgrade26: 1, upgrade31: 1, totalCoinOwned: 5000, achievementAccelBoosts: 2,
+      research93: 0, sumOfRuneLevels: 0, research3: 0, challengeCompletions14: 0,
+      research16: 0, research17: 0, research88: 0, antBuildingAcceleratorBoostMult: 1,
+      research127: 0, research142: 0, research157: 0, research172: 0,
+      research187: 0, research200: 0, cubeUpgrade50: 0,
+      hepteractEffectiveAcceleratorBoost: 0, upgrade73: 0,
+      inReincarnationChallenge: false, acceleratorBoostBought: 7
+    },
+    // Mid-game: some researches + ant building mult + cc14 contribution
+    {
+      upgrade26: 1, upgrade31: 1, totalCoinOwned: 1e10, achievementAccelBoosts: 10,
+      research93: 1, sumOfRuneLevels: 200, research3: 5, challengeCompletions14: 5,
+      research16: 1, research17: 1, research88: 1, antBuildingAcceleratorBoostMult: 1.5,
+      research127: 10, research142: 10, research157: 10, research172: 10,
+      research187: 10, research200: 100, cubeUpgrade50: 10,
+      hepteractEffectiveAcceleratorBoost: 100, upgrade73: 0,
+      inReincarnationChallenge: false, acceleratorBoostBought: 50
+    },
+    // Reincarnation-challenge × upgrade73 doubles
+    {
+      upgrade26: 1, upgrade31: 1, totalCoinOwned: 1e10, achievementAccelBoosts: 10,
+      research93: 1, sumOfRuneLevels: 200, research3: 5, challengeCompletions14: 5,
+      research16: 1, research17: 1, research88: 1, antBuildingAcceleratorBoostMult: 1.5,
+      research127: 10, research142: 10, research157: 10, research172: 10,
+      research187: 10, research200: 100, cubeUpgrade50: 10,
+      hepteractEffectiveAcceleratorBoost: 100, upgrade73: 1,
+      inReincarnationChallenge: true, acceleratorBoostBought: 50
+    },
+    // Reincarnation-challenge but upgrade73 off — no doubling
+    {
+      upgrade26: 1, upgrade31: 1, totalCoinOwned: 1e10, achievementAccelBoosts: 10,
+      research93: 1, sumOfRuneLevels: 200, research3: 5, challengeCompletions14: 5,
+      research16: 1, research17: 1, research88: 1, antBuildingAcceleratorBoostMult: 1.5,
+      research127: 10, research142: 10, research157: 10, research172: 10,
+      research187: 10, research200: 100, cubeUpgrade50: 10,
+      hepteractEffectiveAcceleratorBoost: 100, upgrade73: 0,
+      inReincarnationChallenge: true, acceleratorBoostBought: 50
+    },
+    // Massive late-game — exercises the 1e100 floor cap
+    {
+      upgrade26: 1, upgrade31: 1, totalCoinOwned: 1e150, achievementAccelBoosts: 100,
+      research93: 1, sumOfRuneLevels: 1e6, research3: 100, challengeCompletions14: 100,
+      research16: 100, research17: 100, research88: 100, antBuildingAcceleratorBoostMult: 1e10,
+      research127: 1000, research142: 1000, research157: 1000, research172: 1000,
+      research187: 1000, research200: 10000, cubeUpgrade50: 1000,
+      hepteractEffectiveAcceleratorBoost: 1e8, upgrade73: 1,
+      inReincarnationChallenge: true, acceleratorBoostBought: 1e10
+    }
+  ]
+
+  it.each(cases.map((c, i) => [i, c] as [number, OldAccelBoostArgs]))('case %i', (_i, args) => {
+    const next = newAccelBoost(args)
+    const old = oldAccelBoost(args)
+    expect(closeEnough(next.freeAcceleratorBoost, old.freeAcceleratorBoost)).toBe(true)
+    expect(closeEnough(next.totalAcceleratorBoost, old.totalAcceleratorBoost)).toBe(true)
+  })
+})
+
+describe('parity: calculateAcceleratorMultiplier', () => {
+  const cases: OldAccelMultArgs[] = [
+    // Baseline — all zeros
+    {
+      research1: 0, challengeCompletions14: 0,
+      research6: 0, research7: 0, research8: 0, research9: 0, research10: 0,
+      research86: 0, research126: 0, research141: 0, research156: 0, research171: 0,
+      research186: 0, research200: 0, cubeUpgrade50: 0,
+      upgrade21: 0, upgrade22: 0, upgrade23: 0, upgrade24: 0, upgrade25: 0, upgrade50: 0,
+      inTranscensionOrReincarnationChallenge: false
+    },
+    // Some early researches
+    {
+      research1: 5, challengeCompletions14: 0,
+      research6: 5, research7: 5, research8: 5, research9: 5, research10: 5,
+      research86: 0, research126: 0, research141: 0, research156: 0, research171: 0,
+      research186: 0, research200: 0, cubeUpgrade50: 0,
+      upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1, upgrade50: 0,
+      inTranscensionOrReincarnationChallenge: false
+    },
+    // CalcECC contribution (challengeCompletions14)
+    {
+      research1: 5, challengeCompletions14: 5,
+      research6: 5, research7: 5, research8: 5, research9: 5, research10: 5,
+      research86: 5, research126: 5, research141: 5, research156: 5, research171: 5,
+      research186: 5, research200: 50, cubeUpgrade50: 10,
+      upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1, upgrade50: 1,
+      inTranscensionOrReincarnationChallenge: false
+    },
+    // In challenge × upgrade50 → 1.25× multiplier
+    {
+      research1: 5, challengeCompletions14: 5,
+      research6: 5, research7: 5, research8: 5, research9: 5, research10: 5,
+      research86: 5, research126: 5, research141: 5, research156: 5, research171: 5,
+      research186: 5, research200: 50, cubeUpgrade50: 10,
+      upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1, upgrade50: 1,
+      inTranscensionOrReincarnationChallenge: true
+    },
+    // In challenge but upgrade50 off — no 1.25×
+    {
+      research1: 5, challengeCompletions14: 5,
+      research6: 5, research7: 5, research8: 5, research9: 5, research10: 5,
+      research86: 5, research126: 5, research141: 5, research156: 5, research171: 5,
+      research186: 5, research200: 50, cubeUpgrade50: 10,
+      upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1, upgrade50: 0,
+      inTranscensionOrReincarnationChallenge: true
+    },
+    // High-research late game
+    {
+      research1: 100, challengeCompletions14: 100,
+      research6: 100, research7: 100, research8: 100, research9: 100, research10: 100,
+      research86: 100, research126: 100, research141: 100, research156: 100, research171: 100,
+      research186: 100, research200: 10000, cubeUpgrade50: 1000,
+      upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1, upgrade50: 1,
+      inTranscensionOrReincarnationChallenge: true
+    }
+  ]
+
+  it.each(cases.map((c, i) => [i, c] as [number, OldAccelMultArgs]))('case %i', (_i, args) => {
+    expect(closeEnough(newAccelMult(args), oldAccelMult(args))).toBe(true)
+  })
+})

--- a/packages/logic/test/parity/ambrosia.parity.test.ts
+++ b/packages/logic/test/parity/ambrosia.parity.test.ts
@@ -1,0 +1,244 @@
+// Parity tests for the ambrosia-family formulas lifted from
+// packages/web_ui/src/Calculate.ts. Sweeps cross the digit-reduction
+// thresholds (10000, 30000, 100000, 300000, ...), the blueberry-time
+// 10000 power-kick boundary, the >=50000 / >=500000 quark-mult tier
+// boundaries, the singularity-blueberry milestone steps (64/128/192/256/270),
+// and the upgrade-composer array reducers.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateAmbrosiaCubeMult as newCubeMult,
+  calculateAmbrosiaGenerationOcteractUpgrade as newAmbrosiaGenOct,
+  calculateAmbrosiaGenerationSingularityUpgrade as newAmbrosiaGenSing,
+  calculateAmbrosiaLuckOcteractUpgrade as newAmbrosiaLuckOct,
+  calculateAmbrosiaLuckSingularityUpgrade as newAmbrosiaLuckSing,
+  calculateAmbrosiaQuarkMult as newQuarkMult,
+  calculateNumberOfThresholds as newNumThresholds,
+  calculateRequiredBlueberryTime as newBlueberryTime,
+  calculateRequiredRedAmbrosiaTime as newRedAmbrosiaTime,
+  calculateSingularityMilestoneBlueberries as newSingMilestoneBlue,
+  calculateToNextThreshold as newToNextThreshold
+} from '../../src/mechanics/ambrosia'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+const oldDigitReduction = 4
+
+const oldNumThresholds = (lifetimeAmbrosia: number): number => {
+  const numDigits = lifetimeAmbrosia > 0 ? 1 + Math.floor(Math.log10(lifetimeAmbrosia)) : 0
+  const matissa = Math.floor(lifetimeAmbrosia / Math.pow(10, numDigits - 1))
+  const extraReduction = matissa >= 3 ? 1 : 0
+  return Math.max(0, 2 * (numDigits - oldDigitReduction) - 1 + extraReduction)
+}
+
+const oldToNextThreshold = (lifetimeAmbrosia: number): number => {
+  const numThresholds = oldNumThresholds(lifetimeAmbrosia)
+  if (numThresholds === 0) {
+    return 10000 - lifetimeAmbrosia
+  }
+  if (numThresholds % 2 === 0) {
+    return Math.pow(10, numThresholds / 2 + oldDigitReduction) - lifetimeAmbrosia
+  }
+  return 3 * Math.pow(10, (numThresholds - 1) / 2 + oldDigitReduction) - lifetimeAmbrosia
+}
+
+const oldBlueberryTime = (timePerAmbrosia: number, lifetimeAmbrosia: number, acceleratorMult: number, brickOfLeadMult: number): number => {
+  let val = timePerAmbrosia
+  val += Math.floor(lifetimeAmbrosia / 300)
+  val *= acceleratorMult
+  val *= brickOfLeadMult
+  if (lifetimeAmbrosia >= 10000) {
+    const extraScalingPower = Math.log10(4)
+    val *= Math.pow(lifetimeAmbrosia / 10000, extraScalingPower)
+    return Math.ceil(val)
+  }
+  return val
+}
+
+const oldRedAmbrosiaTime = (timePerRedAmbrosia: number, lifetimeRedAmbrosia: number, barRequirementMultiplier: number): number => {
+  let val = timePerRedAmbrosia
+  val += 200 * lifetimeRedAmbrosia
+  const max = 1e6 * barRequirementMultiplier
+  val *= barRequirementMultiplier
+  return Math.min(max, val)
+}
+
+const oldSingMilestoneBlue = (highestSingularityCount: number): number => {
+  let val = 0
+  if (highestSingularityCount >= 270) val = 5
+  else if (highestSingularityCount >= 256) val = 4
+  else if (highestSingularityCount >= 192) val = 3
+  else if (highestSingularityCount >= 128) val = 2
+  else if (highestSingularityCount >= 64) val = 1
+  return val
+}
+
+const oldCubeMult = (noAmbrosiaUpgradesEnabled: boolean, lifetimeAmbrosia: number): number => {
+  const effectiveAmbrosia = noAmbrosiaUpgradesEnabled ? 0 : lifetimeAmbrosia
+  let multiplier = 1
+  multiplier += Math.min(1.5, Math.floor(effectiveAmbrosia / 66) / 100)
+  if (effectiveAmbrosia >= 10000) {
+    multiplier += Math.min(1.5, Math.floor(effectiveAmbrosia / 666) / 100)
+  }
+  if (effectiveAmbrosia >= 100000) {
+    multiplier += Math.floor(effectiveAmbrosia / 6666) / 100
+  }
+  return multiplier
+}
+
+const oldQuarkMult = (noAmbrosiaUpgradesEnabled: boolean, lifetimeAmbrosia: number): number => {
+  const effectiveAmbrosia = noAmbrosiaUpgradesEnabled ? 0 : lifetimeAmbrosia
+  let multiplier = 1
+  multiplier += Math.min(0.3, Math.floor(effectiveAmbrosia / 1666) / 100)
+  if (effectiveAmbrosia >= 50000) {
+    multiplier += Math.min(0.3, Math.floor(effectiveAmbrosia / 16666) / 100)
+  }
+  if (effectiveAmbrosia >= 500000) {
+    multiplier += Math.floor(effectiveAmbrosia / 166666) / 100
+  }
+  return multiplier
+}
+
+const oldAmbrosiaGen = (effects: number[]): number => effects[0] * effects[1] * effects[2] * effects[3]
+const oldAmbrosiaLuck = (effects: number[]): number => effects[0] + effects[1] + effects[2] + effects[3]
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Lifetime ambrosia grid — crosses every threshold boundary plus a few in
+// between. Thresholds (for digitReduction=4): 10000, 30000, 100000, 300000,
+// 1e6, 3e6, ...
+const lifetimeAmbrosiaGrid = [
+  0, 1, 9, 65, 66, 67, 100, 9999, 10000, 10001, 29999, 30000, 30001,
+  99999, 100000, 100001, 299999, 300000, 300001, 1e6, 3e6, 1e7
+]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateNumberOfThresholds', () => {
+  it.each(lifetimeAmbrosiaGrid)('lifetime=%i', (lifetime) => {
+    expect(newNumThresholds(lifetime)).toBe(oldNumThresholds(lifetime))
+  })
+})
+
+describe('parity: calculateToNextThreshold', () => {
+  it.each(lifetimeAmbrosiaGrid)('lifetime=%i', (lifetime) => {
+    expect(newToNextThreshold(lifetime)).toBe(oldToNextThreshold(lifetime))
+  })
+})
+
+describe('parity: calculateRequiredBlueberryTime', () => {
+  const timePerAmbrosiaGrid = [45]
+  const multGrid = [0.5, 1, 1.5, 2]
+  for (const acceleratorMult of multGrid) {
+    for (const brickOfLeadMult of multGrid) {
+      for (const timePerAmbrosia of timePerAmbrosiaGrid) {
+        it.each(lifetimeAmbrosiaGrid)(
+          `t/a=${timePerAmbrosia} acc=${acceleratorMult} brick=${brickOfLeadMult} lifetime=%i`,
+          (lifetime) => {
+            const next = newBlueberryTime({
+              timePerAmbrosia,
+              lifetimeAmbrosia: lifetime,
+              acceleratorMult,
+              brickOfLeadMult
+            })
+            const old = oldBlueberryTime(timePerAmbrosia, lifetime, acceleratorMult, brickOfLeadMult)
+            expect(closeEnough(next, old)).toBe(true)
+          }
+        )
+      }
+    }
+  }
+})
+
+describe('parity: calculateRequiredRedAmbrosiaTime', () => {
+  const timePerGrid = [100000]
+  const lifetimeRedGrid = [0, 1, 100, 1000, 4900, 5000, 5001, 10000, 1e6]
+  const barMultGrid = [0.5, 1, 1.5, 2, 10]
+  for (const timePerRedAmbrosia of timePerGrid) {
+    for (const barRequirementMultiplier of barMultGrid) {
+      it.each(lifetimeRedGrid)(
+        `t/red=${timePerRedAmbrosia} barMult=${barRequirementMultiplier} lifetimeRed=%i`,
+        (lifetimeRed) => {
+          const next = newRedAmbrosiaTime({
+            timePerRedAmbrosia,
+            lifetimeRedAmbrosia: lifetimeRed,
+            barRequirementMultiplier
+          })
+          const old = oldRedAmbrosiaTime(timePerRedAmbrosia, lifetimeRed, barRequirementMultiplier)
+          expect(closeEnough(next, old)).toBe(true)
+        }
+      )
+    }
+  }
+})
+
+describe('parity: calculateSingularityMilestoneBlueberries', () => {
+  // Grid crosses every step (64, 128, 192, 256, 270) plus -1/+1 around each.
+  const grid = [0, 1, 63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 257, 269, 270, 271, 300]
+  it.each(grid)('highest=%i', (highest) => {
+    expect(newSingMilestoneBlue(highest)).toBe(oldSingMilestoneBlue(highest))
+  })
+})
+
+describe('parity: calculateAmbrosiaCubeMult', () => {
+  const enabledGrid = [true, false]
+  for (const noAmbrosiaUpgradesEnabled of enabledGrid) {
+    it.each(lifetimeAmbrosiaGrid)(`enabled=${noAmbrosiaUpgradesEnabled} lifetime=%i`, (lifetime) => {
+      const next = newCubeMult({ noAmbrosiaUpgradesEnabled, lifetimeAmbrosia: lifetime })
+      const old = oldCubeMult(noAmbrosiaUpgradesEnabled, lifetime)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: calculateAmbrosiaQuarkMult', () => {
+  const enabledGrid = [true, false]
+  // Include grid points around 50000 / 500000 quark-mult tier boundaries.
+  const grid = [
+    ...lifetimeAmbrosiaGrid,
+    49999, 50000, 50001, 499999, 500000, 500001
+  ]
+  for (const noAmbrosiaUpgradesEnabled of enabledGrid) {
+    it.each(grid)(`enabled=${noAmbrosiaUpgradesEnabled} lifetime=%i`, (lifetime) => {
+      const next = newQuarkMult({ noAmbrosiaUpgradesEnabled, lifetimeAmbrosia: lifetime })
+      const old = oldQuarkMult(noAmbrosiaUpgradesEnabled, lifetime)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: ambrosia upgrade composers (sing + octeract)', () => {
+  // Each row is wrapped in an outer array so vitest passes the inner array as
+  // a single argument to the test function (rather than spreading it).
+  const speedSets: [number[]][] = [
+    [[1, 1, 1, 1]],
+    [[1, 1.1, 1.2, 1.3]],
+    [[2, 3, 5, 7]],
+    [[0.5, 1, 1, 1]],
+    [[1, 1, 1, 1.5]]
+  ]
+  const luckSets: [number[]][] = [
+    [[0, 0, 0, 0]],
+    [[1, 2, 3, 4]],
+    [[10, 20, 30, 40]],
+    [[100, 0, 0, 50]],
+    [[5, 5, 5, 5]]
+  ]
+
+  it.each(speedSets)('AmbrosiaGenerationSingularityUpgrade %j', (effects) => {
+    expect(closeEnough(newAmbrosiaGenSing(effects), oldAmbrosiaGen(effects))).toBe(true)
+  })
+  it.each(speedSets)('AmbrosiaGenerationOcteractUpgrade %j', (effects) => {
+    expect(closeEnough(newAmbrosiaGenOct(effects), oldAmbrosiaGen(effects))).toBe(true)
+  })
+  it.each(luckSets)('AmbrosiaLuckSingularityUpgrade %j', (effects) => {
+    expect(newAmbrosiaLuckSing(effects)).toBe(oldAmbrosiaLuck(effects))
+  })
+  it.each(luckSets)('AmbrosiaLuckOcteractUpgrade %j', (effects) => {
+    expect(newAmbrosiaLuckOct(effects)).toBe(oldAmbrosiaLuck(effects))
+  })
+})

--- a/packages/logic/test/parity/ascensions.parity.test.ts
+++ b/packages/logic/test/parity/ascensions.parity.test.ts
@@ -1,0 +1,36 @@
+// Parity tests for the ascension-count calculation lifted from
+// packages/web_ui/src/Calculate.ts. Sweeps cover both gate states and a
+// variety of multiplier arrays (including ones whose product is <1 to
+// exercise the `Math.floor` rounding boundary).
+
+import { describe, expect, it } from 'vitest'
+import { calculateAscensionCount as newAscCount } from '../../src/mechanics/ascensions'
+
+const oldAscCount = (limitedAscensionsEnabled: boolean, mults: number[]): number => {
+  if (limitedAscensionsEnabled) {
+    return 1
+  }
+  return Math.floor(mults.reduce((a, b) => a * b, 1))
+}
+
+const cases: [boolean, number[]][] = [
+  [false, []],
+  [false, [1]],
+  [false, [1, 1, 1]],
+  [false, [2]],
+  [false, [2, 3]],
+  [false, [1.5, 1.5, 2]],
+  [false, [0.5, 1, 1]],
+  [false, [0.99, 1, 1]],
+  [false, [10, 10, 10]],
+  [true, [10, 10, 10]],
+  [true, []],
+  [true, [0.0001]]
+]
+
+describe('parity: calculateAscensionCount', () => {
+  it.each(cases)('enabled=%s mults=%j', (enabled, mults) => {
+    expect(newAscCount({ limitedAscensionsEnabled: enabled, ascensionCountMults: mults }))
+      .toBe(oldAscCount(enabled, mults))
+  })
+})

--- a/packages/logic/test/parity/exaltPenalties.parity.test.ts
+++ b/packages/logic/test/parity/exaltPenalties.parity.test.ts
@@ -1,0 +1,143 @@
+// Parity tests for the Exalt 3 / 4 / 6 penalty math lifted from
+// packages/web_ui/src/Calculate.ts. The `oldXxx` definitions transcribe the
+// pre-migration bodies verbatim — including the private
+// `oldExalt6PenaltyPerMinute` helper that was internal to Calculate.ts.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateExalt3AscensionLimit as newExalt3Limit,
+  calculateExalt3Penalty as newExalt3Penalty,
+  calculateExalt4EffectiveSingularityMultiplier as newExalt4Mult,
+  calculateExalt6Penalty as newExalt6Penalty,
+  calculateExalt6PenaltyPerSecond as newExalt6PerSecond,
+  calculateExalt6TimeLimit as newExalt6TimeLimit
+} from '../../src/mechanics/exaltPenalties'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+const oldExalt3AscensionLimit = (comps: number): number => Math.max(15 - comps * 2, 0)
+
+const oldExalt3Penalty = (
+  limitedAscensionsEnabled: boolean,
+  limitedAscensionsCompletions: number,
+  ascensionCount: number
+): number => {
+  const ascensionLimit = oldExalt3AscensionLimit(limitedAscensionsCompletions)
+  const ascensions = ascensionCount
+  if (!limitedAscensionsEnabled) {
+    return 1
+  } else {
+    return Math.pow(2, Math.max(ascensions - ascensionLimit, 0))
+  }
+}
+
+const oldExalt4Mult = (comps: number, force: boolean, inExalt4: boolean): number => {
+  return inExalt4 || force ? Math.pow(comps + 1, 3) : 1
+}
+
+const oldExalt6TimeLimit = (comps: number): number => {
+  if (comps >= 10) {
+    return 115 - 5 * (comps - 10)
+  } else {
+    return 600 - 60 * comps
+  }
+}
+
+const oldExalt6PenaltyPerMinute = (comps: number): number => {
+  let penaltyPerMinute = 10 + 3 * comps
+  if (comps >= 10) {
+    penaltyPerMinute = 60 + 10 * (comps - 10)
+  }
+  return penaltyPerMinute
+}
+
+const oldExalt6PerSecond = (comps: number): number => {
+  const penaltyPerMinute = oldExalt6PenaltyPerMinute(comps)
+  return Math.pow(penaltyPerMinute, 1 / 60)
+}
+
+const oldExalt6Penalty = (comps: number, time: number): number => {
+  const timeLimit = oldExalt6TimeLimit(comps)
+  const displacedTime = Math.max(0, time - timeLimit)
+  if (displacedTime === 0) {
+    return 1
+  } else {
+    const penaltyPerSecond = oldExalt6PerSecond(comps)
+    return Math.pow(penaltyPerSecond, -displacedTime)
+  }
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Sweeps comps across the 10-comp switching boundary in both directions.
+const compsGrid = [0, 1, 2, 5, 7, 9, 10, 11, 15, 20, 50]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateExalt3AscensionLimit', () => {
+  it.each(compsGrid)('comps=%i', (comps) => {
+    expect(newExalt3Limit(comps)).toBe(oldExalt3AscensionLimit(comps))
+  })
+})
+
+describe('parity: calculateExalt3Penalty', () => {
+  const enabledGrid = [true, false]
+  const compsLocal = [0, 1, 5, 7, 10, 20]
+  const ascensionGrid = [0, 1, 5, 10, 15, 30, 100]
+  for (const enabled of enabledGrid) {
+    for (const comps of compsLocal) {
+      it.each(ascensionGrid)(`enabled=${enabled} comps=${comps} ascensions=%i`, (ascensions) => {
+        const next = newExalt3Penalty({
+          limitedAscensionsEnabled: enabled,
+          limitedAscensionsCompletions: comps,
+          ascensionCount: ascensions
+        })
+        const old = oldExalt3Penalty(enabled, comps, ascensions)
+        expect(next).toBe(old)
+      })
+    }
+  }
+})
+
+describe('parity: calculateExalt4EffectiveSingularityMultiplier', () => {
+  const forceGrid = [true, false]
+  const exalt4Grid = [true, false]
+  for (const force of forceGrid) {
+    for (const inExalt4 of exalt4Grid) {
+      it.each(compsGrid)(`force=${force} inExalt4=${inExalt4} comps=%i`, (comps) => {
+        const next = newExalt4Mult({ comps, force, inExalt4 })
+        const old = oldExalt4Mult(comps, force, inExalt4)
+        expect(next).toBe(old)
+      })
+    }
+  }
+})
+
+describe('parity: calculateExalt6TimeLimit', () => {
+  it.each(compsGrid)('comps=%i', (comps) => {
+    expect(newExalt6TimeLimit(comps)).toBe(oldExalt6TimeLimit(comps))
+  })
+})
+
+describe('parity: calculateExalt6PenaltyPerSecond', () => {
+  it.each(compsGrid)('comps=%i', (comps) => {
+    expect(closeEnough(newExalt6PerSecond(comps), oldExalt6PerSecond(comps))).toBe(true)
+  })
+})
+
+describe('parity: calculateExalt6Penalty', () => {
+  // Sweep time around the timeLimit boundary for each comps value.
+  for (const comps of compsGrid) {
+    const limit = oldExalt6TimeLimit(comps)
+    const timeGrid = [0, limit - 10, limit - 1, limit, limit + 1, limit + 30, limit + 300]
+    it.each(timeGrid)(`comps=${comps} time=%i`, (time) => {
+      const next = newExalt6Penalty(comps, time)
+      const old = oldExalt6Penalty(comps, time)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/octeractBonuses.parity.test.ts
+++ b/packages/logic/test/parity/octeractBonuses.parity.test.ts
@@ -1,0 +1,119 @@
+// Parity tests for the total-octeract bonuses lifted from
+// packages/web_ui/src/Calculate.ts. Sweeps across the 1000-octeract branching
+// boundary, the small-value 1.00001 tolerance threshold, the octeractPow
+// effect curve (the formula switches at 10 completions), and all combinations
+// of the gate booleans.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateTotalOcteractCubeBonus as newCubeBonus,
+  calculateTotalOcteractObtainiumBonus as newObtainiumBonus,
+  calculateTotalOcteractOfferingBonus as newOfferingBonus,
+  calculateTotalOcteractQuarkBonus as newQuarkBonus
+} from '../../src/mechanics/octeractBonuses'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+const oldCubeBonus = (exalt4Enabled: boolean, totalWowOcteracts: number, octeractPow: number): number => {
+  if (exalt4Enabled) {
+    return 1
+  }
+  if (totalWowOcteracts < 1000) {
+    const bonus = 1 + (2 / 1000) * totalWowOcteracts
+    return bonus > 1.00001 ? bonus : 1
+  } else {
+    const power = 2 + octeractPow
+    return 3 * Math.pow(Math.log10(totalWowOcteracts) - 2, power)
+  }
+}
+
+const oldQuarkBonus = (exalt4Enabled: boolean, totalWowOcteracts: number): number => {
+  if (exalt4Enabled) {
+    return 1
+  }
+  if (totalWowOcteracts < 1000) {
+    const bonus = 1 + (0.2 / 1000) * totalWowOcteracts
+    return bonus > 1.00001 ? bonus : 1
+  } else {
+    return 1.1 + 0.1 * (Math.log10(totalWowOcteracts) - 2)
+  }
+}
+
+const oldOfferingBonus = (offeringBonusEnabled: boolean, cubeBonus: number): number => {
+  if (!offeringBonusEnabled) {
+    return 1
+  }
+  return Math.pow(cubeBonus, 1.25)
+}
+
+const oldObtainiumBonus = (obtainiumBonusEnabled: boolean, cubeBonus: number): number => {
+  if (!obtainiumBonusEnabled) {
+    return 1
+  }
+  return Math.pow(cubeBonus, 1.25)
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Octeract count grid — crosses 0 (zero check), the small-value tolerance
+// (1.00001 → totalWowOcteracts ~ 0.005), and the 1000 branching boundary.
+const octeractGrid = [0, 0.001, 0.004, 0.005, 0.006, 1, 10, 100, 500, 999, 1000, 1001, 5000, 1e6, 1e9]
+
+// Octeract pow grid — what getSingularityChallengeEffect returns for
+// completions 0..15. Below 10 it's 0.02*n; at 10+ it's 0.2 + (n-10)/100.
+const octeractPowGrid = [0, 0.02, 0.1, 0.18, 0.2, 0.21, 0.25, 0.3, 0.35]
+
+// Cube bonus grid for the downstream offering/obtainium tests.
+const cubeBonusGrid = [1, 1.5, 2, 3, 5, 10, 50, 100]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateTotalOcteractCubeBonus', () => {
+  const enabledGrid = [true, false]
+  for (const exalt4Enabled of enabledGrid) {
+    for (const octeractPow of octeractPowGrid) {
+      it.each(octeractGrid)(`exalt4=${exalt4Enabled} pow=${octeractPow} oct=%s`, (totalWowOcteracts) => {
+        const next = newCubeBonus({ exalt4Enabled, totalWowOcteracts, octeractPow })
+        const old = oldCubeBonus(exalt4Enabled, totalWowOcteracts, octeractPow)
+        expect(closeEnough(next, old)).toBe(true)
+      })
+    }
+  }
+})
+
+describe('parity: calculateTotalOcteractQuarkBonus', () => {
+  const enabledGrid = [true, false]
+  for (const exalt4Enabled of enabledGrid) {
+    it.each(octeractGrid)(`exalt4=${exalt4Enabled} oct=%s`, (totalWowOcteracts) => {
+      const next = newQuarkBonus({ exalt4Enabled, totalWowOcteracts })
+      const old = oldQuarkBonus(exalt4Enabled, totalWowOcteracts)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: calculateTotalOcteractOfferingBonus', () => {
+  const enabledGrid = [true, false]
+  for (const offeringBonusEnabled of enabledGrid) {
+    it.each(cubeBonusGrid)(`enabled=${offeringBonusEnabled} cubeBonus=%s`, (cubeBonus) => {
+      const next = newOfferingBonus({ offeringBonusEnabled, cubeBonus })
+      const old = oldOfferingBonus(offeringBonusEnabled, cubeBonus)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: calculateTotalOcteractObtainiumBonus', () => {
+  const enabledGrid = [true, false]
+  for (const obtainiumBonusEnabled of enabledGrid) {
+    it.each(cubeBonusGrid)(`enabled=${obtainiumBonusEnabled} cubeBonus=%s`, (cubeBonus) => {
+      const next = newObtainiumBonus({ obtainiumBonusEnabled, cubeBonus })
+      const old = oldObtainiumBonus(obtainiumBonusEnabled, cubeBonus)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/overfluxBonuses.parity.test.ts
+++ b/packages/logic/test/parity/overfluxBonuses.parity.test.ts
@@ -1,0 +1,111 @@
+// Parity tests for the overflux-derived multipliers lifted from
+// packages/web_ui/src/Calculate.ts. Powder grids hit the 10000 boundary;
+// the cube-to-quark orbs sweep crosses every singularity-unlock threshold
+// (1, 2, 5, 10, 15, 20, 25, 30, 35) and toggles `autoWarpCheck`.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateCubeMultFromPowder as newCubeMultPowder,
+  calculateCubeQuarkMultiplier as newCubeQuark,
+  calculateQuarkMultFromPowder as newQuarkMultPowder
+} from '../../src/mechanics/overfluxBonuses'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+const oldSigmoid = (constant: number, factor: number, divisor: number): number => {
+  return 1 + (constant - 1) * (1 - Math.pow(2, -factor / divisor))
+}
+
+const oldCubeMultPowder = (overfluxPowder: number): number => {
+  return overfluxPowder > 10000
+    ? 1 + (1 / 16) * Math.pow(Math.log10(overfluxPowder), 2)
+    : 1 + (1 / 10000) * overfluxPowder
+}
+
+const oldQuarkMultPowder = (overfluxPowder: number): number => {
+  return overfluxPowder > 10000
+    ? 1 + (1 / 40) * Math.log10(overfluxPowder)
+    : 1 + (1 / 100000) * overfluxPowder
+}
+
+const oldCubeQuark = (
+  overfluxOrbs: number,
+  highestSingularityCount: number,
+  cubeToQuarkAllMult: number,
+  autoWarpCheck: boolean,
+  dailyPowderResetUses: number
+): number => {
+  return (
+    (oldSigmoid(2, Math.pow(overfluxOrbs, 0.5), 40)
+      + oldSigmoid(1.5, Math.pow(overfluxOrbs, 0.5), 160)
+      + oldSigmoid(1.5, Math.pow(overfluxOrbs, 0.5), 640)
+      + oldSigmoid(1.15, +(highestSingularityCount >= 1) * Math.pow(overfluxOrbs, 0.45), 2560)
+      + oldSigmoid(1.15, +(highestSingularityCount >= 2) * Math.pow(overfluxOrbs, 0.4), 10000)
+      + oldSigmoid(1.25, +(highestSingularityCount >= 5) * Math.pow(overfluxOrbs, 0.35), 40000)
+      + oldSigmoid(1.25, +(highestSingularityCount >= 10) * Math.pow(overfluxOrbs, 0.32), 160000)
+      + oldSigmoid(1.35, +(highestSingularityCount >= 15) * Math.pow(overfluxOrbs, 0.27), 640000)
+      + oldSigmoid(1.45, +(highestSingularityCount >= 20) * Math.pow(overfluxOrbs, 0.24), 2e6)
+      + oldSigmoid(1.55, +(highestSingularityCount >= 25) * Math.pow(overfluxOrbs, 0.21), 1e7)
+      + oldSigmoid(1.85, +(highestSingularityCount >= 30) * Math.pow(overfluxOrbs, 0.18), 4e7)
+      + oldSigmoid(3, +(highestSingularityCount >= 35) * Math.pow(overfluxOrbs, 0.15), 1e8)
+      - 11)
+    * cubeToQuarkAllMult
+    * (autoWarpCheck ? 1 + dailyPowderResetUses : 1)
+  )
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateCubeMultFromPowder', () => {
+  const grid = [0, 1, 100, 1000, 9999, 10000, 10001, 1e5, 1e7, 1e10]
+  it.each(grid)('powder=%s', (powder) => {
+    expect(closeEnough(newCubeMultPowder(powder), oldCubeMultPowder(powder))).toBe(true)
+  })
+})
+
+describe('parity: calculateQuarkMultFromPowder', () => {
+  const grid = [0, 1, 100, 1000, 9999, 10000, 10001, 1e5, 1e7, 1e10]
+  it.each(grid)('powder=%s', (powder) => {
+    expect(closeEnough(newQuarkMultPowder(powder), oldQuarkMultPowder(powder))).toBe(true)
+  })
+})
+
+describe('parity: calculateCubeQuarkMultiplier', () => {
+  // Orbs grid — spans a few decades; small values hit the early sigmoids,
+  // large values exercise all 12 contributors.
+  const orbsGrid = [0, 1, 10, 100, 1000, 1e4, 1e6, 1e8, 1e10]
+  // Singularity grid hits every gate boundary and just above/below.
+  const highGrid = [0, 1, 2, 4, 5, 9, 10, 14, 15, 19, 20, 24, 25, 29, 30, 34, 35, 100]
+  const cubeToQuarkAllGrid = [1, 1.25, 2]
+  const autoWarpGrid = [true, false]
+  const dailyPowderGrid = [0, 1, 5]
+
+  for (const cubeToQuarkAllMult of cubeToQuarkAllGrid) {
+    for (const autoWarpCheck of autoWarpGrid) {
+      for (const dailyPowderResetUses of dailyPowderGrid) {
+        for (const high of highGrid) {
+          it.each(orbsGrid)(
+            `c2q=${cubeToQuarkAllMult} warp=${autoWarpCheck} daily=${dailyPowderResetUses} high=${high} orbs=%s`,
+            (orbs) => {
+              const next = newCubeQuark({
+                overfluxOrbs: orbs,
+                highestSingularityCount: high,
+                cubeToQuarkAllMult,
+                autoWarpCheck,
+                dailyPowderResetUses
+              })
+              const old = oldCubeQuark(orbs, high, cubeToQuarkAllMult, autoWarpCheck, dailyPowderResetUses)
+              expect(closeEnough(next, old)).toBe(true)
+            }
+          )
+        }
+      }
+    }
+  }
+})

--- a/packages/logic/test/parity/potionBonuses.parity.test.ts
+++ b/packages/logic/test/parity/potionBonuses.parity.test.ts
@@ -1,0 +1,219 @@
+// Parity tests for the potion-consumed base bonuses lifted from
+// packages/web_ui/src/Calculate.ts. Each old impl transcribes the
+// `findInsertionIndex` binary search verbatim, then computes the
+// `{amount, toNext}` pair the same way as the production code.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import {
+  calculateObtainiumPotionBaseObtainium as newObtainiumPotion,
+  calculateOfferingPotionBaseOfferings as newOfferingPotion,
+  calculatePotionValue as newPotionValue
+} from '../../src/mechanics/potionBonuses'
+
+// ─── Threshold tables (verbatim from old Calculate.ts) ─────────────────────
+
+const oldOfferingPotionThresholds = [
+  1,
+  10,
+  25,
+  50,
+  100,
+  500,
+  1000,
+  10000,
+  5e4,
+  1e5,
+  1e6,
+  1e7,
+  1e8,
+  1e9,
+  1e10,
+  1e11,
+  1e12,
+  1e13,
+  1e14,
+  1e15
+]
+
+const oldObtainiumPotionThresholds = [
+  1, 20, 50, 250, 1000, 20000, 4e5, 1e7, 4e8, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15
+]
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Utility.ts and
+//     Calculate.ts) ───
+
+const oldFindInsertionIndex = (target: number, array: number[]): number => {
+  if (array.length === 0 || target < array[0]) {
+    return 0
+  }
+  if (target >= array[array.length - 1]) {
+    return array.length
+  }
+
+  let low = 0
+  let high = array.length - 1
+
+  while (low < high) {
+    const mid = Math.floor((low + high + 1) / 2)
+    if (array[mid] <= target) {
+      low = mid
+    } else {
+      high = mid - 1
+    }
+  }
+
+  return low + 1
+}
+
+const oldOfferingPotion = (consumed: number) => {
+  const amount = oldFindInsertionIndex(consumed, oldOfferingPotionThresholds)
+  return {
+    amount,
+    toNext: amount < oldOfferingPotionThresholds.length
+      ? oldOfferingPotionThresholds[amount] - consumed
+      : Number.POSITIVE_INFINITY
+  }
+}
+
+const oldObtainiumPotion = (consumed: number) => {
+  const amount = oldFindInsertionIndex(consumed, oldObtainiumPotionThresholds)
+  return {
+    amount,
+    toNext: amount < oldObtainiumPotionThresholds.length
+      ? oldObtainiumPotionThresholds[amount] - consumed
+      : Number.POSITIVE_INFINITY
+  }
+}
+
+// Build a grid that hits every threshold boundary (value, value - 1, value + 1)
+// plus 0 and a value beyond the final threshold.
+const boundaryGrid = (thresholds: number[]): number[] => {
+  const out = new Set<number>([0, 1e16])
+  for (const t of thresholds) {
+    out.add(Math.max(0, t - 1))
+    out.add(t)
+    out.add(t + 1)
+  }
+  return [...out].sort((a, b) => a - b)
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateOfferingPotionBaseOfferings', () => {
+  it.each(boundaryGrid(oldOfferingPotionThresholds))('consumed=%s', (consumed) => {
+    expect(newOfferingPotion(consumed)).toEqual(oldOfferingPotion(consumed))
+  })
+})
+
+describe('parity: calculateObtainiumPotionBaseObtainium', () => {
+  it.each(boundaryGrid(oldObtainiumPotionThresholds))('consumed=%s', (consumed) => {
+    expect(newObtainiumPotion(consumed)).toEqual(oldObtainiumPotion(consumed))
+  })
+})
+
+// ─── calculatePotionValue ──────────────────────────────────────────────────
+
+// Old impl (verbatim from packages/web_ui/src/Calculate.ts) with the i18next-
+// free dependencies inlined as scalars.
+const oldFastForwardResourcesGlobal = (
+  resetTime: number,
+  fastForwardAmount: Decimal,
+  resourceMult: Decimal,
+  baseResource: number,
+  halfMindUnlocked: boolean,
+  globalSpeedMult: number,
+  resetTimeThreshold: number
+): Decimal => {
+  let timeMultiplier: Decimal = new Decimal('1')
+  const deltaTime = fastForwardAmount.times(
+    halfMindUnlocked ? 10 : globalSpeedMult
+  )
+  timeMultiplier = Decimal.min(
+    deltaTime.times(2 * resetTime).div(resetTimeThreshold ** 2),
+    deltaTime.div(resetTimeThreshold)
+  )
+  // NOTE: dead code in original — `.times(...)` discarded, preserved verbatim.
+  timeMultiplier.times(halfMindUnlocked ? globalSpeedMult / 10 : 1)
+  return Decimal.max(fastForwardAmount.times(baseResource), resourceMult.times(timeMultiplier))
+}
+
+const oldPotionValue = (
+  resetTime: number,
+  resourceMult: Decimal,
+  baseResource: number,
+  halfMindUnlocked: boolean,
+  globalSpeedMult: number,
+  resetTimeThreshold: number,
+  potionMultipliers: number
+): Decimal => {
+  const potionTimeValue = new Decimal(7200)
+  const fastForwardMult = oldFastForwardResourcesGlobal(
+    resetTime,
+    potionTimeValue,
+    resourceMult,
+    baseResource,
+    halfMindUnlocked,
+    globalSpeedMult,
+    resetTimeThreshold
+  )
+  return fastForwardMult.times(potionMultipliers)
+}
+
+const decimalClose = (a: Decimal, b: Decimal, rel = 1e-12): boolean => {
+  if (a.equals(b)) return true
+  const diff = a.minus(b).abs()
+  const max = Decimal.max(a.abs(), b.abs())
+  if (max.lessThan(1)) return diff.lessThan(rel)
+  return diff.div(max).lessThan(rel)
+}
+
+describe('parity: calculatePotionValue', () => {
+  // Sweeps: halfMind branch flip, resetTime around threshold², various
+  // resourceMult magnitudes, baseResource scales, and potionMultipliers
+  // values typical of the early-game (~1) and stacked late-game (~10⁵).
+  const halfMindGrid = [true, false]
+  const resetTimeGrid = [0, 1, 60, 600, 3600, 86400]
+  const globalSpeedMultGrid = [1, 5, 100, 1e6]
+  const resetTimeThresholdGrid = [5, 10]
+  const resourceMultGrid = [new Decimal(1), new Decimal('1e10'), new Decimal('1e100')]
+  const baseResourceGrid = [0, 1, 1e6]
+  const potionMultsGrid = [1, 10, 1e5]
+
+  for (const halfMindUnlocked of halfMindGrid) {
+    for (const resetTimeThreshold of resetTimeThresholdGrid) {
+      for (const globalSpeedMult of globalSpeedMultGrid) {
+        for (const resourceMult of resourceMultGrid) {
+          for (const baseResource of baseResourceGrid) {
+            for (const potionMultipliers of potionMultsGrid) {
+              it.each(resetTimeGrid)(
+                `halfMind=${halfMindUnlocked} thresh=${resetTimeThreshold} gsm=${globalSpeedMult} rm=${resourceMult.toString()} baseRes=${baseResource} mults=${potionMultipliers} resetTime=%s`,
+                (resetTime) => {
+                  const next = newPotionValue({
+                    resetTime,
+                    resourceMult,
+                    baseResource,
+                    halfMindUnlocked,
+                    globalSpeedMult,
+                    resetTimeThreshold,
+                    potionMultipliers
+                  })
+                  const old = oldPotionValue(
+                    resetTime,
+                    resourceMult,
+                    baseResource,
+                    halfMindUnlocked,
+                    globalSpeedMult,
+                    resetTimeThreshold,
+                    potionMultipliers
+                  )
+                  expect(decimalClose(next, old)).toBe(true)
+                }
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+})

--- a/packages/logic/test/parity/redAmbrosiaBonuses.parity.test.ts
+++ b/packages/logic/test/parity/redAmbrosiaBonuses.parity.test.ts
@@ -1,0 +1,110 @@
+// Parity tests for the red-ambrosia bonuses lifted from
+// packages/web_ui/src/Calculate.ts. Sweeps cross both gate states (unlocked
+// true/false), the cubeUpgrade[79] === 0 gate for cookie luck, and a grid of
+// lifetimeRedAmbrosia spanning 0 → 1e9 plus a few small/decimal values where
+// the log10 / Math.pow curves are sensitive.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateCookieUpgrade29Luck as newCookie29,
+  calculateRedAmbrosiaCubes as newRedCubes,
+  calculateRedAmbrosiaObtainium as newRedObtainium,
+  calculateRedAmbrosiaOffering as newRedOffering
+} from '../../src/mechanics/redAmbrosiaBonuses'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+const oldCookie29 = (cubeUpgrade79: number, lifetimeRedAmbrosia: number): number => {
+  if (cubeUpgrade79 === 0 || lifetimeRedAmbrosia === 0) {
+    return 0
+  } else {
+    return 10 * Math.pow(Math.log10(lifetimeRedAmbrosia), 2)
+  }
+}
+
+const oldRedCubes = (unlocked: boolean, lifetimeRedAmbrosia: number, extraExponent: number): number => {
+  if (unlocked) {
+    const exponent = 0.4 + extraExponent
+    return 1 + Math.pow(lifetimeRedAmbrosia, exponent) / 100
+  } else {
+    return 1
+  }
+}
+
+const oldRedObtainium = (unlocked: boolean, lifetimeRedAmbrosia: number): number => {
+  if (unlocked) {
+    return 1 + Math.pow(lifetimeRedAmbrosia, 0.6) / 100
+  } else {
+    return 1
+  }
+}
+
+const oldRedOffering = (unlocked: boolean, lifetimeRedAmbrosia: number): number => {
+  if (unlocked) {
+    return 1 + Math.pow(lifetimeRedAmbrosia, 0.6) / 100
+  } else {
+    return 1
+  }
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+const lifetimeRedAmbrosiaGrid = [0, 1, 2, 10, 100, 1000, 10000, 1e5, 1e6, 1e9]
+const extraExponentGrid = [0, 0.05, 0.1, 0.2, 0.5]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateCookieUpgrade29Luck', () => {
+  // Sweep cubeUpgrade79 across 0 (gate off), 1, and a higher value (gate is
+  // boolean-ish: only the === 0 path matters).
+  const cubeUpgrade79Grid = [0, 1, 2, 5]
+  for (const cubeUpgrade79 of cubeUpgrade79Grid) {
+    it.each(lifetimeRedAmbrosiaGrid)(`cu79=${cubeUpgrade79} lifetimeRed=%i`, (lifetime) => {
+      const next = newCookie29({ cubeUpgrade79, lifetimeRedAmbrosia: lifetime })
+      const old = oldCookie29(cubeUpgrade79, lifetime)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: calculateRedAmbrosiaCubes', () => {
+  const unlockedGrid = [true, false]
+  for (const unlocked of unlockedGrid) {
+    for (const extraExponent of extraExponentGrid) {
+      it.each(lifetimeRedAmbrosiaGrid)(
+        `unlocked=${unlocked} extra=${extraExponent} lifetimeRed=%i`,
+        (lifetime) => {
+          const next = newRedCubes({ unlocked, lifetimeRedAmbrosia: lifetime, extraExponent })
+          const old = oldRedCubes(unlocked, lifetime, extraExponent)
+          expect(closeEnough(next, old)).toBe(true)
+        }
+      )
+    }
+  }
+})
+
+describe('parity: calculateRedAmbrosiaObtainium', () => {
+  const unlockedGrid = [true, false]
+  for (const unlocked of unlockedGrid) {
+    it.each(lifetimeRedAmbrosiaGrid)(`unlocked=${unlocked} lifetimeRed=%i`, (lifetime) => {
+      const next = newRedObtainium({ unlocked, lifetimeRedAmbrosia: lifetime })
+      const old = oldRedObtainium(unlocked, lifetime)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: calculateRedAmbrosiaOffering', () => {
+  const unlockedGrid = [true, false]
+  for (const unlocked of unlockedGrid) {
+    it.each(lifetimeRedAmbrosiaGrid)(`unlocked=${unlocked} lifetimeRed=%i`, (lifetime) => {
+      const next = newRedOffering({ unlocked, lifetimeRedAmbrosia: lifetime })
+      const old = oldRedOffering(unlocked, lifetime)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/sigmoid.parity.test.ts
+++ b/packages/logic/test/parity/sigmoid.parity.test.ts
@@ -1,0 +1,51 @@
+// Parity tests for the sigmoid helpers lifted from
+// packages/web_ui/src/Calculate.ts. Sweeps constants below/above 1 (the
+// curves are inverted when constant < 1), factor/coefficient values around
+// zero and far above, and a divisor grid for `calculateSigmoid`.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateSigmoid as newSigmoid,
+  calculateSigmoidExponential as newSigmoidExp
+} from '../../src/math/sigmoid'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+const oldSigmoid = (constant: number, factor: number, divisor: number): number => {
+  return 1 + (constant - 1) * (1 - Math.pow(2, -factor / divisor))
+}
+
+const oldSigmoidExp = (constant: number, coefficient: number): number => {
+  return 1 + (constant - 1) * (1 - Math.exp(-coefficient))
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateSigmoid', () => {
+  const constants = [0.5, 1, 1.05, 2, 10, 100, 1e6]
+  const factors = [0, 0.5, 1, 10, 100, 1e6, 1e18]
+  const divisors = [1, 100, 1e6, 1e18]
+  for (const constant of constants) {
+    for (const divisor of divisors) {
+      it.each(factors)(`constant=${constant} divisor=${divisor} factor=%s`, (factor) => {
+        expect(closeEnough(newSigmoid(constant, factor, divisor), oldSigmoid(constant, factor, divisor))).toBe(true)
+      })
+    }
+  }
+})
+
+describe('parity: calculateSigmoidExponential', () => {
+  const constants = [0.5, 1, 1.05, 2, 20, 40, 1e6, 49000001]
+  const coefficients = [0, 0.001, 0.5, 1, 10, 100]
+  for (const constant of constants) {
+    it.each(coefficients)(`constant=${constant} coeff=%s`, (coeff) => {
+      expect(closeEnough(newSigmoidExp(constant, coeff), oldSigmoidExp(constant, coeff))).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/singularityMilestones.parity.test.ts
+++ b/packages/logic/test/parity/singularityMilestones.parity.test.ts
@@ -1,0 +1,226 @@
+// Parity tests for the singularity-milestone bonuses lifted from
+// packages/web_ui/src/Calculate.ts. Each `oldXxx` transcribes the
+// pre-migration body verbatim (including the threshold-array literals as they
+// were spelled out in web_ui); each test sweeps a grid that crosses every
+// threshold boundary in the relevant array, plus a few in-between and
+// extreme values.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateBaseGoldenQuarks as newBaseGoldenQuarks,
+  calculateDilatedFiveLeafBonus as newDilatedFiveLeaf,
+  calculateImmaculateAlchemyBonus as newImmaculateAlchemy,
+  calculateSingularityAmbrosiaLuckMilestoneBonus as newSingAmbrosiaLuck,
+  calculateSingularityQuarkMilestoneMultiplier as newSingQuarkMult,
+  derpsmithCornucopiaBonus as newDerpsmith,
+  inheritanceTokens as newInheritanceTokens,
+  singularityBonusTokenMult as newSingularityBonusTokenMult,
+  sumOfExaltCompletions as newSumOfExaltCompletions
+} from '../../src/mechanics/singularityMilestones'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Calculate.ts) ───
+
+// dprint-ignore
+const oldSingQuarkMilestoneThresholds = [
+  5, 7, 10, 20, 35, 50, 65, 80, 90, 100, 121, 144, 150, 160, 166, 169, 170,
+  175, 180, 190, 196, 200, 201, 202, 203, 204, 205, 210, 213, 216, 219, 225,
+  228, 231, 234, 237, 240, 244, 248, 252, 256, 260, 264, 268, 272, 276, 280,
+  284, 288, 290
+]
+
+const oldAmbrosiaLuckSingThresholds1 = [35, 42, 49, 56, 63, 70, 77]
+const oldAmbrosiaLuckSingThresholds2 = [135, 142, 149, 156, 163, 170, 177]
+
+const oldDerpsmithSingCounts = [
+  18, 38, 58, 78, 88, 98, 118, 148, 178, 188, 198, 208, 218, 228, 238, 248
+]
+
+const oldImmaculateAlchemyThresholds = [50, 90, 130, 170, 200, 217, 235, 253, 271, 289]
+
+const oldInheritanceLevels = [2, 5, 10, 17, 26, 37, 50, 65, 82, 101, 220, 240, 260, 270, 277]
+const oldInheritanceTokenValues = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
+
+const oldBonusTokenLevels = [41, 58, 113, 163, 229]
+
+const oldSingQuarkMult = (singularityCount: number): number => {
+  let multiplier = 1
+  for (const sing of oldSingQuarkMilestoneThresholds) {
+    if (singularityCount >= sing) {
+      multiplier *= 1.05
+    }
+  }
+  return multiplier
+}
+
+const oldBaseGoldenQuarks = (singularity: number, quarksThisSingularity: number, highestSingularityCount: number): number => {
+  const minimumValue = 100 * Math.pow(1.04, singularity)
+  const contributionFromQuarks = quarksThisSingularity / 1e5
+  const firstTenBonus = 10 * Math.min(highestSingularityCount, 10)
+  return Math.floor(minimumValue + contributionFromQuarks + firstTenBonus)
+}
+
+const oldSingAmbrosiaLuck = (highestSingularityCount: number): number => {
+  let bonus = 0
+  for (const sing of oldAmbrosiaLuckSingThresholds1) {
+    if (highestSingularityCount >= sing) bonus += 5
+  }
+  for (const sing of oldAmbrosiaLuckSingThresholds2) {
+    if (highestSingularityCount >= sing) bonus += 6
+  }
+  return bonus
+}
+
+const oldDilatedFiveLeaf = (highestSingularityCount: number): number => {
+  const singThresholds = [100, 150, 200, 225, 250, 255, 260, 265, 269, 272]
+  for (let i = 0; i < singThresholds.length; i++) {
+    if (highestSingularityCount < singThresholds[i]) return i / 100
+  }
+  return singThresholds.length / 100
+}
+
+const oldDerpsmithCornucopia = (highestSingularityCount: number): number => {
+  let counter = 0
+  for (const sing of oldDerpsmithSingCounts) {
+    if (highestSingularityCount >= sing) counter += 1
+  }
+  return 1 + (counter * highestSingularityCount) / 100
+}
+
+const oldImmaculateAlchemy = (singularityCount: number): number => {
+  let bonus = 1
+  for (let i = 0; i < oldImmaculateAlchemyThresholds.length; i++) {
+    if (singularityCount >= oldImmaculateAlchemyThresholds[i]) bonus += 0.4
+  }
+  return bonus
+}
+
+const oldInheritance = (highestSingularityCount: number): number => {
+  for (let i = 15; i > 0; i--) {
+    if (highestSingularityCount >= oldInheritanceLevels[i]) {
+      return oldInheritanceTokenValues[i]
+    }
+  }
+  return 0
+}
+
+const oldSingularityBonusToken = (highestSingularityCount: number): number => {
+  for (let i = 5; i > 0; i--) {
+    if (highestSingularityCount >= oldBonusTokenLevels[i - 1]) {
+      return 1 + 0.02 * i
+    }
+  }
+  return 1
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Build a grid that hits every threshold boundary (value, value - 1, value + 1)
+// plus 0 and a high cap.
+const boundaryGrid = (thresholds: number[]): number[] => {
+  const out = new Set<number>([0, 1, 500])
+  for (const t of thresholds) {
+    out.add(Math.max(0, t - 1))
+    out.add(t)
+    out.add(t + 1)
+  }
+  return [...out].sort((a, b) => a - b)
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateSingularityQuarkMilestoneMultiplier', () => {
+  it.each(boundaryGrid(oldSingQuarkMilestoneThresholds))('singularityCount=%i', (count) => {
+    expect(closeEnough(newSingQuarkMult(count), oldSingQuarkMult(count))).toBe(true)
+  })
+})
+
+describe('parity: calculateBaseGoldenQuarks', () => {
+  const singularityGrid = [0, 1, 5, 10, 25, 50, 100, 200, 290]
+  const quarksGrid = [0, 1, 1e4, 1e5, 1e6, 1e9, 1e12]
+  const highestGrid = [0, 1, 5, 10, 11, 50, 290]
+
+  for (const singularity of singularityGrid) {
+    for (const quarks of quarksGrid) {
+      it.each(highestGrid)(`s=${singularity} q=${quarks} highest=%i`, (highest) => {
+        const next = newBaseGoldenQuarks({
+          singularity,
+          quarksThisSingularity: quarks,
+          highestSingularityCount: highest
+        })
+        const old = oldBaseGoldenQuarks(singularity, quarks, highest)
+        expect(next).toBe(old)
+      })
+    }
+  }
+})
+
+describe('parity: calculateSingularityAmbrosiaLuckMilestoneBonus', () => {
+  const grid = boundaryGrid([...oldAmbrosiaLuckSingThresholds1, ...oldAmbrosiaLuckSingThresholds2])
+  it.each(grid)('highest=%i', (highest) => {
+    expect(newSingAmbrosiaLuck(highest)).toBe(oldSingAmbrosiaLuck(highest))
+  })
+})
+
+describe('parity: calculateDilatedFiveLeafBonus', () => {
+  const grid = boundaryGrid([100, 150, 200, 225, 250, 255, 260, 265, 269, 272])
+  it.each(grid)('highest=%i', (highest) => {
+    expect(closeEnough(newDilatedFiveLeaf(highest), oldDilatedFiveLeaf(highest))).toBe(true)
+  })
+})
+
+describe('parity: derpsmithCornucopiaBonus', () => {
+  const grid = boundaryGrid(oldDerpsmithSingCounts)
+  it.each(grid)('highest=%i', (highest) => {
+    expect(closeEnough(newDerpsmith(highest), oldDerpsmithCornucopia(highest))).toBe(true)
+  })
+})
+
+describe('parity: calculateImmaculateAlchemyBonus', () => {
+  const grid = boundaryGrid(oldImmaculateAlchemyThresholds)
+  it.each(grid)('singularityCount=%i', (count) => {
+    expect(closeEnough(newImmaculateAlchemy(count), oldImmaculateAlchemy(count))).toBe(true)
+  })
+})
+
+describe('parity: inheritanceTokens', () => {
+  const grid = boundaryGrid(oldInheritanceLevels)
+  it.each(grid)('highest=%i', (highest) => {
+    expect(newInheritanceTokens(highest)).toBe(oldInheritance(highest))
+  })
+})
+
+describe('parity: singularityBonusTokenMult', () => {
+  const grid = boundaryGrid(oldBonusTokenLevels)
+  it.each(grid)('highest=%i', (highest) => {
+    expect(closeEnough(newSingularityBonusTokenMult(highest), oldSingularityBonusToken(highest))).toBe(true)
+  })
+})
+
+// ─── sumOfExaltCompletions ─────────────────────────────────────────────────
+
+const oldSumOfExaltCompletions = (completionsList: number[]): number => {
+  let sum = 0
+  for (const completions of completionsList) {
+    sum += completions
+  }
+  return sum
+}
+
+describe('parity: sumOfExaltCompletions', () => {
+  const cases: [number[]][] = [
+    [[]],
+    [[0]],
+    [[1]],
+    [[1, 2, 3, 4, 5]],
+    [[0, 0, 0, 0]],
+    [[15, 15, 15, 15, 15, 15, 15, 15]],
+    [[10, 0, 5, 0, 3, 12, 0]]
+  ]
+  it.each(cases)('list=%j', (list) => {
+    expect(newSumOfExaltCompletions(list)).toBe(oldSumOfExaltCompletions(list))
+  })
+})

--- a/packages/logic/test/parity/summations.parity.test.ts
+++ b/packages/logic/test/parity/summations.parity.test.ts
@@ -1,0 +1,193 @@
+// Parity tests for the summation/cost helpers lifted from
+// packages/web_ui/src/Calculate.ts. The old impls used i18next-translated
+// strings in their throw paths — the new versions throw plain codes
+// (`SUMMATIONS_*`); the value-comparison sweeps don't exercise those
+// throws, and separate `expect.toThrow` cases assert the code identity.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateCubicSumData as newCubicSumData,
+  calculateSummationCubic as newSummationCubic,
+  calculateSummationNonLinear as newSummationNonLinear,
+  solveQuadratic as newSolveQuadratic
+} from '../../src/math/summations'
+
+// ─── Old implementations (verbatim, with throw messages replaced by codes
+//     to match the new behavior) ─────────────────────────────────────────
+
+const oldSummationNonLinear = (
+  baseLevel: number,
+  baseCost: number,
+  resourceAvailable: number,
+  diffPerLevel: number,
+  buyAmount: number
+): { levelCanBuy: number; cost: number } => {
+  const c = diffPerLevel / 2
+  resourceAvailable = resourceAvailable || 0
+  const alreadySpent = baseCost * (c * Math.pow(baseLevel, 2) + baseLevel * (1 - c))
+  resourceAvailable += alreadySpent
+  const v = resourceAvailable / baseCost
+  let buyToLevel = c > 0
+    ? Math.max(
+      0,
+      Math.floor(
+        (c - 1) / (2 * c)
+          + Math.pow(Math.pow(1 - c, 2) + 4 * c * v, 1 / 2) / (2 * c)
+      )
+    )
+    : Math.floor(v)
+
+  buyToLevel = Math.min(buyToLevel, buyAmount + baseLevel)
+  buyToLevel = Math.max(buyToLevel, baseLevel)
+  let totalCost = baseCost * (c * Math.pow(buyToLevel, 2) + buyToLevel * (1 - c))
+    - alreadySpent
+  if (buyToLevel === baseLevel) {
+    totalCost = baseCost * (1 + 2 * c * baseLevel)
+  }
+  return { levelCanBuy: buyToLevel, cost: totalCost }
+}
+
+const oldSummationCubic = (n: number): number => {
+  if (n < 0) return -1
+  if (!Number.isInteger(n)) return -1
+  return Math.pow((n * (n + 1)) / 2, 2)
+}
+
+const oldSolveQuadratic = (a: number, b: number, c: number, positive: boolean): number => {
+  if (a < 0) {
+    throw new Error('SUMMATIONS_QUADRATIC_IMPROPER')
+  }
+  const determinant = Math.pow(b, 2) - 4 * a * c
+  if (determinant < 0) {
+    throw new Error('SUMMATIONS_QUADRATIC_DETERMINANT')
+  }
+  if (determinant === 0) {
+    return -b / (2 * a)
+  }
+  const numeratorPos = -b + Math.sqrt(Math.pow(b, 2) - 4 * a * c)
+  const numeratorNeg = -b - Math.sqrt(Math.pow(b, 2) - 4 * a * c)
+  return positive ? numeratorPos / (2 * a) : numeratorNeg / (2 * a)
+}
+
+const oldCubicSumData = (
+  initialLevel: number,
+  baseCost: number,
+  amountToSpend: number,
+  maxLevel: number
+) => {
+  if (initialLevel >= maxLevel) {
+    return { levelCanBuy: maxLevel, cost: 0 }
+  }
+  const alreadySpent = baseCost * oldSummationCubic(initialLevel)
+  const totalToSpend = alreadySpent + amountToSpend
+
+  if (totalToSpend < 0) {
+    throw new Error('SUMMATIONS_CUBIC_SUM_NEGATIVE')
+  }
+
+  const determinantRoot = Math.pow(totalToSpend / baseCost, 0.5)
+  const solution = oldSolveQuadratic(1, 1, -2 * determinantRoot, true)
+
+  const levelToBuy = Math.max(
+    Math.min(maxLevel, Math.floor(solution)),
+    initialLevel
+  )
+  const realCost = levelToBuy === initialLevel
+    ? baseCost * Math.pow(initialLevel + 1, 3)
+    : baseCost * oldSummationCubic(levelToBuy) - alreadySpent
+
+  return { levelCanBuy: levelToBuy, cost: realCost }
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateSummationNonLinear', () => {
+  const baseLevels = [0, 1, 10, 100]
+  const baseCosts = [1, 10, 100, 1e6]
+  const resources = [0, 1, 10, 100, 1e4, 1e8, 1e15]
+  const diffs = [0, 0.5, 1, 2]
+  const buyAmounts = [1, 10, 100, 1000]
+  for (const baseLevel of baseLevels) {
+    for (const baseCost of baseCosts) {
+      for (const diff of diffs) {
+        for (const buyAmount of buyAmounts) {
+          it.each(resources)(
+            `baseLvl=${baseLevel} baseCost=${baseCost} diff=${diff} buyAmt=${buyAmount} res=%s`,
+            (res) => {
+              const next = newSummationNonLinear(baseLevel, baseCost, res, diff, buyAmount)
+              const old = oldSummationNonLinear(baseLevel, baseCost, res, diff, buyAmount)
+              expect(next.levelCanBuy).toBe(old.levelCanBuy)
+              expect(closeEnough(next.cost, old.cost)).toBe(true)
+            }
+          )
+        }
+      }
+    }
+  }
+})
+
+describe('parity: calculateSummationCubic', () => {
+  // Cover the special-return-(-1) paths (negative, non-integer) and the
+  // happy path with various positive integers.
+  const grid = [-5, -1, 0, 1, 2, 3, 10, 50, 100, 1000]
+  it.each(grid)('n=%s', (n) => {
+    expect(newSummationCubic(n)).toBe(oldSummationCubic(n))
+  })
+  it.each([0.5, 1.5, 99.9])('n=%s (non-integer)', (n) => {
+    expect(newSummationCubic(n)).toBe(oldSummationCubic(n))
+  })
+})
+
+describe('parity: solveQuadratic', () => {
+  const cases: Array<[number, number, number, boolean]> = [
+    [1, 0, -4, true],
+    [1, 0, -4, false],
+    [1, -5, 6, true],
+    [1, -5, 6, false],
+    [1, 2, 1, true],
+    [1, 2, 1, false],
+    [1, 1, -6, true],
+    [2, 4, 2, true]
+  ]
+  it.each(cases)('a=%s b=%s c=%s pos=%s', (a, b, c, positive) => {
+    expect(closeEnough(newSolveQuadratic(a, b, c, positive), oldSolveQuadratic(a, b, c, positive))).toBe(true)
+  })
+
+  it('throws SUMMATIONS_QUADRATIC_IMPROPER when a < 0', () => {
+    expect(() => newSolveQuadratic(-1, 0, 0, true)).toThrow('SUMMATIONS_QUADRATIC_IMPROPER')
+  })
+
+  it('throws SUMMATIONS_QUADRATIC_DETERMINANT when discriminant < 0', () => {
+    expect(() => newSolveQuadratic(1, 0, 1, true)).toThrow('SUMMATIONS_QUADRATIC_DETERMINANT')
+  })
+})
+
+describe('parity: calculateCubicSumData', () => {
+  const cases: Array<[number, number, number, number]> = [
+    [0, 100, 0, 10],
+    [0, 100, 100, 10],
+    [0, 100, 1000, 10],
+    [0, 100, 1e6, 100],
+    [5, 50, 50000, 100],
+    [10, 100, 0, 10],
+    [10, 100, 1, 10],
+    [100, 1, 1, 100],
+    [50, 1000, 1e9, 200]
+  ]
+  it.each(cases)('init=%s base=%s spend=%s max=%s', (init, base, spend, max) => {
+    const next = newCubicSumData(init, base, spend, max)
+    const old = oldCubicSumData(init, base, spend, max)
+    expect(next.levelCanBuy).toBe(old.levelCanBuy)
+    expect(closeEnough(next.cost, old.cost)).toBe(true)
+  })
+
+  it('throws SUMMATIONS_CUBIC_SUM_NEGATIVE when totalToSpend < 0', () => {
+    expect(() => newCubicSumData(0, 100, -1, 10)).toThrow('SUMMATIONS_CUBIC_SUM_NEGATIVE')
+  })
+})

--- a/packages/web_ui/index.html
+++ b/packages/web_ui/index.html
@@ -94,7 +94,7 @@
               <img src="/Pictures/Default/BackedPrestige.png" class="offlineStatIcon">
               <span id="offlinePrestigeCount" class="offlineStatElement" i18n="offlineProgress.prestigeCount"></span>
             </div>
-            <div class="offlineStat" id="offlinePrestigeTimerDiv">
+            <div class="offlineStat prestigeunlock" id="offlinePrestigeTimerDiv">
               <img src="/Pictures/Default/BackedPrestigeOffTimer.png" class="offlineStatIcon">
               <span id="offlinePrestigeTimer" class="offlineStatElement" i18n="offlineProgress.currentPrestigeTimer"></span>
             </div>

--- a/packages/web_ui/src/Calculate.ts
+++ b/packages/web_ui/src/Calculate.ts
@@ -1,19 +1,39 @@
 import {
+  calculateAcceleratorMultiplier as logicCalcAcceleratorMultiplier,
   calculateActualAntSpeedMult as logicCalcActualAntSpeedMult,
   calculateAllCubeMultiplier as logicCalcAllCubeMultiplier,
   calculateAmbrosiaAdditiveLuckMult as logicCalcAmbrosiaAdditiveLuckMult,
+  calculateAmbrosiaCubeMult as logicCalcAmbrosiaCubeMult,
+  calculateAmbrosiaGenerationOcteractUpgrade as logicCalcAmbrosiaGenerationOcteractUpgrade,
+  calculateAmbrosiaGenerationSingularityUpgrade as logicCalcAmbrosiaGenerationSingularityUpgrade,
   calculateAmbrosiaGenerationSpeed as logicCalcAmbrosiaGenerationSpeed,
   calculateAmbrosiaGenerationSpeedRaw as logicCalcAmbrosiaGenerationSpeedRaw,
   calculateAmbrosiaLuck as logicCalcAmbrosiaLuck,
+  calculateAmbrosiaLuckOcteractUpgrade as logicCalcAmbrosiaLuckOcteractUpgrade,
   calculateAmbrosiaLuckRaw as logicCalcAmbrosiaLuckRaw,
+  calculateAmbrosiaLuckSingularityUpgrade as logicCalcAmbrosiaLuckSingularityUpgrade,
+  calculateAmbrosiaQuarkMult as logicCalcAmbrosiaQuarkMult,
   calculateAntSacrificeMultiplier as logicCalcAntSacrificeMultiplier,
+  calculateAscensionCount as logicCalcAscensionCount,
   calculateAscensionSpeedExponentSpread as logicCalcAscensionSpeedExponentSpread,
   calculateAscensionSpeedMult as logicCalcAscensionSpeedMult,
+  calculateBaseGoldenQuarks as logicCalcBaseGoldenQuarks,
   calculateBaseObtainium as logicCalcBaseObtainium,
   calculateBaseOfferings as logicCalcBaseOfferings,
   calculateBlueberryInventory as logicCalcBlueberryInventory,
+  calculateCookieUpgrade29Luck as logicCalcCookieUpgrade29Luck,
+  calculateCubeMultFromPowder as logicCalcCubeMultFromPowder,
+  calculateCubeQuarkMultiplier as logicCalcCubeQuarkMultiplier,
+  calculateCubicSumData as logicCalcCubicSumData,
   calculateCubeMultiplier as logicCalcCubeMultiplier,
   calculateCubeMultiplierWithTau as logicCalcCubeMultiplierWithTau,
+  calculateDilatedFiveLeafBonus as logicCalcDilatedFiveLeafBonus,
+  calculateExalt3AscensionLimit as logicCalcExalt3AscensionLimit,
+  calculateExalt3Penalty as logicCalcExalt3Penalty,
+  calculateExalt4EffectiveSingularityMultiplier as logicCalcExalt4EffSingMult,
+  calculateExalt6Penalty as logicCalcExalt6Penalty,
+  calculateExalt6PenaltyPerSecond as logicCalcExalt6PenaltyPerSecond,
+  calculateExalt6TimeLimit as logicCalcExalt6TimeLimit,
   calculateFreeShopInfinityUpgrades as logicCalcFreeShopInfinityUpgrades,
   calculateGlobalSpeedDREnabledMult as logicCalcGlobalSpeedDREnabledMult,
   calculateGlobalSpeedDRIgnoreMult as logicCalcGlobalSpeedDRIgnoreMult,
@@ -22,7 +42,13 @@ import {
   calculateGoldenQuarks as logicCalcGoldenQuarks,
   calculateHepteractMultiplier as logicCalcHepteractMultiplier,
   calculateHypercubeMultiplier as logicCalcHypercubeMultiplier,
+  calculateImmaculateAlchemyBonus as logicCalcImmaculateAlchemyBonus,
   calculateLuckConversion as logicCalcLuckConversion,
+  calculateNumberOfThresholds as logicCalcNumberOfThresholds,
+  calculateObtainiumPotionBaseObtainium as logicCalcObtainiumPotionBaseObtainium,
+  calculateOfferingPotionBaseOfferings as logicCalcOfferingPotionBaseOfferings,
+  calculatePotionValue as logicCalcPotionValue,
+  calculateQuarkMultFromPowder as logicCalcQuarkMultFromPowder,
   calculateNegativeSalvage as logicCalcNegativeSalvage,
   calculateNegativeSalvageMultiplier as logicCalcNegativeSalvageMultiplier,
   calculateObtainium as logicCalcObtainium,
@@ -41,19 +67,39 @@ import {
   calculateRawAscensionSpeedMult as logicCalcRawAscensionSpeedMult,
   calculateRawNegativeSalvage as logicCalcRawNegativeSalvage,
   calculateRawPositiveSalvage as logicCalcRawPositiveSalvage,
+  calculateRedAmbrosiaCubes as logicCalcRedAmbrosiaCubes,
   calculateRedAmbrosiaGenerationSpeed as logicCalcRedAmbrosiaGenerationSpeed,
   calculateRedAmbrosiaLuck as logicCalcRedAmbrosiaLuck,
+  calculateRedAmbrosiaObtainium as logicCalcRedAmbrosiaObtainium,
+  calculateRedAmbrosiaOffering as logicCalcRedAmbrosiaOffering,
+  calculateRequiredBlueberryTime as logicCalcRequiredBlueberryTime,
+  calculateRequiredRedAmbrosiaTime as logicCalcRequiredRedAmbrosiaTime,
   calculateSalvageRuneEXPMultiplier as logicCalcSalvageRuneEXPMultiplier,
+  calculateSigmoid as logicCalcSigmoid,
+  calculateSigmoidExponential as logicCalcSigmoidExponential,
+  calculateSingularityAmbrosiaLuckMilestoneBonus as logicCalcSingAmbrosiaLuckBonus,
+  calculateSingularityMilestoneBlueberries as logicCalcSingularityMilestoneBlueberries,
+  calculateSingularityQuarkMilestoneMultiplier as logicCalcSingQuarkMilestoneMult,
+  calculateSummationNonLinear as logicCalcSummationNonLinear,
   calculateTesseractMultiplier as logicCalcTesseractMultiplier,
+  calculateTotalAcceleratorBoost as logicCalcTotalAcceleratorBoost,
   calculateTotalCoinOwned as logicCalcTotalCoinOwned,
-  calculateTotalSalvage as logicCalcTotalSalvage
+  calculateTotalOcteractCubeBonus as logicCalcTotalOcteractCubeBonus,
+  calculateTotalOcteractObtainiumBonus as logicCalcTotalOcteractObtainiumBonus,
+  calculateTotalOcteractOfferingBonus as logicCalcTotalOcteractOfferingBonus,
+  calculateTotalOcteractQuarkBonus as logicCalcTotalOcteractQuarkBonus,
+  calculateToNextThreshold as logicCalcToNextThreshold,
+  calculateTotalSalvage as logicCalcTotalSalvage,
+  derpsmithCornucopiaBonus as logicDerpsmithCornucopiaBonus,
+  inheritanceTokens as logicInheritanceTokens,
+  singularityBonusTokenMult as logicSingularityBonusTokenMult,
+  sumOfExaltCompletions as logicSumOfExaltCompletions
 } from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
 import { awardUngroupedAchievement, getAchievementReward } from './Achievements'
 import { getAmbrosiaUpgradeEffects } from './BlueberryUpgrades'
 import { DOMCacheGetOrSet } from './Cache/DOM'
-import { CalcECC } from './Challenges'
 import { calculateAntSacrificeCubeBlessing, calculateObtainiumCubeBlessing } from './Cubes'
 import { BuffType, calculateEventSourceBuff } from './Event'
 import { generateAntsAndCrumbs } from './Features/Ants/AntProducers/lib/generate-ant-producers'
@@ -115,19 +161,10 @@ import { format, getTimePinnedToLoadDate, player, resourceGain, saveSynergy, upd
 import { getTalismanEffects, toggleTalismanBuy, updateTalismanInventory } from './Talismans'
 import { clearInterval, setInterval } from './Timers'
 import { Alert, Prompt } from './UpdateHTML'
-import { findInsertionIndex } from './Utility'
 import { Globals as G } from './Variables'
 
 const posSalvagePerkSings = [230, 245, 260, 275, 290]
 const negSalvagePerkSings = [75, 85, 105, 125, 155, 185, 215, 245, 260, 275]
-
-// dprint-ignore
-const singQuarkMilestoneThresholds = [
-  5, 7, 10, 20, 35, 50, 65, 80, 90, 100, 121, 144, 150, 160, 166, 169, 170,
-  175, 180, 190, 196, 200, 201, 202, 203, 204, 205, 210, 213, 216, 219, 225,
-  228, 231, 234, 237, 240, 244, 248, 252, 256, 260, 264, 268, 272, 276, 280,
-  284, 288, 290
-];
 
 const challengeScoreArrays2 = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450]
 const challengeScoreArrays3 = [
@@ -156,60 +193,6 @@ const challengeScoreArrays4 = [
   5000,
   7500
 ]
-
-const ambrosiaLuckSingThresholds1 = [35, 42, 49, 56, 63, 70, 77]
-const ambrosiaLuckSingThresholds2 = [135, 142, 149, 156, 163, 170, 177]
-
-const derpsmithSingCounts = [
-  18,
-  38,
-  58,
-  78,
-  88,
-  98,
-  118,
-  148,
-  178,
-  188,
-  198,
-  208,
-  218,
-  228,
-  238,
-  248
-]
-
-const immaculateAlchemyThresholds = [50, 90, 130, 170, 200, 217, 235, 253, 271, 289]
-
-const inheritanceLevels = [2, 5, 10, 17, 26, 37, 50, 65, 82, 101, 220, 240, 260, 270, 277]
-const inheritanceTokenValues = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
-
-const bonusTokenLevels = [41, 58, 113, 163, 229]
-
-const offeringPotionThresholds = [
-  1,
-  10,
-  25,
-  50,
-  100,
-  500,
-  1000,
-  10000,
-  5e4,
-  1e5,
-  1e6,
-  1e7,
-  1e8,
-  1e9,
-  1e10,
-  1e11,
-  1e12,
-  1e13,
-  1e14,
-  1e15
-]
-
-const obtainiumPotionThresholds = [1, 20, 50, 250, 1000, 20000, 4e5, 1e7, 4e8, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15]
 
 export const calculateAllCubeMultiplier = () => logicCalcAllCubeMultiplier(allCubeStats.map(s => s.stat()))
 export const calculateCubeMultiplier = () => logicCalcCubeMultiplier(allWowCubeStats.map(s => s.stat()))
@@ -281,53 +264,19 @@ export const calculateObtainium = (timeMultUsed = true) => {
   })
 }
 
-const calculateFastForwardResourcesGlobal = (
-  resetTime: number,
-  fastForwardAmount: Decimal,
-  resourceMult: Decimal,
-  baseResource: number
-) => {
-  // We're going to use the log trick to account for the fact that resourceMult * timeMult can still be >1e300
-  // Even if timeMult is very small.
-
-  // Math to compute the change in multiplier based on time
-  // The amount of offerings to give is proportional to the difference in
-  // Time Multipliers.
-  let timeMultiplier: Decimal = new Decimal('1')
-
-  const deltaTime = fastForwardAmount.times(
-    getGQUpgradeEffect('halfMind', 'unlocked') ? 10 : calculateGlobalSpeedMult()
-  )
-
-  // Build approximations through direct computation of the derivative of time multiplier
-  // And then multiplying by deltaTime, so basically a linear approximation (See: Calculus)
-
-  // In order for the time multiplier to not decrease as your resetTime increases, while accurately portraying
-  //  take the min of
-  // two approximations: one with quadratic penalty (if less than threshold) and that of linear penalty
-  // Use the derivative of the quadratic part
-
-  timeMultiplier = Decimal.min(
-    deltaTime.times(2 * resetTime).div(resetTimeThreshold() ** 2),
-    deltaTime.div(resetTimeThreshold())
-  )
-
-  // Correct multiplier if half mind is purchased
-  timeMultiplier.times(getGQUpgradeEffect('halfMind', 'unlocked') ? calculateGlobalSpeedMult() / 10 : 1)
-
-  return Decimal.max(fastForwardAmount.times(baseResource), resourceMult.times(timeMultiplier))
-}
-
-export const calculatePotionValue = (resetTime: number, resourceMult: Decimal, baseResource: number) => {
-  const potionTimeValue = new Decimal(7200)
-  const fastForwardMult = calculateFastForwardResourcesGlobal(resetTime, potionTimeValue, resourceMult, baseResource)
-  const potionMultipliers = getGQUpgradeEffect('potionBuff', 'potionPowerMult')
-    * getGQUpgradeEffect('potionBuff2', 'potionPowerMult')
-    * getGQUpgradeEffect('potionBuff3', 'potionPowerMult')
-    * getOcteractUpgradeEffect('octeractAutoPotionEfficiency', 'potionPowerMult')
-
-  return fastForwardMult.times(potionMultipliers)
-}
+export const calculatePotionValue = (resetTime: number, resourceMult: Decimal, baseResource: number) =>
+  logicCalcPotionValue({
+    resetTime,
+    resourceMult,
+    baseResource,
+    halfMindUnlocked: getGQUpgradeEffect('halfMind', 'unlocked'),
+    globalSpeedMult: calculateGlobalSpeedMult(),
+    resetTimeThreshold: resetTimeThreshold(),
+    potionMultipliers: getGQUpgradeEffect('potionBuff', 'potionPowerMult')
+      * getGQUpgradeEffect('potionBuff2', 'potionPowerMult')
+      * getGQUpgradeEffect('potionBuff3', 'potionPowerMult')
+      * getOcteractUpgradeEffect('octeractAutoPotionEfficiency', 'potionPowerMult')
+  })
 
 export const calculateResearchAutomaticObtainium = (deltaTime: number) => {
   if (player.currentChallenge.ascension === 14) {
@@ -449,84 +398,61 @@ export const calculateTotalCoinOwned = () => logicCalcTotalCoinOwned({
 })
 
 export const calculateTotalAcceleratorBoost = () => {
-  let b = 0
-  const totalCoinOwned = calculateTotalCoinOwned()
-  if (player.upgrades[26] > 0.5) {
-    b += 1
-  }
-  if (player.upgrades[31] > 0.5) {
-    b += (Math.floor(totalCoinOwned / 2000) * 100) / 100
-  }
-  b += +getAchievementReward('accelBoosts')
-
-  b += player.researches[93]
-    * Math.floor(
-      (1 / 20)
-        * sumOfRuneLevels()
-    )
-  b *= 1
-    + (1 / 5)
-      * player.researches[3]
-      * (1 + (1 / 2) * CalcECC('ascension', player.challengecompletions[14]))
-  b *= 1 + (1 / 20) * player.researches[16] + (1 / 20) * player.researches[17]
-  b *= 1 + (1 / 20) * player.researches[88]
-  b *= getAntUpgradeEffect(AntUpgrades.AcceleratorBoosts).acceleratorBoostMult
-  b *= 1 + (1 / 100) * player.researches[127]
-  b *= 1 + (0.8 / 100) * player.researches[142]
-  b *= 1 + (0.6 / 100) * player.researches[157]
-  b *= 1 + (0.4 / 100) * player.researches[172]
-  b *= 1 + (0.2 / 100) * player.researches[187]
-  b *= 1 + (0.01 / 100) * player.researches[200]
-  b *= 1 + (0.01 / 100) * player.cubeUpgrades[50]
-  b *= 1 + (1 / 1000) * hepteractEffective('acceleratorBoost')
-  if (
-    player.upgrades[73] > 0.5
-    && player.currentChallenge.reincarnation !== 0
-  ) {
-    b *= 2
-  }
-  b = Math.min(1e100, Math.floor(b))
-  G.freeAcceleratorBoost = b
-
-  G.totalAcceleratorBoost = (Math.floor(player.acceleratorBoostBought + G.freeAcceleratorBoost) * 100)
-    / 100
+  const { freeAcceleratorBoost, totalAcceleratorBoost } = logicCalcTotalAcceleratorBoost({
+    upgrade26: player.upgrades[26],
+    upgrade31: player.upgrades[31],
+    totalCoinOwned: calculateTotalCoinOwned(),
+    achievementAccelBoosts: +getAchievementReward('accelBoosts'),
+    research93: player.researches[93],
+    sumOfRuneLevels: sumOfRuneLevels(),
+    research3: player.researches[3],
+    challengeCompletions14: player.challengecompletions[14],
+    research16: player.researches[16],
+    research17: player.researches[17],
+    research88: player.researches[88],
+    antBuildingAcceleratorBoostMult: getAntUpgradeEffect(AntUpgrades.AcceleratorBoosts).acceleratorBoostMult,
+    research127: player.researches[127],
+    research142: player.researches[142],
+    research157: player.researches[157],
+    research172: player.researches[172],
+    research187: player.researches[187],
+    research200: player.researches[200],
+    cubeUpgrade50: player.cubeUpgrades[50],
+    hepteractEffectiveAcceleratorBoost: hepteractEffective('acceleratorBoost'),
+    upgrade73: player.upgrades[73],
+    inReincarnationChallenge: player.currentChallenge.reincarnation !== 0,
+    acceleratorBoostBought: player.acceleratorBoostBought
+  })
+  G.freeAcceleratorBoost = freeAcceleratorBoost
+  G.totalAcceleratorBoost = totalAcceleratorBoost
 }
 
 export const calculateAcceleratorMultiplier = () => {
-  G.acceleratorMultiplier = 1
-  G.acceleratorMultiplier *= 1
-    + (1 / 5)
-      * player.researches[1]
-      * (1 + (1 / 2) * CalcECC('ascension', player.challengecompletions[14]))
-  G.acceleratorMultiplier *= 1
-    + (1 / 20) * player.researches[6]
-    + (1 / 25) * player.researches[7]
-    + (1 / 40) * player.researches[8]
-    + (3 / 200) * player.researches[9]
-    + (1 / 200) * player.researches[10]
-  G.acceleratorMultiplier *= 1 + (1 / 20) * player.researches[86]
-  G.acceleratorMultiplier *= 1 + (1 / 100) * player.researches[126]
-  G.acceleratorMultiplier *= 1 + (0.8 / 100) * player.researches[141]
-  G.acceleratorMultiplier *= 1 + (0.6 / 100) * player.researches[156]
-  G.acceleratorMultiplier *= 1 + (0.4 / 100) * player.researches[171]
-  G.acceleratorMultiplier *= 1 + (0.2 / 100) * player.researches[186]
-  G.acceleratorMultiplier *= 1 + (0.01 / 100) * player.researches[200]
-  G.acceleratorMultiplier *= 1 + (0.01 / 100) * player.cubeUpgrades[50]
-  G.acceleratorMultiplier *= Math.pow(
-    1.01,
-    player.upgrades[21]
-      + player.upgrades[22]
-      + player.upgrades[23]
-      + player.upgrades[24]
-      + player.upgrades[25]
-  )
-  if (
-    (player.currentChallenge.transcension !== 0
-      || player.currentChallenge.reincarnation !== 0)
-    && player.upgrades[50] > 0.5
-  ) {
-    G.acceleratorMultiplier *= 1.25
-  }
+  G.acceleratorMultiplier = logicCalcAcceleratorMultiplier({
+    research1: player.researches[1],
+    challengeCompletions14: player.challengecompletions[14],
+    research6: player.researches[6],
+    research7: player.researches[7],
+    research8: player.researches[8],
+    research9: player.researches[9],
+    research10: player.researches[10],
+    research86: player.researches[86],
+    research126: player.researches[126],
+    research141: player.researches[141],
+    research156: player.researches[156],
+    research171: player.researches[171],
+    research186: player.researches[186],
+    research200: player.researches[200],
+    cubeUpgrade50: player.cubeUpgrades[50],
+    upgrade21: player.upgrades[21],
+    upgrade22: player.upgrades[22],
+    upgrade23: player.upgrades[23],
+    upgrade24: player.upgrades[24],
+    upgrade25: player.upgrades[25],
+    upgrade50: player.upgrades[50],
+    inTranscensionOrReincarnationChallenge: player.currentChallenge.transcension !== 0
+      || player.currentChallenge.reincarnation !== 0
+  })
 }
 
 export const calculatePositiveSalvageMultiplier = () => logicCalcPositiveSalvageMultiplier({
@@ -848,196 +774,69 @@ export const calculateSigmoid = (
   constant: number,
   factor: number,
   divisor: number
-) => {
-  return 1 + (constant - 1) * (1 - Math.pow(2, -factor / divisor))
-}
+) => logicCalcSigmoid(constant, factor, divisor)
 
 export const calculateSigmoidExponential = (
   constant: number,
   coefficient: number
-) => {
-  return 1 + (constant - 1) * (1 - Math.exp(-coefficient))
-}
+) => logicCalcSigmoidExponential(constant, coefficient)
 
-export const calculateTotalOcteractCubeBonus = () => {
-  if (player.singularityChallenges.noOcteracts.enabled) {
-    return 1
-  }
-  if (player.totalWowOcteracts < 1000) {
-    const bonus = 1 + (2 / 1000) * player.totalWowOcteracts // At 1,000 returns 3
-    return bonus > 1.00001 ? bonus : 1
-  } else {
-    const power = 2 + getSingularityChallengeEffect('noOcteracts', 'octeractPow')
-    return 3 * Math.pow(Math.log10(player.totalWowOcteracts) - 2, power) // At 1,000 returns 3
-  }
-}
+export const calculateTotalOcteractCubeBonus = () =>
+  logicCalcTotalOcteractCubeBonus({
+    exalt4Enabled: player.singularityChallenges.noOcteracts.enabled,
+    totalWowOcteracts: player.totalWowOcteracts,
+    octeractPow: getSingularityChallengeEffect('noOcteracts', 'octeractPow')
+  })
 
-export const calculateTotalOcteractQuarkBonus = () => {
-  if (player.singularityChallenges.noOcteracts.enabled) {
-    return 1
-  }
-  if (player.totalWowOcteracts < 1000) {
-    const bonus = 1 + (0.2 / 1000) * player.totalWowOcteracts // At 1,000 returns 1.20
-    return bonus > 1.00001 ? bonus : 1
-  } else {
-    return 1.1 + 0.1 * (Math.log10(player.totalWowOcteracts) - 2) // At 1,000 returns 1.20
-  }
-}
+export const calculateTotalOcteractQuarkBonus = () =>
+  logicCalcTotalOcteractQuarkBonus({
+    exalt4Enabled: player.singularityChallenges.noOcteracts.enabled,
+    totalWowOcteracts: player.totalWowOcteracts
+  })
 
-export const calculateTotalOcteractOfferingBonus = () => {
-  if (!getSingularityChallengeEffect('noOcteracts', 'offeringBonus')) {
-    return 1
-  }
-  return Math.pow(calculateTotalOcteractCubeBonus(), 1.25)
-}
+export const calculateTotalOcteractOfferingBonus = () =>
+  logicCalcTotalOcteractOfferingBonus({
+    offeringBonusEnabled: getSingularityChallengeEffect('noOcteracts', 'offeringBonus'),
+    cubeBonus: calculateTotalOcteractCubeBonus()
+  })
 
-export const calculateTotalOcteractObtainiumBonus = () => {
-  if (!getSingularityChallengeEffect('noOcteracts', 'obtainiumBonus')) {
-    return 1
-  }
-  return Math.pow(calculateTotalOcteractCubeBonus(), 1.25)
-}
+export const calculateTotalOcteractObtainiumBonus = () =>
+  logicCalcTotalOcteractObtainiumBonus({
+    obtainiumBonusEnabled: getSingularityChallengeEffect('noOcteracts', 'obtainiumBonus'),
+    cubeBonus: calculateTotalOcteractCubeBonus()
+  })
 
-export const calculateSingularityQuarkMilestoneMultiplier = () => {
-  let multiplier = 1
-  for (const sing of singQuarkMilestoneThresholds) {
-    if (player.singularityCount >= sing) {
-      multiplier *= 1.05
-    }
-  }
+export const calculateSingularityQuarkMilestoneMultiplier = () =>
+  logicCalcSingQuarkMilestoneMult(player.singularityCount)
 
-  return multiplier
-}
-
-// If you want to sum from a baseline level baseLevel to some level where the cost per level is base * (1 + level * diffPerLevel), this finds out how many total levels you can buy.
 export const calculateSummationNonLinear = (
   baseLevel: number,
   baseCost: number,
   resourceAvailable: number,
   diffPerLevel: number,
   buyAmount: number
-): { levelCanBuy: number; cost: number } => {
-  const c = diffPerLevel / 2
-  resourceAvailable = resourceAvailable || 0
-  const alreadySpent = baseCost * (c * Math.pow(baseLevel, 2) + baseLevel * (1 - c))
-  resourceAvailable += alreadySpent
-  const v = resourceAvailable / baseCost
-  let buyToLevel = c > 0
-    ? Math.max(
-      0,
-      Math.floor(
-        (c - 1) / (2 * c)
-          + Math.pow(Math.pow(1 - c, 2) + 4 * c * v, 1 / 2) / (2 * c)
-      )
-    )
-    : Math.floor(v)
+): { levelCanBuy: number; cost: number } =>
+  logicCalcSummationNonLinear(baseLevel, baseCost, resourceAvailable, diffPerLevel, buyAmount)
 
-  buyToLevel = Math.min(buyToLevel, buyAmount + baseLevel)
-  buyToLevel = Math.max(buyToLevel, baseLevel)
-  let totalCost = baseCost * (c * Math.pow(buyToLevel, 2) + buyToLevel * (1 - c))
-    - alreadySpent
-  if (buyToLevel === baseLevel) {
-    totalCost = baseCost * (1 + 2 * c * baseLevel)
-  }
-  return {
-    levelCanBuy: buyToLevel,
-    cost: totalCost
-  }
+const cubicSumErrorMessageByCode: Record<string, string> = {
+  SUMMATIONS_QUADRATIC_IMPROPER: 'calculate.quadraticImproperError',
+  SUMMATIONS_QUADRATIC_DETERMINANT: 'calculate.quadraticDeterminantError',
+  SUMMATIONS_CUBIC_SUM_NEGATIVE: 'calculate.cubicSumNegativeError'
 }
 
-/**
- * @param n A nonnegative integer
- * @returns The sum of the first n positive cubes, 0 if n = 0, or -1 otherwise.
- */
-const calculateSummationCubic = (n: number) => {
-  if (n < 0) {
-    return -1
-  }
-  if (!Number.isInteger(n)) {
-    return -1
-  }
-
-  return Math.pow((n * (n + 1)) / 2, 2)
-}
-
-/**
- * Solves a*n^2 + b*n + c = 0 for real solutions.
- * @param a Coefficient of n^2. Must be nonzero!
- * @param b Coefficient of n.
- * @param c Coefficient of constant term
- * @param positive Boolean which if true makes solution use positive discriminant.
- * @returns Positive root of the quadratic, if it exists, and positive is true, otherwise false
- */
-const solveQuadratic = (
-  a: number,
-  b: number,
-  c: number,
-  positive: boolean
-) => {
-  if (a < 0) {
-    throw new Error(String(i18next.t('calculate.quadraticImproperError')))
-  }
-  const determinant = Math.pow(b, 2) - 4 * a * c
-  if (determinant < 0) {
-    throw new Error(String(i18next.t('calculate.quadraticDeterminantError')))
-  }
-
-  if (determinant === 0) {
-    return -b / (2 * a)
-  }
-  const numeratorPos = -b + Math.sqrt(Math.pow(b, 2) - 4 * a * c)
-  const numeratorNeg = -b - Math.sqrt(Math.pow(b, 2) - 4 * a * c)
-
-  if (positive) {
-    return numeratorPos / (2 * a)
-  } else {
-    return numeratorNeg / (2 * a)
-  }
-}
-
-/**
- * @param initialLevel
- * @param base
- * @param amountToSpend
- */
 export const calculateCubicSumData = (
   initialLevel: number,
   baseCost: number,
   amountToSpend: number,
   maxLevel: number
 ) => {
-  if (initialLevel >= maxLevel) {
-    return {
-      levelCanBuy: maxLevel,
-      cost: 0
+  try {
+    return logicCalcCubicSumData(initialLevel, baseCost, amountToSpend, maxLevel)
+  } catch (err) {
+    if (err instanceof Error && err.message in cubicSumErrorMessageByCode) {
+      throw new Error(String(i18next.t(cubicSumErrorMessageByCode[err.message])))
     }
-  }
-  const alreadySpent = baseCost * calculateSummationCubic(initialLevel)
-  const totalToSpend = alreadySpent + amountToSpend
-
-  // Solves (n(n+1)/2)^2 * baseCost = totalToSpend
-  /* Create a det = Sqrt(totalToSpend / baseCost)
-   *  Simplification gives n * (n+1) = 2 * det
-   *  We can rewrite as n^2 + n - 2 * det = 0 and solve for n.
-   */
-  if (totalToSpend < 0) {
-    throw new Error(String(i18next.t('calculate.cubicSumNegativeError')))
-  }
-
-  const determinantRoot = Math.pow(totalToSpend / baseCost, 0.5) // Assume nonnegative!
-  const solution = solveQuadratic(1, 1, -2 * determinantRoot, true)
-
-  const levelToBuy = Math.max(
-    Math.min(maxLevel, Math.floor(solution)),
-    initialLevel
-  )
-  const realCost = levelToBuy === initialLevel
-    ? baseCost * Math.pow(initialLevel + 1, 3)
-    : baseCost * calculateSummationCubic(levelToBuy) - alreadySpent
-
-  return {
-    levelCanBuy: levelToBuy,
-    cost: realCost
+    throw err
   }
 }
 
@@ -1213,311 +1012,125 @@ export const CalcCorruptionStuff = () => {
   ]*/
 }
 
-export const calculateAscensionCount = () => {
-  if (player.singularityChallenges.limitedAscensions.enabled) {
-    return 1
-  }
-  return Math.floor(ascensionCountMultStats.reduce(
-    (a, b) => a * b.stat(),
-    1
-  ))
-}
+export const calculateAscensionCount = () =>
+  logicCalcAscensionCount({
+    limitedAscensionsEnabled: player.singularityChallenges.limitedAscensions.enabled,
+    ascensionCountMults: ascensionCountMultStats.map(s => s.stat())
+  })
 
-export const calculateCubeQuarkMultiplier = () => {
-  return (
-    (calculateSigmoid(2, Math.pow(player.overfluxOrbs, 0.5), 40)
-      + calculateSigmoid(1.5, Math.pow(player.overfluxOrbs, 0.5), 160)
-      + calculateSigmoid(1.5, Math.pow(player.overfluxOrbs, 0.5), 640)
-      + calculateSigmoid(
-        1.15,
-        +(player.highestSingularityCount >= 1)
-          * Math.pow(player.overfluxOrbs, 0.45),
-        2560
-      )
-      + calculateSigmoid(
-        1.15,
-        +(player.highestSingularityCount >= 2)
-          * Math.pow(player.overfluxOrbs, 0.4),
-        10000
-      )
-      + calculateSigmoid(
-        1.25,
-        +(player.highestSingularityCount >= 5)
-          * Math.pow(player.overfluxOrbs, 0.35),
-        40000
-      )
-      + calculateSigmoid(
-        1.25,
-        +(player.highestSingularityCount >= 10)
-          * Math.pow(player.overfluxOrbs, 0.32),
-        160000
-      )
-      + calculateSigmoid(
-        1.35,
-        +(player.highestSingularityCount >= 15)
-          * Math.pow(player.overfluxOrbs, 0.27),
-        640000
-      )
-      + calculateSigmoid(
-        1.45,
-        +(player.highestSingularityCount >= 20)
-          * Math.pow(player.overfluxOrbs, 0.24),
-        2e6
-      )
-      + calculateSigmoid(
-        1.55,
-        +(player.highestSingularityCount >= 25)
-          * Math.pow(player.overfluxOrbs, 0.21),
-        1e7
-      )
-      + calculateSigmoid(
-        1.85,
-        +(player.highestSingularityCount >= 30)
-          * Math.pow(player.overfluxOrbs, 0.18),
-        4e7
-      )
-      + calculateSigmoid(
-        3,
-        +(player.highestSingularityCount >= 35)
-          * Math.pow(player.overfluxOrbs, 0.15),
-        1e8
-      )
-      - 11)
-    * getShopUpgradeEffects('cubeToQuarkAll', 'quarkMult')
-    * (player.autoWarpCheck ? 1 + player.dailyPowderResetUses : 1)
-  )
-}
+export const calculateCubeQuarkMultiplier = () =>
+  logicCalcCubeQuarkMultiplier({
+    overfluxOrbs: player.overfluxOrbs,
+    highestSingularityCount: player.highestSingularityCount,
+    cubeToQuarkAllMult: getShopUpgradeEffects('cubeToQuarkAll', 'quarkMult'),
+    autoWarpCheck: player.autoWarpCheck,
+    dailyPowderResetUses: player.dailyPowderResetUses
+  })
 
-export const calculateCubeMultFromPowder = () => {
-  return player.overfluxPowder > 10000
-    ? 1 + (1 / 16) * Math.pow(Math.log10(player.overfluxPowder), 2)
-    : 1 + (1 / 10000) * player.overfluxPowder
-}
+export const calculateCubeMultFromPowder = () => logicCalcCubeMultFromPowder(player.overfluxPowder)
 
-export const calculateQuarkMultFromPowder = () => {
-  return player.overfluxPowder > 10000
-    ? 1 + (1 / 40) * Math.log10(player.overfluxPowder)
-    : 1 + (1 / 100000) * player.overfluxPowder
-}
+export const calculateQuarkMultFromPowder = () => logicCalcQuarkMultFromPowder(player.overfluxPowder)
 
-export const calculateBaseGoldenQuarks = (singularity: number) => {
-  const minimumValue = 100 * Math.pow(1.04, singularity)
-  const contributionFromQuarks = player.quarksThisSingularity / 1e5
-  const firstTenBonus = 10 * Math.min(player.highestSingularityCount, 10)
-  return Math.floor(minimumValue + contributionFromQuarks + firstTenBonus)
-}
+export const calculateBaseGoldenQuarks = (singularity: number) =>
+  logicCalcBaseGoldenQuarks({
+    singularity,
+    quarksThisSingularity: player.quarksThisSingularity,
+    highestSingularityCount: player.highestSingularityCount
+  })
 
-export const calculateSingularityAmbrosiaLuckMilestoneBonus = () => {
-  let bonus = 0
+export const calculateSingularityAmbrosiaLuckMilestoneBonus = () =>
+  logicCalcSingAmbrosiaLuckBonus(player.highestSingularityCount)
 
-  for (const sing of ambrosiaLuckSingThresholds1) {
-    if (player.highestSingularityCount >= sing) {
-      bonus += 5
-    }
-  }
+export const calculateAmbrosiaGenerationSingularityUpgrade = () =>
+  logicCalcAmbrosiaGenerationSingularityUpgrade([
+    getGQUpgradeEffect('singAmbrosiaGeneration', 'ambrosiaBarSpeedMult'),
+    getGQUpgradeEffect('singAmbrosiaGeneration2', 'ambrosiaBarSpeedMult'),
+    getGQUpgradeEffect('singAmbrosiaGeneration3', 'ambrosiaBarSpeedMult'),
+    getGQUpgradeEffect('singAmbrosiaGeneration4', 'ambrosiaBarSpeedMult')
+  ])
 
-  for (const sing of ambrosiaLuckSingThresholds2) {
-    if (player.highestSingularityCount >= sing) {
-      bonus += 6
-    }
-  }
+export const calculateAmbrosiaLuckSingularityUpgrade = () =>
+  logicCalcAmbrosiaLuckSingularityUpgrade([
+    getGQUpgradeEffect('singAmbrosiaLuck', 'ambrosiaLuck'),
+    getGQUpgradeEffect('singAmbrosiaLuck2', 'ambrosiaLuck'),
+    getGQUpgradeEffect('singAmbrosiaLuck3', 'ambrosiaLuck'),
+    getGQUpgradeEffect('singAmbrosiaLuck4', 'ambrosiaLuck')
+  ])
 
-  return bonus
-}
+export const calculateAmbrosiaGenerationOcteractUpgrade = () =>
+  logicCalcAmbrosiaGenerationOcteractUpgrade([
+    getOcteractUpgradeEffect('octeractAmbrosiaGeneration', 'ambrosiaBarSpeedMult'),
+    getOcteractUpgradeEffect('octeractAmbrosiaGeneration2', 'ambrosiaBarSpeedMult'),
+    getOcteractUpgradeEffect('octeractAmbrosiaGeneration3', 'ambrosiaBarSpeedMult'),
+    getOcteractUpgradeEffect('octeractAmbrosiaGeneration4', 'ambrosiaBarSpeedMult')
+  ])
 
-export const calculateAmbrosiaGenerationSingularityUpgrade = () => {
-  return getGQUpgradeEffect('singAmbrosiaGeneration', 'ambrosiaBarSpeedMult')
-    * getGQUpgradeEffect('singAmbrosiaGeneration2', 'ambrosiaBarSpeedMult')
-    * getGQUpgradeEffect('singAmbrosiaGeneration3', 'ambrosiaBarSpeedMult')
-    * getGQUpgradeEffect('singAmbrosiaGeneration4', 'ambrosiaBarSpeedMult')
-}
+export const calculateAmbrosiaLuckOcteractUpgrade = () =>
+  logicCalcAmbrosiaLuckOcteractUpgrade([
+    getOcteractUpgradeEffect('octeractAmbrosiaLuck', 'ambrosiaLuck'),
+    getOcteractUpgradeEffect('octeractAmbrosiaLuck2', 'ambrosiaLuck'),
+    getOcteractUpgradeEffect('octeractAmbrosiaLuck3', 'ambrosiaLuck'),
+    getOcteractUpgradeEffect('octeractAmbrosiaLuck4', 'ambrosiaLuck')
+  ])
 
-export const calculateAmbrosiaLuckSingularityUpgrade = () => {
-  return getGQUpgradeEffect('singAmbrosiaLuck', 'ambrosiaLuck')
-    + getGQUpgradeEffect('singAmbrosiaLuck2', 'ambrosiaLuck')
-    + getGQUpgradeEffect('singAmbrosiaLuck3', 'ambrosiaLuck')
-    + getGQUpgradeEffect('singAmbrosiaLuck4', 'ambrosiaLuck')
-}
+export const calculateNumberOfThresholds = () => logicCalcNumberOfThresholds(player.lifetimeAmbrosia)
 
-export const calculateAmbrosiaGenerationOcteractUpgrade = () => {
-  return (
-    getOcteractUpgradeEffect('octeractAmbrosiaGeneration', 'ambrosiaBarSpeedMult')
-    * getOcteractUpgradeEffect('octeractAmbrosiaGeneration2', 'ambrosiaBarSpeedMult')
-    * getOcteractUpgradeEffect('octeractAmbrosiaGeneration3', 'ambrosiaBarSpeedMult')
-    * getOcteractUpgradeEffect('octeractAmbrosiaGeneration4', 'ambrosiaBarSpeedMult')
-  )
-}
+export const calculateToNextThreshold = () => logicCalcToNextThreshold(player.lifetimeAmbrosia)
 
-export const calculateAmbrosiaLuckOcteractUpgrade = () => {
-  return (
-    getOcteractUpgradeEffect('octeractAmbrosiaLuck', 'ambrosiaLuck')
-    + getOcteractUpgradeEffect('octeractAmbrosiaLuck2', 'ambrosiaLuck')
-    + getOcteractUpgradeEffect('octeractAmbrosiaLuck3', 'ambrosiaLuck')
-    + getOcteractUpgradeEffect('octeractAmbrosiaLuck4', 'ambrosiaLuck')
-  )
-}
+export const calculateRequiredBlueberryTime = () =>
+  logicCalcRequiredBlueberryTime({
+    timePerAmbrosia: G.TIME_PER_AMBROSIA,
+    lifetimeAmbrosia: player.lifetimeAmbrosia,
+    acceleratorMult: getShopUpgradeEffects('shopAmbrosiaAccelerator', 'ambrosiaPointRequirementMult'),
+    brickOfLeadMult: getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'barRequirementMult')
+  })
 
-const digitReduction = 4
+export const calculateRequiredRedAmbrosiaTime = () =>
+  logicCalcRequiredRedAmbrosiaTime({
+    timePerRedAmbrosia: G.TIME_PER_RED_AMBROSIA,
+    lifetimeRedAmbrosia: player.lifetimeRedAmbrosia,
+    barRequirementMultiplier: getSingularityChallengeEffect('limitedTime', 'barRequirementMultiplier')
+  })
 
-export const calculateNumberOfThresholds = () => {
-  const numDigits = player.lifetimeAmbrosia > 0 ? 1 + Math.floor(Math.log10(player.lifetimeAmbrosia)) : 0
-  const matissa = Math.floor(player.lifetimeAmbrosia / Math.pow(10, numDigits - 1))
+export const calculateSingularityMilestoneBlueberries = () =>
+  logicCalcSingularityMilestoneBlueberries(player.highestSingularityCount)
 
-  const extraReduction = matissa >= 3 ? 1 : 0
+export const calculateAmbrosiaCubeMult = () =>
+  logicCalcAmbrosiaCubeMult({
+    noAmbrosiaUpgradesEnabled: player.singularityChallenges.noAmbrosiaUpgrades.enabled,
+    lifetimeAmbrosia: player.lifetimeAmbrosia
+  })
 
-  // First reduction at 10^(digitReduction+1), add 1 at 3 * 10^(digitReduction+1)
-  return Math.max(0, 2 * (numDigits - digitReduction) - 1 + extraReduction)
-}
+export const calculateAmbrosiaQuarkMult = () =>
+  logicCalcAmbrosiaQuarkMult({
+    noAmbrosiaUpgradesEnabled: player.singularityChallenges.noAmbrosiaUpgrades.enabled,
+    lifetimeAmbrosia: player.lifetimeAmbrosia
+  })
 
-export const calculateToNextThreshold = () => {
-  const numThresholds = calculateNumberOfThresholds()
+export const calculateExalt3AscensionLimit = (comps: number) => logicCalcExalt3AscensionLimit(comps)
 
-  if (numThresholds === 0) {
-    return 10000 - player.lifetimeAmbrosia
-  } else {
-    // This is when the previous threshold is of the form 3 * 10^n
-    if (numThresholds % 2 === 0) {
-      return Math.pow(10, numThresholds / 2 + digitReduction) - player.lifetimeAmbrosia
-    } // Previous threshold is of the form 10^n
-    else {
-      return 3 * Math.pow(10, (numThresholds - 1) / 2 + digitReduction) - player.lifetimeAmbrosia
-    }
-  }
-}
+export const calculateExalt3Penalty = () =>
+  logicCalcExalt3Penalty({
+    limitedAscensionsEnabled: player.singularityChallenges.limitedAscensions.enabled,
+    limitedAscensionsCompletions: player.singularityChallenges.limitedAscensions.completions,
+    ascensionCount: player.ascensionCount
+  })
 
-export const calculateRequiredBlueberryTime = () => {
-  let val = G.TIME_PER_AMBROSIA // Currently 45
-  val += Math.floor(player.lifetimeAmbrosia / 300)
+export const calculateExalt4EffectiveSingularityMultiplier = (comps: number, force: boolean) =>
+  logicCalcExalt4EffSingMult({
+    comps,
+    force,
+    inExalt4: player.singularityChallenges.noOcteracts.enabled
+  })
 
-  const acceleratorMult = getShopUpgradeEffects('shopAmbrosiaAccelerator', 'ambrosiaPointRequirementMult')
-  const brickOfLeadMult = getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'barRequirementMult')
+export const calculateExalt6TimeLimit = (comps: number) => logicCalcExalt6TimeLimit(comps)
 
-  val *= acceleratorMult
-  val *= brickOfLeadMult
+export const calculateExalt6PenaltyPerSecond = (comps: number) => logicCalcExalt6PenaltyPerSecond(comps)
 
-  if (player.lifetimeAmbrosia >= 10000) {
-    const extraScalingPower = Math.log10(4)
-    val *= Math.pow(player.lifetimeAmbrosia / 10000, extraScalingPower)
-    return Math.ceil(val)
-  } else {
-    return val
-  }
-}
+export const calculateExalt6Penalty = (comps: number, time: number) => logicCalcExalt6Penalty(comps, time)
 
-export const calculateRequiredRedAmbrosiaTime = () => {
-  let val = G.TIME_PER_RED_AMBROSIA // Currently 100,000
-  val += 200 * player.lifetimeRedAmbrosia
-
-  const max = 1e6 * getSingularityChallengeEffect('limitedTime', 'barRequirementMultiplier')
-  val *= getSingularityChallengeEffect('limitedTime', 'barRequirementMultiplier')
-
-  return Math.min(max, val)
-}
-
-export const calculateSingularityMilestoneBlueberries = () => {
-  let val = 0
-  if (player.highestSingularityCount >= 270) val = 5
-  else if (player.highestSingularityCount >= 256) val = 4
-  else if (player.highestSingularityCount >= 192) val = 3
-  else if (player.highestSingularityCount >= 128) val = 2
-  else if (player.highestSingularityCount >= 64) val = 1
-
-  return val
-}
-
-export const calculateAmbrosiaCubeMult = () => {
-  const effectiveAmbrosia = (player.singularityChallenges.noAmbrosiaUpgrades.enabled) ? 0 : player.lifetimeAmbrosia
-  let multiplier = 1
-  multiplier += Math.min(1.5, Math.floor(effectiveAmbrosia / 66) / 100)
-  if (effectiveAmbrosia >= 10000) {
-    multiplier += Math.min(
-      1.5,
-      Math.floor(effectiveAmbrosia / 666) / 100
-    )
-  }
-  if (effectiveAmbrosia >= 100000) {
-    multiplier += Math.floor(effectiveAmbrosia / 6666) / 100
-  }
-
-  return multiplier
-}
-
-export const calculateAmbrosiaQuarkMult = () => {
-  const effectiveAmbrosia = (player.singularityChallenges.noAmbrosiaUpgrades.enabled) ? 0 : player.lifetimeAmbrosia
-  let multiplier = 1
-  multiplier += Math.min(0.3, Math.floor(effectiveAmbrosia / 1666) / 100)
-  if (effectiveAmbrosia >= 50000) {
-    multiplier += Math.min(
-      0.3,
-      Math.floor(effectiveAmbrosia / 16666) / 100
-    )
-  }
-  if (effectiveAmbrosia >= 500000) {
-    multiplier += Math.floor(effectiveAmbrosia / 166666) / 100
-  }
-
-  return multiplier
-}
-
-export const calculateExalt3AscensionLimit = (comps: number) => {
-  return Math.max(15 - comps * 2, 0)
-}
-
-export const calculateExalt3Penalty = () => {
-  const ascensionLimit = calculateExalt3AscensionLimit(player.singularityChallenges.limitedAscensions.completions)
-  const ascensions = player.ascensionCount
-  if (!player.singularityChallenges.limitedAscensions.enabled) {
-    return 1
-  } else {
-    return Math.pow(2, Math.max(ascensions - ascensionLimit, 0))
-  }
-}
-
-export const calculateExalt4EffectiveSingularityMultiplier = (comps: number, force: boolean) => {
-  const inExalt4 = player.singularityChallenges.noOcteracts.enabled
-  return inExalt4 || force ? Math.pow(comps + 1, 3) : 1
-}
-
-export const calculateExalt6TimeLimit = (comps: number) => {
-  if (comps >= 10) {
-    return 115 - 5 * (comps - 10)
-  } else {
-    return 600 - 60 * comps
-  }
-}
-
-const calculateExalt6PenaltyPerMinute = (comps: number) => {
-  let penaltyPerMinute = 10 + 3 * comps
-  if (comps >= 10) {
-    penaltyPerMinute = 60 + 10 * (comps - 10)
-  }
-  return penaltyPerMinute
-}
-
-export const calculateExalt6PenaltyPerSecond = (comps: number) => {
-  const penaltyPerMinute = calculateExalt6PenaltyPerMinute(comps)
-  return Math.pow(penaltyPerMinute, 1 / 60)
-}
-
-export const calculateExalt6Penalty = (comps: number, time: number) => {
-  const timeLimit = calculateExalt6TimeLimit(comps)
-  const displacedTime = Math.max(0, time - timeLimit)
-  if (displacedTime === 0) {
-    return 1
-  } else {
-    const penaltyPerSecond = calculateExalt6PenaltyPerSecond(comps)
-    return Math.pow(penaltyPerSecond, -displacedTime)
-  }
-}
-
-export const calculateDilatedFiveLeafBonus = () => {
-  const singThresholds = [100, 150, 200, 225, 250, 255, 260, 265, 269, 272]
-  for (let i = 0; i < singThresholds.length; i++) {
-    if (player.highestSingularityCount < singThresholds[i]) return i / 100
-  }
-
-  return singThresholds.length / 100
-}
+export const calculateDilatedFiveLeafBonus = () =>
+  logicCalcDilatedFiveLeafBonus(player.highestSingularityCount)
 
 export const dailyResetCheck = () => {
   if (!player.dayCheck) {
@@ -1579,54 +1192,20 @@ export const calculateEventBuff = (buff: BuffType) => {
   return calculateEventSourceBuff(buff)
 }
 
-export const derpsmithCornucopiaBonus = () => {
-  let counter = 0
-  for (const sing of derpsmithSingCounts) {
-    if (player.highestSingularityCount >= sing) {
-      counter += 1
-    }
-  }
+export const derpsmithCornucopiaBonus = () =>
+  logicDerpsmithCornucopiaBonus(player.highestSingularityCount)
 
-  return 1 + (counter * player.highestSingularityCount) / 100
-}
+export const calculateImmaculateAlchemyBonus = () =>
+  logicCalcImmaculateAlchemyBonus(player.singularityCount)
 
-export const calculateImmaculateAlchemyBonus = () => {
-  let bonus = 1
-  for (let i = 0; i < immaculateAlchemyThresholds.length; i++) {
-    if (player.singularityCount >= immaculateAlchemyThresholds[i]) {
-      bonus += 0.4
-    }
-  }
-  return bonus
-}
+export const sumOfExaltCompletions = () =>
+  logicSumOfExaltCompletions(Object.values(player.singularityChallenges).map(c => c.completions))
 
-export const sumOfExaltCompletions = () => {
-  let sum = 0
-  for (const challenge of Object.values(player.singularityChallenges)) {
-    sum += challenge.completions
-  }
-  return sum
-}
+export const inheritanceTokens = () =>
+  logicInheritanceTokens(player.highestSingularityCount)
 
-export const inheritanceTokens = () => {
-  for (let i = 15; i > 0; i--) {
-    if (player.highestSingularityCount >= inheritanceLevels[i]) {
-      return inheritanceTokenValues[i]
-    }
-  }
-
-  return 0
-}
-
-export const singularityBonusTokenMult = () => {
-  for (let i = 5; i > 0; i--) {
-    if (player.highestSingularityCount >= bonusTokenLevels[i - 1]) {
-      return 1 + 0.02 * i
-    }
-  }
-
-  return 1
-}
+export const singularityBonusTokenMult = () =>
+  logicSingularityBonusTokenMult(player.highestSingularityCount)
 
 export const resetTimeThreshold = () => {
   const base = 10
@@ -1639,27 +1218,11 @@ export const resetTimeThreshold = () => {
 
 const calculatePlatonic7UpgradePower = () => logicCalcPlatonic7UpgradePower(player.platonicUpgrades[7])
 
-export const calculateOfferingPotionBaseOfferings = () => {
-  const amount = findInsertionIndex(player.shopPotionsConsumed.offering, offeringPotionThresholds)
+export const calculateOfferingPotionBaseOfferings = () =>
+  logicCalcOfferingPotionBaseOfferings(player.shopPotionsConsumed.offering)
 
-  return {
-    amount: amount,
-    toNext: (amount < offeringPotionThresholds.length)
-      ? offeringPotionThresholds[amount] - player.shopPotionsConsumed.offering
-      : Number.POSITIVE_INFINITY
-  }
-}
-
-export const calculateObtainiumPotionBaseObtainium = () => {
-  const amount = findInsertionIndex(player.shopPotionsConsumed.obtainium, obtainiumPotionThresholds)
-
-  return {
-    amount: amount,
-    toNext: (amount < obtainiumPotionThresholds.length)
-      ? obtainiumPotionThresholds[amount] - player.shopPotionsConsumed.obtainium
-      : Number.POSITIVE_INFINITY
-  }
-}
+export const calculateObtainiumPotionBaseObtainium = () =>
+  logicCalcObtainiumPotionBaseObtainium(player.shopPotionsConsumed.obtainium)
 
 export const calculateAscensionSpeedExponentSpread = () => logicCalcAscensionSpeedExponentSpread({
   singAscensionSpeedExponentSpread: getGQUpgradeEffect('singAscensionSpeed', 'exponentSpread'),
@@ -1667,35 +1230,27 @@ export const calculateAscensionSpeedExponentSpread = () => logicCalcAscensionSpe
   chronometerInfinityExponentSpread: getShopUpgradeEffects('chronometerInfinity', 'exponentSpread')
 })
 
-export const calculateCookieUpgrade29Luck = () => {
-  if (player.cubeUpgrades[79] === 0 || player.lifetimeRedAmbrosia === 0) {
-    return 0
-  } else {
-    return 10 * Math.pow(Math.log10(player.lifetimeRedAmbrosia), 2)
-  }
-}
+export const calculateCookieUpgrade29Luck = () =>
+  logicCalcCookieUpgrade29Luck({
+    cubeUpgrade79: player.cubeUpgrades[79],
+    lifetimeRedAmbrosia: player.lifetimeRedAmbrosia
+  })
 
-export const calculateRedAmbrosiaCubes = () => {
-  if (getRedAmbrosiaUpgradeEffects('redAmbrosiaCube', 'unlockedRedAmbrosiaCube')) {
-    const exponent = 0.4 + getRedAmbrosiaUpgradeEffects('redAmbrosiaCubeImprover', 'extraExponent')
-    return 1 + Math.pow(player.lifetimeRedAmbrosia, exponent) / 100
-  } else {
-    return 1
-  }
-}
+export const calculateRedAmbrosiaCubes = () =>
+  logicCalcRedAmbrosiaCubes({
+    unlocked: getRedAmbrosiaUpgradeEffects('redAmbrosiaCube', 'unlockedRedAmbrosiaCube'),
+    lifetimeRedAmbrosia: player.lifetimeRedAmbrosia,
+    extraExponent: getRedAmbrosiaUpgradeEffects('redAmbrosiaCubeImprover', 'extraExponent')
+  })
 
-export const calculateRedAmbrosiaObtainium = () => {
-  if (getRedAmbrosiaUpgradeEffects('redAmbrosiaObtainium', 'unlockRedAmbrosiaObtainium')) {
-    return 1 + Math.pow(player.lifetimeRedAmbrosia, 0.6) / 100
-  } else {
-    return 1
-  }
-}
+export const calculateRedAmbrosiaObtainium = () =>
+  logicCalcRedAmbrosiaObtainium({
+    unlocked: getRedAmbrosiaUpgradeEffects('redAmbrosiaObtainium', 'unlockRedAmbrosiaObtainium'),
+    lifetimeRedAmbrosia: player.lifetimeRedAmbrosia
+  })
 
-export const calculateRedAmbrosiaOffering = () => {
-  if (getRedAmbrosiaUpgradeEffects('redAmbrosiaOffering', 'unlockRedAmbrosiaOffering')) {
-    return 1 + Math.pow(player.lifetimeRedAmbrosia, 0.6) / 100
-  } else {
-    return 1
-  }
-}
+export const calculateRedAmbrosiaOffering = () =>
+  logicCalcRedAmbrosiaOffering({
+    unlocked: getRedAmbrosiaUpgradeEffects('redAmbrosiaOffering', 'unlockRedAmbrosiaOffering'),
+    lifetimeRedAmbrosia: player.lifetimeRedAmbrosia
+  })


### PR DESCRIPTION
## Summary

- Lifts the next 9 calculation clusters out of `packages/web_ui/src/Calculate.ts` into the headless `@synergism/logic` package. Each batch follows the established shape: pure logic in a new `mechanics/` or `math/` file, Calculate.ts becomes a thin shim that reads `player`/`G` state and forwards.
- `Calculate.ts` net change: **+391 / −734** (-343 lines). Drops orphaned `CalcECC` and `findInsertionIndex` imports.
- Bonus UI fix: [`offlinePrestigeTimerDiv`](packages/web_ui/index.html) was missing the `prestigeunlock` class its sibling Count div has, so the timer row leaked through on saves without prestige unlocked.

### Batches landed

| Batch | Module | Functions |
|---|---|---|
| 1 | [`mechanics/singularityMilestones.ts`](packages/logic/src/mechanics/singularityMilestones.ts) | 8 milestone bonuses + `sumOfExaltCompletions` |
| 2 | [`mechanics/exaltPenalties.ts`](packages/logic/src/mechanics/exaltPenalties.ts) | 6 fns: Exalt 3 (limitedAscensions) / 4 (noOcteracts) / 6 (limitedTime) penalty math |
| 3 | [`mechanics/octeractBonuses.ts`](packages/logic/src/mechanics/octeractBonuses.ts) | 4 fns: Cube/Quark/Offering/Obtainium bonuses (gated by Exalt 4) |
| 4 | [`mechanics/ambrosia.ts`](packages/logic/src/mechanics/ambrosia.ts) | 11 fns: threshold counters, blueberry/red-ambrosia times, cube/quark mults, sing/octeract upgrade composers |
| 5 | [`mechanics/redAmbrosiaBonuses.ts`](packages/logic/src/mechanics/redAmbrosiaBonuses.ts) | 4 fns: Cookie29 luck + 3 red ambrosia resource bonuses |
| 6 | [`mechanics/potionBonuses.ts`](packages/logic/src/mechanics/potionBonuses.ts) | offering/obtainium base awards + `calculatePotionValue` (with private fastForward helper) |
| 7 | [`math/sigmoid.ts`](packages/logic/src/math/sigmoid.ts) + [`math/summations.ts`](packages/logic/src/math/summations.ts) | Sigmoid curves; nonlinear/cubic summations + quadratic solver. Throws plain `Error('SUMMATIONS_*')` codes; the shim re-translates via i18next. |
| 8 | [`mechanics/overfluxBonuses.ts`](packages/logic/src/mechanics/overfluxBonuses.ts) + [`mechanics/ascensions.ts`](packages/logic/src/mechanics/ascensions.ts) | 3 overflux fns (cube-quark mult is the first intra-logic dep, consuming `math/sigmoid`) + `calculateAscensionCount` |
| 9 | [`mechanics/acceleratorMultipliers.ts`](packages/logic/src/mechanics/acceleratorMultipliers.ts) | 2 fns: `calculateTotalAcceleratorBoost` + `calculateAcceleratorMultiplier`. Establishes the "logic returns pure value, shim writes G" pattern for the first time. |

### Parity coverage

- **13,727** tests in `@synergism/logic` pass (12,612 new sweeps in this branch)
- Every parity test transcribes the old web_ui implementation verbatim, sweeps boundary values, and asserts byte-for-byte (or `closeEnough` for FP) equivalence
- Notable sweeps:
  - 2,936 overflux sigmoid-stack cases crossing every singularity-count unlock threshold
  - 2,592 potion-value cases across the halfMind branch + resetTime/threshold² boundary
  - 1,825 summation cases (5-dim grid for nonlinear, edge cases + throw paths for cubic/quadratic)
  - 807 singularity-milestone threshold boundaries

## Test plan

- [ ] CI tests pass (`@synergism/logic` parity tests should be the bulk of new test coverage)
- [ ] `npm run check:tsc` clean (no leftover unused imports)
- [ ] Local smoke test: start the dev server, confirm offline modal correctly hides resource rows on a fresh save, confirm `G.freeAcceleratorBoost` / `G.totalAcceleratorBoost` / `G.acceleratorMultiplier` get written on tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)