### PR TITLE
refactor: migrate 5 calculation clusters into @synergism/logic

### DIFF
--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -158,6 +158,11 @@ export {
   getNextRegularChallenge
 } from './mechanics/challenges'
 export type {
+  QuarkHandlerInput,
+  QuarkHandlerResult
+} from './mechanics/quarks'
+export { quarkHandler } from './mechanics/quarks'
+export type {
   AntiquitiesRuneInput,
   AntiquitiesRuneKey,
   DuplicationRuneKey,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -137,7 +137,26 @@ export {
   multiplierHepteractEffects,
   quarkHepteractEffects
 } from './mechanics/cubes/hepteracts'
-export { CalcECC } from './mechanics/challenges'
+export type {
+  Challenge15ScoreMultiplierInput,
+  ChallengeRequirementInput,
+  ChallengeRequirementMultiplierInput,
+  ChallengeType,
+  GetMaxChallengesInput,
+  GetNextAscensionChallengeInput,
+  GetNextRegularChallengeInput
+} from './mechanics/challenges'
+export {
+  autoAscensionChallengeSweepUnlock,
+  CalcECC,
+  calculateChallengeRequirementMultiplier,
+  challenge15ScoreMultiplier,
+  challengeRequirement,
+  challengeScoreDisplay,
+  getMaxChallenges,
+  getNextAscensionChallenge,
+  getNextRegularChallenge
+} from './mechanics/challenges'
 export type {
   AntiquitiesRuneInput,
   AntiquitiesRuneKey,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -163,6 +163,16 @@ export type {
 } from './mechanics/quarks'
 export { quarkHandler } from './mechanics/quarks'
 export type {
+  GetCubeCostInput,
+  GetCubeCostResult,
+  GetCubeMaxInput
+} from './mechanics/cubeUpgrades'
+export {
+  getCubeCost,
+  getCubeMax,
+  getCubeUpgradeBaseCost
+} from './mechanics/cubeUpgrades'
+export type {
   AntiquitiesRuneInput,
   AntiquitiesRuneKey,
   DuplicationRuneKey,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -173,6 +173,20 @@ export {
   getCubeUpgradeBaseCost
 } from './mechanics/cubeUpgrades'
 export type {
+  DroughtEffectInput,
+  HyperchallengeEffectInput,
+  IlliteracyEffectInput,
+  MaxCorruptionLevelInput,
+  ViscosityEffectInput
+} from './mechanics/corruptions'
+export {
+  droughtEffect,
+  hyperchallengeEffect,
+  illiteracyEffect,
+  maxCorruptionLevel,
+  viscosityEffect
+} from './mechanics/corruptions'
+export type {
   AntiquitiesRuneInput,
   AntiquitiesRuneKey,
   DuplicationRuneKey,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -225,10 +225,15 @@ export {
 } from './mechanics/talismanEffects'
 export type {
   ActualAntSpeedMultInput,
+  AscensionScoreBonusMultiplierInput,
   AscensionSpeedMultInput,
+  CalcCorruptionStuffInput,
+  CalcCorruptionStuffResult,
   CalculateAmbrosiaGenerationSpeedInput,
   CalculateAmbrosiaLuckInput,
   CalculateAntSacrificeMultiplierInput,
+  CalculateAscensionScoreInput,
+  CalculateAscensionScoreResult,
   CalculateAscensionSpeedExponentSpreadInput,
   CalculateCubeMultiplierWithTauInput,
   CalculateNegativeSalvageInput,
@@ -335,6 +340,7 @@ export {
   sumOfExaltCompletions
 } from './mechanics/singularityMilestones'
 export {
+  CalcCorruptionStuff,
   calculateActualAntSpeedMult,
   calculateAllCubeMultiplier,
   calculateAmbrosiaAdditiveLuckMult,
@@ -343,6 +349,7 @@ export {
   calculateAmbrosiaLuck,
   calculateAmbrosiaLuckRaw,
   calculateAntSacrificeMultiplier,
+  calculateAscensionScore,
   calculateAscensionSpeedExponentSpread,
   calculateAscensionSpeedMult,
   calculateBaseObtainium,
@@ -383,5 +390,6 @@ export {
   calculateTesseractMultiplier,
   calculateTotalCoinOwned,
   calculateTotalSalvage,
+  computeAscensionScoreBonusMultiplier,
   getReductionValue
 } from './mechanics/calculate'

--- a/packages/logic/src/mechanics/calculate.ts
+++ b/packages/logic/src/mechanics/calculate.ts
@@ -467,3 +467,237 @@ export function calculateTotalCoinOwned(input: CalculateTotalCoinOwnedInput): nu
     + input.fourthOwnedCoin
     + input.fifthOwnedCoin
 }
+
+// ─── Ascension score bonus multiplier ──────────────────────────────────────
+
+export interface AscensionScoreBonusMultiplierInput {
+  /** G.challenge15Rewards.score.value — defaults 1 until C15 unlocks. */
+  challenge15ScoreReward: number
+  /** calculateAscensionScorePlatonicBlessing() output. */
+  platonicBlessingMult: number
+  /** player.campaigns.ascensionScoreMultiplier. */
+  campaignAscensionScoreMult: number
+  /** getRuneEffects('finiteDescent', 'ascensionScore'). */
+  finiteDescentAscensionScore: number
+  /** player.cubeUpgrades[21] — only contributes if > 0 (`1 + 0.05*n`). */
+  cubeUpgrade21: number
+  /** player.cubeUpgrades[31]. Same `1 + 0.05*n` shape. */
+  cubeUpgrade31: number
+  /** player.cubeUpgrades[41]. Same `1 + 0.05*n` shape. */
+  cubeUpgrade41: number
+  /** +getAchievementReward('ascensionScore') — coerced to number in web_ui. */
+  ascensionScoreAchievementReward: number
+  /** getGQUpgradeEffect('masterPack', 'ascensionScoreMult'). */
+  masterPackAscensionScoreMult: number
+  /**
+   * Pass 0 if no event active; pass `calculateEventBuff(BuffType.AscensionScore)`
+   * when G.isEvent. The web_ui side guards on G.isEvent before computing this.
+   */
+  eventBuff: number
+}
+
+/**
+ * Bonus multiplier applied on top of (baseScore * corruptionMultiplier) inside
+ * calculateAscensionScore. Verbatim from web_ui's private
+ * computeAscensionScoreBonusMultiplier.
+ */
+export function computeAscensionScoreBonusMultiplier(input: AscensionScoreBonusMultiplierInput): number {
+  let multiplier = 1
+  multiplier *= input.challenge15ScoreReward
+  multiplier *= input.platonicBlessingMult
+  multiplier *= input.campaignAscensionScoreMult
+  multiplier *= input.finiteDescentAscensionScore
+  if (input.cubeUpgrade21 > 0) multiplier *= 1 + 0.05 * input.cubeUpgrade21
+  if (input.cubeUpgrade31 > 0) multiplier *= 1 + 0.05 * input.cubeUpgrade31
+  if (input.cubeUpgrade41 > 0) multiplier *= 1 + 0.05 * input.cubeUpgrade41
+  multiplier *= input.ascensionScoreAchievementReward
+  multiplier *= input.masterPackAscensionScoreMult
+  multiplier *= 1 + input.eventBuff
+  return multiplier
+}
+
+// ─── Ascension score ───────────────────────────────────────────────────────
+
+// Score weights for transcend tier (i=1..5) at thresholds {0, 75, 750, 9000}
+// and reincarnation tier (i=6..10) at thresholds {0, 25, 60}. These mirror
+// the same constants used by challengeScoreDisplay, kept local to keep this
+// function self-contained.
+const baseScoreArray = [0, 8, 10, 12, 15, 20, 60, 80, 120, 180, 300]
+const tier2ScoreArray = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450]
+const tier3ScoreArray = [0, 20, 30, 50, 100, 200, 250, 300, 400, 500, 750]
+const tier4ScoreArray = [0, 10000, 10000, 10000, 10000, 10000, 2000, 3000, 4000, 5000, 7500]
+
+export interface CalculateAscensionScoreInput {
+  /**
+   * player.highestchallengecompletions, indexed 0..10. Indices 1..10 are read;
+   * the rest are ignored. (Index 0 exists in the player object but isn't a
+   * real challenge.)
+   */
+  highestChallengeCompletions: readonly number[]
+  /**
+   * player.cubeUpgrades[56]. Added to the per-completion baseScore for
+   * challenges 1, 2, and 3 only — the "Cube 7x6" bonus.
+   */
+  cubeUpgrade56: number
+  /**
+   * player.cubeUpgrades[39]. Contributes 0.005/level to the C10 exponent
+   * (1.03 base + cu39 + plat 5/10). Maxes the base out at 1.0425.
+   */
+  cubeUpgrade39: number
+  /** player.platonicUpgrades[5] — ALPHA. +0.0025 to C10 exponent. */
+  platonicUpgrade5: number
+  /** player.platonicUpgrades[10] — BETA. +0.0025 to C10 exponent. */
+  platonicUpgrade10: number
+  /** player.corruptions.used.totalCorruptionAscensionMultiplier. */
+  corruptionMultiplier: number
+  /** getAntUpgradeEffect(AntUpgrades.AscensionScore).ascensionScoreBase. */
+  antUpgradeAscensionScoreBase: number
+  /** getGQUpgradeEffect('expertPack', 'ascensionScoreMult'). */
+  expertPackAscensionScoreMult: number
+  /** Output of computeAscensionScoreBonusMultiplier — passed in to keep this pure. */
+  bonusMultiplier: number
+}
+
+export interface CalculateAscensionScoreResult {
+  baseScore: number
+  corruptionMultiplier: number
+  bonusMultiplier: number
+  effectiveScore: number
+}
+
+/**
+ * Pre-cube ascension score. Sums per-challenge contributions across the four
+ * score-array bands, multiplies by the C10 exponent power, then applies
+ * corruption × bonus multipliers. The `effectiveScore > 1e23` softcap
+ * (`sqrt(score) * sqrt(1e23)`) and the final `expertPack` mult are preserved
+ * verbatim from web_ui.
+ */
+export function calculateAscensionScore(input: CalculateAscensionScoreInput): CalculateAscensionScoreResult {
+  let baseScore = 0
+  // Per-challenge baseline gets bumped on challenges 1/2/3 by cubeUpgrade[56].
+  const challengeScoreArrays1 = baseScoreArray.slice()
+  challengeScoreArrays1[1] += input.cubeUpgrade56
+  challengeScoreArrays1[2] += input.cubeUpgrade56
+  challengeScoreArrays1[3] += input.cubeUpgrade56
+
+  for (let i = 1; i <= 10; i++) {
+    const completions = input.highestChallengeCompletions[i]
+    baseScore += challengeScoreArrays1[i] * completions
+    if (i <= 5 && completions >= 75) {
+      baseScore += tier2ScoreArray[i] * (completions - 75)
+      if (completions >= 750) {
+        baseScore += tier3ScoreArray[i] * (completions - 750)
+      }
+      if (completions >= 9000) {
+        baseScore += tier4ScoreArray[i] * (completions - 9000)
+      }
+    }
+    if (i <= 10 && i > 5 && completions >= 25) {
+      baseScore += tier2ScoreArray[i] * (completions - 25)
+      if (completions >= 60) {
+        baseScore += tier3ScoreArray[i] * (completions - 60)
+      }
+    }
+  }
+
+  baseScore += input.antUpgradeAscensionScoreBase
+
+  // C10 exponent: 1.03 + 0.005*cu39 + 0.0025*(plat5+plat10), raised to the
+  // power of how many times you've beaten C10. Maxes ~1.0425.
+  baseScore *= Math.pow(
+    1.03 + 0.005 * input.cubeUpgrade39 + 0.0025 * (input.platonicUpgrade5 + input.platonicUpgrade10),
+    input.highestChallengeCompletions[10]
+  )
+
+  let effectiveScore = baseScore * input.corruptionMultiplier * input.bonusMultiplier
+  if (effectiveScore > 1e23) {
+    effectiveScore = Math.pow(effectiveScore, 0.5) * Math.pow(1e23, 0.5)
+  }
+  effectiveScore *= input.expertPackAscensionScoreMult
+
+  return {
+    baseScore,
+    corruptionMultiplier: input.corruptionMultiplier,
+    bonusMultiplier: input.bonusMultiplier,
+    effectiveScore
+  }
+}
+
+// ─── CalcCorruptionStuff: cube/tess/hyper/platonic/hept gains per ascension ─
+
+export interface CalcCorruptionStuffInput {
+  /** Output of calculateAscensionScore. */
+  scores: CalculateAscensionScoreResult
+  /** calculateCubeMultiplierWithTau() — pre-floor cube gain multiplier. */
+  cubeMultiplier: number
+  /** calculateTesseractMultiplier() — pre-base tess multiplier. */
+  tesseractMultiplier: number
+  /** calculateHypercubeMultiplier(). */
+  hypercubeMultiplier: number
+  /** calculatePlatonicMultiplier(). */
+  platonicMultiplier: number
+  /** calculateHepteractMultiplier(). */
+  hepteractMultiplier: number
+  /**
+   * G.challenge15Rewards.hepteractsUnlocked.value — 0 or 1 (number). Gates
+   * hepteract gain. Original web_ui code uses this in a `&&` truthy context.
+   */
+  hepteractsUnlocked: number
+  /** player.singularityCount — floor for tesseract gain. */
+  singularityCount: number
+}
+
+export interface CalcCorruptionStuffResult {
+  wowCubes: number
+  wowTesseracts: number
+  wowHypercubes: number
+  wowPlatonicCubes: number
+  wowHepteracts: number
+  baseScore: number
+  bonusMultiplier: number
+  corruptionMultiplier: number
+  effectiveScore: number
+}
+
+/**
+ * Cube gains for the current ascension, gated on effectiveScore thresholds:
+ *
+ *   tesseract  base 1, +0.5 once score ≥ 1e5
+ *   hypercube  unlocked at score ≥ 1e9
+ *   platonic   unlocked at score ≥ 2.666e12
+ *   hepteract  unlocked at score ≥ 1.666e17 AND hepteractsUnlocked flag
+ *
+ * Each final count is floored and clamped to 1e300. Tesseracts also have a
+ * `max(singularityCount, …)` floor — the singularity perks guarantee
+ * minimum tess per ascension.
+ */
+export function CalcCorruptionStuff(input: CalcCorruptionStuffInput): CalcCorruptionStuffResult {
+  const effectiveScore = input.scores.effectiveScore
+
+  const cubeGain = input.cubeMultiplier
+
+  let tesseractGain = 1
+  if (effectiveScore >= 100000) tesseractGain += 0.5
+  tesseractGain *= input.tesseractMultiplier
+
+  let hypercubeGain = effectiveScore >= 1e9 ? 1 : 0
+  hypercubeGain *= input.hypercubeMultiplier
+
+  let platonicGain = effectiveScore >= 2.666e12 ? 1 : 0
+  platonicGain *= input.platonicMultiplier
+
+  let hepteractGain = input.hepteractsUnlocked && effectiveScore >= 1.666e17 ? 1 : 0
+  hepteractGain *= input.hepteractMultiplier
+
+  return {
+    wowCubes: Math.min(1e300, Math.floor(cubeGain)),
+    wowTesseracts: Math.min(1e300, Math.max(input.singularityCount, Math.floor(tesseractGain))),
+    wowHypercubes: Math.min(1e300, Math.floor(hypercubeGain)),
+    wowPlatonicCubes: Math.min(1e300, Math.floor(platonicGain)),
+    wowHepteracts: Math.min(1e300, Math.floor(hepteractGain)),
+    baseScore: Math.floor(input.scores.baseScore),
+    bonusMultiplier: input.scores.bonusMultiplier,
+    corruptionMultiplier: input.scores.corruptionMultiplier,
+    effectiveScore: Math.floor(effectiveScore)
+  }
+}

--- a/packages/logic/src/mechanics/challenges.ts
+++ b/packages/logic/src/mechanics/challenges.ts
@@ -3,6 +3,10 @@
 // that get called from many other modules (Buy.ts, Runes.ts, Statistics, ...).
 // Migrate those one at a time; the UI + sweep state machine stays in web_ui.
 
+import { Decimal } from '../math/bignum'
+
+export type ChallengeType = 'transcend' | 'reincarnation' | 'ascension'
+
 /**
  * Effective Challenge Completions. Three piecewise linear curves keyed by
  * challenge tier, each diminishing returns past the first knee:
@@ -16,7 +20,7 @@
  * their challenge-4 amplifier, and the rune EXP curve uses it too.
  */
 export function CalcECC(
-  type: 'transcend' | 'reincarnation' | 'ascension',
+  type: ChallengeType,
   completions: number
 ): number {
   let effective = 0
@@ -39,4 +43,438 @@ export function CalcECC(
       throw new Error(`Unhandled challenge type: ${type satisfies never}`)
     }
   }
+}
+
+// ─── Challenge-15 score-tier arrays ────────────────────────────────────────
+// Per-completion ascension-score weights, keyed by `[challengeIndex]` (1-10).
+// Each row is the rate inside one completion band; the bands are:
+//   transcend:     1..74, 75..749, 750..8999, 9000+
+//   reincarnation: 1..24, 25..59,  60+
+// (Banding lives in challengeScoreDisplay / calculateAscensionScore below.)
+const challengeScoreArray1 = [0, 8, 10, 12, 15, 20, 60, 80, 120, 180, 300]
+const challengeScoreArray2 = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450]
+const challengeScoreArray3 = [0, 20, 30, 50, 100, 200, 250, 300, 400, 500, 750]
+const challengeScoreArray4 = [0, 10000, 10000, 10000, 10000, 10000, 2000, 3000, 4000, 5000, 7500]
+
+/**
+ * Per-completion score weight shown in the challenge UI ("each future
+ * completion is worth X score"). Matches the banding used inside
+ * calculateAscensionScore. Returns 0 for challenges outside 1..10.
+ */
+export function challengeScoreDisplay(
+  challenge: number,
+  highestCompletions: number
+): number {
+  if (challenge >= 1 && challenge <= 5) {
+    if (highestCompletions >= 9000) return challengeScoreArray4[challenge]
+    if (highestCompletions >= 750) return challengeScoreArray3[challenge]
+    if (highestCompletions >= 75) return challengeScoreArray2[challenge]
+    return challengeScoreArray1[challenge]
+  }
+  if (challenge >= 6 && challenge <= 10) {
+    if (highestCompletions >= 60) return challengeScoreArray3[challenge]
+    if (highestCompletions >= 25) return challengeScoreArray2[challenge]
+    return challengeScoreArray1[challenge]
+  }
+  return 0
+}
+
+// ─── getMaxChallenges ──────────────────────────────────────────────────────
+
+export interface GetMaxChallengesInput {
+  /** 1..15. Out-of-range and 15 return 0. */
+  challenge: number
+  /** player.singularityChallenges.oneChallengeCap.enabled — caps every tier to 1. */
+  oneChallengeCapEnabled: boolean
+
+  // ── Transcension tier (1..5)
+  /** player.researches[105] — "Infinite T. Challenges" research; returns 9001 if > 0. */
+  infiniteTranscendResearch: number
+  /** player.researches[65 + challenge] for the matching T. challenge slot (3x16..3x20). */
+  transcendResearchForChallenge: number
+
+  // ── Reincarnation tier (6..10)
+  /** player.cubeUpgrades[29] — +4/level. */
+  cubeUpgrade29: number
+  /** getShopUpgradeEffects('challengeExtension', 'reincarnationChallengeCap'). */
+  challengeExtensionCap: number
+  /** Sum of GQ singChallengeExtension/2/3 'reincarnationCapIncrease'. */
+  gqReincarnationCapIncrease: number
+  /** Sum of singularity-challenge oneChallengeCap capIncrease + reinCapIncrease2. */
+  singReincarnationCapIncrease: number
+
+  // ── Ascension tier (11..14; 15 has no completions)
+  /** Sum of GQ singChallengeExtension/2/3 'ascensionCapIncrease'. */
+  gqAscensionCapIncrease: number
+  /** singularity-challenge oneChallengeCap 'ascCapIncrease2'. */
+  singAscensionCapIncrease: number
+
+  // ── Shared platonic flags (apply to both reinc and ascension tiers)
+  /** player.platonicUpgrades[5] > 0 — ALPHA. Reinc: +10, Asc: +5. */
+  platonicUpgrade5: number
+  /** player.platonicUpgrades[10] > 0 — BETA. Reinc: +10, Asc: +5. */
+  platonicUpgrade10: number
+  /** player.platonicUpgrades[15] > 0 — OMEGA. Reinc: +30, Asc: +20. */
+  platonicUpgrade15: number
+}
+
+/**
+ * Max completions for a given challenge, given the constellation of unlocks
+ * that can extend the cap. Mirrors the web_ui body verbatim — every branch is
+ * either pure arithmetic on these inputs or one of the early-return sentinels
+ * (`oneChallengeCap → 1`, `research105 > 0 → 9001`).
+ *
+ * Challenge 15 has no completions — returns 0 even if `oneChallengeCap` is set
+ * (the original short-circuits the same way: the `i === 15` branch comes
+ * before the cap check inside the asc tier).
+ */
+export function getMaxChallenges(input: GetMaxChallengesInput): number {
+  const i = input.challenge
+  let maxChallenge = 0
+
+  if (i >= 1 && i <= 5) {
+    if (input.oneChallengeCapEnabled) return 1
+    maxChallenge = 25
+    if (input.infiniteTranscendResearch > 0) return 9001
+    maxChallenge += 5 * input.transcendResearchForChallenge
+    return maxChallenge
+  }
+
+  if (i >= 6 && i <= 10) {
+    if (input.oneChallengeCapEnabled) return 1
+    maxChallenge = 40
+    maxChallenge += 4 * input.cubeUpgrade29
+    maxChallenge += input.challengeExtensionCap
+    if (input.platonicUpgrade5 > 0) maxChallenge += 10
+    if (input.platonicUpgrade10 > 0) maxChallenge += 10
+    if (input.platonicUpgrade15 > 0) maxChallenge += 30
+    maxChallenge += input.gqReincarnationCapIncrease
+    maxChallenge += input.singReincarnationCapIncrease
+    return maxChallenge
+  }
+
+  if (i >= 11 && i <= 15) {
+    if (i === 15) return 0
+    if (input.oneChallengeCapEnabled) return 1
+    maxChallenge = 30
+    if (input.platonicUpgrade5 > 0) maxChallenge += 5
+    if (input.platonicUpgrade10 > 0) maxChallenge += 5
+    if (input.platonicUpgrade15 > 0) maxChallenge += 20
+    maxChallenge += input.gqAscensionCapIncrease
+    maxChallenge += input.singAscensionCapIncrease
+    return maxChallenge
+  }
+
+  return maxChallenge
+}
+
+// ─── Challenge requirement (target value to beat the challenge) ────────────
+
+export interface ChallengeRequirementMultiplierInput {
+  type: ChallengeType
+  completions: number
+  /**
+   * For reincarnation challenges: which challenge "special" multipliers apply
+   * (6/7/8/9/10 each scale differently past the 60/70/80/90 thresholds).
+   * For ascension: 15 selects the Decimal.pow(1000, completions) branch.
+   * Transcend ignores it. 0 means "no special".
+   */
+  special: number
+  /**
+   * G.hyperchallengeMultiplier[player.corruptions.used.hyperchallenge] —
+   * baseline corruption-driven scaling. Transcend/reincarnation only;
+   * ascension forces this to 1 internally.
+   */
+  hyperchallengeMultiplier: number
+  /** player.platonicUpgrades[8] — divides the corruption baseline by 1 + n/2.5. */
+  platonicUpgrade8: number
+  /** G.challenge15Rewards.transcendChallengeReduction.value (defaults 1). */
+  challenge15TranscendReduction: number
+  /** G.challenge15Rewards.reincarnationChallengeReduction.value (defaults 1). */
+  challenge15ReincarnationReduction: number
+  /** getShopUpgradeEffects('challengeTome', 'c9c10ScalingReduction'). */
+  challengeTomeC9C10ScalingReduction: number
+  /** getShopUpgradeEffects('challengeTome2', 'c9c10ScalingReduction'). */
+  challengeTome2C9C10ScalingReduction: number
+}
+
+/**
+ * Multiplier on the base challenge requirement. The transcend and
+ * reincarnation branches are piles of `if completions >= K` softcap stages;
+ * ascension just scales linearly past 10 completions (or geometrically for
+ * c15). Identical to web_ui's calculateChallengeRequirementMultiplier.
+ */
+export function calculateChallengeRequirementMultiplier(
+  input: ChallengeRequirementMultiplierInput
+): number {
+  const { type, completions, special } = input
+
+  let requirementMultiplier = Math.max(
+    1,
+    input.hyperchallengeMultiplier / (1 + input.platonicUpgrade8 / 2.5)
+  )
+  if (type === 'ascension') {
+    // Normalize back to 1 for ascension; the corruption baseline only applies
+    // to T/R tiers.
+    requirementMultiplier = 1
+  }
+
+  switch (type) {
+    case 'transcend':
+      requirementMultiplier *= input.challenge15TranscendReduction
+      if (completions >= 75) {
+        requirementMultiplier *= Math.pow(1 + completions, 12) / Math.pow(75, 8)
+      } else {
+        requirementMultiplier *= Math.pow(1 + completions, 2)
+      }
+      if (completions >= 1000) {
+        requirementMultiplier *= 10 * Math.pow(completions / 1000, 3)
+      }
+      if (completions >= 9000) {
+        requirementMultiplier *= 1337
+      }
+      if (completions >= 9001) {
+        requirementMultiplier *= completions - 8999
+      }
+      return requirementMultiplier
+
+    case 'reincarnation':
+      if (completions >= 100 && (special === 9 || special === 10)) {
+        requirementMultiplier *= Math.pow(1.05, (completions - 100) * (1 + (completions - 100) / 20))
+      }
+      if (completions >= 90) {
+        if (special === 6) requirementMultiplier *= 100
+        else if (special === 7) requirementMultiplier *= 50
+        else if (special === 8) requirementMultiplier *= 10
+        else requirementMultiplier *= 4
+      }
+      if (completions >= 80) {
+        if (special === 6) requirementMultiplier *= 50
+        else if (special === 7) requirementMultiplier *= 20
+        else if (special === 8) requirementMultiplier *= 4
+        else requirementMultiplier *= 2
+      }
+      if (completions >= 70) {
+        if (special === 6) requirementMultiplier *= 20
+        else if (special === 7) requirementMultiplier *= 10
+        else if (special === 8) requirementMultiplier *= 2
+        else requirementMultiplier *= 1
+      }
+      if (completions >= 60 && (special === 9 || special === 10)) {
+        requirementMultiplier *= Math.pow(
+          1000,
+          (completions - 60)
+            * (1 + input.challengeTomeC9C10ScalingReduction + input.challengeTome2C9C10ScalingReduction)
+            / 10
+        )
+      }
+      if (completions >= 25) {
+        requirementMultiplier *= Math.pow(1 + completions, 5) / 625
+      }
+      if (completions < 25) {
+        requirementMultiplier *= Math.min(Math.pow(1 + completions, 2), Math.pow(1.3797, completions))
+      }
+      requirementMultiplier *= input.challenge15ReincarnationReduction
+      return requirementMultiplier
+
+    case 'ascension':
+      if (special !== 15) {
+        if (completions >= 10) {
+          requirementMultiplier *= 2 * (1 + completions) - 10
+        } else {
+          requirementMultiplier *= 1 + completions
+        }
+      } else {
+        requirementMultiplier *= Math.pow(1000, completions)
+      }
+      return requirementMultiplier
+
+    default: {
+      throw new Error(`Unhandled challenge type: ${type satisfies never}`)
+    }
+  }
+}
+
+export interface ChallengeRequirementInput {
+  challenge: number
+  completion: number
+  /** See ChallengeRequirementMultiplierInput.special. */
+  special: number
+  /** G.challengeBaseRequirements[challenge - 1]. */
+  challengeBaseRequirement: number
+  /**
+   * Subtracted from the base for challenge 10 only:
+   *   1e8 * (researches[140] + 155 + 170 + 185)
+   *   + challengeTome 'c10RequirementReduction'
+   *   + challengeTome2 'c10RequirementReduction'
+   * Pass 0 for any other challenge.
+   */
+  c10RequirementReduction: number
+  hyperchallengeMultiplier: number
+  platonicUpgrade8: number
+  challenge15TranscendReduction: number
+  challenge15ReincarnationReduction: number
+  challengeTomeC9C10ScalingReduction: number
+  challengeTome2C9C10ScalingReduction: number
+}
+
+/**
+ * Target value to beat the challenge. T/R: 10^(base * multiplier). Ascension
+ * 11..14: just the multiplier. Ascension 15: 10^(1e30 * multiplier). Challenges
+ * outside 1..15 return 0.
+ *
+ * Returns Decimal for T/R/15 (can exceed JS number range) and number for
+ * 11..14.
+ */
+export function challengeRequirement(input: ChallengeRequirementInput): Decimal | number {
+  const { challenge, completion, special } = input
+  const multInput: ChallengeRequirementMultiplierInput = {
+    type: 'transcend',
+    completions: completion,
+    special,
+    hyperchallengeMultiplier: input.hyperchallengeMultiplier,
+    platonicUpgrade8: input.platonicUpgrade8,
+    challenge15TranscendReduction: input.challenge15TranscendReduction,
+    challenge15ReincarnationReduction: input.challenge15ReincarnationReduction,
+    challengeTomeC9C10ScalingReduction: input.challengeTomeC9C10ScalingReduction,
+    challengeTome2C9C10ScalingReduction: input.challengeTome2C9C10ScalingReduction
+  }
+
+  if (challenge >= 1 && challenge <= 5) {
+    multInput.type = 'transcend'
+    return Decimal.pow(10, input.challengeBaseRequirement * calculateChallengeRequirementMultiplier(multInput))
+  }
+  if (challenge >= 6 && challenge <= 10) {
+    multInput.type = 'reincarnation'
+    return Decimal.pow(
+      10,
+      (input.challengeBaseRequirement - input.c10RequirementReduction)
+        * calculateChallengeRequirementMultiplier(multInput)
+    )
+  }
+  if (challenge >= 11 && challenge <= 14) {
+    multInput.type = 'ascension'
+    return calculateChallengeRequirementMultiplier(multInput)
+  }
+  if (challenge === 15) {
+    multInput.type = 'ascension'
+    return Decimal.pow(
+      10,
+      1 * Math.pow(10, 30) * calculateChallengeRequirementMultiplier(multInput)
+    )
+  }
+  return 0
+}
+
+// ─── Challenge 15 score multiplier ─────────────────────────────────────────
+
+export interface Challenge15ScoreMultiplierInput {
+  /** player.campaigns.c15Bonus. */
+  c15Bonus: number
+  /** hepteractEffective('challenge') — the challenge-hepteract effective count. */
+  challengeHepteractEffective: number
+  /** player.platonicUpgrades[15]. */
+  platonicUpgrade15: number
+}
+
+/**
+ * Score multiplier for the C15 ascension challenge. Three independent legs
+ * multiplied together: campaign bonus, challenge-hepteract scaling, and
+ * platonic OMEGA bonus.
+ */
+export function challenge15ScoreMultiplier(input: Challenge15ScoreMultiplierInput): number {
+  return input.c15Bonus
+    * (1 + 5 / 10000 * input.challengeHepteractEffective)
+    * (1 + 0.25 * input.platonicUpgrade15)
+}
+
+// ─── Auto-challenge sweep traversal helpers ────────────────────────────────
+
+const NUM_ELIGIBLE_CHALLENGES = 10
+
+export interface GetNextRegularChallengeInput {
+  /** Where to start the scan; 1..10. */
+  startIndex: number
+  /** Already-attempted challenges this sweep round. */
+  explored: ReadonlySet<number>
+  /**
+   * Indexed by challenge number 1..10. The caller precomputes one slot per
+   * challenge — the same getMaxChallenges shape, evaluated for each tier.
+   */
+  maxChallenges: readonly number[]
+  /** player.highestchallengecompletions, indexed by challenge number. */
+  highestCompletions: readonly number[]
+  /** player.autoChallengeToggles, indexed by challenge number. */
+  autoChallengeToggles: readonly boolean[]
+}
+
+/**
+ * "Next eligible normal (non-asc) challenge" — wraps around 10 → 1.
+ * Returns -1 if no challenge in 1..10 is eligible (toggled on AND under cap
+ * AND not already explored this round).
+ */
+export function getNextRegularChallenge(input: GetNextRegularChallengeInput): number {
+  let challenge = input.startIndex
+  for (let i = 0; i < NUM_ELIGIBLE_CHALLENGES; i++) {
+    if (
+      !input.explored.has(challenge)
+      && input.highestCompletions[challenge] < input.maxChallenges[challenge]
+      && input.autoChallengeToggles[challenge]
+    ) {
+      return challenge
+    }
+    challenge++
+    if (challenge > NUM_ELIGIBLE_CHALLENGES) {
+      challenge = 1
+    }
+  }
+  return -1
+}
+
+export interface GetNextAscensionChallengeInput {
+  /** Where to start the scan; 11..15. */
+  startIndex: number
+  /** Indexed by challenge number 11..15; maxChallenges[15] is ignored. */
+  maxChallenges: readonly number[]
+  /** player.highestchallengecompletions. */
+  highestCompletions: readonly number[]
+  /** player.autoChallengeToggles. */
+  autoChallengeToggles: readonly boolean[]
+}
+
+/**
+ * "Next eligible ascension challenge" — wraps 15 → 11. Returns the same value
+ * as startIndex if nothing else is eligible (mirrors the web_ui contract —
+ * no `explored` set is threaded through, only one wrap is attempted).
+ *
+ * c15 is treated as always-eligible since it has no completions cap.
+ */
+export function getNextAscensionChallenge(input: GetNextAscensionChallengeInput): number {
+  let nextChallenge = input.startIndex
+  for (let i = 0; i < 5; i++) {
+    nextChallenge++
+    if (nextChallenge > 15) {
+      nextChallenge = 11
+    }
+    if (
+      input.autoChallengeToggles[nextChallenge]
+      && (input.highestCompletions[nextChallenge] < input.maxChallenges[nextChallenge] || nextChallenge === 15)
+    ) {
+      return nextChallenge
+    }
+  }
+  return nextChallenge
+}
+
+// ─── Misc unlock checks ────────────────────────────────────────────────────
+
+/**
+ * Ascension-challenge auto-sweep is gated behind singularity 101 + the
+ * instantChallenge2 shop upgrade. The web_ui caller passes both bits in.
+ */
+export function autoAscensionChallengeSweepUnlock(
+  highestSingularityCount: number,
+  instantChallenge2Unlocked: boolean
+): boolean {
+  return highestSingularityCount >= 101 && instantChallenge2Unlocked
 }

--- a/packages/logic/src/mechanics/corruptions.ts
+++ b/packages/logic/src/mechanics/corruptions.ts
@@ -1,0 +1,142 @@
+// Corruption math, migrated from packages/web_ui/src/Corruptions.ts. The
+// CorruptionLoadout / CorruptionSaves classes and the UI loadout table stay
+// in web_ui — they touch DOM, Notification, and the i18next loadout-export
+// flow. Logic owns the per-corruption multipliers and the cap formula.
+
+// ─── Cap on per-corruption level ───────────────────────────────────────────
+
+export interface MaxCorruptionLevelInput {
+  /** player.challengecompletions[11]. +5 to cap when any completion exists. */
+  challenge11Completions: number
+  /** player.challengecompletions[12]. +2 to cap when any. */
+  challenge12Completions: number
+  /** player.challengecompletions[13]. +2 to cap when any. */
+  challenge13Completions: number
+  /** player.challengecompletions[14]. +2 to cap when any. */
+  challenge14Completions: number
+  /** player.platonicUpgrades[5]. +1 when any. */
+  platonicUpgrade5: number
+  /** player.platonicUpgrades[10]. +1 when any. */
+  platonicUpgrade10: number
+  /**
+   * getGQUpgradeEffect('platonicTau', 'unlocked'). Floor of 13 — applied
+   * AFTER the challenge/platonic adds, BEFORE corruptionFourteen.
+   */
+  platonicTauUnlocked: boolean
+  /**
+   * getGQUpgradeEffect('corruptionFourteen', 'unlocked'). +1 to the final
+   * cap (after the platonicTau floor).
+   */
+  corruptionFourteenUnlocked: boolean
+  /**
+   * getOcteractUpgradeEffect('octeractCorruption', 'corruptionLevelCapIncrease').
+   * Added to the final cap.
+   */
+  octeractCorruptionCapIncrease: number
+}
+
+/**
+ * Maximum corruption level players can set on any single corruption. Sum of
+ * challenge / platonic / GQ / octeract contributions, with a platonicTau
+ * floor of 13 if that upgrade is unlocked.
+ */
+export function maxCorruptionLevel(input: MaxCorruptionLevelInput): number {
+  let max = 0
+  if (input.challenge11Completions > 0) max += 5
+  if (input.challenge12Completions > 0) max += 2
+  if (input.challenge13Completions > 0) max += 2
+  if (input.challenge14Completions > 0) max += 2
+  if (input.platonicUpgrade5 > 0) max += 1
+  if (input.platonicUpgrade10 > 0) max += 1
+
+  if (input.platonicTauUnlocked) {
+    max = Math.max(13, max)
+  }
+
+  if (input.corruptionFourteenUnlocked) {
+    max += 1
+  }
+  max += input.octeractCorruptionCapIncrease
+
+  return max
+}
+
+// ─── Per-corruption effect calculators ─────────────────────────────────────
+//
+// Each takes the looked-up `basePower` from web_ui's G.<corruption>Power
+// table (web_ui owns the data arrays). Returns the multiplicative effect
+// applied to the matching system — production for viscosity/illiteracy,
+// salvage for drought, challenge requirements for hyperchallenge.
+
+export interface ViscosityEffectInput {
+  /** G.viscosityPower[level] — the level-indexed base exponent. */
+  basePower: number
+  /** player.platonicUpgrades[6]. Multiplies base by (1 + n / 30). */
+  platonicUpgrade6: number
+}
+
+/**
+ * Viscosity production exponent. Clamped to ≤ 1 — buffs can only soften the
+ * corruption, never reverse it.
+ */
+export function viscosityEffect(input: ViscosityEffectInput): number {
+  return Math.min(input.basePower * (1 + input.platonicUpgrade6 / 30), 1)
+}
+
+export interface DroughtEffectInput {
+  /** G.droughtSalvage[level]. */
+  baseSalvage: number
+  /** player.platonicUpgrades[13]. When > 0, halves the salvage reduction. */
+  platonicUpgrade13: number
+}
+
+/**
+ * Drought salvage reduction multiplier. Platonic 13 halves the reduction.
+ */
+export function droughtEffect(input: DroughtEffectInput): number {
+  return input.platonicUpgrade13 > 0
+    ? input.baseSalvage * 0.5
+    : input.baseSalvage
+}
+
+export interface IlliteracyEffectInput {
+  /** G.illiteracyPower[level]. */
+  basePower: number
+  /** player.platonicUpgrades[9]. */
+  platonicUpgrade9: number
+  /**
+   * `player.obtainium.gte(1)` AND `Decimal.log10(player.obtainium)` — the
+   * obtainium-based boost only applies when obtainium ≥ 1. Pass:
+   *   - `null` if obtainium < 1 (boost path skipped)
+   *   - the log10 value (capped at 100 by the caller or here) otherwise
+   * Letting null in keeps the Decimal dependency on the wrapper side.
+   */
+  obtainiumLog10OrNull: number | null
+}
+
+/**
+ * Illiteracy production exponent. When obtainium ≥ 1, gets bumped by
+ * `1 + (platonic9 / 100) * min(100, log10(obtainium))`. Clamped to ≤ 1.
+ */
+export function illiteracyEffect(input: IlliteracyEffectInput): number {
+  const multiplier = input.obtainiumLog10OrNull === null
+    ? 1
+    : 1 + (1 / 100) * input.platonicUpgrade9 * Math.min(100, input.obtainiumLog10OrNull)
+  return Math.min(input.basePower * multiplier, 1)
+}
+
+export interface HyperchallengeEffectInput {
+  /** G.hyperchallengeMultiplier[level]. */
+  baseEffect: number
+  /** player.platonicUpgrades[8]. Divides base by (1 + 2/5 * n). */
+  platonicUpgrade8: number
+}
+
+/**
+ * Hyperchallenge requirement multiplier. Floored at 1 — platonic-8 can soften
+ * the corruption but never make challenges easier than baseline.
+ */
+export function hyperchallengeEffect(input: HyperchallengeEffectInput): number {
+  const divisor = 1 + 2 / 5 * input.platonicUpgrade8
+  return Math.max(1, input.baseEffect / divisor)
+}

--- a/packages/logic/src/mechanics/cubeUpgrades.ts
+++ b/packages/logic/src/mechanics/cubeUpgrades.ts
@@ -1,0 +1,131 @@
+// Cube-upgrade cost + max-level math, migrated from packages/web_ui/src/Cubes.ts.
+// The UI-side getters (cubeUpgradeDesc, updateCubeUpgradeBG, buyCubeUpgrades)
+// stay in web_ui — they touch DOM, i18next, and call upgradeupdate. Logic
+// owns just the pure cost-curve and cap math.
+
+import {
+  calculateCubicSumData,
+  type CalculateCubicSumDataResult,
+  calculateSummationNonLinear,
+  type CalculateSummationNonLinearResult
+} from '../math/summations'
+
+// ─── Truth tables ──────────────────────────────────────────────────────────
+//
+// Per-upgrade base cost (index 0 ignored — cube upgrades are 1-indexed).
+// dprint-ignore
+const CUBE_BASE_COSTS: readonly number[] = [
+  200, 200, 200, 500, 500, 500, 500, 500, 2000, 40000,
+  5000, 1000, 10000, 20000, 40000, 10000, 4000, 1e4, 50000, 12500,
+  5e4, 3e4, 3e4, 4e4, 2e5, 4e5, 1e5, 177777, 1e5, 1e6,
+  5e5, 3e5, 2e6, 4e7, 4e7, 1e8, 1e8, 1e9, 2e9, 2e8,
+  2e8, 5e8, 1e9, 2e9, 2e9, 5e8, 9876543210, 1e10, 42934819467, 1e8,
+  1, 1e4, 1e8, 1e12, 1e16, 10, 1e5, 1e9, 1e13, 1e17,
+  1e2, 1e6, 1e10, 1e14, 1e18, 1e20, 1e30, 1e40, 1e50, 1e60,
+  1, 1, 1e8, 1e16, 1e30, 1e100, 1e100, 1e200, 1e250, 1e300
+]
+
+// Per-upgrade maximum level. Cube upgrade 57 (cookie row-leader bonus) bumps
+// indices 1/11/21/31/41 by +1 — see getCubeMax.
+// dprint-ignore
+const CUBE_MAX_LEVELS: readonly number[] = [
+  3, 10, 5, 1, 1, 1, 1, 1, 1, 1,
+  3, 10, 1, 10, 10, 10, 5, 1, 1, 1,
+  5, 10, 1, 10, 10, 10, 1, 1, 5, 1,
+  5, 1, 1, 10, 10, 10, 10, 1, 1, 10,
+  5, 10, 10, 10, 10, 20, 1, 1, 1, 100000,
+  1, 900, 100, 900, 900, 20, 1, 1, 400, 10000,
+  100, 1, 1, 1, 1, 1, 1, 1000, 1, 100000,
+  1, 1, 5, 1, 30, 2, 25, 30, 1, 1
+]
+
+/**
+ * Base cost (in wow cubes) for a single level of cube upgrade `index` (1-indexed).
+ * The growth curve on top of this base differs by tier — see getCubeCost.
+ * Web_ui's updateCubeUpgradeBG calls this when refunding over-leveled
+ * upgrades after a max-level drop.
+ */
+export function getCubeUpgradeBaseCost(index: number): number {
+  return CUBE_BASE_COSTS[index - 1]
+}
+
+// ─── getCubeMax ────────────────────────────────────────────────────────────
+
+export interface GetCubeMaxInput {
+  /** 1..80 (the cube upgrade index). */
+  cubeUpgradeIndex: number
+  /**
+   * player.cubeUpgrades[57]. Once bought, the "row leader" upgrades (indices
+   * 1, 11, 21, 31, 41 — i.e. `i % 10 === 1` and `i < 50`) get +1 max level.
+   */
+  cubeUpgrade57: number
+}
+
+export function getCubeMax(input: GetCubeMaxInput): number {
+  let baseValue = CUBE_MAX_LEVELS[input.cubeUpgradeIndex - 1]
+  if (
+    input.cubeUpgrade57 > 0
+    && input.cubeUpgradeIndex < 50
+    && input.cubeUpgradeIndex % 10 === 1
+  ) {
+    baseValue += 1
+  }
+  return baseValue
+}
+
+// ─── getCubeCost ───────────────────────────────────────────────────────────
+
+export interface GetCubeCostInput {
+  /** 1..80. */
+  cubeUpgradeIndex: number
+  /** False = buy 1 level; true = buy up to 1e5 (non-cubic) or max (cubic). */
+  buyMax: boolean
+  /** player.cubeUpgrades[i]. */
+  currentLevel: number
+  /** Precomputed via getCubeMax(); avoids the wrapper double-computing it. */
+  maxLevel: number
+  /** Number(player.wowCubes). */
+  wowCubes: number
+  /**
+   * For i ≤ 50: calculateSingularityDebuff('Cube Upgrades'). For i > 50:
+   * pass 1 (the original web_ui code never applied the debuff above 50).
+   */
+  singularityDebuff: number
+}
+
+export type GetCubeCostResult = CalculateSummationNonLinearResult | CalculateCubicSumDataResult
+
+/**
+ * Cube cost curve. Three regimes:
+ *
+ *   i === 50           linear growth 0.01 + singularity-debuffed base
+ *   i  <  50 (≠ 50)    flat per-level + singularity-debuffed base
+ *   i  >  50           cubic sum, no singularity debuff
+ *
+ * Returns the standard `{ levelCanBuy, cost }` shape from the summation
+ * primitives. Callers feed `cost` back into player.wowCubes.sub().
+ */
+export function getCubeCost(input: GetCubeCostInput): GetCubeCostResult {
+  const i = input.cubeUpgradeIndex
+  const linGrowth = i === 50 ? 0.01 : 0
+  const cubic = i > 50
+  const cubeUpgrade = input.currentLevel
+  const baseCost = CUBE_BASE_COSTS[i - 1]
+
+  if (cubic) {
+    // Cubic regime uses a different buy-amount rule: buyMax goes up to
+    // maxLevel; single-purchase goes one above current.
+    const amountToBuy = input.buyMax ? input.maxLevel : Math.min(input.maxLevel, cubeUpgrade + 1)
+    return calculateCubicSumData(cubeUpgrade, baseCost, input.wowCubes, amountToBuy)
+  }
+
+  let amountToBuy = input.buyMax ? 1e5 : 1
+  amountToBuy = Math.min(input.maxLevel - cubeUpgrade, amountToBuy)
+  return calculateSummationNonLinear(
+    cubeUpgrade,
+    baseCost * input.singularityDebuff,
+    input.wowCubes,
+    linGrowth,
+    amountToBuy
+  )
+}

--- a/packages/logic/src/mechanics/quarks.ts
+++ b/packages/logic/src/mechanics/quarks.ts
@@ -1,0 +1,71 @@
+// Quark export accumulator math. The web_ui side wraps this and gathers
+// the player/octeract inputs; the QuarkHandler class and the personal/global
+// quark bonus state stay in web_ui (DOM + i18next + fetch).
+
+export interface QuarkHandlerInput {
+  /**
+   * player.researches[195] — "Research 8x20". Each level adds 18000s
+   * (5 hours) to the export cap. Zero means the base 90000s window.
+   */
+  research195: number
+  /**
+   * Sum of player.researches at the five quark-yielding slots:
+   * researches[99] + [100] + [125] + [180] + [195]. Added to the base
+   * 5 quarks/hour rate before the octeract multiplier.
+   */
+  researchesSum: number
+  /**
+   * getOcteractUpgradeEffect('octeractExportQuarks', 'exportQuarkMult') —
+   * multiplicative boost on the per-hour rate. Defaults to 1 if the upgrade
+   * isn't bought.
+   */
+  exportQuarkMult: number
+  /**
+   * player.quarkstimer — seconds of accumulated export time. The actual
+   * quark gain is `floor(quarksTimer * perHour / 3600)`; capped externally
+   * by web_ui when timer exceeds maxTime.
+   */
+  quarksTimer: number
+  /**
+   * calculateCubeQuarkMultiplier() — already migrated, passed through
+   * unchanged. Kept here so callers get a single object to destructure.
+   */
+  cubeMult: number
+}
+
+export interface QuarkHandlerResult {
+  /** Maximum accumulator window, in seconds. */
+  maxTime: number
+  /** Effective quarks/hour given all bonuses. */
+  perHour: number
+  /** floor(perHour * maxTime / 3600) — total quarks the cap can hold. */
+  capacity: number
+  /** floor(quarksTimer * perHour / 3600) — quarks gained right now. */
+  gain: number
+  /** Pass-through of input.cubeMult. */
+  cubeMult: number
+}
+
+/**
+ * Computes the export-time / per-hour / capacity / current-gain quartet
+ * used by every quark-display surface. Verbatim from web_ui's quarkHandler
+ * with the five player/G reads lifted into explicit inputs.
+ */
+export function quarkHandler(input: QuarkHandlerInput): QuarkHandlerResult {
+  let maxTime = 90000
+  if (input.research195 > 0) {
+    maxTime += 18000 * input.research195
+  }
+
+  const perHour = (5 + input.researchesSum) * input.exportQuarkMult
+  const capacity = Math.floor(perHour * maxTime / 3600)
+  const gain = Math.floor(input.quarksTimer * perHour / 3600)
+
+  return {
+    maxTime,
+    perHour,
+    capacity,
+    gain,
+    cubeMult: input.cubeMult
+  }
+}

--- a/packages/logic/test/parity/ascensionScore.parity.test.ts
+++ b/packages/logic/test/parity/ascensionScore.parity.test.ts
@@ -1,0 +1,422 @@
+// Parity tests for the ascension-score and corruption-stuff transforms
+// migrated from packages/web_ui/src/Calculate.ts. The OLD implementations
+// are transcribed verbatim below with all `player.*` / `G.*` reads lifted
+// into explicit parameters.
+
+import { describe, expect, it } from 'vitest'
+import {
+  CalcCorruptionStuff as newCalcCorruption,
+  calculateAscensionScore as newCalcAscensionScore,
+  computeAscensionScoreBonusMultiplier as newComputeBonus
+} from '../../src/mechanics/calculate'
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!isFinite(a) || !isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── computeAscensionScoreBonusMultiplier ─────────────────────────────────
+
+interface OldBonusInputs {
+  challenge15ScoreReward: number
+  platonicBlessingMult: number
+  campaignAscensionScoreMult: number
+  finiteDescentAscensionScore: number
+  cubeUpgrade21: number
+  cubeUpgrade31: number
+  cubeUpgrade41: number
+  ascensionScoreAchievementReward: number
+  masterPackAscensionScoreMult: number
+  eventBuff: number // 0 if no event active
+}
+
+const oldComputeBonus = (i: OldBonusInputs): number => {
+  let multiplier = 1
+  multiplier *= i.challenge15ScoreReward
+  multiplier *= i.platonicBlessingMult
+  multiplier *= i.campaignAscensionScoreMult
+  multiplier *= i.finiteDescentAscensionScore
+  if (i.cubeUpgrade21 > 0) multiplier *= 1 + 0.05 * i.cubeUpgrade21
+  if (i.cubeUpgrade31 > 0) multiplier *= 1 + 0.05 * i.cubeUpgrade31
+  if (i.cubeUpgrade41 > 0) multiplier *= 1 + 0.05 * i.cubeUpgrade41
+  multiplier *= i.ascensionScoreAchievementReward
+  multiplier *= i.masterPackAscensionScoreMult
+  // The web_ui code guards on `G.isEvent` before adding; here the caller
+  // passes 0 when no event is active.
+  multiplier *= 1 + i.eventBuff
+  return multiplier
+}
+
+describe('parity: computeAscensionScoreBonusMultiplier', () => {
+  const cases: OldBonusInputs[] = [
+    // Identity-ish baseline
+    {
+      challenge15ScoreReward: 1,
+      platonicBlessingMult: 1,
+      campaignAscensionScoreMult: 1,
+      finiteDescentAscensionScore: 1,
+      cubeUpgrade21: 0,
+      cubeUpgrade31: 0,
+      cubeUpgrade41: 0,
+      ascensionScoreAchievementReward: 1,
+      masterPackAscensionScoreMult: 1,
+      eventBuff: 0
+    },
+    // Cube upgrades trigger 1 + 0.05*n branch
+    {
+      challenge15ScoreReward: 2,
+      platonicBlessingMult: 1.5,
+      campaignAscensionScoreMult: 1.2,
+      finiteDescentAscensionScore: 1.1,
+      cubeUpgrade21: 10,
+      cubeUpgrade31: 5,
+      cubeUpgrade41: 2,
+      ascensionScoreAchievementReward: 1.5,
+      masterPackAscensionScoreMult: 1.25,
+      eventBuff: 0
+    },
+    // Event active
+    {
+      challenge15ScoreReward: 1,
+      platonicBlessingMult: 1,
+      campaignAscensionScoreMult: 1,
+      finiteDescentAscensionScore: 1,
+      cubeUpgrade21: 0,
+      cubeUpgrade31: 0,
+      cubeUpgrade41: 0,
+      ascensionScoreAchievementReward: 1,
+      masterPackAscensionScoreMult: 1,
+      eventBuff: 0.5
+    },
+    // All bumps + event
+    {
+      challenge15ScoreReward: 3,
+      platonicBlessingMult: 2,
+      campaignAscensionScoreMult: 1.5,
+      finiteDescentAscensionScore: 1.3,
+      cubeUpgrade21: 20,
+      cubeUpgrade31: 15,
+      cubeUpgrade41: 10,
+      ascensionScoreAchievementReward: 2,
+      masterPackAscensionScoreMult: 1.5,
+      eventBuff: 0.25
+    }
+  ]
+
+  for (const [i, input] of cases.entries()) {
+    it(`case ${i}`, () => {
+      expect(closeEnough(newComputeBonus(input), oldComputeBonus(input))).toBe(true)
+    })
+  }
+})
+
+// ─── calculateAscensionScore ──────────────────────────────────────────────
+
+interface OldAscScoreInputs {
+  highestChallengeCompletions: readonly number[]
+  cubeUpgrade56: number
+  cubeUpgrade39: number
+  platonicUpgrade5: number
+  platonicUpgrade10: number
+  corruptionMultiplier: number
+  antUpgradeAscensionScoreBase: number
+  expertPackAscensionScoreMult: number
+  bonusMultiplier: number
+}
+
+const oldChallengeScoreArrays2 = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450]
+const oldChallengeScoreArrays3 = [0, 20, 30, 50, 100, 200, 250, 300, 400, 500, 750]
+const oldChallengeScoreArrays4 = [0, 10000, 10000, 10000, 10000, 10000, 2000, 3000, 4000, 5000, 7500]
+
+const oldCalcAscensionScore = (input: OldAscScoreInputs) => {
+  let baseScore = 0
+  const challengeScoreArrays1 = [0, 8, 10, 12, 15, 20, 60, 80, 120, 180, 300]
+  challengeScoreArrays1[1] += input.cubeUpgrade56
+  challengeScoreArrays1[2] += input.cubeUpgrade56
+  challengeScoreArrays1[3] += input.cubeUpgrade56
+
+  for (let i = 1; i <= 10; i++) {
+    const c = input.highestChallengeCompletions[i]
+    baseScore += challengeScoreArrays1[i] * c
+    if (i <= 5 && c >= 75) {
+      baseScore += oldChallengeScoreArrays2[i] * (c - 75)
+      if (c >= 750) baseScore += oldChallengeScoreArrays3[i] * (c - 750)
+      if (c >= 9000) baseScore += oldChallengeScoreArrays4[i] * (c - 9000)
+    }
+    if (i <= 10 && i > 5 && c >= 25) {
+      baseScore += oldChallengeScoreArrays2[i] * (c - 25)
+      if (c >= 60) baseScore += oldChallengeScoreArrays3[i] * (c - 60)
+    }
+  }
+
+  baseScore += input.antUpgradeAscensionScoreBase
+
+  baseScore *= Math.pow(
+    1.03 + 0.005 * input.cubeUpgrade39 + 0.0025 * (input.platonicUpgrade5 + input.platonicUpgrade10),
+    input.highestChallengeCompletions[10]
+  )
+
+  let effectiveScore = baseScore * input.corruptionMultiplier * input.bonusMultiplier
+  if (effectiveScore > 1e23) effectiveScore = Math.pow(effectiveScore, 0.5) * Math.pow(1e23, 0.5)
+  effectiveScore *= input.expertPackAscensionScoreMult
+
+  return {
+    baseScore,
+    corruptionMultiplier: input.corruptionMultiplier,
+    bonusMultiplier: input.bonusMultiplier,
+    effectiveScore
+  }
+}
+
+describe('parity: calculateAscensionScore', () => {
+  // Each case exercises a different combination of thresholds:
+  // - completions below every band (only baseScoreArray contributes)
+  // - exactly at the 75/750/9000 transcend boundaries
+  // - exactly at the 25/60 reincarnation boundaries
+  // - past the 1e23 effectiveScore softcap
+  const cases: OldAscScoreInputs[] = [
+    // Baseline: zeroes everywhere
+    {
+      highestChallengeCompletions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      cubeUpgrade56: 0,
+      cubeUpgrade39: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      corruptionMultiplier: 1,
+      antUpgradeAscensionScoreBase: 0,
+      expertPackAscensionScoreMult: 1,
+      bonusMultiplier: 1
+    },
+    // Below 75, transcend baseline only
+    {
+      highestChallengeCompletions: [0, 50, 50, 50, 50, 50, 0, 0, 0, 0, 0],
+      cubeUpgrade56: 0,
+      cubeUpgrade39: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      corruptionMultiplier: 1,
+      antUpgradeAscensionScoreBase: 0,
+      expertPackAscensionScoreMult: 1,
+      bonusMultiplier: 1
+    },
+    // Cross 75 threshold for transcend, 25 for reincarnation
+    {
+      highestChallengeCompletions: [0, 100, 100, 100, 100, 100, 50, 50, 50, 50, 50],
+      cubeUpgrade56: 0,
+      cubeUpgrade39: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      corruptionMultiplier: 1,
+      antUpgradeAscensionScoreBase: 100,
+      expertPackAscensionScoreMult: 1,
+      bonusMultiplier: 1
+    },
+    // Cross 750 transcend + 60 reincarnation thresholds, cubeUpgrade56 active
+    {
+      highestChallengeCompletions: [0, 800, 800, 800, 100, 100, 80, 80, 80, 80, 80],
+      cubeUpgrade56: 5,
+      cubeUpgrade39: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      corruptionMultiplier: 1.5,
+      antUpgradeAscensionScoreBase: 0,
+      expertPackAscensionScoreMult: 1.2,
+      bonusMultiplier: 1.1
+    },
+    // Cross 9000 transcend threshold, max C10 exponent contributors
+    {
+      highestChallengeCompletions: [0, 9100, 9100, 100, 100, 100, 80, 80, 80, 80, 50],
+      cubeUpgrade56: 10,
+      cubeUpgrade39: 5,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      corruptionMultiplier: 2,
+      antUpgradeAscensionScoreBase: 1000,
+      expertPackAscensionScoreMult: 1.5,
+      bonusMultiplier: 1.3
+    },
+    // Force effectiveScore past 1e23 softcap
+    {
+      highestChallengeCompletions: [0, 9100, 9100, 9100, 9100, 9100, 100, 100, 100, 100, 500],
+      cubeUpgrade56: 10,
+      cubeUpgrade39: 5,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      corruptionMultiplier: 1e10,
+      antUpgradeAscensionScoreBase: 0,
+      expertPackAscensionScoreMult: 2,
+      bonusMultiplier: 1e10
+    }
+  ]
+
+  for (const [i, input] of cases.entries()) {
+    it(`case ${i}`, () => {
+      const newRes = newCalcAscensionScore(input)
+      const oldRes = oldCalcAscensionScore(input)
+      expect(closeEnough(newRes.baseScore, oldRes.baseScore)).toBe(true)
+      expect(closeEnough(newRes.corruptionMultiplier, oldRes.corruptionMultiplier)).toBe(true)
+      expect(closeEnough(newRes.bonusMultiplier, oldRes.bonusMultiplier)).toBe(true)
+      expect(closeEnough(newRes.effectiveScore, oldRes.effectiveScore)).toBe(true)
+    })
+  }
+})
+
+// ─── CalcCorruptionStuff ──────────────────────────────────────────────────
+
+describe('parity: CalcCorruptionStuff', () => {
+  const cases = [
+    // Below every threshold: only cubes/tess
+    {
+      label: 'below all thresholds',
+      effectiveScore: 1e3,
+      cubeMult: 5,
+      tessMult: 2,
+      hyperMult: 3,
+      platMult: 4,
+      heptMult: 5,
+      hepteractsUnlocked: 0,
+      singularityCount: 0
+    },
+    // Cross 1e5 — tess base bumps to 1.5
+    {
+      label: 'tess base bumps',
+      effectiveScore: 2e5,
+      cubeMult: 10,
+      tessMult: 2,
+      hyperMult: 1,
+      platMult: 1,
+      heptMult: 1,
+      hepteractsUnlocked: 0,
+      singularityCount: 0
+    },
+    // Cross 1e9 — hypercubes unlock
+    {
+      label: 'hyper unlocks',
+      effectiveScore: 5e9,
+      cubeMult: 100,
+      tessMult: 50,
+      hyperMult: 25,
+      platMult: 1,
+      heptMult: 1,
+      hepteractsUnlocked: 0,
+      singularityCount: 0
+    },
+    // Cross 2.666e12 — platonic unlocks
+    {
+      label: 'platonic unlocks',
+      effectiveScore: 1e13,
+      cubeMult: 1e5,
+      tessMult: 1e4,
+      hyperMult: 1e3,
+      platMult: 100,
+      heptMult: 1,
+      hepteractsUnlocked: 0,
+      singularityCount: 0
+    },
+    // Cross 1.666e17 + hepteracts unlocked
+    {
+      label: 'hepteract unlocks',
+      effectiveScore: 5e17,
+      cubeMult: 1e8,
+      tessMult: 1e7,
+      hyperMult: 1e6,
+      platMult: 1e4,
+      heptMult: 100,
+      hepteractsUnlocked: 1,
+      singularityCount: 0
+    },
+    // Hepteract threshold met but flag locked
+    {
+      label: 'hept threshold but flag locked',
+      effectiveScore: 5e17,
+      cubeMult: 1,
+      tessMult: 1,
+      hyperMult: 1,
+      platMult: 1,
+      heptMult: 100,
+      hepteractsUnlocked: 0,
+      singularityCount: 0
+    },
+    // singularityCount floor for tesseracts
+    {
+      label: 'sing count > tess gain',
+      effectiveScore: 1e6,
+      cubeMult: 1,
+      tessMult: 5,
+      hyperMult: 1,
+      platMult: 1,
+      heptMult: 1,
+      hepteractsUnlocked: 0,
+      singularityCount: 50
+    },
+    // 1e300 ceiling clamps — use 1e308 (the largest finite double-ish exponent)
+    // to push the floored values past 1e300 without overflowing to Infinity.
+    {
+      label: '1e300 clamps',
+      effectiveScore: 1e30,
+      cubeMult: 1e308,
+      tessMult: 1e308,
+      hyperMult: 1e308,
+      platMult: 1e308,
+      heptMult: 1e308,
+      hepteractsUnlocked: 1,
+      singularityCount: 0
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.label, () => {
+      const scores = {
+        baseScore: c.effectiveScore / 2,
+        corruptionMultiplier: 1,
+        bonusMultiplier: 1,
+        effectiveScore: c.effectiveScore
+      }
+      const newRes = newCalcCorruption({
+        scores,
+        cubeMultiplier: c.cubeMult,
+        tesseractMultiplier: c.tessMult,
+        hypercubeMultiplier: c.hyperMult,
+        platonicMultiplier: c.platMult,
+        hepteractMultiplier: c.heptMult,
+        hepteractsUnlocked: c.hepteractsUnlocked,
+        singularityCount: c.singularityCount
+      })
+
+      // OLD transcription
+      const cubeGain = c.cubeMult
+      let tesseractGain = 1
+      if (c.effectiveScore >= 100000) tesseractGain += 0.5
+      tesseractGain *= c.tessMult
+      let hypercubeGain = c.effectiveScore >= 1e9 ? 1 : 0
+      hypercubeGain *= c.hyperMult
+      let platonicGain = c.effectiveScore >= 2.666e12 ? 1 : 0
+      platonicGain *= c.platMult
+      let hepteractGain = c.hepteractsUnlocked && c.effectiveScore >= 1.666e17 ? 1 : 0
+      hepteractGain *= c.heptMult
+      const oldRes = {
+        wowCubes: Math.min(1e300, Math.floor(cubeGain)),
+        wowTesseracts: Math.min(1e300, Math.max(c.singularityCount, Math.floor(tesseractGain))),
+        wowHypercubes: Math.min(1e300, Math.floor(hypercubeGain)),
+        wowPlatonicCubes: Math.min(1e300, Math.floor(platonicGain)),
+        wowHepteracts: Math.min(1e300, Math.floor(hepteractGain)),
+        baseScore: Math.floor(scores.baseScore),
+        bonusMultiplier: scores.bonusMultiplier,
+        corruptionMultiplier: scores.corruptionMultiplier,
+        effectiveScore: Math.floor(c.effectiveScore)
+      }
+
+      expect(newRes.wowCubes).toBe(oldRes.wowCubes)
+      expect(newRes.wowTesseracts).toBe(oldRes.wowTesseracts)
+      expect(newRes.wowHypercubes).toBe(oldRes.wowHypercubes)
+      expect(newRes.wowPlatonicCubes).toBe(oldRes.wowPlatonicCubes)
+      expect(newRes.wowHepteracts).toBe(oldRes.wowHepteracts)
+      expect(newRes.baseScore).toBe(oldRes.baseScore)
+      expect(newRes.bonusMultiplier).toBe(oldRes.bonusMultiplier)
+      expect(newRes.corruptionMultiplier).toBe(oldRes.corruptionMultiplier)
+      expect(newRes.effectiveScore).toBe(oldRes.effectiveScore)
+    })
+  }
+})

--- a/packages/logic/test/parity/challenges.parity.test.ts
+++ b/packages/logic/test/parity/challenges.parity.test.ts
@@ -1,16 +1,26 @@
-// Parity test for CalcECC.
-//
-// Pre-migration source: packages/web_ui/src/Challenges.ts at HEAD. The OLD
-// function is verbatim — it takes only (type, completions) and has no
-// external dependencies, so the parity transcription is identical to the
-// new implementation modulo file location.
+// Parity tests for the pure-math helpers migrated from
+// packages/web_ui/src/Challenges.ts. The OLD implementations are transcribed
+// verbatim below, with the previously-implicit dependencies (G state, shop
+// upgrades, player flags) lifted into explicit parameters.
 
 import { describe, expect, it } from 'vitest'
-import { CalcECC as newCalcECC } from '../../src/mechanics/challenges'
+import { Decimal } from '../../src/math/bignum'
+import {
+  autoAscensionChallengeSweepUnlock as newAutoAscChallengeSweepUnlock,
+  CalcECC as newCalcECC,
+  calculateChallengeRequirementMultiplier as newCalcReqMult,
+  challenge15ScoreMultiplier as newChal15ScoreMult,
+  challengeRequirement as newChallengeRequirement,
+  challengeScoreDisplay as newScoreDisplay,
+  type ChallengeType,
+  getMaxChallenges as newGetMax,
+  getNextAscensionChallenge as newNextAscChallenge,
+  getNextRegularChallenge as newNextRegularChallenge
+} from '../../src/mechanics/challenges'
 
-type Type = 'transcend' | 'reincarnation' | 'ascension'
+// ─── CalcECC ───────────────────────────────────────────────────────────────
 
-const oldCalcECC = (type: Type, completions: number): number => {
+const oldCalcECC = (type: ChallengeType, completions: number): number => {
   let effective = 0
   if (type === 'transcend') {
     effective += Math.min(100, completions)
@@ -31,7 +41,7 @@ const oldCalcECC = (type: Type, completions: number): number => {
 }
 
 describe('parity: CalcECC', () => {
-  const types: Type[] = ['transcend', 'reincarnation', 'ascension']
+  const types: ChallengeType[] = ['transcend', 'reincarnation', 'ascension']
   // Sample across each piecewise segment for every type, including
   // boundary values (10/25/75/100/1000) and well past the last knee.
   const completionsGrid = [0, 1, 5, 9, 10, 11, 24, 25, 26, 50, 74, 75, 76, 99, 100, 101, 500, 999, 1000, 1001, 5000, 100000]
@@ -43,4 +53,501 @@ describe('parity: CalcECC', () => {
       })
     })
   }
+})
+
+// ─── OLD calculateChallengeRequirementMultiplier ──────────────────────────
+
+const oldCalcReqMult = (
+  type: ChallengeType,
+  completions: number,
+  special: number,
+  hyperchallengeMultiplier: number,
+  platonicUpgrade8: number,
+  chal15TranscendReduction: number,
+  chal15ReincarnationReduction: number,
+  c9c10ScalingReduction: number,
+  c9c10ScalingReduction2: number
+): number => {
+  let requirementMultiplier = Math.max(
+    1,
+    hyperchallengeMultiplier / (1 + platonicUpgrade8 / 2.5)
+  )
+  if (type === 'ascension') {
+    requirementMultiplier = 1
+  }
+  switch (type) {
+    case 'transcend':
+      requirementMultiplier *= chal15TranscendReduction
+      if (completions >= 75) {
+        requirementMultiplier *= Math.pow(1 + completions, 12) / Math.pow(75, 8)
+      } else {
+        requirementMultiplier *= Math.pow(1 + completions, 2)
+      }
+      if (completions >= 1000) {
+        requirementMultiplier *= 10 * Math.pow(completions / 1000, 3)
+      }
+      if (completions >= 9000) {
+        requirementMultiplier *= 1337
+      }
+      if (completions >= 9001) {
+        requirementMultiplier *= completions - 8999
+      }
+      return requirementMultiplier
+    case 'reincarnation':
+      if (completions >= 100 && (special === 9 || special === 10)) {
+        requirementMultiplier *= Math.pow(1.05, (completions - 100) * (1 + (completions - 100) / 20))
+      }
+      if (completions >= 90) {
+        if (special === 6) requirementMultiplier *= 100
+        else if (special === 7) requirementMultiplier *= 50
+        else if (special === 8) requirementMultiplier *= 10
+        else requirementMultiplier *= 4
+      }
+      if (completions >= 80) {
+        if (special === 6) requirementMultiplier *= 50
+        else if (special === 7) requirementMultiplier *= 20
+        else if (special === 8) requirementMultiplier *= 4
+        else requirementMultiplier *= 2
+      }
+      if (completions >= 70) {
+        if (special === 6) requirementMultiplier *= 20
+        else if (special === 7) requirementMultiplier *= 10
+        else if (special === 8) requirementMultiplier *= 2
+        else requirementMultiplier *= 1
+      }
+      if (completions >= 60 && (special === 9 || special === 10)) {
+        requirementMultiplier *= Math.pow(
+          1000,
+          (completions - 60)
+            * (1 + c9c10ScalingReduction + c9c10ScalingReduction2)
+            / 10
+        )
+      }
+      if (completions >= 25) {
+        requirementMultiplier *= Math.pow(1 + completions, 5) / 625
+      }
+      if (completions < 25) {
+        requirementMultiplier *= Math.min(Math.pow(1 + completions, 2), Math.pow(1.3797, completions))
+      }
+      requirementMultiplier *= chal15ReincarnationReduction
+      return requirementMultiplier
+    case 'ascension':
+      if (special !== 15) {
+        if (completions >= 10) {
+          requirementMultiplier *= 2 * (1 + completions) - 10
+        } else {
+          requirementMultiplier *= 1 + completions
+        }
+      } else {
+        requirementMultiplier *= Math.pow(1000, completions)
+      }
+      return requirementMultiplier
+    default:
+      throw new Error('unreachable')
+  }
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!isFinite(a) || !isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+const decimalClose = (a: Decimal | number, b: Decimal | number, rel = 1e-12): boolean => {
+  const aD = a instanceof Decimal ? a : new Decimal(a)
+  const bD = b instanceof Decimal ? b : new Decimal(b)
+  if (aD.eq(bD)) return true
+  if (!aD.isFinite() || !bD.isFinite()) return aD.eq(bD)
+  const diff = aD.sub(bD).abs()
+  const denom = Decimal.max(aD.abs(), bD.abs())
+  return diff.div(denom).lt(rel)
+}
+
+// ─── calculateChallengeRequirementMultiplier ──────────────────────────────
+
+describe('parity: calculateChallengeRequirementMultiplier — transcend', () => {
+  // Hits the 75/1000/9000/9001 thresholds plus the < 75 branch.
+  const completionsGrid = [0, 1, 25, 50, 74, 75, 100, 500, 999, 1000, 1001, 5000, 8999, 9000, 9001, 9100]
+  const hyperGrid = [1, 1.5, 5, 100]
+  const plat8Grid = [0, 1, 5]
+  const reductionGrid = [0.5, 1]
+
+  for (const completions of completionsGrid) {
+    for (const hyper of hyperGrid) {
+      for (const plat8 of plat8Grid) {
+        for (const reduction of reductionGrid) {
+          it(`c=${completions} h=${hyper} p8=${plat8} red=${reduction}`, () => {
+            const oldVal = oldCalcReqMult(
+              'transcend',
+              completions,
+              0,
+              hyper,
+              plat8,
+              reduction,
+              1,
+              0,
+              0
+            )
+            const newVal = newCalcReqMult({
+              type: 'transcend',
+              completions,
+              special: 0,
+              hyperchallengeMultiplier: hyper,
+              platonicUpgrade8: plat8,
+              challenge15TranscendReduction: reduction,
+              challenge15ReincarnationReduction: 1,
+              challengeTomeC9C10ScalingReduction: 0,
+              challengeTome2C9C10ScalingReduction: 0
+            })
+            expect(closeEnough(newVal, oldVal)).toBe(true)
+          })
+        }
+      }
+    }
+  }
+})
+
+describe('parity: calculateChallengeRequirementMultiplier — reincarnation', () => {
+  // Each special triggers a different multiplier path in the >=70/80/90/100 bands.
+  const completionsGrid = [0, 10, 24, 25, 50, 60, 70, 80, 90, 100, 150]
+  const specialGrid = [0, 6, 7, 8, 9, 10]
+  const c9c10Grid = [0, -0.1, -0.5]
+
+  for (const completions of completionsGrid) {
+    for (const special of specialGrid) {
+      for (const c9c10 of c9c10Grid) {
+        it(`c=${completions} s=${special} c9c10=${c9c10}`, () => {
+          const oldVal = oldCalcReqMult(
+            'reincarnation',
+            completions,
+            special,
+            1,
+            0,
+            1,
+            1,
+            c9c10,
+            0
+          )
+          const newVal = newCalcReqMult({
+            type: 'reincarnation',
+            completions,
+            special,
+            hyperchallengeMultiplier: 1,
+            platonicUpgrade8: 0,
+            challenge15TranscendReduction: 1,
+            challenge15ReincarnationReduction: 1,
+            challengeTomeC9C10ScalingReduction: c9c10,
+            challengeTome2C9C10ScalingReduction: 0
+          })
+          expect(closeEnough(newVal, oldVal)).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+describe('parity: calculateChallengeRequirementMultiplier — ascension', () => {
+  // Two branches: special=15 (Math.pow(1000, completions)) vs others (linear/quadratic).
+  // hyperchallenge is normalized to 1 internally so we don't sweep it.
+  const completionsGrid = [0, 1, 9, 10, 11, 50, 100]
+  const specialGrid = [0, 11, 12, 13, 14, 15]
+
+  for (const completions of completionsGrid) {
+    for (const special of specialGrid) {
+      it(`c=${completions} s=${special}`, () => {
+        const oldVal = oldCalcReqMult('ascension', completions, special, 1, 0, 1, 1, 0, 0)
+        const newVal = newCalcReqMult({
+          type: 'ascension',
+          completions,
+          special,
+          hyperchallengeMultiplier: 1,
+          platonicUpgrade8: 0,
+          challenge15TranscendReduction: 1,
+          challenge15ReincarnationReduction: 1,
+          challengeTomeC9C10ScalingReduction: 0,
+          challengeTome2C9C10ScalingReduction: 0
+        })
+        expect(closeEnough(newVal, oldVal)).toBe(true)
+      })
+    }
+  }
+})
+
+// ─── challengeRequirement (Decimal output for T/R/15, number for 11..14) ─
+
+describe('parity: challengeRequirement', () => {
+  const baseRequirements = [10, 20, 60, 100, 200, 125, 500, 7500, 2.0e8, 2.5e9]
+  const cases: Array<{ challenge: number; completion: number; special?: number; c10red?: number }> = [
+    { challenge: 1, completion: 0 },
+    { challenge: 1, completion: 100 },
+    { challenge: 5, completion: 750 },
+    { challenge: 6, completion: 25, special: 6 },
+    { challenge: 9, completion: 70, special: 9 },
+    { challenge: 10, completion: 50, special: 10, c10red: 5 },
+    { challenge: 11, completion: 0 },
+    { challenge: 12, completion: 15 },
+    { challenge: 15, completion: 1 },
+    { challenge: 16, completion: 0 } // out-of-range → 0
+  ]
+
+  for (const c of cases) {
+    it(`challenge ${c.challenge} completion ${c.completion}`, () => {
+      const special = c.special ?? 0
+      const c10red = c.c10red ?? 0
+      const newVal = newChallengeRequirement({
+        challenge: c.challenge,
+        completion: c.completion,
+        special,
+        challengeBaseRequirement: baseRequirements[c.challenge - 1] ?? 0,
+        c10RequirementReduction: c10red,
+        hyperchallengeMultiplier: 1,
+        platonicUpgrade8: 0,
+        challenge15TranscendReduction: 1,
+        challenge15ReincarnationReduction: 1,
+        challengeTomeC9C10ScalingReduction: 0,
+        challengeTome2C9C10ScalingReduction: 0
+      })
+
+      const mult = oldCalcReqMult(
+        c.challenge <= 5 ? 'transcend' : c.challenge <= 10 ? 'reincarnation' : 'ascension',
+        c.completion,
+        special,
+        1,
+        0,
+        1,
+        1,
+        0,
+        0
+      )
+      let oldVal: Decimal | number
+      if (c.challenge >= 1 && c.challenge <= 5) {
+        oldVal = Decimal.pow(10, (baseRequirements[c.challenge - 1] ?? 0) * mult)
+      } else if (c.challenge >= 6 && c.challenge <= 10) {
+        oldVal = Decimal.pow(10, ((baseRequirements[c.challenge - 1] ?? 0) - c10red) * mult)
+      } else if (c.challenge >= 11 && c.challenge <= 14) {
+        oldVal = mult
+      } else if (c.challenge === 15) {
+        oldVal = Decimal.pow(10, 1 * Math.pow(10, 30) * mult)
+      } else {
+        oldVal = 0
+      }
+
+      if (typeof newVal === 'number' && typeof oldVal === 'number') {
+        expect(closeEnough(newVal, oldVal)).toBe(true)
+      } else {
+        expect(decimalClose(newVal as Decimal | number, oldVal as Decimal | number)).toBe(true)
+      }
+    })
+  }
+})
+
+// ─── challenge15ScoreMultiplier ────────────────────────────────────────────
+
+describe('parity: challenge15ScoreMultiplier', () => {
+  const cases = [
+    { c15: 1, hept: 0, p15: 0 },
+    { c15: 2, hept: 1e4, p15: 1 },
+    { c15: 0.5, hept: 5e3, p15: 3 },
+    { c15: 1.5, hept: 1e6, p15: 4 }
+  ]
+  for (const { c15, hept, p15 } of cases) {
+    it(`c15=${c15} hept=${hept} p15=${p15}`, () => {
+      const oldVal = c15 * (1 + 5 / 10000 * hept) * (1 + 0.25 * p15)
+      const newVal = newChal15ScoreMult({
+        c15Bonus: c15,
+        challengeHepteractEffective: hept,
+        platonicUpgrade15: p15
+      })
+      expect(closeEnough(newVal, oldVal)).toBe(true)
+    })
+  }
+})
+
+// ─── getMaxChallenges ──────────────────────────────────────────────────────
+
+describe('parity: getMaxChallenges', () => {
+  it('oneChallengeCap clamps every tier (and c15 still 0)', () => {
+    const base = {
+      oneChallengeCapEnabled: true,
+      infiniteTranscendResearch: 0,
+      transcendResearchForChallenge: 0,
+      cubeUpgrade29: 0,
+      challengeExtensionCap: 0,
+      gqReincarnationCapIncrease: 0,
+      singReincarnationCapIncrease: 0,
+      gqAscensionCapIncrease: 0,
+      singAscensionCapIncrease: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicUpgrade15: 0
+    }
+    expect(newGetMax({ challenge: 1, ...base })).toBe(1)
+    expect(newGetMax({ challenge: 6, ...base })).toBe(1)
+    expect(newGetMax({ challenge: 14, ...base })).toBe(1)
+    expect(newGetMax({ challenge: 15, ...base })).toBe(0)
+  })
+
+  it('transcend tier: research 105 short-circuits to 9001', () => {
+    const out = newGetMax({
+      challenge: 3,
+      oneChallengeCapEnabled: false,
+      infiniteTranscendResearch: 1,
+      transcendResearchForChallenge: 10,
+      cubeUpgrade29: 0,
+      challengeExtensionCap: 0,
+      gqReincarnationCapIncrease: 0,
+      singReincarnationCapIncrease: 0,
+      gqAscensionCapIncrease: 0,
+      singAscensionCapIncrease: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicUpgrade15: 0
+    })
+    expect(out).toBe(9001)
+  })
+
+  it('reincarnation tier sums every contributor (40 + 4*cu29 + ext + plats + gq + sing)', () => {
+    const out = newGetMax({
+      challenge: 7,
+      oneChallengeCapEnabled: false,
+      infiniteTranscendResearch: 0,
+      transcendResearchForChallenge: 0,
+      cubeUpgrade29: 2,
+      challengeExtensionCap: 3,
+      gqReincarnationCapIncrease: 7,
+      singReincarnationCapIncrease: 11,
+      gqAscensionCapIncrease: 0,
+      singAscensionCapIncrease: 0,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      platonicUpgrade15: 1
+    })
+    // 40 + 4*2 + 3 + 10 + 10 + 30 + 7 + 11 = 119
+    expect(out).toBe(119)
+  })
+
+  it('ascension tier (11..14) sums to 30 + 5 + 5 + 20 + asc contributions', () => {
+    const out = newGetMax({
+      challenge: 12,
+      oneChallengeCapEnabled: false,
+      infiniteTranscendResearch: 0,
+      transcendResearchForChallenge: 0,
+      cubeUpgrade29: 0,
+      challengeExtensionCap: 0,
+      gqReincarnationCapIncrease: 0,
+      singReincarnationCapIncrease: 0,
+      gqAscensionCapIncrease: 2,
+      singAscensionCapIncrease: 3,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      platonicUpgrade15: 1
+    })
+    // 30 + 5 + 5 + 20 + 2 + 3 = 65
+    expect(out).toBe(65)
+  })
+})
+
+// ─── challengeScoreDisplay (banding for the UI) ───────────────────────────
+
+describe('parity: challengeScoreDisplay bands', () => {
+  // Transcend: 0..74 → array1, 75..749 → array2, 750..8999 → array3, 9000+ → array4
+  it('transcend c=1', () => {
+    expect(newScoreDisplay(1, 0)).toBe(8)
+    expect(newScoreDisplay(1, 75)).toBe(10)
+    expect(newScoreDisplay(1, 750)).toBe(20)
+    expect(newScoreDisplay(1, 9000)).toBe(10000)
+  })
+  // Reincarnation: 0..24 → array1, 25..59 → array2, 60+ → array3
+  it('reincarnation c=7', () => {
+    expect(newScoreDisplay(7, 0)).toBe(80)
+    expect(newScoreDisplay(7, 25)).toBe(120)
+    expect(newScoreDisplay(7, 60)).toBe(300)
+  })
+  it('out of range → 0', () => {
+    expect(newScoreDisplay(0, 100)).toBe(0)
+    expect(newScoreDisplay(11, 100)).toBe(0)
+    expect(newScoreDisplay(15, 100)).toBe(0)
+  })
+})
+
+// ─── auto-ascension sweep unlock ───────────────────────────────────────────
+
+describe('parity: autoAscensionChallengeSweepUnlock', () => {
+  it('requires both singularity >= 101 AND instantChallenge2 unlocked', () => {
+    expect(newAutoAscChallengeSweepUnlock(100, true)).toBe(false)
+    expect(newAutoAscChallengeSweepUnlock(101, false)).toBe(false)
+    expect(newAutoAscChallengeSweepUnlock(101, true)).toBe(true)
+    expect(newAutoAscChallengeSweepUnlock(500, true)).toBe(true)
+  })
+})
+
+// ─── traversal helpers ────────────────────────────────────────────────────
+
+describe('parity: getNextRegularChallenge', () => {
+  it('finds first eligible, wraps around', () => {
+    const maxChallenges = [0, 25, 25, 25, 25, 25, 40, 40, 40, 40, 40]
+    const highestCompletions = [0, 25, 25, 25, 25, 25, 40, 40, 0, 40, 40] // only c8 eligible
+    const autoChallengeToggles = [false, true, true, true, true, true, true, true, true, true, true]
+    expect(newNextRegularChallenge({
+      startIndex: 1,
+      explored: new Set(),
+      maxChallenges,
+      highestCompletions,
+      autoChallengeToggles
+    })).toBe(8)
+  })
+
+  it('returns -1 if all explored or maxed', () => {
+    const maxChallenges = [0, 25, 25, 25, 25, 25, 40, 40, 40, 40, 40]
+    const highestCompletions = [0, 25, 25, 25, 25, 25, 40, 40, 40, 40, 40]
+    const autoChallengeToggles = [false, true, true, true, true, true, true, true, true, true, true]
+    expect(newNextRegularChallenge({
+      startIndex: 1,
+      explored: new Set(),
+      maxChallenges,
+      highestCompletions,
+      autoChallengeToggles
+    })).toBe(-1)
+  })
+
+  it('skips toggled-off challenges', () => {
+    const maxChallenges = [0, 25, 25, 25, 25, 25, 40, 40, 40, 40, 40]
+    const highestCompletions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    const autoChallengeToggles = [false, false, true, false, false, false, false, false, false, false, false]
+    expect(newNextRegularChallenge({
+      startIndex: 1,
+      explored: new Set(),
+      maxChallenges,
+      highestCompletions,
+      autoChallengeToggles
+    })).toBe(2)
+  })
+})
+
+describe('parity: getNextAscensionChallenge', () => {
+  it('wraps 15 → 11', () => {
+    const maxChallenges = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 30, 30, 30, 0]
+    const highestCompletions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0]
+    const autoChallengeToggles = [false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true]
+    // Start at 12: ++ goes to 13, 13 is below max → return 13
+    expect(newNextAscChallenge({
+      startIndex: 12,
+      maxChallenges,
+      highestCompletions,
+      autoChallengeToggles
+    })).toBe(13)
+  })
+
+  it('c15 is always eligible if toggled on', () => {
+    const maxChallenges = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 30, 30, 30, 0]
+    const highestCompletions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 30, 30, 30, 0]
+    const autoChallengeToggles = [false, false, false, false, false, false, false, false, false, false, false, true, true, true, true, true]
+    expect(newNextAscChallenge({
+      startIndex: 14,
+      maxChallenges,
+      highestCompletions,
+      autoChallengeToggles
+    })).toBe(15)
+  })
 })

--- a/packages/logic/test/parity/corruptions.parity.test.ts
+++ b/packages/logic/test/parity/corruptions.parity.test.ts
@@ -1,0 +1,220 @@
+// Parity tests for the corruption pure-math migrated from
+// packages/web_ui/src/Corruptions.ts. The OLD implementations are
+// transcribed below; the original functions read player/G/octeract state
+// directly, the migration takes those as named-field inputs.
+
+import { describe, expect, it } from 'vitest'
+import {
+  droughtEffect as newDrought,
+  hyperchallengeEffect as newHyperchallenge,
+  illiteracyEffect as newIlliteracy,
+  type MaxCorruptionLevelInput,
+  maxCorruptionLevel as newMaxLevel,
+  viscosityEffect as newViscosity
+} from '../../src/mechanics/corruptions'
+
+// ─── maxCorruptionLevel ────────────────────────────────────────────────────
+
+const oldMaxLevel = (i: MaxCorruptionLevelInput): number => {
+  let max = 0
+  if (i.challenge11Completions > 0) max += 5
+  if (i.challenge12Completions > 0) max += 2
+  if (i.challenge13Completions > 0) max += 2
+  if (i.challenge14Completions > 0) max += 2
+  if (i.platonicUpgrade5 > 0) max += 1
+  if (i.platonicUpgrade10 > 0) max += 1
+  if (i.platonicTauUnlocked) max = Math.max(13, max)
+  if (i.corruptionFourteenUnlocked) max += 1
+  max += i.octeractCorruptionCapIncrease
+  return max
+}
+
+describe('parity: maxCorruptionLevel', () => {
+  // Sweep the bit-flag-ish challenge/platonic/unlock combinations.
+  // Each input is independent: testing all 2^7 × octeract-grid would be huge,
+  // so pick representative configurations exercising every branch.
+  const cases: MaxCorruptionLevelInput[] = [
+    // All zero
+    {
+      challenge11Completions: 0,
+      challenge12Completions: 0,
+      challenge13Completions: 0,
+      challenge14Completions: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicTauUnlocked: false,
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 0
+    },
+    // Just challenge 11
+    {
+      challenge11Completions: 1,
+      challenge12Completions: 0,
+      challenge13Completions: 0,
+      challenge14Completions: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicTauUnlocked: false,
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 0
+    },
+    // All challenges (sum: 5+2+2+2 = 11)
+    {
+      challenge11Completions: 100,
+      challenge12Completions: 50,
+      challenge13Completions: 25,
+      challenge14Completions: 10,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicTauUnlocked: false,
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 0
+    },
+    // All challenges + both platonics (sum: 11+2 = 13)
+    {
+      challenge11Completions: 1,
+      challenge12Completions: 1,
+      challenge13Completions: 1,
+      challenge14Completions: 1,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      platonicTauUnlocked: false,
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 0
+    },
+    // platonicTau floors at 13 when sum is less
+    {
+      challenge11Completions: 0,
+      challenge12Completions: 0,
+      challenge13Completions: 0,
+      challenge14Completions: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicTauUnlocked: true,
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 0
+    },
+    // platonicTau preserves higher accumulated sum
+    {
+      challenge11Completions: 1,
+      challenge12Completions: 1,
+      challenge13Completions: 1,
+      challenge14Completions: 1,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      platonicTauUnlocked: true, // sum 13 already, no floor change
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 0
+    },
+    // corruptionFourteen + octeract on top
+    {
+      challenge11Completions: 1,
+      challenge12Completions: 1,
+      challenge13Completions: 1,
+      challenge14Completions: 1,
+      platonicUpgrade5: 1,
+      platonicUpgrade10: 1,
+      platonicTauUnlocked: true,
+      corruptionFourteenUnlocked: true,
+      octeractCorruptionCapIncrease: 3
+    },
+    // octeract-only contribution
+    {
+      challenge11Completions: 0,
+      challenge12Completions: 0,
+      challenge13Completions: 0,
+      challenge14Completions: 0,
+      platonicUpgrade5: 0,
+      platonicUpgrade10: 0,
+      platonicTauUnlocked: false,
+      corruptionFourteenUnlocked: false,
+      octeractCorruptionCapIncrease: 5
+    }
+  ]
+
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx}`, () => {
+      expect(newMaxLevel(c)).toBe(oldMaxLevel(c))
+    })
+  }
+})
+
+// ─── viscosityEffect ───────────────────────────────────────────────────────
+
+describe('parity: viscosityEffect', () => {
+  const cases = [
+    { basePower: 1, platonicUpgrade6: 0 }, // 1 * 1 = 1 → clamped
+    { basePower: 0.9, platonicUpgrade6: 0 }, // 0.9
+    { basePower: 0.5, platonicUpgrade6: 10 }, // 0.5 * (1 + 10/30) ≈ 0.667
+    { basePower: 0.8, platonicUpgrade6: 30 }, // 0.8 * 2 = 1.6 → clamped to 1
+    { basePower: 0.01, platonicUpgrade6: 0 } // tiny base
+  ]
+  for (const c of cases) {
+    it(`base=${c.basePower} p6=${c.platonicUpgrade6}`, () => {
+      const oldVal = Math.min(c.basePower * (1 + c.platonicUpgrade6 / 30), 1)
+      expect(newViscosity(c)).toBe(oldVal)
+    })
+  }
+})
+
+// ─── droughtEffect ─────────────────────────────────────────────────────────
+
+describe('parity: droughtEffect', () => {
+  const cases = [
+    { baseSalvage: 1, platonicUpgrade13: 0 },
+    { baseSalvage: 0.5, platonicUpgrade13: 0 },
+    { baseSalvage: 0.5, platonicUpgrade13: 1 }, // halved → 0.25
+    { baseSalvage: 0.1, platonicUpgrade13: 5 } // halved → 0.05
+  ]
+  for (const c of cases) {
+    it(`base=${c.baseSalvage} p13=${c.platonicUpgrade13}`, () => {
+      const oldVal = c.platonicUpgrade13 > 0 ? c.baseSalvage * 0.5 : c.baseSalvage
+      expect(newDrought(c)).toBe(oldVal)
+    })
+  }
+})
+
+// ─── illiteracyEffect ──────────────────────────────────────────────────────
+
+describe('parity: illiteracyEffect', () => {
+  const cases = [
+    // No obtainium → multiplier stays 1
+    { basePower: 0.9, platonicUpgrade9: 5, obtainiumLog10OrNull: null },
+    // Below cap on log10
+    { basePower: 0.8, platonicUpgrade9: 10, obtainiumLog10OrNull: 50 },
+    // At cap (100)
+    { basePower: 0.5, platonicUpgrade9: 100, obtainiumLog10OrNull: 100 },
+    // Above cap (gets clamped to 100)
+    { basePower: 0.5, platonicUpgrade9: 100, obtainiumLog10OrNull: 500 },
+    // Clamps to 1 from above
+    { basePower: 0.99, platonicUpgrade9: 100, obtainiumLog10OrNull: 100 }
+  ]
+  for (const c of cases) {
+    it(`base=${c.basePower} p9=${c.platonicUpgrade9} log10=${c.obtainiumLog10OrNull}`, () => {
+      const multiplier = c.obtainiumLog10OrNull === null
+        ? 1
+        : 1 + (1 / 100) * c.platonicUpgrade9 * Math.min(100, c.obtainiumLog10OrNull)
+      const oldVal = Math.min(c.basePower * multiplier, 1)
+      expect(newIlliteracy(c)).toBe(oldVal)
+    })
+  }
+})
+
+// ─── hyperchallengeEffect ──────────────────────────────────────────────────
+
+describe('parity: hyperchallengeEffect', () => {
+  const cases = [
+    { baseEffect: 1, platonicUpgrade8: 0 }, // 1 / 1 = 1
+    { baseEffect: 5, platonicUpgrade8: 0 }, // 5
+    { baseEffect: 5, platonicUpgrade8: 5 }, // 5 / (1 + 2) = 1.667
+    { baseEffect: 0.5, platonicUpgrade8: 10 }, // 0.5 / 5 = 0.1 → floored to 1
+    { baseEffect: 100, platonicUpgrade8: 1 } // 100 / 1.4 ≈ 71.4
+  ]
+  for (const c of cases) {
+    it(`base=${c.baseEffect} p8=${c.platonicUpgrade8}`, () => {
+      const divisor = 1 + 2 / 5 * c.platonicUpgrade8
+      const oldVal = Math.max(1, c.baseEffect / divisor)
+      expect(newHyperchallenge(c)).toBe(oldVal)
+    })
+  }
+})

--- a/packages/logic/test/parity/cubeUpgrades.parity.test.ts
+++ b/packages/logic/test/parity/cubeUpgrades.parity.test.ts
@@ -1,0 +1,197 @@
+// Parity tests for getCubeMax + getCubeCost migrated from
+// packages/web_ui/src/Cubes.ts. The OLD implementations are transcribed
+// below with player/G reads lifted into explicit parameters.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateCubicSumData,
+  calculateSummationNonLinear
+} from '../../src/math/summations'
+import {
+  getCubeCost as newGetCubeCost,
+  getCubeMax as newGetCubeMax,
+  getCubeUpgradeBaseCost as newBaseCost
+} from '../../src/mechanics/cubeUpgrades'
+
+// dprint-ignore
+const oldCubeBaseCost = [
+  200, 200, 200, 500, 500, 500, 500, 500, 2000, 40000,
+  5000, 1000, 10000, 20000, 40000, 10000, 4000, 1e4, 50000, 12500,
+  5e4, 3e4, 3e4, 4e4, 2e5, 4e5, 1e5, 177777, 1e5, 1e6,
+  5e5, 3e5, 2e6, 4e7, 4e7, 1e8, 1e8, 1e9, 2e9, 2e8,
+  2e8, 5e8, 1e9, 2e9, 2e9, 5e8, 9876543210, 1e10, 42934819467, 1e8,
+  1, 1e4, 1e8, 1e12, 1e16, 10, 1e5, 1e9, 1e13, 1e17,
+  1e2, 1e6, 1e10, 1e14, 1e18, 1e20, 1e30, 1e40, 1e50, 1e60,
+  1, 1, 1e8, 1e16, 1e30, 1e100, 1e100, 1e200, 1e250, 1e300
+]
+
+// dprint-ignore
+const oldCubeMaxLevel = [
+  3, 10, 5, 1, 1, 1, 1, 1, 1, 1,
+  3, 10, 1, 10, 10, 10, 5, 1, 1, 1,
+  5, 10, 1, 10, 10, 10, 1, 1, 5, 1,
+  5, 1, 1, 10, 10, 10, 10, 1, 1, 10,
+  5, 10, 10, 10, 10, 20, 1, 1, 1, 100000,
+  1, 900, 100, 900, 900, 20, 1, 1, 400, 10000,
+  100, 1, 1, 1, 1, 1, 1, 1000, 1, 100000,
+  1, 1, 5, 1, 30, 2, 25, 30, 1, 1
+]
+
+const oldGetCubeMax = (i: number, cubeUpgrade57: number): number => {
+  let baseValue = oldCubeMaxLevel[i - 1]
+  if (cubeUpgrade57 > 0 && i < 50 && i % 10 === 1) {
+    baseValue += 1
+  }
+  return baseValue
+}
+
+const oldGetCubeCost = (
+  i: number,
+  buyMax: boolean,
+  currentLevel: number,
+  cubeUpgrade57: number,
+  wowCubes: number,
+  singularityDebuff: number
+) => {
+  const linGrowth = i === 50 ? 0.01 : 0
+  const cubic = i > 50
+  const maxLevel = oldGetCubeMax(i, cubeUpgrade57)
+  let amountToBuy = buyMax ? 1e5 : 1
+  amountToBuy = Math.min(maxLevel - currentLevel, amountToBuy)
+  // Original collapses singularityDebuff to 1 for i > 50; the wrapper does
+  // the same, so we can take the parameter as authoritative here.
+  if (cubic) {
+    amountToBuy = buyMax ? maxLevel : Math.min(maxLevel, currentLevel + 1)
+    return calculateCubicSumData(currentLevel, oldCubeBaseCost[i - 1], wowCubes, amountToBuy)
+  }
+  return calculateSummationNonLinear(
+    currentLevel,
+    oldCubeBaseCost[i - 1] * singularityDebuff,
+    wowCubes,
+    linGrowth,
+    amountToBuy
+  )
+}
+
+// ─── getCubeMax ────────────────────────────────────────────────────────────
+
+describe('parity: getCubeMax', () => {
+  it('matches base table when cubeUpgrade57 = 0', () => {
+    for (let i = 1; i <= 80; i++) {
+      expect(newGetCubeMax({ cubeUpgradeIndex: i, cubeUpgrade57: 0 })).toBe(oldGetCubeMax(i, 0))
+    }
+  })
+
+  it('cubeUpgrade57 > 0: +1 only on row leaders (i % 10 === 1, i < 50)', () => {
+    for (let i = 1; i <= 80; i++) {
+      const newVal = newGetCubeMax({ cubeUpgradeIndex: i, cubeUpgrade57: 1 })
+      const oldVal = oldGetCubeMax(i, 1)
+      expect(newVal).toBe(oldVal)
+    }
+  })
+
+  it('row leader 1 bumps from 3 → 4 with cu57', () => {
+    expect(newGetCubeMax({ cubeUpgradeIndex: 1, cubeUpgrade57: 1 })).toBe(4)
+  })
+
+  it('i=51 (above 50) does NOT bump even with cu57', () => {
+    expect(newGetCubeMax({ cubeUpgradeIndex: 51, cubeUpgrade57: 1 })).toBe(1)
+  })
+
+  it('i=2 (not row leader) does NOT bump with cu57', () => {
+    expect(newGetCubeMax({ cubeUpgradeIndex: 2, cubeUpgrade57: 1 })).toBe(10)
+  })
+})
+
+// ─── getCubeUpgradeBaseCost ────────────────────────────────────────────────
+
+describe('parity: getCubeUpgradeBaseCost', () => {
+  it('returns the base cost table verbatim', () => {
+    for (let i = 1; i <= 80; i++) {
+      expect(newBaseCost(i)).toBe(oldCubeBaseCost[i - 1])
+    }
+  })
+})
+
+// ─── getCubeCost ───────────────────────────────────────────────────────────
+
+describe('parity: getCubeCost — non-cubic (i ≤ 50)', () => {
+  // Sample one upgrade from each of the row-1..5 tiers, plus i=50 (linear-growth).
+  const indices = [1, 12, 23, 35, 50]
+  const buyMaxValues = [false, true]
+  const currentLevels = [0, 1, 2]
+  const wowCubesValues = [0, 1e3, 1e10, 1e30]
+  const debuffValues = [1, 1.5, 0.5]
+
+  for (const i of indices) {
+    for (const buyMax of buyMaxValues) {
+      for (const currentLevel of currentLevels) {
+        for (const wow of wowCubesValues) {
+          for (const debuff of debuffValues) {
+            it(`i=${i} buyMax=${buyMax} cur=${currentLevel} wow=${wow} debuff=${debuff}`, () => {
+              const maxLevel = oldGetCubeMax(i, 0)
+              if (currentLevel >= maxLevel) return
+              const newRes = newGetCubeCost({
+                cubeUpgradeIndex: i,
+                buyMax,
+                currentLevel,
+                maxLevel,
+                wowCubes: wow,
+                singularityDebuff: debuff
+              })
+              const oldRes = oldGetCubeCost(i, buyMax, currentLevel, 0, wow, debuff)
+              expect(newRes).toEqual(oldRes)
+            })
+          }
+        }
+      }
+    }
+  }
+})
+
+describe('parity: getCubeCost — cubic (i > 50)', () => {
+  // Sample across cubic tiers including the 1e300 base cost extreme.
+  const indices = [51, 60, 70, 80]
+  const buyMaxValues = [false, true]
+  const currentLevels = [0, 1]
+  const wowCubesValues = [0, 1e10, 1e50, 1e200]
+
+  for (const i of indices) {
+    for (const buyMax of buyMaxValues) {
+      for (const currentLevel of currentLevels) {
+        for (const wow of wowCubesValues) {
+          it(`i=${i} buyMax=${buyMax} cur=${currentLevel} wow=${wow}`, () => {
+            const maxLevel = oldGetCubeMax(i, 0)
+            if (currentLevel >= maxLevel) return
+            const newRes = newGetCubeCost({
+              cubeUpgradeIndex: i,
+              buyMax,
+              currentLevel,
+              maxLevel,
+              wowCubes: wow,
+              singularityDebuff: 1 // ignored for cubic
+            })
+            const oldRes = oldGetCubeCost(i, buyMax, currentLevel, 0, wow, 1)
+            expect(newRes).toEqual(oldRes)
+          })
+        }
+      }
+    }
+  }
+})
+
+describe('parity: getCubeCost — cu57 row-leader bumps max', () => {
+  it('row leader 1 with cu57 can buy past the original max', () => {
+    const maxLevelWithCu57 = oldGetCubeMax(1, 1) // 4
+    const newRes = newGetCubeCost({
+      cubeUpgradeIndex: 1,
+      buyMax: true,
+      currentLevel: 3, // would have hit cap at 3 without cu57
+      maxLevel: maxLevelWithCu57,
+      wowCubes: 1e10,
+      singularityDebuff: 1
+    })
+    const oldRes = oldGetCubeCost(1, true, 3, 1, 1e10, 1)
+    expect(newRes).toEqual(oldRes)
+  })
+})

--- a/packages/logic/test/parity/quarks.parity.test.ts
+++ b/packages/logic/test/parity/quarks.parity.test.ts
@@ -1,0 +1,134 @@
+// Parity test for quarkHandler migrated from packages/web_ui/src/Quark.ts.
+// The OLD function is transcribed below with the implicit player/octeract
+// reads lifted into explicit parameters.
+
+import { describe, expect, it } from 'vitest'
+import {
+  type QuarkHandlerInput,
+  quarkHandler as newQuarkHandler
+} from '../../src/mechanics/quarks'
+
+const oldQuarkHandler = (input: QuarkHandlerInput) => {
+  let maxTime = 90000
+  if (input.research195 > 0) {
+    maxTime += 18000 * input.research195
+  }
+  let baseQuarkPerHour = 5
+  // The old loop summed researches[99/100/125/180/195]; the migration takes
+  // that sum precomputed.
+  baseQuarkPerHour += input.researchesSum
+  baseQuarkPerHour *= input.exportQuarkMult
+  const quarkPerHour = baseQuarkPerHour
+  const capacity = Math.floor(quarkPerHour * maxTime / 3600)
+  const quarkGain = Math.floor(input.quarksTimer * quarkPerHour / 3600)
+  return {
+    maxTime,
+    perHour: quarkPerHour,
+    capacity,
+    gain: quarkGain,
+    cubeMult: input.cubeMult
+  }
+}
+
+describe('parity: quarkHandler', () => {
+  const cases: QuarkHandlerInput[] = [
+    // Defaults: no researches, no octeract, no timer
+    {
+      research195: 0,
+      researchesSum: 0,
+      exportQuarkMult: 1,
+      quarksTimer: 0,
+      cubeMult: 1
+    },
+    // research195 extends maxTime
+    {
+      research195: 5,
+      researchesSum: 0,
+      exportQuarkMult: 1,
+      quarksTimer: 0,
+      cubeMult: 1
+    },
+    // researchesSum bumps base rate; quarksTimer mid-window
+    {
+      research195: 0,
+      researchesSum: 10,
+      exportQuarkMult: 1,
+      quarksTimer: 45000,
+      cubeMult: 1
+    },
+    // Octeract multiplier active
+    {
+      research195: 0,
+      researchesSum: 0,
+      exportQuarkMult: 2.5,
+      quarksTimer: 90000,
+      cubeMult: 1
+    },
+    // All bumps + timer at full capacity
+    {
+      research195: 10,
+      researchesSum: 50,
+      exportQuarkMult: 3,
+      quarksTimer: 90000 + 18000 * 10,
+      cubeMult: 1.5
+    },
+    // Timer way past capacity — gain keeps scaling (clamping is web_ui's job)
+    {
+      research195: 0,
+      researchesSum: 0,
+      exportQuarkMult: 1,
+      quarksTimer: 1e6,
+      cubeMult: 7
+    },
+    // Floor truncation: rates that produce non-integer perHour
+    {
+      research195: 0,
+      researchesSum: 0,
+      exportQuarkMult: 1.337,
+      quarksTimer: 3600,
+      cubeMult: 1
+    }
+  ]
+
+  for (const [i, input] of cases.entries()) {
+    it(`case ${i}`, () => {
+      const newRes = newQuarkHandler(input)
+      const oldRes = oldQuarkHandler(input)
+      expect(newRes).toEqual(oldRes)
+    })
+  }
+
+  it('research195 = 0 leaves maxTime at the 90000 baseline', () => {
+    expect(newQuarkHandler({
+      research195: 0,
+      researchesSum: 0,
+      exportQuarkMult: 1,
+      quarksTimer: 0,
+      cubeMult: 1
+    }).maxTime).toBe(90000)
+  })
+
+  it('cubeMult passes through unchanged', () => {
+    const res = newQuarkHandler({
+      research195: 0,
+      researchesSum: 0,
+      exportQuarkMult: 1,
+      quarksTimer: 0,
+      cubeMult: 42.5
+    })
+    expect(res.cubeMult).toBe(42.5)
+  })
+
+  it('capacity == perHour * maxTime / 3600 (floored)', () => {
+    const res = newQuarkHandler({
+      research195: 2, // maxTime = 90000 + 36000 = 126000
+      researchesSum: 5, // perHour = (5+5) * 2 = 20
+      exportQuarkMult: 2,
+      quarksTimer: 0,
+      cubeMult: 1
+    })
+    expect(res.maxTime).toBe(126000)
+    expect(res.perHour).toBe(20)
+    expect(res.capacity).toBe(Math.floor(20 * 126000 / 3600))
+  })
+})

--- a/packages/web_ui/src/Calculate.ts
+++ b/packages/web_ui/src/Calculate.ts
@@ -1,8 +1,10 @@
 import {
+  CalcCorruptionStuff as logicCalcCorruptionStuff,
   calculateAcceleratorMultiplier as logicCalcAcceleratorMultiplier,
   calculateActualAntSpeedMult as logicCalcActualAntSpeedMult,
   calculateAllCubeMultiplier as logicCalcAllCubeMultiplier,
   calculateAmbrosiaAdditiveLuckMult as logicCalcAmbrosiaAdditiveLuckMult,
+  calculateAscensionScore as logicCalcAscensionScore,
   calculateAmbrosiaCubeMult as logicCalcAmbrosiaCubeMult,
   calculateAmbrosiaGenerationOcteractUpgrade as logicCalcAmbrosiaGenerationOcteractUpgrade,
   calculateAmbrosiaGenerationSingularityUpgrade as logicCalcAmbrosiaGenerationSingularityUpgrade,
@@ -90,6 +92,7 @@ import {
   calculateTotalOcteractQuarkBonus as logicCalcTotalOcteractQuarkBonus,
   calculateToNextThreshold as logicCalcToNextThreshold,
   calculateTotalSalvage as logicCalcTotalSalvage,
+  computeAscensionScoreBonusMultiplier as logicComputeAscScoreBonusMult,
   derpsmithCornucopiaBonus as logicDerpsmithCornucopiaBonus,
   inheritanceTokens as logicInheritanceTokens,
   singularityBonusTokenMult as logicSingularityBonusTokenMult,
@@ -165,34 +168,6 @@ import { Globals as G } from './Variables'
 
 const posSalvagePerkSings = [230, 245, 260, 275, 290]
 const negSalvagePerkSings = [75, 85, 105, 125, 155, 185, 215, 245, 260, 275]
-
-const challengeScoreArrays2 = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450]
-const challengeScoreArrays3 = [
-  0,
-  20,
-  30,
-  50,
-  100,
-  200,
-  250,
-  300,
-  400,
-  500,
-  750
-]
-const challengeScoreArrays4 = [
-  0,
-  10000,
-  10000,
-  10000,
-  10000,
-  10000,
-  2000,
-  3000,
-  4000,
-  5000,
-  7500
-]
 
 export const calculateAllCubeMultiplier = () => logicCalcAllCubeMultiplier(allCubeStats.map(s => s.stat()))
 export const calculateCubeMultiplier = () => logicCalcCubeMultiplier(allWowCubeStats.map(s => s.stat()))
@@ -847,170 +822,44 @@ export const calculateCubicSumData = (
     own function (specifically: calc of effective score and other global multipliers) to make it easy.
 */
 
-const computeAscensionScoreBonusMultiplier = () => {
-  let multiplier = 1
-  multiplier *= G.challenge15Rewards.score.value
-  multiplier *= calculateAscensionScorePlatonicBlessing()
-  multiplier *= player.campaigns.ascensionScoreMultiplier
-  multiplier *= getRuneEffects('finiteDescent', 'ascensionScore')
-  if (player.cubeUpgrades[21] > 0) {
-    multiplier *= 1 + 0.05 * player.cubeUpgrades[21]
-  }
-  if (player.cubeUpgrades[31] > 0) {
-    multiplier *= 1 + 0.05 * player.cubeUpgrades[31]
-  }
-  if (player.cubeUpgrades[41] > 0) {
-    multiplier *= 1 + 0.05 * player.cubeUpgrades[41]
-  }
-  multiplier *= +getAchievementReward('ascensionScore')
-  multiplier *= getGQUpgradeEffect('masterPack', 'ascensionScoreMult')
-  if (G.isEvent) {
-    multiplier *= 1 + calculateEventBuff(BuffType.AscensionScore)
-  }
+const computeAscensionScoreBonusMultiplier = () =>
+  logicComputeAscScoreBonusMult({
+    challenge15ScoreReward: G.challenge15Rewards.score.value,
+    platonicBlessingMult: calculateAscensionScorePlatonicBlessing(),
+    campaignAscensionScoreMult: player.campaigns.ascensionScoreMultiplier,
+    finiteDescentAscensionScore: getRuneEffects('finiteDescent', 'ascensionScore'),
+    cubeUpgrade21: player.cubeUpgrades[21],
+    cubeUpgrade31: player.cubeUpgrades[31],
+    cubeUpgrade41: player.cubeUpgrades[41],
+    ascensionScoreAchievementReward: +getAchievementReward('ascensionScore'),
+    masterPackAscensionScoreMult: getGQUpgradeEffect('masterPack', 'ascensionScoreMult'),
+    eventBuff: G.isEvent ? calculateEventBuff(BuffType.AscensionScore) : 0
+  })
 
-  return multiplier
-}
+export const calculateAscensionScore = () =>
+  logicCalcAscensionScore({
+    highestChallengeCompletions: player.highestchallengecompletions,
+    cubeUpgrade56: player.cubeUpgrades[56],
+    cubeUpgrade39: player.cubeUpgrades[39],
+    platonicUpgrade5: player.platonicUpgrades[5],
+    platonicUpgrade10: player.platonicUpgrades[10],
+    corruptionMultiplier: player.corruptions.used.totalCorruptionAscensionMultiplier,
+    antUpgradeAscensionScoreBase: getAntUpgradeEffect(AntUpgrades.AscensionScore).ascensionScoreBase,
+    expertPackAscensionScoreMult: getGQUpgradeEffect('expertPack', 'ascensionScoreMult'),
+    bonusMultiplier: computeAscensionScoreBonusMultiplier()
+  })
 
-export const calculateAscensionScore = () => {
-  let baseScore = 0
-  const corruptionMultiplier = player.corruptions.used.totalCorruptionAscensionMultiplier
-  let effectiveScore = 0
-
-  // let bonusLevel = getGQUpgradeEffect('corruptionFifteen')
-  // bonusLevel += +player.singularityChallenges.oneChallengeCap.rewards.freeCorruptionLevel
-
-  // Init Arrays with challenge values :)
-  const challengeScoreArrays1 = [0, 8, 10, 12, 15, 20, 60, 80, 120, 180, 300]
-
-  challengeScoreArrays1[1] += player.cubeUpgrades[56]
-  challengeScoreArrays1[2] += player.cubeUpgrades[56]
-  challengeScoreArrays1[3] += player.cubeUpgrades[56]
-
-  // Iterate challenges 1 through 10 and award base score according to the array values
-  // Transcend Challenge: First Threshold at 75 completions, second at 750
-  // Reincarnation Challenge: First at 25, second at 60. It probably should be higher but Platonic is a dumb dumb
-  for (let i = 1; i <= 10; i++) {
-    baseScore += challengeScoreArrays1[i] * player.highestchallengecompletions[i]
-    if (i <= 5 && player.highestchallengecompletions[i] >= 75) {
-      baseScore += challengeScoreArrays2[i] * (player.highestchallengecompletions[i] - 75)
-      if (player.highestchallengecompletions[i] >= 750) {
-        baseScore += challengeScoreArrays3[i]
-          * (player.highestchallengecompletions[i] - 750)
-      }
-      if (player.highestchallengecompletions[i] >= 9000) {
-        baseScore += challengeScoreArrays4[i]
-          * (player.highestchallengecompletions[i] - 9000)
-      }
-    }
-    if (i <= 10 && i > 5 && player.highestchallengecompletions[i] >= 25) {
-      baseScore += challengeScoreArrays2[i] * (player.highestchallengecompletions[i] - 25)
-      if (player.highestchallengecompletions[i] >= 60) {
-        baseScore += challengeScoreArrays3[i]
-          * (player.highestchallengecompletions[i] - 60)
-      }
-    }
-  }
-
-  baseScore += getAntUpgradeEffect(AntUpgrades.AscensionScore).ascensionScoreBase
-
-  // Calculation of Challenge 10 Exponent (It gives a constant multiplier per completion)
-  // 1.03 +
-  // 0.005 from Cube 3x9 +
-  // 0.0025 from Platonic ALPHA (Plat 1x5)
-  // 0.005 from Platonic BETA (Plat 2x5)
-  // Max: 1.0425
-  baseScore *= Math.pow(
-    1.03
-      + 0.005 * player.cubeUpgrades[39]
-      + 0.0025 * (player.platonicUpgrades[5] + player.platonicUpgrades[10]),
-    player.highestchallengecompletions[10]
-  )
-  // Corruption Multiplier is the product of all Corruption Score multipliers based on used corruptions
-  // let bonusVal = getGQUpgradeEffect('advancedPack')
-  //   ? 0.33
-  //   : 0
-  // bonusVal += +player.singularityChallenges.oneChallengeCap.rewards.corrScoreIncrease
-  // bonusVal += 0.3 * player.cubeUpgrades[74]
-
-  const bonusMultiplier = computeAscensionScoreBonusMultiplier()
-
-  effectiveScore = baseScore * corruptionMultiplier * bonusMultiplier
-  if (effectiveScore > 1e23) {
-    effectiveScore = Math.pow(effectiveScore, 0.5) * Math.pow(1e23, 0.5)
-  }
-
-  effectiveScore *= getGQUpgradeEffect('expertPack', 'ascensionScoreMult')
-
-  return {
-    baseScore,
-    corruptionMultiplier,
-    bonusMultiplier,
-    effectiveScore
-  }
-}
-
-export const CalcCorruptionStuff = () => {
-  const scores = calculateAscensionScore()
-
-  const baseScore = scores.baseScore
-  const corruptionMultiplier = scores.corruptionMultiplier
-  const bonusMultiplier = scores.bonusMultiplier
-  const effectiveScore = scores.effectiveScore
-
-  // Calculation of Cubes :)
-  const cubeGain = calculateCubeMultiplierWithTau()
-
-  // Calculation of Tesseracts :))
-  let tesseractGain = 1
-  if (effectiveScore >= 100000) {
-    tesseractGain += 0.5
-  }
-  tesseractGain *= calculateTesseractMultiplier()
-
-  // Calculation of Hypercubes :)))
-  let hypercubeGain = effectiveScore >= 1e9 ? 1 : 0
-  hypercubeGain *= calculateHypercubeMultiplier()
-
-  // Calculation of Platonic Cubes :))))
-  let platonicGain = effectiveScore >= 2.666e12 ? 1 : 0
-  platonicGain *= calculatePlatonicMultiplier()
-
-  // Calculation of Hepteracts :)))))
-  let hepteractGain = G.challenge15Rewards.hepteractsUnlocked.value
-      && effectiveScore >= 1.666e17
-    ? 1
-    : 0
-  hepteractGain *= calculateHepteractMultiplier()
-
-  return {
-    wowCubes: Math.min(1e300, Math.floor(cubeGain)),
-    wowTesseracts: Math.min(1e300, Math.max(player.singularityCount, Math.floor(tesseractGain))),
-    wowHypercubes: Math.min(1e300, Math.floor(hypercubeGain)),
-    wowPlatonicCubes: Math.min(1e300, Math.floor(platonicGain)),
-    wowHepteracts: Math.min(1e300, Math.floor(hepteractGain)),
-    baseScore: Math.floor(baseScore),
-    bonusMultiplier: bonusMultiplier,
-    corruptionMultiplier: corruptionMultiplier,
-    effectiveScore: Math.floor(effectiveScore)
-  }
-  /*return [
-    // WTF IS THIS...
-    // Also, I don't think the first element of this array is used anywhere. So stupid
-    cubeGain,
-    Math.floor(baseScore),
-    corruptionMultiplier,
-    Math.floor(effectiveScore),
-    Math.min(1e300, Math.floor(cubeGain)),
-    Math.min(
-      1e300,
-      Math.max(player.singularityCount, Math.floor(tesseractGain))
-    ),
-    Math.min(1e300, Math.floor(hypercubeGain)),
-    Math.min(1e300, Math.floor(platonicGain)),
-    Math.min(1e300, Math.floor(hepteractGain)),
-    bonusMultiplier
-  ]*/
-}
+export const CalcCorruptionStuff = () =>
+  logicCalcCorruptionStuff({
+    scores: calculateAscensionScore(),
+    cubeMultiplier: calculateCubeMultiplierWithTau(),
+    tesseractMultiplier: calculateTesseractMultiplier(),
+    hypercubeMultiplier: calculateHypercubeMultiplier(),
+    platonicMultiplier: calculatePlatonicMultiplier(),
+    hepteractMultiplier: calculateHepteractMultiplier(),
+    hepteractsUnlocked: G.challenge15Rewards.hepteractsUnlocked.value,
+    singularityCount: player.singularityCount
+  })
 
 export const calculateAscensionCount = () =>
   logicCalcAscensionCount({

--- a/packages/web_ui/src/Challenges.ts
+++ b/packages/web_ui/src/Challenges.ts
@@ -1,4 +1,13 @@
-import { CalcECC as logicCalcECC } from '@synergism/logic'
+import {
+  autoAscensionChallengeSweepUnlock as logicAutoAscChallengeSweepUnlock,
+  CalcECC as logicCalcECC,
+  challenge15ScoreMultiplier as logicChallenge15ScoreMultiplier,
+  challengeRequirement as logicChallengeRequirement,
+  challengeScoreDisplay as logicChallengeScoreDisplay,
+  getMaxChallenges as logicGetMaxChallenges,
+  getNextAscensionChallenge as logicGetNextAscChallenge,
+  getNextRegularChallenge as logicGetNextRegularChallenge
+} from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
@@ -58,93 +67,27 @@ export type Challenge15RewardsInformation = {
 
 export type Challenge15RewardObject = Record<Challenge15Rewards, Challenge15RewardsInformation>
 
-const challengeScoreArray1 = [0, 8, 10, 12, 15, 20, 60, 80, 120, 180, 300]
-const challengeScoreArray2 = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450]
-const challengeScoreArray3 = [0, 20, 30, 50, 100, 200, 250, 300, 400, 500, 750]
-const challengeScoreArray4 = [0, 10000, 10000, 10000, 10000, 10000, 2000, 3000, 4000, 5000, 7500]
-
-export const getMaxChallenges = (i: number) => {
-  let maxChallenge = 0
-  // Transcension Challenges
-  if (i <= 5) {
-    if (player.singularityChallenges.oneChallengeCap.enabled) {
-      return 1
-    }
-    // Start with base 25 max completions
-    maxChallenge = 25
-    // Check Research 5x5 ('Infinite' T. Challenges)
-    if (player.researches[105] > 0) {
-      return 9001
-    }
-    // Max T. Challenge depends on researches 3x16 to 3x20
-    maxChallenge += 5 * player.researches[65 + i]
-    return maxChallenge
-  }
-  // Reincarnation Challenges
-  if (i <= 10 && i > 5) {
-    if (player.singularityChallenges.oneChallengeCap.enabled) {
-      return 1
-    }
-    // Start with base of 40 max completions
-    maxChallenge = 40
-    // Cube Upgrade 2x9: +4/level
-    maxChallenge += 4 * player.cubeUpgrades[29]
-    // Shop Upgrade "Challenge Extension": +2/level
-    maxChallenge += getShopUpgradeEffects('challengeExtension', 'reincarnationChallengeCap')
-    // Platonic Upgrade 5 (ALPHA): +10
-    if (player.platonicUpgrades[5] > 0) {
-      maxChallenge += 10
-    }
-    // Platonic Upgrade 10 (BETA): +10
-    if (player.platonicUpgrades[10] > 0) {
-      maxChallenge += 10
-    }
-    // Platonic Upgrade 15 (OMEGA): +30
-    if (player.platonicUpgrades[15] > 0) {
-      maxChallenge += 30
-    }
-
-    maxChallenge += getGQUpgradeEffect('singChallengeExtension', 'reincarnationCapIncrease')
-    maxChallenge += getGQUpgradeEffect('singChallengeExtension2', 'reincarnationCapIncrease')
-    maxChallenge += getGQUpgradeEffect('singChallengeExtension3', 'reincarnationCapIncrease')
-
-    maxChallenge += getSingularityChallengeEffect('oneChallengeCap', 'capIncrease')
-    maxChallenge += getSingularityChallengeEffect('oneChallengeCap', 'reinCapIncrease2')
-    return maxChallenge
-  }
-  // Ascension Challenge
-  if (i <= 15 && i > 10) {
-    // Challenge 15 does not have 'completions'
-    if (i === 15) {
-      return 0
-    }
-    if (player.singularityChallenges.oneChallengeCap.enabled) {
-      return 1
-    }
-    // Start with base of 30 max completions
-    maxChallenge = 30
-    // Platonic Upgrade 5 (ALPHA): +5
-    if (player.platonicUpgrades[5] > 0) {
-      maxChallenge += 5
-    }
-    // Platonic Upgrade 10 (BETA): +5
-    if (player.platonicUpgrades[10] > 0) {
-      maxChallenge += 5
-    }
-    // Platonic Upgrade 15 (OMEGA): +20
-    if (player.platonicUpgrades[15] > 0) {
-      maxChallenge += 20
-    }
-
-    maxChallenge += getGQUpgradeEffect('singChallengeExtension', 'ascensionCapIncrease')
-    maxChallenge += getGQUpgradeEffect('singChallengeExtension2', 'ascensionCapIncrease')
-    maxChallenge += getGQUpgradeEffect('singChallengeExtension3', 'ascensionCapIncrease')
-    maxChallenge += getSingularityChallengeEffect('oneChallengeCap', 'ascCapIncrease2')
-    return maxChallenge
-  }
-
-  return maxChallenge
-}
+export const getMaxChallenges = (i: number) =>
+  logicGetMaxChallenges({
+    challenge: i,
+    oneChallengeCapEnabled: player.singularityChallenges.oneChallengeCap.enabled,
+    infiniteTranscendResearch: player.researches[105],
+    transcendResearchForChallenge: player.researches[65 + i],
+    cubeUpgrade29: player.cubeUpgrades[29],
+    challengeExtensionCap: getShopUpgradeEffects('challengeExtension', 'reincarnationChallengeCap'),
+    gqReincarnationCapIncrease: getGQUpgradeEffect('singChallengeExtension', 'reincarnationCapIncrease')
+      + getGQUpgradeEffect('singChallengeExtension2', 'reincarnationCapIncrease')
+      + getGQUpgradeEffect('singChallengeExtension3', 'reincarnationCapIncrease'),
+    singReincarnationCapIncrease: getSingularityChallengeEffect('oneChallengeCap', 'capIncrease')
+      + getSingularityChallengeEffect('oneChallengeCap', 'reinCapIncrease2'),
+    gqAscensionCapIncrease: getGQUpgradeEffect('singChallengeExtension', 'ascensionCapIncrease')
+      + getGQUpgradeEffect('singChallengeExtension2', 'ascensionCapIncrease')
+      + getGQUpgradeEffect('singChallengeExtension3', 'ascensionCapIncrease'),
+    singAscensionCapIncrease: getSingularityChallengeEffect('oneChallengeCap', 'ascCapIncrease2'),
+    platonicUpgrade5: player.platonicUpgrades[5],
+    platonicUpgrade10: player.platonicUpgrades[10],
+    platonicUpgrade15: player.platonicUpgrades[15]
+  })
 
 export const challengeDisplay = (i: number, changefocus = true) => {
   let quarksMultiplier = 1
@@ -322,27 +265,7 @@ export const challengeDisplay = (i: number, changefocus = true) => {
     d.textContent = i18next.t('challenges.15.noGoal')
   }
 
-  let scoreDisplay = 0
-  if (i <= 5) {
-    if (player.highestchallengecompletions[i] >= 9000) {
-      scoreDisplay = challengeScoreArray4[i]
-    } else if (player.highestchallengecompletions[i] >= 750) {
-      scoreDisplay = challengeScoreArray3[i]
-    } else if (player.highestchallengecompletions[i] >= 75) {
-      scoreDisplay = challengeScoreArray2[i]
-    } else {
-      scoreDisplay = challengeScoreArray1[i]
-    }
-  }
-  if (i > 5 && i <= 10) {
-    if (player.highestchallengecompletions[i] >= 60) {
-      scoreDisplay = challengeScoreArray3[i]
-    } else if (player.highestchallengecompletions[i] >= 25) {
-      scoreDisplay = challengeScoreArray2[i]
-    } else {
-      scoreDisplay = challengeScoreArray1[i]
-    }
-  }
+  const scoreDisplay = logicChallengeScoreDisplay(i, player.highestchallengecompletions[i])
   if (changefocus) {
     j.textContent = ''
   }
@@ -443,146 +366,30 @@ export const highestChallengeRewards = (chalNum: number, highestValue: number) =
   }
 }
 
-// Works to mitigate the difficulty of calculating challenge multipliers when considering softcapping
-const calculateChallengeRequirementMultiplier = (
-  type: 'transcend' | 'reincarnation' | 'ascension',
-  completions: number,
-  special = 0
-) => {
-  let requirementMultiplier = Math.max(
-    1,
-    G.hyperchallengeMultiplier[player.corruptions.used.hyperchallenge] / (1 + player.platonicUpgrades[8] / 2.5)
-  )
-  if (type === 'ascension') {
-    // Normalize back to 1 if looking at ascension challenges in particular.
-    requirementMultiplier = 1
-  }
-  switch (type) {
-    case 'transcend':
-      requirementMultiplier *= G.challenge15Rewards.transcendChallengeReduction.value
-      if (completions >= 75) {
-        requirementMultiplier *= Math.pow(1 + completions, 12) / Math.pow(75, 8)
-      } else {
-        requirementMultiplier *= Math.pow(1 + completions, 2)
-      }
-
-      if (completions >= 1000) {
-        requirementMultiplier *= 10 * Math.pow(completions / 1000, 3)
-      }
-      if (completions >= 9000) {
-        requirementMultiplier *= 1337
-      }
-      if (completions >= 9001) {
-        requirementMultiplier *= completions - 8999
-      }
-      return requirementMultiplier
-    case 'reincarnation':
-      if (completions >= 100 && (special === 9 || special === 10)) {
-        requirementMultiplier *= Math.pow(1.05, (completions - 100) * (1 + (completions - 100) / 20))
-      }
-      if (completions >= 90) {
-        if (special === 6) {
-          requirementMultiplier *= 100
-        } else if (special === 7) {
-          requirementMultiplier *= 50
-        } else if (special === 8) {
-          requirementMultiplier *= 10
-        } else {
-          requirementMultiplier *= 4
-        }
-      }
-      if (completions >= 80) {
-        if (special === 6) {
-          requirementMultiplier *= 50
-        } else if (special === 7) {
-          requirementMultiplier *= 20
-        } else if (special === 8) {
-          requirementMultiplier *= 4
-        } else {
-          requirementMultiplier *= 2
-        }
-      }
-      if (completions >= 70) {
-        if (special === 6) {
-          // Multiplier is reduced significantly for challenges requiring mythos shards
-          requirementMultiplier *= 20
-        } else if (special === 7) {
-          requirementMultiplier *= 10
-        } else if (special === 8) {
-          requirementMultiplier *= 2
-        } else {
-          requirementMultiplier *= 1
-        }
-      }
-      if (completions >= 60) {
-        if (special === 9 || special === 10) {
-          requirementMultiplier *= Math.pow(
-            1000,
-            (completions - 60)
-              * (1 + getShopUpgradeEffects('challengeTome', 'c9c10ScalingReduction')
-                + getShopUpgradeEffects('challengeTome2', 'c9c10ScalingReduction'))
-              / 10
-          )
-        }
-      }
-      if (completions >= 25) {
-        requirementMultiplier *= Math.pow(1 + completions, 5) / 625
-      }
-      if (completions < 25) {
-        requirementMultiplier *= Math.min(Math.pow(1 + completions, 2), Math.pow(1.3797, completions))
-      }
-      requirementMultiplier *= G.challenge15Rewards.reincarnationChallengeReduction.value
-      return requirementMultiplier
-    case 'ascension':
-      if (special !== 15) {
-        if (completions >= 10) {
-          requirementMultiplier *= 2 * (1 + completions) - 10
-        } else {
-          requirementMultiplier *= 1 + completions
-        }
-      } else {
-        requirementMultiplier *= Math.pow(1000, completions)
-      }
-      return requirementMultiplier
-    default: {
-      throw new Error(`Unhandled challenge type: ${type satisfies never}`)
-    }
-  }
-}
-
-/**
- * Works to mitigate the difficulty of calculating challenge reward multipliers when considering softcapping
- */
 // Re-export of @synergism/logic's pure CalcECC. ECC stands for "Effective
 // Challenge Completions" — three piecewise linear curves keyed by tier.
 export const CalcECC = logicCalcECC
 
 export const challengeRequirement = (challenge: number, completion: number, special = 0) => {
-  const base = G.challengeBaseRequirements[challenge - 1]
-  if (challenge <= 5) {
-    return Decimal.pow(10, base * calculateChallengeRequirementMultiplier('transcend', completion, special))
-  } else if (challenge <= 10) {
-    let c10Reduction = 0
-    if (challenge === 10) {
-      c10Reduction =
-        1e8 * (player.researches[140] + player.researches[155] + player.researches[170] + player.researches[185])
-        + getShopUpgradeEffects('challengeTome', 'c10RequirementReduction')
-        + getShopUpgradeEffects('challengeTome2', 'c10RequirementReduction')
-    }
-    return Decimal.pow(
-      10,
-      (base - c10Reduction) * calculateChallengeRequirementMultiplier('reincarnation', completion, special)
-    )
-  } else if (challenge <= 14) {
-    return calculateChallengeRequirementMultiplier('ascension', completion, special)
-  } else if (challenge === 15) {
-    return Decimal.pow(
-      10,
-      1 * Math.pow(10, 30) * calculateChallengeRequirementMultiplier('ascension', completion, special)
-    )
-  } else {
-    return 0
-  }
+  const c10Reduction = challenge === 10
+    ? 1e8 * (player.researches[140] + player.researches[155] + player.researches[170] + player.researches[185])
+      + getShopUpgradeEffects('challengeTome', 'c10RequirementReduction')
+      + getShopUpgradeEffects('challengeTome2', 'c10RequirementReduction')
+    : 0
+
+  return logicChallengeRequirement({
+    challenge,
+    completion,
+    special,
+    challengeBaseRequirement: G.challengeBaseRequirements[challenge - 1],
+    c10RequirementReduction: c10Reduction,
+    hyperchallengeMultiplier: G.hyperchallengeMultiplier[player.corruptions.used.hyperchallenge],
+    platonicUpgrade8: player.platonicUpgrades[8],
+    challenge15TranscendReduction: G.challenge15Rewards.transcendChallengeReduction.value,
+    challenge15ReincarnationReduction: G.challenge15Rewards.reincarnationChallengeReduction.value,
+    challengeTomeC9C10ScalingReduction: getShopUpgradeEffects('challengeTome', 'c9c10ScalingReduction'),
+    challengeTome2C9C10ScalingReduction: getShopUpgradeEffects('challengeTome2', 'c9c10ScalingReduction')
+  })
 }
 
 // Challenge State Machine
@@ -594,9 +401,6 @@ type SweepStates =
   | { kind: 'active'; index: number; explored: Set<number> }
   | { kind: 'c15_wait' } // Happens when you can autoGain c15 Exponent
   | { kind: 'finished' } // Challenges 1-10 are all completely maxed
-
-// 1-5 are transcension, 6-10 reincarnation
-const NUM_ELIGIBLE_CHALLENGES = 10
 
 let currentSweepState: SweepStates = { kind: 'idle' }
 
@@ -770,10 +574,11 @@ export function tickChallengeSweep (dt: number): void {
   }
 }
 
-export const autoAscensionChallengeSweepUnlock = () => {
-  return player.highestSingularityCount >= 101 // I believe this is a perk...
-    && getShopUpgradeEffects('instantChallenge2', 'unlocked')
-}
+export const autoAscensionChallengeSweepUnlock = () =>
+  logicAutoAscChallengeSweepUnlock(
+    player.highestSingularityCount,
+    getShopUpgradeEffects('instantChallenge2', 'unlocked')
+  )
 
 const challenge15AutoExponentCheck = () => {
   return autoAscensionChallengeSweepUnlock()
@@ -785,52 +590,34 @@ const challenge15AutoExponentCheck = () => {
     && player.ascensionCounterRealReal >= Math.max(0.1, player.autoAscendThreshold - 5)
 }
 
-export const challenge15ScoreMultiplier = () => {
-  return (
-    player.campaigns.c15Bonus // Campaign Bonus to c15
-    * (1 + 5 / 10000 * hepteractEffective('challenge')) // Challenge Hepteract
-    * (1 + 0.25 * player.platonicUpgrades[15]) // Omega Upgrade
-  )
-}
+export const challenge15ScoreMultiplier = () =>
+  logicChallenge15ScoreMultiplier({
+    c15Bonus: player.campaigns.c15Bonus,
+    challengeHepteractEffective: hepteractEffective('challenge'),
+    platonicUpgrade15: player.platonicUpgrades[15]
+  })
 
 // "Regular" just means not ascension challenge
 export const getNextRegularChallenge = (startIndex: number, explored: Set<number>) => {
-  let challenge = startIndex
-  for (let i = 0; i < NUM_ELIGIBLE_CHALLENGES; i++) {
-    if (
-      !explored.has(challenge)
-      && player.highestchallengecompletions[challenge] < getMaxChallenges(challenge)
-      && player.autoChallengeToggles[challenge]
-    ) {
-      return challenge
-    }
-    challenge++
-    if (challenge > NUM_ELIGIBLE_CHALLENGES) {
-      challenge = 1
-    }
-  }
-
-  // No challenge found!
-  return -1
+  const maxChallenges: number[] = []
+  for (let i = 1; i <= 10; i++) maxChallenges[i] = getMaxChallenges(i)
+  return logicGetNextRegularChallenge({
+    startIndex,
+    explored,
+    maxChallenges,
+    highestCompletions: player.highestchallengecompletions,
+    autoChallengeToggles: player.autoChallengeToggles
+  })
 }
 
 // Ascension Challenge 'next' Check. We don't have access to explored so we can't just use the same logic again. Sad!
 export const getNextAscensionChallenge = (startIndex: number) => {
-  let nextChallenge = startIndex
-
-  for (let i = 0; i < 5; i++) {
-    nextChallenge++
-    if (nextChallenge > 15) {
-      nextChallenge = 11
-    }
-    if (
-      player.autoChallengeToggles[nextChallenge]
-      && (player.highestchallengecompletions[nextChallenge] < getMaxChallenges(nextChallenge) || nextChallenge === 15)
-    ) {
-      return nextChallenge
-    }
-  }
-
-  // This returns the same as startIndex if no valid Challenges are found.
-  return nextChallenge
+  const maxChallenges: number[] = []
+  for (let i = 11; i <= 14; i++) maxChallenges[i] = getMaxChallenges(i)
+  return logicGetNextAscChallenge({
+    startIndex,
+    maxChallenges,
+    highestCompletions: player.highestchallengecompletions,
+    autoChallengeToggles: player.autoChallengeToggles
+  })
 }

--- a/packages/web_ui/src/Corruptions.ts
+++ b/packages/web_ui/src/Corruptions.ts
@@ -1,3 +1,10 @@
+import {
+  droughtEffect as logicDroughtEffect,
+  hyperchallengeEffect as logicHyperchallengeEffect,
+  illiteracyEffect as logicIlliteracyEffect,
+  maxCorruptionLevel as logicMaxCorruptionLevel,
+  viscosityEffect as logicViscosityEffect
+} from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
 import { z } from 'zod'
@@ -170,17 +177,17 @@ export class CorruptionLoadout {
   }
 
   #viscosityEffect () {
-    const base = G.viscosityPower[this.#levels.viscosity]
-    const multiplier = 1 + player.platonicUpgrades[6] / 30
-    return Math.min(base * multiplier, 1)
+    return logicViscosityEffect({
+      basePower: G.viscosityPower[this.#levels.viscosity],
+      platonicUpgrade6: player.platonicUpgrades[6]
+    })
   }
 
   #droughtEffect () {
-    let baseSalvageReduction = G.droughtSalvage[this.#levels.drought]
-    if (player.platonicUpgrades[13] > 0) {
-      baseSalvageReduction *= 0.5
-    }
-    return baseSalvageReduction
+    return logicDroughtEffect({
+      baseSalvage: G.droughtSalvage[this.#levels.drought],
+      platonicUpgrade13: player.platonicUpgrades[13]
+    })
   }
 
   #deflationEffect () {
@@ -192,11 +199,11 @@ export class CorruptionLoadout {
   }
 
   #illiteracyEffect () {
-    const base = G.illiteracyPower[this.#levels.illiteracy]
-    const multiplier = (player.obtainium.gte(1))
-      ? 1 + (1 / 100) * player.platonicUpgrades[9] * Math.min(100, Decimal.log10(player.obtainium))
-      : 1
-    return Math.min(base * multiplier, 1)
+    return logicIlliteracyEffect({
+      basePower: G.illiteracyPower[this.#levels.illiteracy],
+      platonicUpgrade9: player.platonicUpgrades[9],
+      obtainiumLog10OrNull: player.obtainium.gte(1) ? Decimal.log10(player.obtainium) : null
+    })
   }
 
   #recessionEffect () {
@@ -208,10 +215,10 @@ export class CorruptionLoadout {
   }
 
   #hyperchallengeEffect () {
-    const baseEffect = G.hyperchallengeMultiplier[this.#levels.hyperchallenge]
-    let divisor = 1
-    divisor *= 1 + 2 / 5 * player.platonicUpgrades[8]
-    return Math.max(1, baseEffect / divisor)
+    return logicHyperchallengeEffect({
+      baseEffect: G.hyperchallengeMultiplier[this.#levels.hyperchallenge],
+      platonicUpgrade8: player.platonicUpgrades[8]
+    })
   }
 
   corruptionEffects (corr: keyof Corruptions) {
@@ -402,40 +409,18 @@ export class CorruptionSaves {
   }
 }
 
-export const maxCorruptionLevel = () => {
-  let max = 0
-
-  if (player.challengecompletions[11] > 0) {
-    max += 5
-  }
-  if (player.challengecompletions[12] > 0) {
-    max += 2
-  }
-  if (player.challengecompletions[13] > 0) {
-    max += 2
-  }
-  if (player.challengecompletions[14] > 0) {
-    max += 2
-  }
-  if (player.platonicUpgrades[5] > 0) {
-    max += 1
-  }
-  if (player.platonicUpgrades[10] > 0) {
-    max += 1
-  }
-
-  // Overrides everything above.
-  if (getGQUpgradeEffect('platonicTau', 'unlocked')) {
-    max = Math.max(13, max)
-  }
-
-  if (getGQUpgradeEffect('corruptionFourteen', 'unlocked')) {
-    max += 1
-  }
-  max += getOcteractUpgradeEffect('octeractCorruption', 'corruptionLevelCapIncrease')
-
-  return max
-}
+export const maxCorruptionLevel = () =>
+  logicMaxCorruptionLevel({
+    challenge11Completions: player.challengecompletions[11],
+    challenge12Completions: player.challengecompletions[12],
+    challenge13Completions: player.challengecompletions[13],
+    challenge14Completions: player.challengecompletions[14],
+    platonicUpgrade5: player.platonicUpgrades[5],
+    platonicUpgrade10: player.platonicUpgrades[10],
+    platonicTauUnlocked: getGQUpgradeEffect('platonicTau', 'unlocked'),
+    corruptionFourteenUnlocked: getGQUpgradeEffect('corruptionFourteen', 'unlocked'),
+    octeractCorruptionCapIncrease: getOcteractUpgradeEffect('octeractCorruption', 'corruptionLevelCapIncrease')
+  })
 
 export const corrIcons: Record<keyof Corruptions, string> = {
   viscosity: '/CorruptViscosity.png',

--- a/packages/web_ui/src/Cubes.ts
+++ b/packages/web_ui/src/Cubes.ts
@@ -1,5 +1,4 @@
 import type Decimal from 'break_infinity.js'
-import i18next from 'i18next'
 import {
   calculateAcceleratorCubeBlessing as logicCalcAcceleratorCube,
   calculateAntELOCubeBlessing as logicCalcAntELOCube,
@@ -10,10 +9,14 @@ import {
   calculateObtainiumCubeBlessing as logicCalcObtainiumCube,
   calculateOfferingCubeBlessing as logicCalcOfferingCube,
   calculateRuneEffectivenessCubeBlessing as logicCalcRuneEffectivenessCube,
-  calculateSalvageCubeBlessing as logicCalcSalvageCube
+  calculateSalvageCubeBlessing as logicCalcSalvageCube,
+  getCubeCost as logicGetCubeCost,
+  type GetCubeCostResult,
+  getCubeMax as logicGetCubeMax,
+  getCubeUpgradeBaseCost
 } from '@synergism/logic'
+import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
-import { calculateCubicSumData, calculateSummationNonLinear } from './Calculate'
 import { researchData, updateResearchBG } from './Research'
 import { calculateSingularityDebuff, getGQUpgradeEffect } from './singularity'
 import { format, player } from './Synergism'
@@ -32,10 +35,7 @@ import {
 import { revealStuff } from './UpdateHTML'
 import { upgradeupdate } from './Upgrades'
 
-export interface IMultiBuy {
-  levelCanBuy: number
-  cost: number
-}
+export type IMultiBuy = GetCubeCostResult
 
 // dprint-ignore
 const cubeAutomationIndices = [
@@ -55,67 +55,21 @@ const researchAutomationIndices = [
   190                     // row 8
 ]
 
-// dprint-ignore
-const cubeBaseCost = [
-  200, 200, 200, 500, 500, 500, 500, 500, 2000, 40000,
-  5000, 1000, 10000, 20000, 40000, 10000, 4000, 1e4, 50000, 12500,
-  5e4, 3e4, 3e4, 4e4, 2e5, 4e5, 1e5, 177777, 1e5, 1e6,
-  5e5, 3e5, 2e6, 4e7, 4e7, 1e8, 1e8, 1e9, 2e9, 2e8,
-  2e8, 5e8, 1e9, 2e9, 2e9, 5e8, 9876543210, 1e10, 42934819467, 1e8,
-  1, 1e4, 1e8, 1e12, 1e16, 10, 1e5, 1e9, 1e13, 1e17,
-  1e2, 1e6, 1e10, 1e14, 1e18, 1e20, 1e30, 1e40, 1e50, 1e60,
-  1, 1, 1e8, 1e16, 1e30, 1e100, 1e100, 1e200, 1e250, 1e300, 
-]
+const getCubeMax = (i: number) =>
+  logicGetCubeMax({
+    cubeUpgradeIndex: i,
+    cubeUpgrade57: player.cubeUpgrades[57]
+  })
 
-// dprint-ignore
-const cubeMaxLevel = [
-  3, 10, 5, 1, 1, 1, 1, 1, 1, 1,
-  3, 10, 1, 10, 10, 10, 5, 1, 1, 1,
-  5, 10, 1, 10, 10, 10, 1, 1, 5, 1,
-  5, 1, 1, 10, 10, 10, 10, 1, 1, 10,
-  5, 10, 10, 10, 10, 20, 1, 1, 1, 100000,
-  1, 900, 100, 900, 900, 20, 1, 1, 400, 10000,
-  100, 1, 1, 1, 1, 1, 1, 1000, 1, 100000,
-  1, 1, 5, 1, 30, 2, 25, 30, 1, 1
-]
-
-const getCubeCost = (i: number, buyMax: boolean): IMultiBuy => {
-  const linGrowth = i === 50 ? 0.01 : 0
-  const cubic = i > 50
-  const maxLevel = getCubeMax(i)
-  let amountToBuy = buyMax ? 1e5 : 1
-  const cubeUpgrade = player.cubeUpgrades[i]!
-  amountToBuy = Math.min(maxLevel - cubeUpgrade, amountToBuy)
-  const singularityMultiplier = (i <= 50) ? calculateSingularityDebuff('Cube Upgrades') : 1
-
-  let metaData: IMultiBuy
-
-  if (cubic) {
-    // TODO: Fix this inconsistency later.
-    amountToBuy = buyMax ? maxLevel : Math.min(maxLevel, cubeUpgrade + 1)
-    metaData = calculateCubicSumData(cubeUpgrade, cubeBaseCost[i - 1], Number(player.wowCubes), amountToBuy)
-  } else {
-    metaData = calculateSummationNonLinear(
-      cubeUpgrade,
-      cubeBaseCost[i - 1] * singularityMultiplier,
-      Number(player.wowCubes),
-      linGrowth,
-      amountToBuy
-    )
-  }
-
-  return metaData
-}
-
-const getCubeMax = (i: number) => {
-  let baseValue = cubeMaxLevel[i - 1]
-
-  if (player.cubeUpgrades[57] > 0 && i < 50 && i % 10 === 1) {
-    baseValue += 1
-  }
-
-  return baseValue
-}
+const getCubeCost = (i: number, buyMax: boolean): IMultiBuy =>
+  logicGetCubeCost({
+    cubeUpgradeIndex: i,
+    buyMax,
+    currentLevel: player.cubeUpgrades[i]!,
+    maxLevel: getCubeMax(i),
+    wowCubes: Number(player.wowCubes),
+    singularityDebuff: i <= 50 ? calculateSingularityDebuff('Cube Upgrades') : 1
+  })
 
 export const cubeUpgradeDesc = (i: number, buyMax = player.cubeUpgradesBuyMaxToggle) => {
   const metaData = getCubeCost(i, buyMax)
@@ -154,7 +108,7 @@ export const updateCubeUpgradeBG = (i: number) => {
   const maxCubeLevel = getCubeMax(i)
   const cubeUpgrade = player.cubeUpgrades[i]!
   if (cubeUpgrade > maxCubeLevel) {
-    player.wowCubes.add((cubeUpgrade - maxCubeLevel) * cubeBaseCost[i - 1])
+    player.wowCubes.add((cubeUpgrade - maxCubeLevel) * getCubeUpgradeBaseCost(i))
     player.cubeUpgrades[i] = maxCubeLevel
   }
 

--- a/packages/web_ui/src/Quark.ts
+++ b/packages/web_ui/src/Quark.ts
@@ -1,3 +1,4 @@
+import { quarkHandler as logicQuarkHandler } from '@synergism/logic'
 import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import { calculateCubeQuarkMultiplier, calculateQuarkMultiplier } from './Calculate'
@@ -5,42 +6,18 @@ import { apiBaseUrl } from './Config'
 import { getOcteractUpgradeEffect } from './Octeracts'
 import { format, player } from './Synergism'
 
-const quarkResearches = [99, 100, 125, 180, 195]
-
-export const quarkHandler = () => {
-  let maxTime = 90000 // In Seconds
-  if (player.researches[195] > 0) {
-    maxTime += 18000 * player.researches[195] // Research 8x20
-  }
-
-  // Part 2: Calculate quark gain per hour
-  let baseQuarkPerHour = 5
-
-  for (const el of quarkResearches) {
-    baseQuarkPerHour += player.researches[el]
-  }
-
-  baseQuarkPerHour *= getOcteractUpgradeEffect('octeractExportQuarks', 'exportQuarkMult')
-
-  const quarkPerHour = baseQuarkPerHour
-
-  // Part 3: Calculates capacity of quarks on export
-  const capacity = Math.floor(quarkPerHour * maxTime / 3600)
-
-  // Part 4: Calculate how many quarks are to be gained.
-  const quarkGain = Math.floor(player.quarkstimer * quarkPerHour / 3600)
-
-  // Part 5 [June 9, 2021]: Calculate bonus awarded to cube quarks.
-  const cubeMult = calculateCubeQuarkMultiplier()
-  // Return maxTime, quarkPerHour, capacity and quarkGain as object
-  return {
-    maxTime,
-    perHour: quarkPerHour,
-    capacity,
-    gain: quarkGain,
-    cubeMult
-  }
-}
+export const quarkHandler = () =>
+  logicQuarkHandler({
+    research195: player.researches[195],
+    researchesSum: player.researches[99]
+      + player.researches[100]
+      + player.researches[125]
+      + player.researches[180]
+      + player.researches[195],
+    exportQuarkMult: getOcteractUpgradeEffect('octeractExportQuarks', 'exportQuarkMult'),
+    quarksTimer: player.quarkstimer,
+    cubeMult: calculateCubeQuarkMultiplier()
+  })
 
 let bonus = 0
 let personalQuarkBonus = 0


### PR DESCRIPTION
## Summary
Continues the migration of pure game math from \`packages/web_ui\` into \`packages/logic\`. Five logical clusters land in this branch:

1. **Challenges.ts pure math** — \`getMaxChallenges\`, \`challengeRequirement\` (+ its multiplier subroutine), \`challenge15ScoreMultiplier\`, \`getNextRegularChallenge\`/\`getNextAscensionChallenge\`, \`autoAscensionChallengeSweepUnlock\`, plus a new \`challengeScoreDisplay\` UI banding helper
2. **Ascension-score math from Calculate.ts** — \`computeAscensionScoreBonusMultiplier\`, \`calculateAscensionScore\`, \`CalcCorruptionStuff\` (cube/tess/hyper/platonic/hept gain thresholds with 1e300 clamps + the singularityCount tess floor)
3. **\`quarkHandler\` from Quark.ts** — the maxTime / perHour / capacity / gain quartet
4. **Cube-upgrade cost helpers** — \`getCubeMax\`, \`getCubeCost\`, \`getCubeUpgradeBaseCost\` + the 80-entry cost/level truth tables
5. **Corruption pure math** — \`maxCorruptionLevel\` + the 4 non-trivial corruption effect calculators (viscosity, drought, illiteracy, hyperchallenge)

## Test plan

- [x] \`npm run check:tsc\` clean (logic + web_ui + desktop_ui)
- [x] \`npx oxlint\` clean (only pre-existing warnings)
- [x] \`npx vitest run --root packages/logic\` — 14,864 tests pass (1,213 new parity tests added across 5 new test files)
- [x] \`npm test --workspaces --if-present\` — both workspaces green
- [x] Pre-commit hook passes (lint + csslint + htmllint + check:tsc + build:esbuild)

## Migration pattern
Each commit follows the established shape:
- Logic function takes precomputed inputs via a named-field interface — no \`player\` / \`G\` / \`document\` / \`i18next\` reads
- Web_ui side becomes a thin wrapper that gathers state and calls into logic
- Parity test transcribes the pre-migration implementation verbatim and sweeps the threshold/branch boundaries

## Commits
- 630a29e6 Challenges.ts pure math
- 3ea3d83e Ascension-score math
- cf4ed2b5 quarkHandler
- 3b95e0d5 Cube-upgrade cost helpers
- 0140df18 Corruption pure math

🤖 Generated with [Claude Code](https://claude.com/claude-code)