### PR TITLE
refactor: migrate 16 pure-math clusters into @synergism/logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260520.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260520.1.tgz",
-      "integrity": "sha512-7ilR8QUWpFO2RdulPuYkrwRYZxi7iuX8+11G9z97bdS7wCSFuetBsgsr2ISK7l/qzCiG5zshnfIwcdlYWD01Ag==",
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260521.1.tgz",
+      "integrity": "sha512-aiNdXmxlhwGjTSajL3I7uQPpN4lAOcXjvg5ZOlJKIywnevr798n9XCS6lvuqgniM3KjurBNWRRypMJntg/eSLg==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260520.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260520.1.tgz",
-      "integrity": "sha512-6LVIEI0Tx3hfcXiEM+eHsIQVsOz1IAAoAMMsRlrx+7YaNiuHMib7yWfyzAlZPhiAg1BgiS5oB8iDn7Ws1amG+Q==",
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260521.1.tgz",
+      "integrity": "sha512-ikN8aKSi4Ak28ndOkuSO5rq6lmV6wwDQu9F9Vu6J7EkwAOth74J/Hjn4j4EuFceW/npw2Ws0Y/muzA6WKHl4TA==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260520.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260520.1.tgz",
-      "integrity": "sha512-7oV9YK7o63aiHnpBeKlxOIA3nK4sKxuwhnklCwJFb0LirkSemSG1LQlVvtVInoWSYDCTCoUeGkiPsS8WsZqcEw==",
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260521.1.tgz",
+      "integrity": "sha512-D/gUhvQcG0pJr5aJl6yUoi2JxbFpjVtDq9xUJHPjfkAjL28TUVgCR/e5r8YGirepv4I1DK7ihuii9LZ2GGMJbw==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260520.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260520.1.tgz",
-      "integrity": "sha512-hzc/UKzw1/z+iTptBZVX7XYZTmJXsgn6RC9uKtQGUQxENxkoO1teba8qxVlKZT0AbPCQs5rg63Lsk0/eQhteqQ==",
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260521.1.tgz",
+      "integrity": "sha512-vhjWPIHenczegTakhRPwEmTeaavCpNqsuo3RlLCkUdU47HrwLvy/4QersGggs4+kF4Do+IE/EznCGyT40xYcLA==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260520.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260520.1.tgz",
-      "integrity": "sha512-BjMBhXqlEPaVc68tXihFI+YcU/5T4Jmj4ELDJaEa6NuCcbUMORESgO4OJZIDS4+rC2Lkv37telOktQxEOkqY3g==",
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260521.1.tgz",
+      "integrity": "sha512-wBolYC/+lnGIEbkkPdzFtjTOWip2uQH6maeAP1ZV0kyxi5SGpsa83+wD5rH5OOle+sHE5qJMdwCKjwRwj+FKJg==",
       "cpu": [
         "x64"
       ],
@@ -496,6 +496,31 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -3806,9 +3831,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4114,29 +4139,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/fs-extra": {
@@ -5371,28 +5373,26 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.54.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.6"
       }
     },
     "node_modules/min-indent": {
@@ -5406,16 +5406,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260520.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260520.0.tgz",
-      "integrity": "sha512-krgebvYME9k7CjxiveTzx89kAMeIstfK3KfTqtzLb/4mtLMD74KHtU009h/I0CTDSVIYtXm0JzJ40OtiVRGmOA==",
+      "version": "4.20260521.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260521.0.tgz",
+      "integrity": "sha512-roRfxPq49OkuSeQsc43hRjSB1+HdHtDNKRwDEVk2hCjCBuBWxb5Wvwq88b0ULj6QVEJLN/+ZqF19M+h4VYJ/zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
         "undici": "7.24.8",
-        "workerd": "1.20260520.1",
+        "workerd": "1.20260521.1",
         "ws": "8.20.1",
         "youch": "4.1.0-beta.10"
       },
@@ -5424,6 +5424,28 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/minimatch": {
@@ -5520,22 +5542,22 @@
       }
     },
     "node_modules/msw/node_modules/tldts": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
-      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.32.tgz",
+      "integrity": "sha512-5eDV0tK2NhLAAqBeXDAQ36+EwuStd1HbsSOnGsp+JbExITnExcALLL5M1kTH8gjDYN5QvwmUWimE3GoMZ2A7xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.30"
+        "tldts-core": "^7.0.32"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/msw/node_modules/tldts-core": {
-      "version": "7.0.30",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
-      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.32.tgz",
+      "integrity": "sha512-GbSw6chU2HsHIB/NAyBJYxXQKpcqhtgY6bvWi90OarpbuMia+Z4Gw5BYiW4hJo1DzQ/6k9coba7FU/ijcgVLLw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6402,6 +6424,66 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rosie-skills": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills/-/rosie-skills-0.6.4.tgz",
+      "integrity": "sha512-ojfhSiQRdZ2QyWbmKAHOSAUbaLYrTc5zIH7mS1jKoP8KCFSQddwVhMyFqldckTeybTfW3zNcsZzyOTzGTN1SBA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "rosie-skills": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "rosie-skills-darwin-arm64": "0.6.4",
+        "rosie-skills-freebsd-x64": "0.6.4",
+        "rosie-skills-linux-x64": "0.6.4"
+      }
+    },
+    "node_modules/rosie-skills-darwin-arm64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-darwin-arm64/-/rosie-skills-darwin-arm64-0.6.4.tgz",
+      "integrity": "sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rosie-skills-freebsd-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-freebsd-x64/-/rosie-skills-freebsd-x64-0.6.4.tgz",
+      "integrity": "sha512-SxCRduPBMtfjkQ+q56Yw9OLA3PyaqoALzt7kER7IDKuUVfM2O/1w8sa5xhTDiCvWkZJixnH5d5Ya6KT+/Mwcng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rosie-skills-linux-x64": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/rosie-skills-linux-x64/-/rosie-skills-linux-x64-0.6.4.tgz",
+      "integrity": "sha512-D9Y9mfu7goB0s0X59uU3hcFeUTef3VbpCIDwFMzyvJrAq3XhRACWBDMHQsHlyWdHxTXPX/ILyW65RXyrJlgqng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
@@ -7819,9 +7901,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260520.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260520.1.tgz",
-      "integrity": "sha512-mwW6H/NEKObeBVd0qkq91EGyOIC3TaNJBxp7kj5uChif/+qYD7nM5HE8ZYruwvEd15pRwUet+V8r21DCXCGDQQ==",
+      "version": "1.20260521.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260521.1.tgz",
+      "integrity": "sha512-HzIThcZ0ZVEuzVxpY2IYZ3yssSrTjtrWXAVfmOl5rVwyqcu7aeZXGMiwrEmi9MOcC3wjy+BNv+hFrMMY5OrjQQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -7833,17 +7915,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260520.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260520.1",
-        "@cloudflare/workerd-linux-64": "1.20260520.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260520.1",
-        "@cloudflare/workerd-windows-64": "1.20260520.1"
+        "@cloudflare/workerd-darwin-64": "1.20260521.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260521.1",
+        "@cloudflare/workerd-linux-64": "1.20260521.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260521.1",
+        "@cloudflare/workerd-windows-64": "1.20260521.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.93.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.93.1.tgz",
-      "integrity": "sha512-vV2GyKNWORysoJtryo45N2Tkk8wCnt/MTyW7wsevAAY+MiUArfJGvMiCb6SRB7pV5uWvEyIly1/rslehEjV32g==",
+      "version": "4.94.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.94.0.tgz",
+      "integrity": "sha512-GsNw0DomGFfeXFtKVTwn2X69UKcCxcTB0CXykjsMineJIxOeyrw7LovlHQ/3JU8KJHH7repLB+kOHvfTBA/Eew==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -7851,10 +7933,11 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260520.0",
+        "miniflare": "4.20260521.0",
         "path-to-regexp": "6.3.0",
+        "rosie-skills": "^0.6.3",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260520.1"
+        "workerd": "1.20260521.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -7867,7 +7950,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260520.1"
+        "@cloudflare/workers-types": "^4.20260521.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -7922,9 +8005,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7983,6 +8066,24 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -8092,6 +8193,31 @@
         "rfdc": "^1.4.1",
         "worker-timers": "^8.0.31",
         "zod": "^3.25.76"
+      }
+    },
+    "packages/web_ui/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "packages/web_ui/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     }
   }

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -5,253 +5,44 @@
 
 export type { CoreEvent } from './events/types'
 export { calculateSigmoid, calculateSigmoidExponential } from './math/sigmoid'
-export type {
-  CalculateCubicSumDataResult,
-  CalculateSummationNonLinearResult
-} from './math/summations'
+export type { CalculateCubicSumDataResult, CalculateSummationNonLinearResult } from './math/summations'
 export {
   calculateCubicSumData,
   calculateSummationCubic,
   calculateSummationNonLinear,
   solveQuadratic
 } from './math/summations'
-export type {
-  AcceleratorState,
-  AscendBuildingState,
-  BuyAmount,
-  CrystalUpgradesState,
-  CubeBlessings,
-  HypercubeBlessings,
-  MultiplierState,
-  ParticleBuildingsState,
-  PlatonicBlessings,
-  ProducerFamilyState,
-  TesseractBlessings,
-  TesseractBuildingsState,
-  UpgradesState
-} from './state/schema'
-export type {
-  BuyAcceleratorInput,
-  GetCostAcceleratorInput
-} from './mechanics/accelerators'
-export type {
-  BuyMultiplierInput,
-  GetCostMultiplierInput
-} from './mechanics/multipliers'
-export { buyAccelerator, getCostAccelerator } from './mechanics/accelerators'
 export type { GetAcceleratorBoostCostInput } from './mechanics/acceleratorBoosts'
 export { getAcceleratorBoostCost } from './mechanics/acceleratorBoosts'
-export { buyMultiplier, getCostMultiplier } from './mechanics/multipliers'
 export type {
-  BuyMaxInput,
-  BuyProducerInput,
-  GetProducerCostInput,
-  ProducerIndex,
-  ProducerType
-} from './mechanics/producers'
-export { buyMax, buyProducer, getProducerCost } from './mechanics/producers'
+  CalculateAcceleratorMultiplierInput,
+  CalculateTotalAcceleratorBoostInput,
+  CalculateTotalAcceleratorBoostResult
+} from './mechanics/acceleratorMultipliers'
+export { calculateAcceleratorMultiplier, calculateTotalAcceleratorBoost } from './mechanics/acceleratorMultipliers'
+export type { BuyAcceleratorInput, GetCostAcceleratorInput } from './mechanics/accelerators'
+export { buyAccelerator, getCostAccelerator } from './mechanics/accelerators'
+export { achievementLevelFromPoints, toNextAchievementLevelEXP } from './mechanics/achievementLevels'
 export type {
-  BuyParticleBuildingInput,
-  GetParticleCostInput,
-  ParticleBuildingIndex
-} from './mechanics/particleBuildings'
-export { buyParticleBuilding, getParticleCost } from './mechanics/particleBuildings'
-export type {
-  BuyTesseractBuildingInput,
-  GetTesseractCostInput,
-  TesseractBuildingIndex,
-  TesseractBuildings
-} from './mechanics/tesseractBuildings'
+  AmbrosiaMultInput,
+  CalculateRequiredBlueberryTimeInput,
+  CalculateRequiredRedAmbrosiaTimeInput
+} from './mechanics/ambrosia'
 export {
-  buyTesseractBuilding,
-  calculateTessBuildingsInBudget,
-  getTesseractCost
-} from './mechanics/tesseractBuildings'
-export type { BuyUpgradeInput, UpgradeTier } from './mechanics/upgrades'
-export { buyUpgrades } from './mechanics/upgrades'
-export type { BuyCrystalUpgradesInput } from './mechanics/crystalUpgrades'
-export { buyCrystalUpgrades } from './mechanics/crystalUpgrades'
-export {
-  calculateAscensionScorePlatonicBlessing,
-  calculateCubeMultiplierPlatonicBlessing,
-  calculateGlobalSpeedPlatonicBlessing,
-  calculateHypercubeBlessingMultiplierPlatonicBlessing,
-  calculateHypercubeMultiplierPlatonicBlessing,
-  calculatePlatonicMultiplierPlatonicBlessing,
-  calculateTaxPlatonicBlessing,
-  calculateTesseractMultiplierPlatonicBlessing
-} from './mechanics/cubes/platonicBlessings'
-export {
-  calculateAcceleratorHypercubeBlessing,
-  calculateAntELOHypercubeBlessing,
-  calculateAntSacrificeHypercubeBlessing,
-  calculateAntSpeedHypercubeBlessing,
-  calculateGlobalSpeedHypercubeBlessing,
-  calculateMultiplierHypercubeBlessing,
-  calculateObtainiumHypercubeBlessing,
-  calculateOfferingHypercubeBlessing,
-  calculateRuneEffectivenessHypercubeBlessing,
-  calculateSalvageHypercubeBlessing
-} from './mechanics/cubes/hypercubeBlessings'
-export {
-  calculateAcceleratorTesseractBlessing,
-  calculateAntELOTesseractBlessing,
-  calculateAntSacrificeTesseractBlessing,
-  calculateAntSpeedTesseractBlessing,
-  calculateGlobalSpeedTesseractBlessing,
-  calculateMultiplierTesseractBlessing,
-  calculateObtainiumTesseractBlessing,
-  calculateOfferingTesseractBlessing,
-  calculateRuneEffectivenessTesseractBlessing,
-  calculateSalvageTesseractBlessing
-} from './mechanics/cubes/tesseractBlessings'
-export {
-  calculateAcceleratorCubeBlessing,
-  calculateAntELOCubeBlessing,
-  calculateAntSacrificeCubeBlessing,
-  calculateAntSpeedCubeBlessing,
-  calculateGlobalSpeedCubeBlessing,
-  calculateMultiplierCubeBlessing,
-  calculateObtainiumCubeBlessing,
-  calculateOfferingCubeBlessing,
-  calculateRuneEffectivenessCubeBlessing,
-  calculateSalvageCubeBlessing
-} from './mechanics/cubes/cubeBlessings'
-export type {
-  AbyssHepteractEffects,
-  AcceleratorBoostHepteractEffects,
-  AcceleratorHepteractEffects,
-  ChallengeHepteractEffects,
-  ChronosHepteractEffects,
-  HyperrealismHepteractEffects,
-  MultiplierHepteractEffects,
-  QuarkHepteractEffects
-} from './mechanics/cubes/hepteracts'
-export {
-  abyssHepteractEffects,
-  acceleratorBoostHepteractEffects,
-  acceleratorHepteractEffects,
-  challengeHepteractEffects,
-  chronosHepteractEffects,
-  hyperrealismHepteractEffects,
-  multiplierHepteractEffects,
-  quarkHepteractEffects
-} from './mechanics/cubes/hepteracts'
-export type {
-  Challenge15ScoreMultiplierInput,
-  ChallengeRequirementInput,
-  ChallengeRequirementMultiplierInput,
-  ChallengeType,
-  GetMaxChallengesInput,
-  GetNextAscensionChallengeInput,
-  GetNextRegularChallengeInput
-} from './mechanics/challenges'
-export {
-  autoAscensionChallengeSweepUnlock,
-  CalcECC,
-  calculateChallengeRequirementMultiplier,
-  challenge15ScoreMultiplier,
-  challengeRequirement,
-  challengeScoreDisplay,
-  getMaxChallenges,
-  getNextAscensionChallenge,
-  getNextRegularChallenge
-} from './mechanics/challenges'
-export type {
-  QuarkHandlerInput,
-  QuarkHandlerResult
-} from './mechanics/quarks'
-export { quarkHandler } from './mechanics/quarks'
-export type {
-  GetCubeCostInput,
-  GetCubeCostResult,
-  GetCubeMaxInput
-} from './mechanics/cubeUpgrades'
-export {
-  getCubeCost,
-  getCubeMax,
-  getCubeUpgradeBaseCost
-} from './mechanics/cubeUpgrades'
-export type {
-  DroughtEffectInput,
-  HyperchallengeEffectInput,
-  IlliteracyEffectInput,
-  MaxCorruptionLevelInput,
-  ViscosityEffectInput
-} from './mechanics/corruptions'
-export {
-  droughtEffect,
-  hyperchallengeEffect,
-  illiteracyEffect,
-  maxCorruptionLevel,
-  viscosityEffect
-} from './mechanics/corruptions'
-export type {
-  AntiquitiesRuneInput,
-  AntiquitiesRuneKey,
-  DuplicationRuneKey,
-  FiniteDescentRuneKey,
-  HorseShoeRuneKey,
-  InfiniteAscentRuneInput,
-  InfiniteAscentRuneKey,
-  PrismRuneKey,
-  SpeedRuneKey,
-  SuperiorIntellectRuneKey,
-  ThriftRuneKey,
-  TopHatRuneKey
-} from './mechanics/runeEffects'
-export {
-  antiquitiesRuneEffects,
-  duplicationRuneEffects,
-  finiteDescentRuneEffects,
-  horseShoeRuneEffects,
-  infiniteAscentRuneEffects,
-  prismRuneEffects,
-  speedRuneEffects,
-  superiorIntellectRuneEffects,
-  thriftRuneEffects,
-  topHatRuneEffects
-} from './mechanics/runeEffects'
-export type {
-  DuplicationRuneBlessingEffects,
-  PrismRuneBlessingEffects,
-  SpeedRuneBlessingEffects,
-  SuperiorIntellectRuneBlessingEffects,
-  ThriftRuneBlessingEffects
-} from './mechanics/runeBlessingEffects'
-export {
-  duplicationRuneBlessingEffects,
-  prismRuneBlessingEffects,
-  speedRuneBlessingEffects,
-  superiorIntellectRuneBlessingEffects,
-  thriftRuneBlessingEffects
-} from './mechanics/runeBlessingEffects'
-export type {
-  AchievementTalismanEffects,
-  ChronosTalismanEffects,
-  CookieGrandmaTalismanEffects,
-  ExemptionTalismanEffects,
-  HorseShoeTalismanEffects,
-  MetaphysicsTalismanEffects,
-  MidasTalismanEffects,
-  MortuusTalismanEffects,
-  PlasticTalismanEffects,
-  PolymathTalismanEffects,
-  WowSquareTalismanEffects
-} from './mechanics/talismanEffects'
-export {
-  achievementTalismanEffects,
-  chronosTalismanEffects,
-  cookieGrandmaTalismanEffects,
-  exemptionTalismanEffects,
-  horseShoeTalismanEffects,
-  metaphysicsTalismanEffects,
-  midasTalismanEffects,
-  mortuusTalismanEffects,
-  plasticTalismanEffects,
-  polymathTalismanEffects,
-  wowSquareTalismanEffects
-} from './mechanics/talismanEffects'
+  calculateAmbrosiaCubeMult,
+  calculateAmbrosiaGenerationOcteractUpgrade,
+  calculateAmbrosiaGenerationSingularityUpgrade,
+  calculateAmbrosiaLuckOcteractUpgrade,
+  calculateAmbrosiaLuckSingularityUpgrade,
+  calculateAmbrosiaQuarkMult,
+  calculateNumberOfThresholds,
+  calculateRequiredBlueberryTime,
+  calculateRequiredRedAmbrosiaTime,
+  calculateSingularityMilestoneBlueberries,
+  calculateToNextThreshold
+} from './mechanics/ambrosia'
+export type { CalculateAscensionCountInput } from './mechanics/ascensions'
+export { calculateAscensionCount } from './mechanics/ascensions'
 export type {
   ActualAntSpeedMultInput,
   AscensionScoreBonusMultiplierInput,
@@ -277,97 +68,6 @@ export type {
   GlobalSpeedMultInput,
   ReductionValueInput
 } from './mechanics/calculate'
-export type {
-  AmbrosiaMultInput,
-  CalculateRequiredBlueberryTimeInput,
-  CalculateRequiredRedAmbrosiaTimeInput
-} from './mechanics/ambrosia'
-export type {
-  CalculateAcceleratorMultiplierInput,
-  CalculateTotalAcceleratorBoostInput,
-  CalculateTotalAcceleratorBoostResult
-} from './mechanics/acceleratorMultipliers'
-export {
-  calculateAcceleratorMultiplier,
-  calculateTotalAcceleratorBoost
-} from './mechanics/acceleratorMultipliers'
-export type { CalculateAscensionCountInput } from './mechanics/ascensions'
-export { calculateAscensionCount } from './mechanics/ascensions'
-export type { CalculateCubeQuarkMultiplierInput } from './mechanics/overfluxBonuses'
-export {
-  calculateCubeMultFromPowder,
-  calculateCubeQuarkMultiplier,
-  calculateQuarkMultFromPowder
-} from './mechanics/overfluxBonuses'
-export {
-  calculateAmbrosiaCubeMult,
-  calculateAmbrosiaGenerationOcteractUpgrade,
-  calculateAmbrosiaGenerationSingularityUpgrade,
-  calculateAmbrosiaLuckOcteractUpgrade,
-  calculateAmbrosiaLuckSingularityUpgrade,
-  calculateAmbrosiaQuarkMult,
-  calculateNumberOfThresholds,
-  calculateRequiredBlueberryTime,
-  calculateRequiredRedAmbrosiaTime,
-  calculateSingularityMilestoneBlueberries,
-  calculateToNextThreshold
-} from './mechanics/ambrosia'
-export type {
-  CalculateExalt3PenaltyInput,
-  CalculateExalt4EffectiveSingularityMultiplierInput
-} from './mechanics/exaltPenalties'
-export type {
-  CalculatePotionValueInput,
-  PotionBonusResult
-} from './mechanics/potionBonuses'
-export {
-  calculateObtainiumPotionBaseObtainium,
-  calculateOfferingPotionBaseOfferings,
-  calculatePotionValue
-} from './mechanics/potionBonuses'
-export type {
-  CalculateCookieUpgrade29LuckInput,
-  CalculateRedAmbrosiaCubesInput,
-  CalculateRedAmbrosiaResourceInput
-} from './mechanics/redAmbrosiaBonuses'
-export {
-  calculateCookieUpgrade29Luck,
-  calculateRedAmbrosiaCubes,
-  calculateRedAmbrosiaObtainium,
-  calculateRedAmbrosiaOffering
-} from './mechanics/redAmbrosiaBonuses'
-export type {
-  CalculateTotalOcteractCubeBonusInput,
-  CalculateTotalOcteractObtainiumBonusInput,
-  CalculateTotalOcteractOfferingBonusInput,
-  CalculateTotalOcteractQuarkBonusInput
-} from './mechanics/octeractBonuses'
-export {
-  calculateTotalOcteractCubeBonus,
-  calculateTotalOcteractObtainiumBonus,
-  calculateTotalOcteractOfferingBonus,
-  calculateTotalOcteractQuarkBonus
-} from './mechanics/octeractBonuses'
-export {
-  calculateExalt3AscensionLimit,
-  calculateExalt3Penalty,
-  calculateExalt4EffectiveSingularityMultiplier,
-  calculateExalt6Penalty,
-  calculateExalt6PenaltyPerSecond,
-  calculateExalt6TimeLimit
-} from './mechanics/exaltPenalties'
-export type { CalculateBaseGoldenQuarksInput } from './mechanics/singularityMilestones'
-export {
-  calculateBaseGoldenQuarks,
-  calculateDilatedFiveLeafBonus,
-  calculateImmaculateAlchemyBonus,
-  calculateSingularityAmbrosiaLuckMilestoneBonus,
-  calculateSingularityQuarkMilestoneMultiplier,
-  derpsmithCornucopiaBonus,
-  inheritanceTokens,
-  singularityBonusTokenMult,
-  sumOfExaltCompletions
-} from './mechanics/singularityMilestones'
 export {
   CalcCorruptionStuff,
   calculateActualAntSpeedMult,
@@ -422,3 +122,326 @@ export {
   computeAscensionScoreBonusMultiplier,
   getReductionValue
 } from './mechanics/calculate'
+export type {
+  Challenge15ScoreMultiplierInput,
+  ChallengeRequirementInput,
+  ChallengeRequirementMultiplierInput,
+  ChallengeType,
+  GetMaxChallengesInput,
+  GetNextAscensionChallengeInput,
+  GetNextRegularChallengeInput
+} from './mechanics/challenges'
+export {
+  autoAscensionChallengeSweepUnlock,
+  CalcECC,
+  calculateChallengeRequirementMultiplier,
+  challenge15ScoreMultiplier,
+  challengeRequirement,
+  challengeScoreDisplay,
+  getMaxChallenges,
+  getNextAscensionChallenge,
+  getNextRegularChallenge
+} from './mechanics/challenges'
+export type {
+  DroughtEffectInput,
+  HyperchallengeEffectInput,
+  IlliteracyEffectInput,
+  MaxCorruptionLevelInput,
+  ViscosityEffectInput
+} from './mechanics/corruptions'
+export {
+  droughtEffect,
+  hyperchallengeEffect,
+  illiteracyEffect,
+  maxCorruptionLevel,
+  viscosityEffect
+} from './mechanics/corruptions'
+export type { BuyCrystalUpgradesInput } from './mechanics/crystalUpgrades'
+export { buyCrystalUpgrades } from './mechanics/crystalUpgrades'
+export {
+  calculateAcceleratorCubeBlessing,
+  calculateAntELOCubeBlessing,
+  calculateAntSacrificeCubeBlessing,
+  calculateAntSpeedCubeBlessing,
+  calculateGlobalSpeedCubeBlessing,
+  calculateMultiplierCubeBlessing,
+  calculateObtainiumCubeBlessing,
+  calculateOfferingCubeBlessing,
+  calculateRuneEffectivenessCubeBlessing,
+  calculateSalvageCubeBlessing
+} from './mechanics/cubes/cubeBlessings'
+export type {
+  AbyssHepteractEffects,
+  AcceleratorBoostHepteractEffects,
+  AcceleratorHepteractEffects,
+  ChallengeHepteractEffects,
+  ChronosHepteractEffects,
+  HyperrealismHepteractEffects,
+  MultiplierHepteractEffects,
+  QuarkHepteractEffects
+} from './mechanics/cubes/hepteracts'
+export {
+  abyssHepteractEffects,
+  acceleratorBoostHepteractEffects,
+  acceleratorHepteractEffects,
+  challengeHepteractEffects,
+  chronosHepteractEffects,
+  hyperrealismHepteractEffects,
+  multiplierHepteractEffects,
+  quarkHepteractEffects
+} from './mechanics/cubes/hepteracts'
+export {
+  calculateAcceleratorHypercubeBlessing,
+  calculateAntELOHypercubeBlessing,
+  calculateAntSacrificeHypercubeBlessing,
+  calculateAntSpeedHypercubeBlessing,
+  calculateGlobalSpeedHypercubeBlessing,
+  calculateMultiplierHypercubeBlessing,
+  calculateObtainiumHypercubeBlessing,
+  calculateOfferingHypercubeBlessing,
+  calculateRuneEffectivenessHypercubeBlessing,
+  calculateSalvageHypercubeBlessing
+} from './mechanics/cubes/hypercubeBlessings'
+export {
+  calculateAscensionScorePlatonicBlessing,
+  calculateCubeMultiplierPlatonicBlessing,
+  calculateGlobalSpeedPlatonicBlessing,
+  calculateHypercubeBlessingMultiplierPlatonicBlessing,
+  calculateHypercubeMultiplierPlatonicBlessing,
+  calculatePlatonicMultiplierPlatonicBlessing,
+  calculateTaxPlatonicBlessing,
+  calculateTesseractMultiplierPlatonicBlessing
+} from './mechanics/cubes/platonicBlessings'
+export {
+  calculateAcceleratorTesseractBlessing,
+  calculateAntELOTesseractBlessing,
+  calculateAntSacrificeTesseractBlessing,
+  calculateAntSpeedTesseractBlessing,
+  calculateGlobalSpeedTesseractBlessing,
+  calculateMultiplierTesseractBlessing,
+  calculateObtainiumTesseractBlessing,
+  calculateOfferingTesseractBlessing,
+  calculateRuneEffectivenessTesseractBlessing,
+  calculateSalvageTesseractBlessing
+} from './mechanics/cubes/tesseractBlessings'
+export type { GetCubeCostInput, GetCubeCostResult, GetCubeMaxInput } from './mechanics/cubeUpgrades'
+export { getCubeCost, getCubeMax, getCubeUpgradeBaseCost } from './mechanics/cubeUpgrades'
+export type {
+  CalculateExalt3PenaltyInput,
+  CalculateExalt4EffectiveSingularityMultiplierInput
+} from './mechanics/exaltPenalties'
+export {
+  calculateExalt3AscensionLimit,
+  calculateExalt3Penalty,
+  calculateExalt4EffectiveSingularityMultiplier,
+  calculateExalt6Penalty,
+  calculateExalt6PenaltyPerSecond,
+  calculateExalt6TimeLimit
+} from './mechanics/exaltPenalties'
+export type { ActualGQUpgradeTotalLevelsInput, GqUpgradeMaxLevelInput } from './mechanics/gqUpgradeLevels'
+export {
+  actualGQUpgradeTotalLevels,
+  computeGQUpgradeMaxLevel,
+  gqFreeLevelMultiplier,
+  gqUpgradeFreeLevelSoftcap
+} from './mechanics/gqUpgradeLevels'
+export type { LevelMilestoneData, LevelMilestoneKey, SalvageChallengeBuffInput } from './mechanics/levelMilestones'
+export {
+  achievementTalismanEnhancementEffect,
+  duplicationRuneMilestoneEffect,
+  getLevelMilestone,
+  levelMilestones,
+  prismRuneMilestoneEffect,
+  runeAutobuyImproverEffect,
+  salvageChallengeBuffEffect,
+  siRuneMilestoneEffect,
+  speedRuneMilestoneEffect,
+  thriftRuneMilestoneEffect
+} from './mechanics/levelMilestones'
+export type { LevelRewardData, LevelRewardKey } from './mechanics/levelRewards'
+export {
+  ambrosiaLuckEffect,
+  antsEffect,
+  getLevelReward,
+  levelRewards,
+  obtainiumEffect,
+  offeringsEffect,
+  quarksEffect,
+  redAmbrosiaLuckEffect,
+  salvageEffect,
+  wowCubesEffect,
+  wowHepteractCubesEffect,
+  wowHyperCubesEffect,
+  wowOcteractsEffect,
+  wowPlatonicCubesEffect,
+  wowTesseractsEffect
+} from './mechanics/levelRewards'
+export type { BuyMultiplierInput, GetCostMultiplierInput } from './mechanics/multipliers'
+export { buyMultiplier, getCostMultiplier } from './mechanics/multipliers'
+export type {
+  CalculateTotalOcteractCubeBonusInput,
+  CalculateTotalOcteractObtainiumBonusInput,
+  CalculateTotalOcteractOfferingBonusInput,
+  CalculateTotalOcteractQuarkBonusInput
+} from './mechanics/octeractBonuses'
+export {
+  calculateTotalOcteractCubeBonus,
+  calculateTotalOcteractObtainiumBonus,
+  calculateTotalOcteractOfferingBonus,
+  calculateTotalOcteractQuarkBonus
+} from './mechanics/octeractBonuses'
+export type { ActualOcteractUpgradeTotalLevelsInput } from './mechanics/octeractUpgradeLevels'
+export {
+  actualOcteractUpgradeTotalLevels,
+  octeractFreeLevelMultiplier,
+  octeractFreeLevelSoftcap
+} from './mechanics/octeractUpgradeLevels'
+export type { CalculateCubeQuarkMultiplierInput } from './mechanics/overfluxBonuses'
+export {
+  calculateCubeMultFromPowder,
+  calculateCubeQuarkMultiplier,
+  calculateQuarkMultFromPowder
+} from './mechanics/overfluxBonuses'
+export type {
+  BuyParticleBuildingInput,
+  GetParticleCostInput,
+  ParticleBuildingIndex
+} from './mechanics/particleBuildings'
+export { buyParticleBuilding, getParticleCost } from './mechanics/particleBuildings'
+export type { CalculatePotionValueInput, PotionBonusResult } from './mechanics/potionBonuses'
+export {
+  calculateObtainiumPotionBaseObtainium,
+  calculateOfferingPotionBaseOfferings,
+  calculatePotionValue
+} from './mechanics/potionBonuses'
+export type {
+  BuyMaxInput,
+  BuyProducerInput,
+  GetProducerCostInput,
+  ProducerIndex,
+  ProducerType
+} from './mechanics/producers'
+export { buyMax, buyProducer, getProducerCost } from './mechanics/producers'
+export type { QuarkHandlerInput, QuarkHandlerResult } from './mechanics/quarks'
+export { quarkHandler } from './mechanics/quarks'
+export type {
+  CalculateCookieUpgrade29LuckInput,
+  CalculateRedAmbrosiaCubesInput,
+  CalculateRedAmbrosiaResourceInput
+} from './mechanics/redAmbrosiaBonuses'
+export {
+  calculateCookieUpgrade29Luck,
+  calculateRedAmbrosiaCubes,
+  calculateRedAmbrosiaObtainium,
+  calculateRedAmbrosiaOffering
+} from './mechanics/redAmbrosiaBonuses'
+export type {
+  DuplicationRuneBlessingEffects,
+  PrismRuneBlessingEffects,
+  SpeedRuneBlessingEffects,
+  SuperiorIntellectRuneBlessingEffects,
+  ThriftRuneBlessingEffects
+} from './mechanics/runeBlessingEffects'
+export {
+  duplicationRuneBlessingEffects,
+  prismRuneBlessingEffects,
+  speedRuneBlessingEffects,
+  superiorIntellectRuneBlessingEffects,
+  thriftRuneBlessingEffects
+} from './mechanics/runeBlessingEffects'
+export type {
+  AntiquitiesRuneInput,
+  AntiquitiesRuneKey,
+  DuplicationRuneKey,
+  FiniteDescentRuneKey,
+  HorseShoeRuneKey,
+  InfiniteAscentRuneInput,
+  InfiniteAscentRuneKey,
+  PrismRuneKey,
+  SpeedRuneKey,
+  SuperiorIntellectRuneKey,
+  ThriftRuneKey,
+  TopHatRuneKey
+} from './mechanics/runeEffects'
+export {
+  antiquitiesRuneEffects,
+  duplicationRuneEffects,
+  finiteDescentRuneEffects,
+  horseShoeRuneEffects,
+  infiniteAscentRuneEffects,
+  prismRuneEffects,
+  speedRuneEffects,
+  superiorIntellectRuneEffects,
+  thriftRuneEffects,
+  topHatRuneEffects
+} from './mechanics/runeEffects'
+export type { CalculateBaseGoldenQuarksInput } from './mechanics/singularityMilestones'
+export {
+  calculateBaseGoldenQuarks,
+  calculateDilatedFiveLeafBonus,
+  calculateImmaculateAlchemyBonus,
+  calculateSingularityAmbrosiaLuckMilestoneBonus,
+  calculateSingularityQuarkMilestoneMultiplier,
+  derpsmithCornucopiaBonus,
+  inheritanceTokens,
+  singularityBonusTokenMult,
+  sumOfExaltCompletions
+} from './mechanics/singularityMilestones'
+export type {
+  CalculateEffectiveSingularitiesInput,
+  CalculateSingularityDebuffInput,
+  SingularityDebuff
+} from './mechanics/singularityPenalties'
+export { calculateEffectiveSingularities, calculateSingularityDebuff } from './mechanics/singularityPenalties'
+export type { TalismanCraftCosts, TalismanCraftItems } from './mechanics/talismanCosts'
+export { exponentialCostProgression, regularCostProgression } from './mechanics/talismanCosts'
+export type {
+  AchievementTalismanEffects,
+  ChronosTalismanEffects,
+  CookieGrandmaTalismanEffects,
+  ExemptionTalismanEffects,
+  HorseShoeTalismanEffects,
+  MetaphysicsTalismanEffects,
+  MidasTalismanEffects,
+  MortuusTalismanEffects,
+  PlasticTalismanEffects,
+  PolymathTalismanEffects,
+  WowSquareTalismanEffects
+} from './mechanics/talismanEffects'
+export {
+  achievementTalismanEffects,
+  chronosTalismanEffects,
+  cookieGrandmaTalismanEffects,
+  exemptionTalismanEffects,
+  horseShoeTalismanEffects,
+  metaphysicsTalismanEffects,
+  midasTalismanEffects,
+  mortuusTalismanEffects,
+  plasticTalismanEffects,
+  polymathTalismanEffects,
+  wowSquareTalismanEffects
+} from './mechanics/talismanEffects'
+export type {
+  BuyTesseractBuildingInput,
+  GetTesseractCostInput,
+  TesseractBuildingIndex,
+  TesseractBuildings
+} from './mechanics/tesseractBuildings'
+export { buyTesseractBuilding, calculateTessBuildingsInBudget, getTesseractCost } from './mechanics/tesseractBuildings'
+export type { BuyUpgradeInput, UpgradeTier } from './mechanics/upgrades'
+export { buyUpgrades } from './mechanics/upgrades'
+export type {
+  AcceleratorState,
+  AscendBuildingState,
+  BuyAmount,
+  CrystalUpgradesState,
+  CubeBlessings,
+  HypercubeBlessings,
+  MultiplierState,
+  ParticleBuildingsState,
+  PlatonicBlessings,
+  ProducerFamilyState,
+  TesseractBlessings,
+  TesseractBuildingsState,
+  UpgradesState
+} from './state/schema'

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -238,6 +238,8 @@ export {
   calculateExalt6PenaltyPerSecond,
   calculateExalt6TimeLimit
 } from './mechanics/exaltPenalties'
+export type { GQUpgradeCostTNLInput, GQUpgradeSpecialCostForm } from './mechanics/gqUpgradeCost'
+export { gqUpgradeCostTNL } from './mechanics/gqUpgradeCost'
 export type { ActualGQUpgradeTotalLevelsInput, GqUpgradeMaxLevelInput } from './mechanics/gqUpgradeLevels'
 export {
   actualGQUpgradeTotalLevels,
@@ -385,6 +387,12 @@ export {
   runeLevelFromEXP,
   runeOfferingsToLevel
 } from './mechanics/runeLevels'
+export type {
+  CalculateNextSpikeInput,
+  GoldenQuarkCostResult,
+  MaxSingularityLookaheadInput
+} from './mechanics/singularityHelpers'
+export { calculateNextSpike, goldenQuarkCost, maxSingularityLookahead } from './mechanics/singularityHelpers'
 export type { CalculateBaseGoldenQuarksInput } from './mechanics/singularityMilestones'
 export {
   calculateBaseGoldenQuarks,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -253,6 +253,8 @@ export {
   gqFreeLevelMultiplier,
   gqUpgradeFreeLevelSoftcap
 } from './mechanics/gqUpgradeLevels'
+export type { HepteractEffectiveInput } from './mechanics/hepteractValues'
+export { hepteractCap, hepteractEffective, hepteractFinalCap } from './mechanics/hepteractValues'
 export type { LevelMilestoneData, LevelMilestoneKey, SalvageChallengeBuffInput } from './mechanics/levelMilestones'
 export {
   achievementTalismanEnhancementEffect,
@@ -393,6 +395,8 @@ export {
   runeLevelFromEXP,
   runeOfferingsToLevel
 } from './mechanics/runeLevels'
+export type { ShopCostInput } from './mechanics/shopCosts'
+export { shopCost } from './mechanics/shopCosts'
 export type {
   CalculateNextSpikeInput,
   GoldenQuarkCostResult,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -397,6 +397,36 @@ export {
 } from './mechanics/runeLevels'
 export type { ShopCostInput } from './mechanics/shopCosts'
 export { shopCost } from './mechanics/shopCosts'
+export type { SingularityChallengeDataKeys, SingularityChallengeRewards } from './mechanics/singularityChallenges'
+export {
+  limitedAscensionsAchievementPointValue,
+  limitedAscensionsEffect,
+  limitedAscensionsSingularityRequirement,
+  limitedTimeAchievementPointValue,
+  limitedTimeEffect,
+  limitedTimeSingularityRequirement,
+  noAmbrosiaUpgradesAchievementPointValue,
+  noAmbrosiaUpgradesEffect,
+  noAmbrosiaUpgradesSingularityRequirement,
+  noOcteractsAchievementPointValue,
+  noOcteractsEffect,
+  noOcteractsSingularityRequirement,
+  noQuarkUpgradesAchievementPointValue,
+  noQuarkUpgradesEffect,
+  noQuarkUpgradesSingularityRequirement,
+  noSingularityUpgradesAchievementPointValue,
+  noSingularityUpgradesEffect,
+  noSingularityUpgradesSingularityRequirement,
+  oneChallengeCapAchievementPointValue,
+  oneChallengeCapEffect,
+  oneChallengeCapSingularityRequirement,
+  sadisticPrequelAchievementPointValue,
+  sadisticPrequelEffect,
+  sadisticPrequelSingularityRequirement,
+  taxmanLastStandAchievementPointValue,
+  taxmanLastStandEffect,
+  taxmanLastStandSingularityRequirement
+} from './mechanics/singularityChallenges'
 export type {
   CalculateNextSpikeInput,
   GoldenQuarkCostResult,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -143,6 +143,12 @@ export {
   getNextRegularChallenge
 } from './mechanics/challenges'
 export type {
+  CalculateCoinProductionInput,
+  CalculateCoinProductionResult,
+  PerCoinTierInput
+} from './mechanics/coinProduction'
+export { calculateCoinProduction } from './mechanics/coinProduction'
+export type {
   DroughtEffectInput,
   HyperchallengeEffectInput,
   IlliteracyEffectInput,
@@ -439,6 +445,8 @@ export {
   polymathTalismanEffects,
   wowSquareTalismanEffects
 } from './mechanics/talismanEffects'
+export type { CalculateTaxInput, CalculateTaxResult } from './mechanics/tax'
+export { calculateTax } from './mechanics/tax'
 export type {
   BuyTesseractBuildingInput,
   GetTesseractCostInput,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -375,6 +375,16 @@ export {
   thriftRuneEffects,
   topHatRuneEffects
 } from './mechanics/runeEffects'
+export type { UniversalRuneEXPMultInput } from './mechanics/runeEXPMultiplier'
+export { universalRuneEXPMult } from './mechanics/runeEXPMultiplier'
+export type { MaxRuneLevelPurchaseInput, MaxRuneLevelPurchaseResult } from './mechanics/runeLevels'
+export {
+  maxRuneLevelPurchase,
+  runeEXPLeftToLevel,
+  runeEXPToLevel,
+  runeLevelFromEXP,
+  runeOfferingsToLevel
+} from './mechanics/runeLevels'
 export type { CalculateBaseGoldenQuarksInput } from './mechanics/singularityMilestones'
 export {
   calculateBaseGoldenQuarks,

--- a/packages/logic/src/mechanics/achievementLevels.ts
+++ b/packages/logic/src/mechanics/achievementLevels.ts
@@ -1,0 +1,36 @@
+// Achievement-level math, lifted from packages/web_ui/src/Achievements.ts.
+// The level-from-points and exp-to-next-level formulas are pure functions of
+// the achievement points total. Both share a 2500-point regime switch — below
+// that, levels are 50 points apart; above, 100 points apart.
+
+const REGIME_SWITCH_POINTS = 2500
+const REGIME_SWITCH_LEVEL = 50
+const LOW_REGIME_POINTS_PER_LEVEL = 50
+const HIGH_REGIME_POINTS_PER_LEVEL = 100
+
+/**
+ * Achievement level for a given points total. Below 2500 points the level
+ * advances every 50 points; above 2500 it advances every 100 points (with
+ * level 50 reached at exactly 2500). Uses `Math.floor` so partial progress
+ * doesn't count.
+ */
+export function achievementLevelFromPoints (points: number): number {
+  if (points < REGIME_SWITCH_POINTS) {
+    return Math.floor(points / LOW_REGIME_POINTS_PER_LEVEL)
+  }
+  return REGIME_SWITCH_LEVEL + Math.floor((points - REGIME_SWITCH_POINTS) / HIGH_REGIME_POINTS_PER_LEVEL)
+}
+
+/**
+ * Points remaining until the next achievement level. Uses the same 2500-point
+ * regime switch: 50 - (points % 50) below, 100 - (points % 100) above. Note
+ * that the value is the *gap* to the next level, so the caller always sees a
+ * positive number — at the exact threshold, returns the full level cost
+ * (50 below 2500, 100 above).
+ */
+export function toNextAchievementLevelEXP (points: number): number {
+  if (points < REGIME_SWITCH_POINTS) {
+    return LOW_REGIME_POINTS_PER_LEVEL - (points % LOW_REGIME_POINTS_PER_LEVEL)
+  }
+  return HIGH_REGIME_POINTS_PER_LEVEL - (points % HIGH_REGIME_POINTS_PER_LEVEL)
+}

--- a/packages/logic/src/mechanics/coinProduction.ts
+++ b/packages/logic/src/mechanics/coinProduction.ts
@@ -1,0 +1,101 @@
+// Per-tier coin production aggregation, lifted from the first half of
+// packages/web_ui/src/Tax.ts (the `G.produceFirst..Fifth` chunk that
+// pre-dates the tax exponent). Pure Decimal math: each tier's output is
+//   (generated + owned) * globalCoinMulti * coinTierMulti * produceCoin
+// then clamped to 0 below 0.0001 to suppress sub-noise contributions.
+//
+// The five tiers (first/second/third/fourth/fifth) have identical formulas
+// — they correspond to the five base coin producers. `total` is the sum of
+// the (post-clamp) tier outputs; `perSecond` is `total * 40` (the legacy
+// 40 Hz tick rate factor that's still hardcoded into the original formula).
+
+import { Decimal } from '../math/bignum'
+
+// Below this threshold, a per-tier output snaps to 0 — suppresses
+// extremely-small-but-nonzero values that would otherwise pollute the
+// total before they're meaningful.
+const TIER_NOISE_FLOOR = 0.0001
+// Hardcoded 40 Hz tick rate factor that maps total-per-tick to per-second
+// in the legacy display. Lives here rather than in web_ui because it's
+// baked into the math contract callers depend on.
+const TICKS_PER_SECOND = 40
+
+export interface PerCoinTierInput {
+  /** player.<tier>GeneratedCoin — the only field guaranteed to be Decimal. */
+  generated: Decimal
+  /**
+   * player.<tier>OwnedCoin — `number` per the Player schema, fed straight
+   * to Decimal.add (which accepts both).
+   */
+  owned: number
+  /** G.coin<Tier>Multi — per-tier coin multiplier. */
+  coinMulti: Decimal
+  /**
+   * player.<tier>ProduceCoin — `number` per the Player schema, fed to
+   * Decimal.times.
+   */
+  produceCoin: number
+}
+
+export interface CalculateCoinProductionInput {
+  first: PerCoinTierInput
+  second: PerCoinTierInput
+  third: PerCoinTierInput
+  fourth: PerCoinTierInput
+  fifth: PerCoinTierInput
+  /** G.globalCoinMultiplier — applied to every tier. */
+  globalCoinMultiplier: Decimal
+}
+
+export interface CalculateCoinProductionResult {
+  /** Per-tier output, clamped to 0 below TIER_NOISE_FLOOR. */
+  first: Decimal
+  second: Decimal
+  third: Decimal
+  fourth: Decimal
+  fifth: Decimal
+  /**
+   * Sum of pre-clamp tier outputs — matches the legacy `G.produceTotal`
+   * which is computed BEFORE the per-tier 0.0001 clamps. (The clamps only
+   * reset the per-tier displays, not the aggregate.)
+   */
+  total: Decimal
+  /** total * 40 — converts the per-tick total to per-second for display. */
+  perSecond: Decimal
+}
+
+function tierOutput (tier: PerCoinTierInput, globalCoinMultiplier: Decimal): Decimal {
+  return tier.generated.add(tier.owned).times(globalCoinMultiplier).times(tier.coinMulti).times(tier.produceCoin)
+}
+
+function clampNoise (value: Decimal): Decimal {
+  return value.lte(TIER_NOISE_FLOOR) ? new Decimal(0) : value
+}
+
+/**
+ * Per-tier coin production with noise-floor clamping. The aggregate `total`
+ * uses the pre-clamp values (matching legacy behavior); each per-tier field
+ * in the result is post-clamp. `perSecond` is the per-tick total scaled by
+ * the hardcoded 40 Hz tick rate.
+ */
+export function calculateCoinProduction (input: CalculateCoinProductionInput): CalculateCoinProductionResult {
+  const first = tierOutput(input.first, input.globalCoinMultiplier)
+  const second = tierOutput(input.second, input.globalCoinMultiplier)
+  const third = tierOutput(input.third, input.globalCoinMultiplier)
+  const fourth = tierOutput(input.fourth, input.globalCoinMultiplier)
+  const fifth = tierOutput(input.fifth, input.globalCoinMultiplier)
+
+  // Aggregate uses the pre-clamp values — the clamps only affect the
+  // per-tier display, not the total.
+  const total = first.add(second).add(third).add(fourth).add(fifth)
+
+  return {
+    first: clampNoise(first),
+    second: clampNoise(second),
+    third: clampNoise(third),
+    fourth: clampNoise(fourth),
+    fifth: clampNoise(fifth),
+    total,
+    perSecond: total.times(TICKS_PER_SECOND)
+  }
+}

--- a/packages/logic/src/mechanics/gqUpgradeCost.ts
+++ b/packages/logic/src/mechanics/gqUpgradeCost.ts
@@ -1,0 +1,82 @@
+// GQ upgrade cost-to-next-level formula, lifted from
+// packages/web_ui/src/singularity.ts. Four cost-form branches:
+//
+//   - Exponential2: costPerLevel * sqrt(overcapMult) * 2^level
+//   - Cubic:        costPerLevel * overcapMult * ((level+1)^3 - level^3)
+//   - Quadratic:    costPerLevel * overcapMult * ((level+1)^2 - level^2)
+//   - default:      ceil(costPerLevel * (level+1) * overcapMult * noMaxLevelMult)
+//
+// The overcap multiplier (`4^(level - maxLevel + 1)`) applies whenever
+// computedMaxLevel exceeds maxLevel (via overclock-perks / octeract cap
+// bonuses) AND the player is past the base maxLevel. The default branch
+// also has a no-max-level progression: x= maxLevel === -1 upgrades get
+// multiplied by `level/50` past level 100 and `level/100` past level 400.
+// Returns 0 when level === computedMaxLevel (fully maxed).
+
+export type GQUpgradeSpecialCostForm = 'Exponential2' | 'Cubic' | 'Quadratic' | null
+
+export interface GQUpgradeCostTNLInput {
+  /** goldenQuarkUpgrades[k].level — current purchased level. */
+  level: number
+  /** goldenQuarkUpgrades[k].maxLevel — base cap (−1 sentinel for unlimited). */
+  maxLevel: number
+  /** computeGQUpgradeMaxLevel(k) — base cap plus overclock-perks plus octeract cap bonus. */
+  computedMaxLevel: number
+  /** goldenQuarkUpgrades[k].costPerLevel — base cost coefficient. */
+  costPerLevel: number
+  /**
+   * goldenQuarkUpgrades[k].specialCostForm — one of three closed-form
+   * shapes, or null for the default linear-with-overcap branch.
+   */
+  specialCostForm: GQUpgradeSpecialCostForm
+}
+
+/**
+ * Cost to buy the next level of a GQ upgrade.
+ *
+ * Returns 0 if already maxed (level === computedMaxLevel).
+ *
+ * The overcap multiplier kicks in only for upgrades where overclock-perks /
+ * octeract cap bonuses pushed `computedMaxLevel` past the base `maxLevel`,
+ * AND only once the player is past the base `maxLevel`. The three
+ * `specialCostForm` branches each use it differently:
+ *   - Exponential2 takes sqrt(overcap) (softer scaling)
+ *   - Cubic & Quadratic apply overcap directly to the level-delta cost
+ *   - default applies overcap × the no-max-level progression
+ *
+ * The no-max-level progression (level/50 past 100, level/100 past 400) only
+ * applies to default-form upgrades with maxLevel === -1.
+ */
+export function gqUpgradeCostTNL (input: GQUpgradeCostTNLInput): number {
+  if (input.computedMaxLevel === input.level) {
+    return 0
+  }
+
+  let costMultiplier = 1
+
+  // Overcap multiplier — fires only when computedMaxLevel > base maxLevel
+  // AND player is past the base maxLevel.
+  if (input.computedMaxLevel > input.maxLevel && input.level >= input.maxLevel) {
+    costMultiplier *= Math.pow(4, input.level - input.maxLevel + 1)
+  }
+
+  if (input.specialCostForm === 'Exponential2') {
+    return input.costPerLevel * Math.sqrt(costMultiplier) * Math.pow(2, input.level)
+  }
+
+  if (input.specialCostForm === 'Cubic') {
+    return input.costPerLevel * costMultiplier * (Math.pow(input.level + 1, 3) - Math.pow(input.level, 3))
+  }
+
+  if (input.specialCostForm === 'Quadratic') {
+    return input.costPerLevel * costMultiplier * (Math.pow(input.level + 1, 2) - Math.pow(input.level, 2))
+  }
+
+  // Default linear branch with no-max-level progression.
+  costMultiplier *= input.maxLevel === -1 && input.level >= 100 ? input.level / 50 : 1
+  costMultiplier *= input.maxLevel === -1 && input.level >= 400 ? input.level / 100 : 1
+
+  // Web_ui's original code re-checked maxed-out here; we've already returned
+  // early at the top, so just compute the cost.
+  return Math.ceil(input.costPerLevel * (1 + input.level) * costMultiplier)
+}

--- a/packages/logic/src/mechanics/gqUpgradeLevels.ts
+++ b/packages/logic/src/mechanics/gqUpgradeLevels.ts
@@ -1,0 +1,148 @@
+// Golden-quark upgrade effective-level math, lifted from
+// packages/web_ui/src/singularity.ts. The web_ui side keeps the GQ upgrade
+// data table and the buy/UI flow; this module owns the pure formulas that
+// convert per-upgrade snapshot + player-state inputs into the effective
+// level used by effect lookups, the level cap, and the polynomial bonus
+// path unlocked by `octeractImprovedFree`.
+//
+// NOTE: octeract upgrades have a parallel set of helpers in
+// `octeractUpgradeLevels.ts`. The two `computeFreeLevelMultiplier`
+// implementations differ (GQ side reads shop + cube[75]; Octeract side
+// reads cube[78]), so the names are kept distinct (`gqFreeLevelMultiplier`
+// vs `octeractFreeLevelMultiplier`).
+
+// Singularity counts that unlock an extra +1 to a GQ upgrade's level cap
+// when the upgrade is flagged `canExceedCap`. Sorted ascending; we walk the
+// array and stop at the first unmet threshold.
+const overclockPerks = [50, 60, 75, 100, 125, 150, 175, 200, 225, 250]
+
+/**
+ * GQ free-level multiplier. Sums the shop `freeUpgradeMult` contribution
+ * with `0.3% * cubeUpgrades[75]`. Used by both the free-level softcap and
+ * the polynomial-path bonus.
+ */
+export function gqFreeLevelMultiplier (shopFreeUpgradeMult: number, cubeUpgrade75: number): number {
+  return shopFreeUpgradeMult + 0.3 / 100 * cubeUpgrade75
+}
+
+/**
+ * Effective free levels for one GQ upgrade. Above the player's purchased
+ * level, free levels accumulate at a square-root rate — so the formula is
+ * `min(level, baseRealFreeLevels) + sqrt(max(0, baseRealFreeLevels - level))`.
+ * Both pieces matter: the `min` caps the linear contribution at the player's
+ * actual purchases, the `sqrt` adds a softened bonus for unowned free levels.
+ */
+export function gqUpgradeFreeLevelSoftcap (freeLevel: number, level: number, freeLevelMult: number): number {
+  const baseRealFreeLevels = freeLevelMult * freeLevel
+  return Math.min(level, baseRealFreeLevels) + Math.sqrt(Math.max(0, baseRealFreeLevels - level))
+}
+
+export interface GqUpgradeMaxLevelInput {
+  /** `goldenQuarkUpgrades[k].canExceedCap`. When false, returns maxLevel as-is. */
+  canExceedCap: boolean
+  /** The upgrade's base cap — `goldenQuarkUpgrades[k].maxLevel`. */
+  maxLevel: number
+  /** `player.highestSingularityCount` — feeds the overclock-perks loop. */
+  highestSingularityCount: number
+  /**
+   * `getOcteractUpgradeEffect('octeractSingUpgradeCap', 'goldenQuarkUpgradeCapIncrease')`.
+   * Added to the final cap for canExceedCap upgrades.
+   */
+  octeractSingUpgradeCapIncrease: number
+}
+
+/**
+ * Maximum level for a GQ upgrade. For `canExceedCap` upgrades, walks the
+ * overclock-perks array adding +1 per crossed threshold (stops at the first
+ * unmet one), then adds the octeract-cap bonus. For non-`canExceedCap`
+ * upgrades, returns `maxLevel` unchanged.
+ */
+export function computeGQUpgradeMaxLevel (input: GqUpgradeMaxLevelInput): number {
+  if (!input.canExceedCap) {
+    return input.maxLevel
+  }
+  let cap = input.maxLevel
+  for (const perk of overclockPerks) {
+    if (input.highestSingularityCount >= perk) {
+      cap += 1
+    } else {
+      break
+    }
+  }
+  cap += input.octeractSingUpgradeCapIncrease
+  return cap
+}
+
+export interface ActualGQUpgradeTotalLevelsInput {
+  /** The upgrade's purchased level — `goldenQuarkUpgrades[k].level`. */
+  level: number
+  /** The upgrade's accumulated free levels — `goldenQuarkUpgrades[k].freeLevel`. */
+  freeLevel: number
+  /** `goldenQuarkUpgrades[k].qualityOfLife`. QoL upgrades stay active inside the gating challenges. */
+  qualityOfLife: boolean
+  /**
+   * True when `upgradeKey === 'platonicDelta'`. That upgrade gets a hard 0
+   * inside the three Exalt challenges that gate it. The check is
+   * upgrade-key-specific in web_ui; we accept it as a boolean here so logic
+   * doesn't have to know the GQ upgrade key set.
+   */
+  isPlatonicDelta: boolean
+  /** `player.singularityChallenges.noSingularityUpgrades.enabled`. */
+  inNoSingularityUpgrades: boolean
+  /** `player.singularityChallenges.sadisticPrequel.enabled`. */
+  inSadisticPrequel: boolean
+  /** `player.singularityChallenges.limitedAscensions.enabled`. */
+  inLimitedAscensions: boolean
+  /** `player.singularityChallenges.limitedTime.enabled`. */
+  inLimitedTime: boolean
+  /** GQ free-level multiplier — `gqFreeLevelMultiplier(shopMult, cubeUpgrades[75])`. */
+  freeLevelMult: number
+  /**
+   * `getOcteractUpgradeEffect('octeractImprovedFree', 'unlocked')`. Gates
+   * the polynomial-bonus path entirely — when false, the polynomial term
+   * is skipped and only the linear sum contributes.
+   */
+  improvedFreeUnlocked: boolean
+  /**
+   * Sum of the four improved-free `freeLevelPower` / `freeLevelPowerIncrease`
+   * octeract-upgrade effects. The polynomial term is
+   * `(level * actualFreeLevels) ^ exponent`.
+   */
+  improvedFreeExponent: number
+}
+
+/**
+ * Effective total level for one GQ upgrade.
+ *
+ * Three gating layers, in order:
+ *
+ * 1. If inside `noSingularityUpgrades` or `sadisticPrequel` AND the upgrade
+ *    isn't `qualityOfLife`, returns 0.
+ * 2. If the upgrade is platonicDelta AND inside `limitedAscensions`,
+ *    `limitedTime`, or `sadisticPrequel`, returns 0.
+ * 3. Otherwise: `linearLevels = level + actualFreeLevels`. If
+ *    `octeractImprovedFree` is unlocked, also computes
+ *    `polynomialLevels = (level * actualFreeLevels) ^ exponent` and returns
+ *    the max of the two. If not unlocked, just returns linearLevels.
+ */
+export function actualGQUpgradeTotalLevels (input: ActualGQUpgradeTotalLevelsInput): number {
+  if ((input.inNoSingularityUpgrades || input.inSadisticPrequel) && !input.qualityOfLife) {
+    return 0
+  }
+  if (
+    (input.inLimitedAscensions || input.inLimitedTime || input.inSadisticPrequel)
+    && input.isPlatonicDelta
+  ) {
+    return 0
+  }
+
+  const actualFreeLevels = gqUpgradeFreeLevelSoftcap(input.freeLevel, input.level, input.freeLevelMult)
+  const linearLevels = input.level + actualFreeLevels
+  let polynomialLevels = 0
+
+  if (input.improvedFreeUnlocked) {
+    polynomialLevels = Math.pow(input.level * actualFreeLevels, input.improvedFreeExponent)
+  }
+
+  return Math.max(linearLevels, polynomialLevels)
+}

--- a/packages/logic/src/mechanics/hepteractValues.ts
+++ b/packages/logic/src/mechanics/hepteractValues.ts
@@ -1,0 +1,67 @@
+// Hepteract effective-value and cap helpers, lifted from
+// packages/web_ui/src/Hepteracts.ts. Pure math given the per-hept snapshot:
+//
+//   - hepteractEffective: applies the diminishing-returns formula past
+//     LIMIT. Special-cased for `quark` (which uses a custom nonpolynomial
+//     formula web_ui handles separately — here we just pass BAL through
+//     when the caller flags it as the quark hept).
+//   - hepteractCap: BASE_CAP * 2^TIMES_CAP_EXTENDED — the player's
+//     expanded cap before any Exalt 3 doubling.
+//   - hepteractFinalCap: hepteractCap * (limitedAscensions Exalt 3 reward
+//     active ? 2 : 1) — the post-Exalt cap actually used by the UI.
+
+export interface HepteractEffectiveInput {
+  /** hepteracts[k].BAL — raw accumulated value. */
+  rawAmount: number
+  /** hepteracts[k].LIMIT — threshold past which DR applies. */
+  limit: number
+  /**
+   * hepteracts[k].DR + hepteracts[k].DR_INCREASE() — combined diminishing-
+   * returns exponent. Web_ui evaluates DR_INCREASE since it can depend on
+   * upgrade state; this module gets the resolved scalar.
+   */
+  drExponent: number
+  /**
+   * True when this is the `quark` hept. Quark hept has a custom non-
+   * polynomial formula that web_ui owns; logic just passes BAL through.
+   */
+  isQuark: boolean
+}
+
+/**
+ * Effective hepteract value with diminishing returns past LIMIT.
+ *
+ * - quark: just returns `rawAmount` (web_ui's custom formula owns this).
+ * - rawAmount ≤ LIMIT: linear, returns `rawAmount`.
+ * - rawAmount > LIMIT: `LIMIT * (rawAmount/LIMIT)^drExponent` — the
+ *   value past LIMIT is softened by the DR exponent (drExponent < 1
+ *   for most hepts, so growth past LIMIT is sub-linear).
+ */
+export function hepteractEffective (input: HepteractEffectiveInput): number {
+  if (input.isQuark) {
+    return input.rawAmount
+  }
+
+  let effectiveValue = Math.min(input.rawAmount, input.limit)
+  if (input.rawAmount > input.limit) {
+    effectiveValue *= Math.pow(input.rawAmount / input.limit, input.drExponent)
+  }
+  return effectiveValue
+}
+
+/**
+ * Player's expanded hepteract cap before the Exalt 3 doubling.
+ * `BASE_CAP * 2^TIMES_CAP_EXTENDED` — each expansion doubles the cap.
+ */
+export function hepteractCap (baseCap: number, timesCapExtended: number): number {
+  return Math.pow(2, timesCapExtended) * baseCap
+}
+
+/**
+ * The cap actually used by the UI — multiplies hepteractCap by 2 if the
+ * limitedAscensions (Exalt 3) `hepteractCap` reward is active, else 1.
+ */
+export function hepteractFinalCap (baseCap: number, timesCapExtended: number, exalt3HepteractCap: boolean): number {
+  const specialMultiplier = exalt3HepteractCap ? 2 : 1
+  return hepteractCap(baseCap, timesCapExtended) * specialMultiplier
+}

--- a/packages/logic/src/mechanics/levelMilestones.ts
+++ b/packages/logic/src/mechanics/levelMilestones.ts
@@ -1,0 +1,158 @@
+// Per-milestone level scaling formulas, lifted from
+// packages/web_ui/src/Levels.ts (the `synergismLevelMilestones.<key>.effect`
+// fields). Almost every milestone is either a pure `(level: number) => number`
+// or a constant `() => 1` unlock flag — those go in the `levelMilestones`
+// table, and `getLevelMilestone(key, level)` returns the effect or the
+// default depending on the level gate.
+//
+// The one exception is `salvageChallengeBuff`, whose value depends on which
+// challenge the player is in. It lives as a standalone
+// `salvageChallengeBuffEffect(input)` here; web_ui sources the challenge
+// state and calls it directly.
+
+export type LevelMilestoneKey =
+  | 'offeringTimerScaling'
+  | 'autoPrestige'
+  | 'speedRune'
+  | 'duplicationRune'
+  | 'prismRune'
+  | 'thriftRune'
+  | 'SIRune'
+  | 'tier1CrystalAutobuy'
+  | 'tier2CrystalAutobuy'
+  | 'tier3CrystalAutobuy'
+  | 'tier4CrystalAutobuy'
+  | 'tier5CrystalAutobuy'
+  | 'achievementTalismanUnlock'
+  | 'runeAutobuyImprover'
+  | 'achievementTalismanEnhancement'
+  | 'antSpeed2Autobuyer'
+  | 'wowCubesAutobuyer'
+  | 'ascensionScoreAutobuyer'
+  | 'mortuus2Autobuyer'
+
+export interface LevelMilestoneData {
+  /** Pure effect formula. Only called by `getLevelMilestone` once level ≥ levelReq. */
+  effect: (level: number) => number
+  /** Level at which the milestone unlocks. Below this, callers get `defaultValue`. */
+  levelReq: number
+  /** Returned by `getLevelMilestone` when level < levelReq. */
+  defaultValue: number
+}
+
+// ─── Per-milestone effect formulas ─────────────────────────────────────────
+
+/** Constant 1 — pure flag, the milestone exists only to unlock UI behavior. */
+const unlockFlagEffect = () => 1
+
+// The five "rune scaling" milestones share the shape `coeff * (level - threshold)`
+// where (coeff, threshold) is fixed per rune. Pulled into a small helper so the
+// per-rune exports don't repeat the formula five times.
+function runeScalingEffect (level: number, coeff: number, threshold: number): number {
+  return coeff * (level - threshold)
+}
+
+export function speedRuneMilestoneEffect (level: number): number {
+  return runeScalingEffect(level, 0.5, 19)
+}
+export function duplicationRuneMilestoneEffect (level: number): number {
+  return runeScalingEffect(level, 0.4, 39)
+}
+export function prismRuneMilestoneEffect (level: number): number {
+  return runeScalingEffect(level, 0.3, 59)
+}
+export function thriftRuneMilestoneEffect (level: number): number {
+  return runeScalingEffect(level, 0.2, 79)
+}
+export function siRuneMilestoneEffect (level: number): number {
+  return runeScalingEffect(level, 0.1, 99)
+}
+
+/**
+ * Rune autobuyer interval improver — `1.1 + 0.01 * (level - 130)`. Returns 1
+ * below level 130 via `getLevelMilestone`'s default-value gate.
+ */
+export function runeAutobuyImproverEffect (level: number): number {
+  return 1.1 + 0.01 * (level - 130)
+}
+
+/** Achievement Talisman Enhancement just passes the level through. */
+export function achievementTalismanEnhancementEffect (level: number): number {
+  return level
+}
+
+// ─── salvageChallengeBuff (impure — reads challenge state) ─────────────────
+
+export interface SalvageChallengeBuffInput {
+  /**
+   * True when ANY of player.currentChallenge.{transcension,reincarnation,
+   * ascension} is non-zero. Doubles the base buff.
+   */
+  inAnyChallenge: boolean
+  /** True when player.currentChallenge.ascension === 15. Doubles again on top. */
+  inAscension15: boolean
+  /** player.insideSingularityChallenge. Triples on top of any other multipliers. */
+  insideSingularityChallenge: boolean
+}
+
+/**
+ * Salvage buff inside challenges. Base 25; ×2 inside any normal challenge,
+ * ×2 again inside C15 specifically (so ×4 total there), ×3 again inside any
+ * singularity challenge (cumulative with the prior multipliers).
+ */
+export function salvageChallengeBuffEffect (input: SalvageChallengeBuffInput): number {
+  let baseVal = 25
+  if (input.inAnyChallenge) {
+    baseVal *= 2
+  }
+  if (input.inAscension15) {
+    baseVal *= 2
+  }
+  if (input.insideSingularityChallenge) {
+    baseVal *= 3
+  }
+  return baseVal
+}
+
+// ─── Data table (pure milestones only) ─────────────────────────────────────
+
+export const levelMilestones: Record<LevelMilestoneKey, LevelMilestoneData> = {
+  offeringTimerScaling: { effect: unlockFlagEffect, levelReq: 5, defaultValue: 0 },
+  autoPrestige: { effect: unlockFlagEffect, levelReq: 7, defaultValue: 0 },
+  speedRune: { effect: speedRuneMilestoneEffect, levelReq: 20, defaultValue: 0 },
+  duplicationRune: { effect: duplicationRuneMilestoneEffect, levelReq: 40, defaultValue: 0 },
+  prismRune: { effect: prismRuneMilestoneEffect, levelReq: 60, defaultValue: 0 },
+  thriftRune: { effect: thriftRuneMilestoneEffect, levelReq: 80, defaultValue: 0 },
+  SIRune: { effect: siRuneMilestoneEffect, levelReq: 100, defaultValue: 0 },
+  tier1CrystalAutobuy: { effect: unlockFlagEffect, levelReq: 6, defaultValue: 0 },
+  tier2CrystalAutobuy: { effect: unlockFlagEffect, levelReq: 9, defaultValue: 0 },
+  tier3CrystalAutobuy: { effect: unlockFlagEffect, levelReq: 12, defaultValue: 0 },
+  tier4CrystalAutobuy: { effect: unlockFlagEffect, levelReq: 15, defaultValue: 0 },
+  tier5CrystalAutobuy: { effect: unlockFlagEffect, levelReq: 20, defaultValue: 0 },
+  achievementTalismanUnlock: { effect: unlockFlagEffect, levelReq: 100, defaultValue: 0 },
+  runeAutobuyImprover: { effect: runeAutobuyImproverEffect, levelReq: 130, defaultValue: 1 },
+  achievementTalismanEnhancement: {
+    effect: achievementTalismanEnhancementEffect,
+    levelReq: 160,
+    defaultValue: 0
+  },
+  antSpeed2Autobuyer: { effect: unlockFlagEffect, levelReq: 65, defaultValue: 0 },
+  wowCubesAutobuyer: { effect: unlockFlagEffect, levelReq: 80, defaultValue: 0 },
+  ascensionScoreAutobuyer: { effect: unlockFlagEffect, levelReq: 80, defaultValue: 0 },
+  mortuus2Autobuyer: { effect: unlockFlagEffect, levelReq: 225, defaultValue: 0 }
+}
+
+/**
+ * Returns the active milestone value for a given achievement level. Below the
+ * milestone's `levelReq`, returns the `defaultValue`; otherwise invokes the
+ * milestone's `effect`. Does NOT cover `salvageChallengeBuff` — that one
+ * needs challenge state and is exposed separately as
+ * `salvageChallengeBuffEffect`.
+ */
+export function getLevelMilestone (milestone: LevelMilestoneKey, level: number): number {
+  const data = levelMilestones[milestone]
+  if (level >= data.levelReq) {
+    return data.effect(level)
+  }
+  return data.defaultValue
+}

--- a/packages/logic/src/mechanics/levelRewards.ts
+++ b/packages/logic/src/mechanics/levelRewards.ts
@@ -1,0 +1,154 @@
+// Per-reward level scaling formulas, lifted from
+// packages/web_ui/src/Levels.ts (the `synergismLevelRewards.<key>.effect`
+// fields). Each reward is a pure `(level: number) => number` paired with the
+// `minLevel` at which it activates and the `defaultValue` returned below
+// that. The i18n strings, name colors, and DOM wiring stay in web_ui — this
+// module is just the numbers.
+
+export type LevelRewardKey =
+  | 'salvage'
+  | 'quarks'
+  | 'offerings'
+  | 'obtainium'
+  | 'ants'
+  | 'wowCubes'
+  | 'wowTesseracts'
+  | 'wowHyperCubes'
+  | 'wowPlatonicCubes'
+  | 'wowHepteractCubes'
+  | 'wowOcteracts'
+  | 'ambrosiaLuck'
+  | 'redAmbrosiaLuck'
+
+export interface LevelRewardData {
+  /** Pure effect formula. Only called by `getLevelReward` once level ≥ minLevel. */
+  effect: (level: number) => number
+  /** Level at which the reward unlocks. Below this, callers get `defaultValue`. */
+  minLevel: number
+  /** Returned by `getLevelReward` when level < minLevel. */
+  defaultValue: number
+}
+
+// ─── Per-reward effect formulas ────────────────────────────────────────────
+
+/**
+ * Salvage grows by 1/level for the first 100 levels, then 2/level for the
+ * next 100, then 3/level for the next 100, etc. Computed as a stepwise loop
+ * that subtracts a 100-level block per pass, bumping the per-level rate by 1.
+ */
+export function salvageEffect (level: number): number {
+  let salvage = 0
+  let salvagePerLevel = 1
+  let remainingLevels = level
+  while (remainingLevels >= 100) {
+    salvage += salvagePerLevel * 100
+    remainingLevels -= 100
+    salvagePerLevel += 1
+  }
+  salvage += salvagePerLevel * remainingLevels
+  return salvage
+}
+
+/** Quark multiplier — `1.01^floor(level/20)`. Steps up every 20 levels. */
+export function quarksEffect (level: number): number {
+  return Math.pow(1.01, Math.floor(level / 20))
+}
+
+/** Offering multiplier — `1.01^level * 1.02^max(0, level-100)`. */
+export function offeringsEffect (level: number): number {
+  return Math.pow(1.01, level) * Math.pow(1.02, Math.max(0, level - 100))
+}
+
+/** Obtainium multiplier — `1.01^(level-15) * 1.02^max(0, level-100)`. */
+export function obtainiumEffect (level: number): number {
+  return Math.pow(1.01, level - 15) * Math.pow(1.02, Math.max(0, level - 100))
+}
+
+/**
+ * Ant ELO bonus. Three-band linear formula:
+ *   - Levels 60–130: +25 per level (capped at 71 levels' worth)
+ *   - Levels 100–200: +50 per level (capped at 100 levels' worth)
+ *   - Levels 200+: +100 per level
+ * The web_ui-visible behavior is to add these three contributions together,
+ * which gives the documented 25/50/100 step at each band.
+ */
+export function antsEffect (level: number): number {
+  const first100Levels = Math.min(71, level - 59) * 25
+  const next100Levels = Math.max(0, Math.min(100, level - 100)) * 50
+  const remainingLevels = Math.max(0, level - 200) * 100
+  return first100Levels + next100Levels + remainingLevels
+}
+
+/**
+ * Shape shared by the six wow-cube rewards:
+ *   `(1 + (level - linearOffset) / 20) * 1.07^(floor(level/10) - tenthOffset)`
+ *
+ * Each cube tier has different offsets and minLevel — see the per-cube
+ * exports below. Pulled out so the web_ui table doesn't have to repeat the
+ * formula six times verbatim.
+ */
+function wowCubeShapedEffect (level: number, linearOffset: number, tenthOffset: number): number {
+  return (1 + (level - linearOffset) / 20) * Math.pow(1.07, Math.floor(level / 10) - tenthOffset)
+}
+
+export function wowCubesEffect (level: number): number {
+  return wowCubeShapedEffect(level, 60, 6)
+}
+export function wowTesseractsEffect (level: number): number {
+  return wowCubeShapedEffect(level, 80, 8)
+}
+export function wowHyperCubesEffect (level: number): number {
+  return wowCubeShapedEffect(level, 100, 10)
+}
+export function wowPlatonicCubesEffect (level: number): number {
+  return wowCubeShapedEffect(level, 120, 12)
+}
+export function wowHepteractCubesEffect (level: number): number {
+  return wowCubeShapedEffect(level, 150, 15)
+}
+
+/** Octeract multiplier — uses 1.02 base (not 1.07) and a per-level (not per-tenth) exponent. */
+export function wowOcteractsEffect (level: number): number {
+  return (1 + (level - 209) / 20) * Math.pow(1.02, level - 209)
+}
+
+/** Flat 4 ambrosia luck per level past 229. */
+export function ambrosiaLuckEffect (level: number): number {
+  return 4 * (level - 229)
+}
+
+/** Flat 1 red-ambrosia luck per level past 259. */
+export function redAmbrosiaLuckEffect (level: number): number {
+  return level - 259
+}
+
+// ─── Data table ────────────────────────────────────────────────────────────
+
+export const levelRewards: Record<LevelRewardKey, LevelRewardData> = {
+  salvage: { effect: salvageEffect, minLevel: 0, defaultValue: 0 },
+  quarks: { effect: quarksEffect, minLevel: 20, defaultValue: 1 },
+  offerings: { effect: offeringsEffect, minLevel: 0, defaultValue: 1 },
+  obtainium: { effect: obtainiumEffect, minLevel: 15, defaultValue: 1 },
+  ants: { effect: antsEffect, minLevel: 60, defaultValue: 1 },
+  wowCubes: { effect: wowCubesEffect, minLevel: 70, defaultValue: 1 },
+  wowTesseracts: { effect: wowTesseractsEffect, minLevel: 90, defaultValue: 1 },
+  wowHyperCubes: { effect: wowHyperCubesEffect, minLevel: 110, defaultValue: 1 },
+  wowPlatonicCubes: { effect: wowPlatonicCubesEffect, minLevel: 140, defaultValue: 1 },
+  wowHepteractCubes: { effect: wowHepteractCubesEffect, minLevel: 170, defaultValue: 1 },
+  wowOcteracts: { effect: wowOcteractsEffect, minLevel: 210, defaultValue: 1 },
+  ambrosiaLuck: { effect: ambrosiaLuckEffect, minLevel: 230, defaultValue: 0 },
+  redAmbrosiaLuck: { effect: redAmbrosiaLuckEffect, minLevel: 260, defaultValue: 0 }
+}
+
+/**
+ * Returns the active reward value for a given achievement level. Below the
+ * reward's `minLevel`, returns the `defaultValue`; otherwise invokes the
+ * reward's `effect`.
+ */
+export function getLevelReward (reward: LevelRewardKey, level: number): number {
+  const data = levelRewards[reward]
+  if (level >= data.minLevel) {
+    return data.effect(level)
+  }
+  return data.defaultValue
+}

--- a/packages/logic/src/mechanics/octeractUpgradeLevels.ts
+++ b/packages/logic/src/mechanics/octeractUpgradeLevels.ts
@@ -1,0 +1,72 @@
+// Octeract upgrade effective-level math, lifted from
+// packages/web_ui/src/Octeracts.ts. The web_ui side owns the OcteractUpgrades
+// data tables and the buy/UI flow; this module owns the pure formulas that
+// take a per-upgrade `level` / `freeLevel` / `qualityOfLife` snapshot plus
+// the player-state inputs (cubeUpgrades[78] for the multiplier, the two
+// no-octeracts-style challenge gates) and return the effective level used by
+// effect lookups and cost-to-next-level calculations.
+//
+// NOTE: the same name `computeFreeLevelMultiplier` exists in
+// packages/web_ui/src/singularity.ts for golden-quark upgrades, but that's a
+// *different* formula (shop + cube[75], not just cube[78]). The GQ-side math
+// has its own logic module (`gqUpgradeLevels.ts`).
+
+/**
+ * Octeract free-level multiplier. Just `1 + 0.3% * cubeUpgrades[78]`.
+ * cubeUpgrades[78] is the only input the Octeract side reads.
+ */
+export function octeractFreeLevelMultiplier (cubeUpgrade78: number): number {
+  return 1 + 0.3 / 100 * cubeUpgrade78
+}
+
+/**
+ * Softcap on the effective free levels for one octeract upgrade. Just the
+ * upgrade's `freeLevel` scaled by `freeLevelMult` — kept as a named export
+ * because the web_ui display code calls it directly.
+ */
+export function octeractFreeLevelSoftcap (freeLevel: number, freeLevelMult: number): number {
+  return freeLevel * freeLevelMult
+}
+
+export interface ActualOcteractUpgradeTotalLevelsInput {
+  /** The upgrade's purchased level — `octeractUpgrades[k].level`. */
+  level: number
+  /** The upgrade's accumulated free levels — `octeractUpgrades[k].freeLevel`. */
+  freeLevel: number
+  /**
+   * `octeractUpgrades[k].qualityOfLife`. When false, the upgrade is gated
+   * off inside noOcteracts / sadisticPrequel (returns 0).
+   */
+  qualityOfLife: boolean
+  /** `player.cubeUpgrades[78]` — feeds the multiplier. */
+  cubeUpgrade78: number
+  /** `player.singularityChallenges.noOcteracts.enabled`. */
+  inNoOcteracts: boolean
+  /** `player.singularityChallenges.sadisticPrequel.enabled`. */
+  inSadisticPrequel: boolean
+}
+
+/**
+ * Effective total level for one octeract upgrade.
+ *
+ * - Returns 0 if the player is in `noOcteracts` or `sadisticPrequel` AND the
+ *   upgrade isn't flagged `qualityOfLife` (quality-of-life upgrades stay
+ *   active inside those challenges).
+ * - Otherwise: when `level ≥ actualFreeLevels`, returns
+ *   `actualFreeLevels + level` (linear sum). When `level < actualFreeLevels`,
+ *   returns `2 * sqrt(actualFreeLevels * level)` — a smoother softcap that
+ *   matches the linear formula at `level == actualFreeLevels`.
+ */
+export function actualOcteractUpgradeTotalLevels (input: ActualOcteractUpgradeTotalLevelsInput): number {
+  if ((input.inNoOcteracts || input.inSadisticPrequel) && !input.qualityOfLife) {
+    return 0
+  }
+
+  const freeLevelMult = octeractFreeLevelMultiplier(input.cubeUpgrade78)
+  const actualFreeLevels = octeractFreeLevelSoftcap(input.freeLevel, freeLevelMult)
+
+  if (input.level >= actualFreeLevels) {
+    return actualFreeLevels + input.level
+  }
+  return 2 * Math.sqrt(actualFreeLevels * input.level)
+}

--- a/packages/logic/src/mechanics/runeEXPMultiplier.ts
+++ b/packages/logic/src/mechanics/runeEXPMultiplier.ts
@@ -1,0 +1,84 @@
+// Universal rune-EXP-per-offering multiplier, lifted from
+// packages/web_ui/src/Runes.ts. The shape:
+//
+//   (additive multiplier) × (product of all-rune multipliers) × (recycleMult)
+//
+// Three groups of inputs:
+//   1. Additive: base 1, plus C1 completion bonus + per-C1 scaling,
+//      researches 5x2 / 5x3, particle upgrade 3x1 (which scales with the
+//      caller's `purchasedLevels` to discourage low-level dump-and-respec).
+//   2. Multiplicative: researches 4x16 / 4x17, cube upgrade 32 × ascension
+//      counter, constant upgrade 8, challenge-15 rune-EXP reward multiplier.
+//   3. Recycle: the inverse of recycle/salvage chance — passed in from
+//      web_ui's calculateSalvageRuneEXPMultiplier.
+
+import { Decimal } from '../math/bignum'
+
+export interface UniversalRuneEXPMultInput {
+  /** rune.level — the per-rune `purchasedLevels` parameter. Feeds the
+   *  particle-upgrade-3x1 additive contribution. */
+  purchasedLevels: number
+  /** player.highestchallengecompletions[1]. Bonus is `min(1, n) + 0.04 * n`. */
+  c1Completions: number
+  /** player.researches[22]. +0.6 per level. */
+  research22: number
+  /** player.researches[23]. +0.3 per level. */
+  research23: number
+  /** player.upgrades[71]. Particle upgrade 3x1: adds `n * purchasedLevels / 25`. */
+  upgrade71: number
+  /** player.researches[91]. ×(1 + n/20). */
+  research91: number
+  /** player.researches[92]. ×(1 + n/20). */
+  research92: number
+  /** player.ascensionCounter — seconds in current ascension. Feeds the cube-upgrade-32 bonus. */
+  ascensionCounter: number
+  /** player.cubeUpgrades[32]. Bonus ×(1 + ascensionCounter/1000 * n). */
+  cubeUpgrade32: number
+  /** player.constantUpgrades[8]. ×(1 + n/10). */
+  constantUpgrade8: number
+  /** G.challenge15Rewards.runeExp.value — number multiplier from C15 reward formula. */
+  challenge15RuneExpReward: number
+  /**
+   * calculateSalvageRuneEXPMultiplier() — the recycle/salvage multiplier
+   * (the inverse of effective recycle chance). Passed in to avoid pulling
+   * the whole salvage math chain into this module.
+   */
+  salvageRuneEXPMultiplier: Decimal
+}
+
+/**
+ * Universal multiplier applied to the base EXP-per-offering for every rune.
+ * Pure function over the input bundle.
+ *
+ * Returns `additive × multiplicative × recycle`, where `additive` and
+ * `multiplicative` are themselves a sum-of-contributions and a
+ * product-of-contributions as documented above. Result type is Decimal
+ * because the C15 reward and salvage multiplier can both exceed Number range.
+ */
+export function universalRuneEXPMult (input: UniversalRuneEXPMultInput): Decimal {
+  const allRuneExpAdditiveMultiplier = 1
+    // C1 completion: +1 for any completion, +0.04 per completion
+    + Math.min(1, input.c1Completions)
+    + (0.4 / 10) * input.c1Completions
+    // Research 5x2
+    + 0.6 * input.research22
+    // Research 5x3
+    + 0.3 * input.research23
+    // Particle upgrade 3x1 — scales with purchasedLevels
+    + (input.upgrade71 * input.purchasedLevels) / 25
+
+  const allRuneExpMultiplier = [
+    // Research 4x16
+    1 + input.research91 / 20,
+    // Research 4x17
+    1 + input.research92 / 20,
+    // Cube Upgrade 32 × ascension time
+    1 + (input.ascensionCounter / 1000) * input.cubeUpgrade32,
+    // Constant Upgrade 8
+    1 + (1 / 10) * input.constantUpgrade8,
+    // Challenge 15 reward
+    input.challenge15RuneExpReward
+  ].reduce((x, y) => x.times(y), new Decimal('1'))
+
+  return allRuneExpMultiplier.times(allRuneExpAdditiveMultiplier).times(input.salvageRuneEXPMultiplier)
+}

--- a/packages/logic/src/mechanics/runeLevels.ts
+++ b/packages/logic/src/mechanics/runeLevels.ts
@@ -1,0 +1,141 @@
+// Rune EXP / level math, lifted from packages/web_ui/src/Runes.ts. Each
+// function takes the small per-rune snapshot (`costCoefficient`,
+// `levelsPerOOM`, sometimes `currentEXP` and `level`) and is pure Decimal
+// math. The web_ui side owns the rune data table and the offering-spend
+// flow; this module owns the closed-form EXP↔level inversion plus the
+// "given a budget, how many levels can I buy" planner.
+
+import { Decimal } from '../math/bignum'
+
+/**
+ * EXP required to *reach* a target rune level, starting from 0 EXP.
+ * Formula: `costCoefficient * (10^(level/levelsPerOOM) - 1)`.
+ *
+ * The `-1` zeroes out at level 0. `levelsPerOOM` is the number of levels
+ * between each 10x-EXP step.
+ */
+export function runeEXPToLevel (costCoefficient: Decimal, level: number, levelsPerOOM: number): Decimal {
+  return costCoefficient.times(Decimal.pow(10, level / levelsPerOOM).minus(1))
+}
+
+/**
+ * EXP still needed to *reach* a target rune level, given the rune's current
+ * EXP. Clamped at zero (you don't lose EXP by querying a level you've
+ * already passed).
+ */
+export function runeEXPLeftToLevel (
+  costCoefficient: Decimal,
+  targetLevel: number,
+  levelsPerOOM: number,
+  currentRuneEXP: Decimal
+): Decimal {
+  return Decimal.max(0, runeEXPToLevel(costCoefficient, targetLevel, levelsPerOOM).minus(currentRuneEXP))
+}
+
+/**
+ * Offerings required to reach a target rune level given the per-offering
+ * EXP rate. Floored at 1 — the UI never displays "0 offerings to next
+ * level" for an unowned level even if floating-point imprecision would say
+ * so.
+ */
+export function runeOfferingsToLevel (
+  costCoefficient: Decimal,
+  targetLevel: number,
+  levelsPerOOM: number,
+  currentRuneEXP: Decimal,
+  runeEXPPerOffering: Decimal
+): Decimal {
+  return Decimal.max(
+    1,
+    runeEXPLeftToLevel(costCoefficient, targetLevel, levelsPerOOM, currentRuneEXP)
+      .div(runeEXPPerOffering)
+      .ceil()
+  )
+}
+
+/**
+ * Closed-form inverse of `runeEXPToLevel`: given a rune's current EXP,
+ * returns the integer level reached. Equivalent to
+ * `floor(levelsPerOOM * log10(EXP/costCoeff + 1))`.
+ *
+ * Used by the rune-EXP→level resync (after gaining EXP). Does NOT include
+ * the float-imprecision +1 bump that web_ui's `updateLevelsFromEXP` does
+ * afterward — that fix-up uses `runeEXPLeftToLevel` to detect when the
+ * floor undercounted by exactly one.
+ */
+export function runeLevelFromEXP (currentRuneEXP: Decimal, costCoefficient: Decimal, levelsPerOOM: number): number {
+  return Math.floor(levelsPerOOM * Decimal.log10(currentRuneEXP.div(costCoefficient).plus(1)))
+}
+
+export interface MaxRuneLevelPurchaseInput {
+  /** rune.costCoefficient. */
+  costCoefficient: Decimal
+  /** rune.levelsPerOOM + rune.levelsPerOOMIncrease() — combined slope. */
+  levelsPerOOM: number
+  /** rune.level — current purchased level (not the floored-from-EXP level). */
+  currentLevel: number
+  /** rune.runeEXP — current accumulated EXP. */
+  currentRuneEXP: Decimal
+  /** rune.runeEXPPerOffering(currentLevel) — already evaluated by caller. */
+  runeEXPPerOffering: Decimal
+  /** Offerings budget the player wants to spend. */
+  budget: Decimal
+  /**
+   * rune.isUnlocked() — returning 0/0/0 below an unlocked rune is the
+   * legacy behavior the caller relies on for UI display gating.
+   */
+  isUnlocked: boolean
+}
+
+export interface MaxRuneLevelPurchaseResult {
+  /** Number of levels gained — `0` when locked or budget is negative. */
+  levels: number
+  /** Total EXP required to reach `currentLevel + levels`. */
+  expRequired: Decimal
+  /** Offerings actually consumed (≥1 if any level affordable). */
+  offerings: Decimal
+}
+
+/**
+ * Plans the largest level purchase affordable with a given offerings budget.
+ *
+ * Algorithm: convert `budget` to "total available EXP" by adding
+ * `budget * runeEXPPerOffering` to `currentRuneEXP`. Invert the EXP→level
+ * formula in closed form to find the maximum level reachable, floor it,
+ * subtract currentLevel. If that's 0, fall back to "what's the cost of the
+ * very next level" so the UI has something to display.
+ *
+ * Returns {levels: 0, exp: 0, offerings: 0} for locked runes / negative
+ * budgets — matching the legacy null-case shape.
+ */
+export function maxRuneLevelPurchase (input: MaxRuneLevelPurchaseInput): MaxRuneLevelPurchaseResult {
+  if (!input.isUnlocked || input.budget.lt(0)) {
+    return { levels: 0, expRequired: new Decimal(0), offerings: new Decimal(0) }
+  }
+
+  const totalEXPAvailable = input.budget.times(input.runeEXPPerOffering).add(input.currentRuneEXP)
+  // Same closed-form invert as runeLevelFromEXP, but with the budget-augmented
+  // EXP rather than just the current EXP.
+  const maxLevel = Math.floor(input.levelsPerOOM * Decimal.log10(totalEXPAvailable.div(input.costCoefficient).plus(1)))
+  const levelsGained = Math.max(0, maxLevel - input.currentLevel)
+
+  if (levelsGained === 0) {
+    // Budget too small to buy a level; report cost-to-next-level so the UI
+    // can display the gap.
+    const nextLevelEXP = runeEXPToLevel(input.costCoefficient, input.currentLevel + 1, input.levelsPerOOM)
+    const offeringsRequired = Decimal.max(
+      1,
+      nextLevelEXP.minus(input.currentRuneEXP).div(input.runeEXPPerOffering).ceil()
+    )
+    return { levels: 1, expRequired: nextLevelEXP, offerings: offeringsRequired }
+  }
+
+  const expRequired = runeEXPToLevel(input.costCoefficient, input.currentLevel + levelsGained, input.levelsPerOOM)
+  // Recompute offerings — the planner may have undershot the budget if the
+  // last level didn't quite fit.
+  const offeringsRequired = Decimal.max(
+    1,
+    expRequired.minus(input.currentRuneEXP).div(input.runeEXPPerOffering).ceil()
+  )
+  return { levels: levelsGained, expRequired, offerings: offeringsRequired }
+}

--- a/packages/logic/src/mechanics/shopCosts.ts
+++ b/packages/logic/src/mechanics/shopCosts.ts
@@ -1,0 +1,33 @@
+// Shop upgrade cost formula, lifted from packages/web_ui/src/Shop.ts. Pure
+// math given the per-upgrade snapshot — the web_ui side owns the shop data
+// table and feeds the relevant fields in.
+//
+// Two branches:
+//   - Consumables and one-shot upgrades (maxLevel === 1): cost is just
+//     `price`. They have no level-based scaling.
+//   - Stacked upgrades: cost is `price + priceIncrease * currentLevel` —
+//     linear in current level.
+
+export interface ShopCostInput {
+  /** shopUpgrades[k].type === shopUpgradeTypes.CONSUMABLE. Consumables flat-price. */
+  isConsumable: boolean
+  /** shopUpgrades[k].maxLevel. Single-purchase upgrades (maxLevel === 1) flat-price. */
+  maxLevel: number
+  /** shopUpgrades[k].price — base cost. */
+  price: number
+  /** shopUpgrades[k].priceIncrease — per-level cost increment. */
+  priceIncrease: number
+  /** player.shopUpgrades[k] — the player's currently-owned level. */
+  currentLevel: number
+}
+
+/**
+ * Cost to purchase the next level of a shop upgrade. Flat `price` for
+ * consumables and one-shot upgrades; linear scaling for stacked upgrades.
+ */
+export function shopCost (input: ShopCostInput): number {
+  if (input.isConsumable || input.maxLevel === 1) {
+    return input.price
+  }
+  return input.price + input.priceIncrease * input.currentLevel
+}

--- a/packages/logic/src/mechanics/singularityChallenges.ts
+++ b/packages/logic/src/mechanics/singularityChallenges.ts
@@ -1,0 +1,366 @@
+// Per-singularity-challenge effect / requirement / AP-value formulas, lifted
+// from packages/web_ui/src/SingularityChallenges.ts.
+//
+// Web_ui still owns the singularityChallengeData table (it has UI fields
+// the logic tier can't see: i18next-bound alternateDescription closures,
+// HTMLTag for DOM, the scalingrewardcount / uniquerewardcount UI counts).
+// This module owns the three pure-formula fields that every challenge has:
+//
+//   - singularityRequirement(baseReq, completions) → number
+//   - achievementPointValue(n)                    → number
+//   - effect(n, key)                              → reward field
+//
+// And the SingularityChallengeRewards type — pure data with no UI
+// dependency, re-exported from web_ui's SingularityChallenges.ts so the
+// `SingularityChallengeDataKeys` alias and external imports keep compiling.
+
+export type SingularityChallengeRewards = {
+  noSingularityUpgrades: {
+    cubes: number
+    goldenQuarks: number
+    blueberries: number
+    shopUpgrade: boolean
+    additiveLuckMult: number
+    shopUpgrade2: boolean
+  }
+  oneChallengeCap: {
+    corrScoreIncrease: number
+    blueberrySpeedMult: number
+    capIncrease: number
+    freeCorruptionLevel: number
+    shopUpgrade: boolean
+    reinCapIncrease2: number
+    ascCapIncrease2: number
+  }
+  noOcteracts: {
+    octeractPow: number
+    offeringBonus: boolean
+    obtainiumBonus: boolean
+    shopUpgrade: boolean
+  }
+  limitedAscensions: {
+    ascensionSpeedMult: number
+    hepteractCap: boolean
+    shopUpgrade: boolean
+    shopUpgrade2: boolean
+  }
+  noAmbrosiaUpgrades: {
+    bonusAmbrosia: number
+    blueberries: number
+    additiveLuckMult: number
+    ambrosiaLuck: number
+    redLuck: number
+    blueberrySpeedMult: number
+    redSpeedMult: number
+    shopUpgrade: boolean
+    shopUpgrade2: boolean
+  }
+  noQuarkUpgrades: {
+    freeObtainiumLevels: number
+    freeOfferingLevels: number
+    freeSpeedLevels: number
+    freeCubeLevels: number
+    freeQuarkLevel: number
+    freeInfinityLevels: number
+    shopUpgrade: boolean
+    topHatUnlock: boolean
+  }
+  limitedTime: {
+    preserveQuarks: boolean
+    quarkMult: number
+    globalSpeed: number
+    ascensionSpeed: number
+    barRequirementMultiplier: number
+    shopUpgrade: boolean
+    shopUpgrade2: boolean
+  }
+  sadisticPrequel: {
+    extraFree: number
+    quarkMult: number
+    freeUpgradeMult: number
+    shopUpgrade: boolean
+    shopUpgrade2: boolean
+    shopUpgrade3: boolean
+  }
+  taxmanLastStand: {
+    horseShoeUnlock: boolean
+    shopUpgrade: boolean
+    talismanUnlock: boolean
+    talismanFreeLevel: number
+    talismanRuneEffect: number
+    antiquityOOM: number
+    horseShoeOOM: number
+  }
+}
+
+export type SingularityChallengeDataKeys = keyof SingularityChallengeRewards
+
+// ─── Per-challenge singularityRequirement formulas ─────────────────────────
+
+// All nine challenges share the (baseReq, completions) → number shape. Several
+// of them have piecewise scaling past a completion threshold — those are the
+// ones worth sweeping in parity tests. The trivial linear ones get their own
+// arrow exports for code-locality with the matching effect functions below.
+
+export const noSingularityUpgradesSingularityRequirement = (baseReq: number, completions: number): number => {
+  // +16/completion linearly, +8 bonus once you've hit 9 completions.
+  return baseReq + 16 * completions + 8 * (completions >= 9 ? 1 : 0)
+}
+
+export const oneChallengeCapSingularityRequirement = (baseReq: number, completions: number): number => {
+  // +19/completion linearly, with a small -2 discount past 14 completions.
+  return baseReq + 19 * completions - 2 * (completions >= 14 ? 1 : 0)
+}
+
+export const noOcteractsSingularityRequirement = (baseReq: number, completions: number): number => {
+  // +13/completion below 10, +13*9 prefix then +10/completion past.
+  if (completions < 10) {
+    return baseReq + 13 * completions
+  }
+  return baseReq + 13 * 9 + 10 * (completions - 9)
+}
+
+export const limitedAscensionsSingularityRequirement = (baseReq: number, completions: number): number => {
+  return baseReq + 27 * completions
+}
+
+export const noAmbrosiaUpgradesSingularityRequirement = (baseReq: number, completions: number): number => {
+  // +12/completion below 10, then prefix + +4/completion past.
+  if (completions < 10) {
+    return baseReq + 12 * completions
+  }
+  return baseReq + 12 * 9 + 4 * (completions - 9)
+}
+
+export const noQuarkUpgradesSingularityRequirement = (baseReq: number, completions: number): number => {
+  // Three-band piecewise: +15/comp ≤2, +70 prefix then +9/(comp-6) on 3-5,
+  // +185 prefix then +8/(comp-6) past 5. The (completions-6) offsets are
+  // verbatim from the legacy code — yes the middle band's offset references
+  // a higher knee than its own band. Pinned by parity tests.
+  if (completions > 5) {
+    return baseReq + 185 + 8 * (completions - 6)
+  } else if (completions > 2) {
+    return baseReq + 70 + 9 * (completions - 6)
+  }
+  return baseReq + 15 * completions
+}
+
+export const limitedTimeSingularityRequirement = (baseReq: number, completions: number): number => {
+  // +8/completion below 10, hard 277 + 2*(comp-10) past.
+  if (completions > 9) {
+    return 277 + 2 * (completions - 10)
+  }
+  return baseReq + 8 * completions
+}
+
+export const sadisticPrequelSingularityRequirement = (baseReq: number, completions: number): number => {
+  return baseReq + 8 * completions
+}
+
+export const taxmanLastStandSingularityRequirement = (baseReq: number, completions: number): number => {
+  return baseReq + 4 * completions
+}
+
+// ─── Per-challenge achievementPointValue formulas ──────────────────────────
+//
+// All trivial linear scales — kept as named exports for symmetry with the
+// other two function categories and so callers can import individually.
+
+export const noSingularityUpgradesAchievementPointValue = (n: number): number => 15 * n
+export const oneChallengeCapAchievementPointValue = (n: number): number => 15 * n
+export const noOcteractsAchievementPointValue = (n: number): number => 20 * n
+export const limitedAscensionsAchievementPointValue = (n: number): number => 30 * n
+export const noAmbrosiaUpgradesAchievementPointValue = (n: number): number => 25 * n
+export const noQuarkUpgradesAchievementPointValue = (n: number): number => 20 * n
+export const limitedTimeAchievementPointValue = (n: number): number => 30 * n
+export const sadisticPrequelAchievementPointValue = (n: number): number => 40 * n
+export const taxmanLastStandAchievementPointValue = (n: number): number => 50 * n
+
+// ─── Per-challenge effect functions ────────────────────────────────────────
+//
+// Each challenge's `effect(n, key)` returns the matching field of
+// SingularityChallengeRewards[challenge]. Switch-on-key cascades match the
+// legacy if/else if chains verbatim — including the trailing `else` that
+// returns the last-key value without checking it (legacy behavior; the
+// caller is expected to only pass valid keys).
+
+export function noSingularityUpgradesEffect<K extends keyof SingularityChallengeRewards['noSingularityUpgrades']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['noSingularityUpgrades'][K] {
+  if (key === 'cubes') {
+    return (1 + n) as SingularityChallengeRewards['noSingularityUpgrades'][K]
+  } else if (key === 'goldenQuarks') {
+    return (1 + 0.12 * +(n > 0)) as SingularityChallengeRewards['noSingularityUpgrades'][K]
+  } else if (key === 'blueberries') {
+    return (+(n > 0)) as SingularityChallengeRewards['noSingularityUpgrades'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 10) as SingularityChallengeRewards['noSingularityUpgrades'][K]
+  } else if (key === 'additiveLuckMult') {
+    return (n >= 15 ? 0.05 : 0) as SingularityChallengeRewards['noSingularityUpgrades'][K]
+  }
+  // shopUpgrade2
+  return (n >= 15) as SingularityChallengeRewards['noSingularityUpgrades'][K]
+}
+
+export function oneChallengeCapEffect<K extends keyof SingularityChallengeRewards['oneChallengeCap']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['oneChallengeCap'][K] {
+  if (key === 'corrScoreIncrease') {
+    return (0.05 * n) as SingularityChallengeRewards['oneChallengeCap'][K]
+  } else if (key === 'blueberrySpeedMult') {
+    return (1 + n / 60) as SingularityChallengeRewards['oneChallengeCap'][K]
+  } else if (key === 'capIncrease') {
+    return (3 * +(n > 0)) as SingularityChallengeRewards['oneChallengeCap'][K]
+  } else if (key === 'freeCorruptionLevel') {
+    return (+(n >= 12)) as SingularityChallengeRewards['oneChallengeCap'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 12) as SingularityChallengeRewards['oneChallengeCap'][K]
+  } else if (key === 'reinCapIncrease2') {
+    return (7 * +(n >= 15)) as SingularityChallengeRewards['oneChallengeCap'][K]
+  }
+  // ascCapIncrease2
+  return (2 * +(n >= 15)) as SingularityChallengeRewards['oneChallengeCap'][K]
+}
+
+export function noOcteractsEffect<K extends keyof SingularityChallengeRewards['noOcteracts']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['noOcteracts'][K] {
+  if (key === 'octeractPow') {
+    // Piecewise: 0.02n below the 10-completion knee, then 0.2 + (n-10)/100 past.
+    return ((n <= 10) ? 0.02 * n : 0.2 + (n - 10) / 100) as SingularityChallengeRewards['noOcteracts'][K]
+  } else if (key === 'offeringBonus') {
+    return (n > 0) as SingularityChallengeRewards['noOcteracts'][K]
+  } else if (key === 'obtainiumBonus') {
+    return (n >= 10) as SingularityChallengeRewards['noOcteracts'][K]
+  }
+  // shopUpgrade
+  return (n >= 10) as SingularityChallengeRewards['noOcteracts'][K]
+}
+
+export function limitedAscensionsEffect<K extends keyof SingularityChallengeRewards['limitedAscensions']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['limitedAscensions'][K] {
+  if (key === 'ascensionSpeedMult') {
+    return (1 + 0.25 * n / 100) as SingularityChallengeRewards['limitedAscensions'][K]
+  } else if (key === 'hepteractCap') {
+    return (n > 0) as SingularityChallengeRewards['limitedAscensions'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 8) as SingularityChallengeRewards['limitedAscensions'][K]
+  }
+  // shopUpgrade2
+  return (n >= 10) as SingularityChallengeRewards['limitedAscensions'][K]
+}
+
+export function noAmbrosiaUpgradesEffect<K extends keyof SingularityChallengeRewards['noAmbrosiaUpgrades']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['noAmbrosiaUpgrades'][K] {
+  if (key === 'bonusAmbrosia') {
+    return (+(n > 0)) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'blueberries') {
+    // Floor(n/5) plus a +1 bump on first completion. Stair-steps every 5.
+    return (Math.floor(n / 5) + +(n > 0)) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'additiveLuckMult') {
+    return (n / 200) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'ambrosiaLuck') {
+    return (20 * n) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'redLuck') {
+    return (4 * n) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'blueberrySpeedMult') {
+    return (1 + n / 25) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'redSpeedMult') {
+    return (1 + 2 * n / 100) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 8) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+  }
+  // shopUpgrade2
+  return (n >= 10) as SingularityChallengeRewards['noAmbrosiaUpgrades'][K]
+}
+
+export function noQuarkUpgradesEffect<K extends keyof SingularityChallengeRewards['noQuarkUpgrades']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['noQuarkUpgrades'][K] {
+  if (key === 'freeObtainiumLevels') {
+    return n as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  } else if (key === 'freeOfferingLevels') {
+    return n as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  } else if (key === 'freeSpeedLevels') {
+    return n as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  } else if (key === 'freeCubeLevels') {
+    return n as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  } else if (key === 'freeQuarkLevel') {
+    return (n >= 5 ? 1 : 0) as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  } else if (key === 'freeInfinityLevels') {
+    return n as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 1) as SingularityChallengeRewards['noQuarkUpgrades'][K]
+  }
+  // topHatUnlock
+  return (n >= 10) as SingularityChallengeRewards['noQuarkUpgrades'][K]
+}
+
+export function limitedTimeEffect<K extends keyof SingularityChallengeRewards['limitedTime']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['limitedTime'][K] {
+  if (key === 'preserveQuarks') {
+    return (+(n > 0)) as SingularityChallengeRewards['limitedTime'][K]
+  } else if (key === 'quarkMult') {
+    return (1 + 0.02 * n) as SingularityChallengeRewards['limitedTime'][K]
+  } else if (key === 'globalSpeed') {
+    return (1 + 0.12 * n) as SingularityChallengeRewards['limitedTime'][K]
+  } else if (key === 'ascensionSpeed') {
+    return (1 + 0.12 * n) as SingularityChallengeRewards['limitedTime'][K]
+  } else if (key === 'barRequirementMultiplier') {
+    return (1 - 0.02 * n) as SingularityChallengeRewards['limitedTime'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 5) as SingularityChallengeRewards['limitedTime'][K]
+  }
+  // shopUpgrade2
+  return (n >= 10) as SingularityChallengeRewards['limitedTime'][K]
+}
+
+export function sadisticPrequelEffect<K extends keyof SingularityChallengeRewards['sadisticPrequel']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['sadisticPrequel'][K] {
+  if (key === 'extraFree') {
+    return (50 * +(n > 0)) as SingularityChallengeRewards['sadisticPrequel'][K]
+  } else if (key === 'quarkMult') {
+    return (1 + 0.06 * n) as SingularityChallengeRewards['sadisticPrequel'][K]
+  } else if (key === 'freeUpgradeMult') {
+    return (1 + 0.06 * n) as SingularityChallengeRewards['sadisticPrequel'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 5) as SingularityChallengeRewards['sadisticPrequel'][K]
+  } else if (key === 'shopUpgrade2') {
+    return (n >= 10) as SingularityChallengeRewards['sadisticPrequel'][K]
+  }
+  // shopUpgrade3
+  return (n >= 15) as SingularityChallengeRewards['sadisticPrequel'][K]
+}
+
+export function taxmanLastStandEffect<K extends keyof SingularityChallengeRewards['taxmanLastStand']> (
+  n: number,
+  key: K
+): SingularityChallengeRewards['taxmanLastStand'][K] {
+  if (key === 'horseShoeUnlock') {
+    return (n > 0) as SingularityChallengeRewards['taxmanLastStand'][K]
+  } else if (key === 'shopUpgrade') {
+    return (n >= 5) as SingularityChallengeRewards['taxmanLastStand'][K]
+  } else if (key === 'talismanUnlock') {
+    return (n >= 10) as SingularityChallengeRewards['taxmanLastStand'][K]
+  } else if (key === 'talismanFreeLevel') {
+    return (25 * n) as SingularityChallengeRewards['taxmanLastStand'][K]
+  } else if (key === 'talismanRuneEffect') {
+    return (0.03 * n) as SingularityChallengeRewards['taxmanLastStand'][K]
+  } else if (key === 'antiquityOOM') {
+    return (1 / 50 * n / 10) as SingularityChallengeRewards['taxmanLastStand'][K]
+  }
+  // horseShoeOOM
+  return (1 / 20 * n / 10) as SingularityChallengeRewards['taxmanLastStand'][K]
+}

--- a/packages/logic/src/mechanics/singularityHelpers.ts
+++ b/packages/logic/src/mechanics/singularityHelpers.ts
@@ -1,0 +1,96 @@
+// Small singularity-related helpers, lifted from
+// packages/web_ui/src/singularity.ts. None of these warrant their own module
+// but they share the "tiny pure helper called by singularity UI / cost
+// flow" theme:
+//
+//   - maxSingularityLookahead: how many singularities the buy-multi prompt
+//     can preview, given the player's three lookahead-bonus upgrades.
+//   - goldenQuarkCost: wraps the GQ-cost result with a `costReduction`
+//     diff against a fixed 10000-GQ baseline (for the UI's "you saved X
+//     GQ" badge).
+//   - calculateNextSpike: finds the next singularity-penalty threshold the
+//     player will cross, accounting for shop/ambrosia reductions.
+
+// Singularity counts at which a new penalty tier activates. Sorted
+// ascending; calculateNextSpike walks the array and returns the first
+// threshold past the player's current adjusted count.
+const singularityPenaltyThresholds = [11, 26, 37, 51, 101, 151, 201, 216, 230, 270]
+
+// Base cost of one golden quark, used as the baseline for the "you saved X"
+// display in the GQ-buy prompt.
+const GOLDEN_QUARK_BASE_COST = 10000
+
+export interface MaxSingularityLookaheadInput {
+  /**
+   * True when the buy-multi prompt is in "show me what's possible" mode.
+   * The legacy `nonZero` parameter — when false, lookahead is hardcoded 0
+   * (player is just viewing the current sing, not previewing forward).
+   */
+  nonZero: boolean
+  /** getGQUpgradeEffect('singFastForward', 'lookahead'). */
+  singFastForwardLookahead: number
+  /** getGQUpgradeEffect('singFastForward2', 'lookahead'). */
+  singFastForward2Lookahead: number
+  /** getOcteractUpgradeEffect('octeractFastForward', 'lookahead'). */
+  octeractFastForwardLookahead: number
+}
+
+/**
+ * Max number of singularities the buy-multi prompt previews. Always returns
+ * 0 when `nonZero` is false; otherwise sums the three lookahead bonuses
+ * (default 1 + sum of GQ + octeract effects).
+ */
+export function maxSingularityLookahead (input: MaxSingularityLookaheadInput): number {
+  if (!input.nonZero) {
+    return 0
+  }
+  return 1 + input.singFastForwardLookahead + input.singFastForward2Lookahead + input.octeractFastForwardLookahead
+}
+
+export interface GoldenQuarkCostResult {
+  /** The actual per-GQ cost (passed through). */
+  cost: number
+  /**
+   * `max(0, 10000 - cost)` — how much cheaper than the 10000-GQ baseline
+   * the current cost is. Used by the UI to display "you saved X" badges.
+   */
+  costReduction: number
+}
+
+/**
+ * Wraps a calculated GQ cost with its `costReduction` diff against the
+ * 10000-GQ baseline. The reduction is floored at 0 — if cost > 10000 (e.g.
+ * inside a debuffing challenge), no reduction is shown.
+ */
+export function goldenQuarkCost (cost: number): GoldenQuarkCostResult {
+  return {
+    cost,
+    costReduction: Math.max(0, GOLDEN_QUARK_BASE_COST - cost)
+  }
+}
+
+export interface CalculateNextSpikeInput {
+  /** The player's raw singularity count being evaluated. */
+  singularityCount: number
+  /**
+   * Shop/ambrosia singularity reductions. Subtracted from each threshold
+   * when checking if the player has crossed it — matches the
+   * constitutiveSingularityCount logic used elsewhere in singularity math.
+   */
+  singularityReductions: number
+}
+
+/**
+ * Returns the next singularity-penalty threshold the player will cross,
+ * or `-1` if they're past all of them. Each threshold is offset by the
+ * player's singularityReductions, so the spike fires later for players
+ * with reduction upgrades.
+ */
+export function calculateNextSpike (input: CalculateNextSpikeInput): number {
+  for (const sing of singularityPenaltyThresholds) {
+    if (sing + input.singularityReductions > input.singularityCount) {
+      return sing + input.singularityReductions
+    }
+  }
+  return -1
+}

--- a/packages/logic/src/mechanics/singularityPenalties.ts
+++ b/packages/logic/src/mechanics/singularityPenalties.ts
@@ -1,0 +1,235 @@
+// Singularity-penalty math, lifted from packages/web_ui/src/singularity.ts.
+//
+// `calculateEffectiveSingularities` is the post-multiplier singularity count
+// used as the basis for every per-system debuff. `calculateSingularityDebuff`
+// switches on the system tag and produces the actual multiplier (or
+// subtractive amount, for Salvage / Ant ELO). The web_ui side stays
+// responsible for sourcing shop / ambrosia / antiquities / rune state and
+// for the i18n display strings — this module is pure math.
+
+import { calculateExalt4EffectiveSingularityMultiplier } from './exaltPenalties'
+
+export type SingularityDebuff =
+  | 'Offering'
+  | 'Obtainium'
+  | 'Salvage'
+  | 'Global Speed'
+  | 'Researches'
+  | 'Ant ELO'
+  | 'Ascension Speed'
+  | 'Cubes'
+  | 'Cube Upgrades'
+  | 'Platonic Costs'
+  | 'Hepteract Costs'
+
+export interface CalculateEffectiveSingularitiesInput {
+  /** The raw singularity count being evaluated. Callers usually pass the
+   *  constitutive count (singularityCount - reductions), not the raw value. */
+  singularityCount: number
+  /** player.singularityChallenges.noOcteracts.completions — feeds Exalt 4. */
+  noOcteractsCompletions: number
+  /** player.singularityChallenges.noOcteracts.enabled — gates Exalt 4. */
+  inExalt4: boolean
+  /** player.singularityChallenges.taxmanLastStand.enabled — gates the cube
+   *  root of the final value when the suppress-platonic-15 condition is met. */
+  taxmanLastStandEnabled: boolean
+  /** player.singularityChallenges.taxmanLastStand.completions — must be ≥ 8
+   *  alongside an unowned platonic 15 for the ^(3/2) override to kick in. */
+  taxmanLastStandCompletions: number
+  /** player.platonicUpgrades[15] — when > 0, suppresses the taxman override. */
+  platonicUpgrade15: number
+}
+
+/**
+ * Effective singularity count after stacking the staircase of milestone
+ * multipliers (×1.5 past 10, ×2.5 past 25, etc.). The Exalt 4 multiplier and
+ * the taxman-last-stand ^(3/2) override are both applied here.
+ */
+export function calculateEffectiveSingularities (
+  input: CalculateEffectiveSingularitiesInput
+): number {
+  const singularityCount = input.singularityCount
+  let effectiveSingularities = singularityCount
+  effectiveSingularities *= Math.min(4.75, (0.75 * singularityCount) / 10 + 1)
+
+  effectiveSingularities *= calculateExalt4EffectiveSingularityMultiplier({
+    comps: input.noOcteractsCompletions,
+    force: false,
+    inExalt4: input.inExalt4
+  })
+
+  if (singularityCount > 10) {
+    effectiveSingularities *= 1.5
+    effectiveSingularities *= Math.min(
+      4,
+      (1.25 * singularityCount) / 10 - 0.25
+    )
+  }
+  if (singularityCount > 25) {
+    effectiveSingularities *= 2.5
+    effectiveSingularities *= Math.min(6, (1.5 * singularityCount) / 25 - 0.5)
+  }
+  if (singularityCount > 36) {
+    effectiveSingularities *= 4
+    effectiveSingularities *= Math.min(5, singularityCount / 18 - 1)
+    effectiveSingularities *= Math.pow(
+      1.1,
+      Math.min(singularityCount - 36, 64)
+    )
+  }
+  if (singularityCount > 50) {
+    effectiveSingularities *= 5
+    effectiveSingularities *= Math.min(8, (2 * singularityCount) / 50 - 1)
+    effectiveSingularities *= Math.pow(
+      1.1,
+      Math.min(singularityCount - 50, 50)
+    )
+  }
+  if (singularityCount > 100) {
+    effectiveSingularities *= 2
+    effectiveSingularities *= singularityCount / 25
+    effectiveSingularities *= Math.pow(1.1, singularityCount - 100)
+  }
+  if (singularityCount > 150) {
+    effectiveSingularities *= 2
+    effectiveSingularities *= Math.pow(1.05, singularityCount - 150)
+  }
+  if (singularityCount > 200) {
+    effectiveSingularities *= 1.5
+    effectiveSingularities *= Math.pow(1.275, singularityCount - 200)
+  }
+  if (singularityCount > 215) {
+    effectiveSingularities *= 1.25
+    effectiveSingularities *= Math.pow(1.2, singularityCount - 215)
+  }
+  if (singularityCount > 230) {
+    effectiveSingularities *= 2
+  }
+  if (singularityCount > 269) {
+    effectiveSingularities *= 3
+    effectiveSingularities *= Math.pow(3, singularityCount - 269)
+  }
+
+  if (
+    input.taxmanLastStandEnabled
+    && input.taxmanLastStandCompletions >= 8
+    && input.platonicUpgrade15 === 0
+  ) {
+    effectiveSingularities = Math.pow(effectiveSingularities, 3 / 2)
+  }
+
+  return effectiveSingularities
+}
+
+export interface CalculateSingularityDebuffInput {
+  /** Which system the debuff applies to. Determines the formula branch. */
+  debuff: SingularityDebuff
+  /** The raw singularity count being evaluated (usually player.singularityCount). */
+  singularityCount: number
+  /** runes.antiquities.level > 0 — when true, all penalties drop to their
+   *  no-penalty value (0 for Salvage / Ant ELO, 1 otherwise). */
+  antiquitiesRuneActive: boolean
+  /**
+   * Sum of `shopSingularityPenaltyDebuff.singularityPenaltyReducers` and the
+   * appropriate ambrosia singularity-reduction (1 outside sing challenges,
+   * 2 inside). Subtracted from singularityCount to form the constitutive
+   * count used by every formula branch.
+   */
+  singularityReductions: number
+  /**
+   * getShopUpgradeEffects('shopHorseShoe', 'singularityPenaltyMult') — applied
+   * to all multiplicative branches as `baseDebuffMultiplier`. Not applied to
+   * Salvage / Ant ELO (those are subtractive).
+   */
+  horseShoeMult: number
+  /** Pass-through to calculateEffectiveSingularities. */
+  noOcteractsCompletions: number
+  /** Pass-through to calculateEffectiveSingularities. */
+  inExalt4: boolean
+  /** Pass-through to calculateEffectiveSingularities. */
+  taxmanLastStandEnabled: boolean
+  /** Pass-through to calculateEffectiveSingularities. */
+  taxmanLastStandCompletions: number
+  /** Pass-through to calculateEffectiveSingularities. */
+  platonicUpgrade15: number
+}
+
+/**
+ * Per-system singularity penalty.
+ *
+ * - Returns 0 (Salvage / Ant ELO) or 1 (everything else) when the singularity
+ *   count is zero OR the antiquities rune is active OR the constitutive count
+ *   (singularityCount - reductions) is below 1.
+ * - Otherwise switches on `debuff` to pick a formula. Salvage and Ant ELO
+ *   return subtractive amounts (negative of the magnitude); the rest return
+ *   multiplicative penalties.
+ */
+export function calculateSingularityDebuff (
+  input: CalculateSingularityDebuffInput
+): number {
+  if (input.singularityCount === 0 || input.antiquitiesRuneActive) {
+    return (input.debuff === 'Salvage' || input.debuff === 'Ant ELO') ? 0 : 1
+  }
+
+  const constitutiveSingularityCount = input.singularityCount - input.singularityReductions
+  if (constitutiveSingularityCount < 1) {
+    return 1
+  }
+
+  const effectiveSingularities = calculateEffectiveSingularities({
+    singularityCount: constitutiveSingularityCount,
+    noOcteractsCompletions: input.noOcteractsCompletions,
+    inExalt4: input.inExalt4,
+    taxmanLastStandEnabled: input.taxmanLastStandEnabled,
+    taxmanLastStandCompletions: input.taxmanLastStandCompletions,
+    platonicUpgrade15: input.platonicUpgrade15
+  })
+
+  const baseDebuffMultiplier = input.horseShoeMult
+
+  if (input.debuff === 'Offering') {
+    const extraMult = Math.pow(1.02, constitutiveSingularityCount)
+    return extraMult * baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 3 * (Math.sqrt(effectiveSingularities) + 1)
+      : Math.pow(effectiveSingularities, 2 / 3) / 400)
+  } else if (input.debuff === 'Salvage') {
+    return -(4 * constitutiveSingularityCount
+      + 4 * Math.max(0, constitutiveSingularityCount - 100)
+      + 4 * Math.max(0, constitutiveSingularityCount - 200)
+      + 3 * Math.max(0, constitutiveSingularityCount - 250)
+      + 3 * Math.max(0, constitutiveSingularityCount - 270)
+      + 2 * Math.max(0, constitutiveSingularityCount - 280))
+  } else if (input.debuff === 'Ant ELO') {
+    return -Math.min(1, 0.001 * constitutiveSingularityCount)
+  } else if (input.debuff === 'Global Speed') {
+    return baseDebuffMultiplier * (1 + Math.sqrt(effectiveSingularities) / 4)
+  } else if (input.debuff === 'Obtainium') {
+    const extraMult = Math.pow(1.02, constitutiveSingularityCount)
+    return extraMult * baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 3 * (Math.sqrt(effectiveSingularities) + 1)
+      : Math.pow(effectiveSingularities, 2 / 3) / 400)
+  } else if (input.debuff === 'Researches') {
+    return baseDebuffMultiplier * (1 + Math.sqrt(effectiveSingularities) / 2)
+  } else if (input.debuff === 'Ascension Speed') {
+    return baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 1 + Math.sqrt(effectiveSingularities) / 5
+      : 1 + Math.pow(effectiveSingularities, 0.75) / 10000)
+  } else if (input.debuff === 'Cubes') {
+    const extraMult = constitutiveSingularityCount > 100
+      ? 2 * Math.pow(1.03, constitutiveSingularityCount - 100)
+      : 2
+    return baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 3 * (1 + (Math.sqrt(effectiveSingularities) * extraMult) / 4)
+      : 1 + (Math.pow(effectiveSingularities, 0.75) * extraMult) / 1000)
+  } else if (input.debuff === 'Platonic Costs') {
+    return baseDebuffMultiplier * (constitutiveSingularityCount > 36
+      ? 1 + Math.pow(effectiveSingularities, 3 / 10) / 12
+      : 1)
+  } else if (input.debuff === 'Hepteract Costs') {
+    return baseDebuffMultiplier * (constitutiveSingularityCount > 50
+      ? 1 + Math.pow(effectiveSingularities, 11 / 50) / 25
+      : 1)
+  } else {
+    return baseDebuffMultiplier * Math.cbrt(effectiveSingularities + 1)
+  }
+}

--- a/packages/logic/src/mechanics/talismanCosts.ts
+++ b/packages/logic/src/mechanics/talismanCosts.ts
@@ -1,0 +1,112 @@
+// Talisman fragment-cost progression formulas, lifted from
+// packages/web_ui/src/Talismans.ts. Both formulas are pure functions over a
+// Decimal `baseMult` and an integer `level` — no player state, no globals.
+// They return the fragment cost map for the NEXT level of the talisman.
+//
+// `regularCostProgression` is the cubic-tier formula used by most talismans:
+// each fragment tier starts contributing at a level threshold (shard at 0,
+// common at 30, uncommon at 60, etc.) and the base multiplier itself ramps
+// up at higher levels (120/150/180). `exponentialCostProgression` is the
+// alternative used by a handful of talismans whose cost grows as `ratio^level`
+// instead of `level^3` — same tier-threshold scheme, different growth curve.
+
+import { Decimal } from '../math/bignum'
+
+export type TalismanCraftItems =
+  | 'shard'
+  | 'commonFragment'
+  | 'uncommonFragment'
+  | 'rareFragment'
+  | 'epicFragment'
+  | 'legendaryFragment'
+  | 'mythicalFragment'
+
+export type TalismanCraftCosts = Record<TalismanCraftItems, Decimal>
+
+/**
+ * Cubic-tier cost progression. For each tier, the cost is
+ * `floor((level - threshold)^3 / divisor + 1) * priceMult`, clamped at zero
+ * below the tier threshold. `priceMult` itself grows piecewise past levels
+ * 120 / 150 / 180. Returns a 0-cost map until each tier unlocks (shard at 0,
+ * common at 30, uncommon at 60, rare at 90, epic at 120, legendary/mythical
+ * at 150).
+ */
+export function regularCostProgression (baseMult: Decimal, level: number): TalismanCraftCosts {
+  let priceMult = baseMult
+  if (level >= 120) {
+    priceMult = priceMult.times((level - 90) / 30)
+  }
+  if (level >= 150) {
+    priceMult = priceMult.times((level - 120) / 30)
+  }
+  if (level >= 180) {
+    priceMult = priceMult.times((level - 170) / 10)
+  }
+
+  const shardCost = Decimal.pow(level, 3).times(1 / 8).plus(1).floor().times(priceMult)
+  const commonCost = level >= 30
+    ? Decimal.pow(level - 30, 3).times(1 / 32).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const uncommonCost = level >= 60
+    ? Decimal.pow(level - 60, 3).times(1 / 384).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const rareCost = level >= 90
+    ? Decimal.pow(level - 90, 3).times(1 / 500).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const epicCost = level >= 120
+    ? Decimal.pow(level - 120, 3).times(1 / 375).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const legendaryCost = level >= 150
+    ? Decimal.pow(level - 150, 3).times(1 / 192).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const mythicalCost = level >= 150
+    ? Decimal.pow(level - 150, 3).times(1 / 1280).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+
+  return {
+    shard: Decimal.max(0, shardCost),
+    commonFragment: Decimal.max(0, commonCost),
+    uncommonFragment: Decimal.max(0, uncommonCost),
+    rareFragment: Decimal.max(0, rareCost),
+    epicFragment: Decimal.max(0, epicCost),
+    legendaryFragment: Decimal.max(0, legendaryCost),
+    mythicalFragment: Decimal.max(0, mythicalCost)
+  }
+}
+
+/**
+ * Exponential cost progression. For each tier the cost is
+ * `floor(ratio^(level - threshold) * baseMult * tierConstant)`. The tier
+ * constants are fixed (100 / 50 / 25 / 20 / 15 / 10 / 5) and the tier
+ * thresholds match `regularCostProgression`. `ratio` is supplied by the
+ * caller — common values are 2, 10, 1e5, 1e8 (each used by one talisman).
+ */
+export function exponentialCostProgression (
+  baseMult: Decimal,
+  level: number,
+  ratio: number
+): TalismanCraftCosts {
+  const baseMultDecimal = new Decimal(baseMult)
+
+  return {
+    shard: Decimal.pow(ratio, level).times(baseMultDecimal).times(100).floor(),
+    commonFragment: level >= 30
+      ? Decimal.pow(ratio, level - 30).times(baseMultDecimal).times(50).floor()
+      : new Decimal(0),
+    uncommonFragment: level >= 60
+      ? Decimal.pow(ratio, level - 60).times(baseMultDecimal).times(25).floor()
+      : new Decimal(0),
+    rareFragment: level >= 90
+      ? Decimal.pow(ratio, level - 90).times(baseMultDecimal).times(20).floor()
+      : new Decimal(0),
+    epicFragment: level >= 120
+      ? Decimal.pow(ratio, level - 120).times(baseMultDecimal).times(15).floor()
+      : new Decimal(0),
+    legendaryFragment: level >= 150
+      ? Decimal.pow(ratio, level - 150).times(baseMultDecimal).times(10).floor()
+      : new Decimal(0),
+    mythicalFragment: level >= 150
+      ? Decimal.pow(ratio, level - 150).times(baseMultDecimal).times(5).floor()
+      : new Decimal(0)
+  }
+}

--- a/packages/logic/src/mechanics/tax.ts
+++ b/packages/logic/src/mechanics/tax.ts
@@ -1,0 +1,297 @@
+// Tax exponent and divisor formula, lifted from the second half of
+// packages/web_ui/src/Tax.ts. Pure given the full bag of player + effect
+// inputs; the web_ui side does the input gathering and writes the result
+// fields back to G.
+//
+// The function returns the full output bundle plus a `shouldAwardOvertaxed`
+// flag — that one's a side-effect (calls awardUngroupedAchievement in
+// web_ui) which we surface as a boolean so logic stays free of UI calls.
+//
+// Output formulas:
+//   maxexponent      = floor(275 / (log10(1.01) * exponent)) - 1 + flatMaxIncrease
+//   taxdivisor       = 1.01 ^ (divisorExponent * exponent)
+//   taxdivisorcheck  = 1.01 ^ (checkExponent * exponent)
+// where divisorExponent / checkExponent are quadratics in their own
+// exponent bases (which incorporate the produceTotal log and the flat
+// max-exponent increase from ant upgrades).
+
+import { Decimal } from '../math/bignum'
+import { CalcECC } from './challenges'
+
+export interface CalculateTaxInput {
+  // ─── Challenge / completion state ─────────────────────────────────────
+
+  /** player.currentChallenge.reincarnation === 6 — base exp = 3*(1+c6/25)^2. */
+  inReinc6: boolean
+  /** player.currentChallenge.reincarnation === 9 — base exp = 0.005. */
+  inReinc9: boolean
+  /** player.currentChallenge.ascension === 15 — base exp = 0.000005. */
+  inAscension15: boolean
+  /** player.currentChallenge.ascension === 13 — apply C13 exp multiplier. */
+  inAscension13: boolean
+  /** player.challengecompletions[6] — feeds reinc6 base + the 1.075 divisor. */
+  c6Completions: number
+  /** player.challengecompletions[13] — feeds the C13 exp multiplier. */
+  c13Completions: number
+
+  // ─── c13effcompletions inputs ─────────────────────────────────────────
+
+  /**
+   * `sumContents(player.challengecompletions)` — total completion count.
+   * c13effcompletions subtracts the high-tier challenge contributions and
+   * the singularity-15/20 bonuses.
+   */
+  totalChallengeCompletions: number
+  c11Completions: number
+  c12Completions: number
+  c14Completions: number
+  c15Completions: number
+  /** player.singularityCount — feeds the -4 / -1 cuts at 15 / 20. */
+  singularityCount: number
+
+  // ─── Research / cube / platonic reductions ────────────────────────────
+
+  /** player.researches[51]. exponent *= 1 - 0.06 * n. */
+  research51: number
+  /** player.researches[52..55]. Each: exponent *= 1 - 0.05 * n. */
+  research52: number
+  research53: number
+  research54: number
+  research55: number
+  /** player.researches[159]. Feeds 0.98^(3/5 * log10(rareFragments+1) * n). */
+  research159: number
+  /** player.researches[200]. exponent *= 1 - 0.666 * n / 100000. */
+  research200: number
+  /** player.cubeUpgrades[50]. exponent *= 1 - 0.666 * n / 100000. */
+  cubeUpgrade50: number
+  /** player.platonicUpgrades[5]. Adds 0.1 * n to the ascendShards exponent. */
+  platonicUpgrade5: number
+  /** player.platonicUpgrades[10]. Adds 0.2 * n to the ascendShards exponent. */
+  platonicUpgrade10: number
+  /** calculateTaxPlatonicBlessing(). Added to the ascendShards exponent. */
+  taxPlatonicBlessing: number
+  /** player.upgrades[121]. When > 0, halves the exponent. */
+  upgrade121: number
+  /** player.upgrades[125]. Feeds the ascendShards exponent with c10 scaling. */
+  upgrade125: number
+  /** player.challengecompletions[10]. Scales upgrade[125]'s contribution. */
+  c10Completions: number
+
+  // ─── Singularity / late-game ──────────────────────────────────────────
+
+  /** player.highestSingularityCount. When ≥ 281, halves the exponent. */
+  highestSingularityCount: number
+  /** player.singularityChallenges.taxmanLastStand.enabled. */
+  taxmanLastStandEnabled: boolean
+  /** player.unlocks.ascensions — adds ×4 inside taxmanLastStand. */
+  ascensionsUnlocked: boolean
+  /** player.highestchallengecompletions[14] — adds ×5 inside taxmanLastStand when > 0. */
+  highestC14Completions: number
+
+  // ─── Pre-evaluated effect values (sourced by web_ui) ──────────────────
+
+  /** +getAchievementReward('taxReduction') — the `+` coerces a boolean to 0/1. */
+  taxReductionAchievement: number
+  /** getRuneEffects('duplication', 'taxReduction'). */
+  duplicationRuneTaxReduction: number
+  /** getRuneEffects('thrift', 'taxReduction'). */
+  thriftRuneTaxReduction: number
+  /** getAntUpgradeEffect(AntUpgrades.Taxes).taxReduction. */
+  antTaxReduction: number
+  /** getTalismanEffects('exemption').taxReduction. */
+  exemptionTalismanTaxReduction: number
+  /** G.challenge15Rewards.taxes.value. */
+  challenge15TaxesReward: number
+  /** player.campaigns.taxMultiplier. */
+  campaignTaxMultiplier: number
+
+  // ─── Decimal inputs (for log10) ───────────────────────────────────────
+
+  /** player.ascendShards — log10 feeds the divisor in the exponent chain. */
+  ascendShards: Decimal
+  /** player.rareFragments — log10 feeds research[159]'s 0.98^... term. */
+  rareFragments: Decimal
+  /**
+   * getAntUpgradeEffect(AntUpgrades.Coins).coinMultiplier — log10 of this
+   * is added to flatMaxExponentIncrease (Fortunae Formicidae is tax-exempt).
+   */
+  fortunaeFormicidaeCoinMultiplier: Decimal
+  /**
+   * calculateBuildingPowerCoinMultiplier() — also log10'd into the
+   * flatMaxExponentIncrease.
+   */
+  buildingPowerCoinMultiplier: Decimal
+
+  /**
+   * G.produceTotal — sum of pre-clamp tier outputs. Its log10 feeds the
+   * exponentForDivisor (clamped to [0, maxexponent]).
+   */
+  produceTotal: Decimal
+}
+
+export interface CalculateTaxResult {
+  /** The final tax exponent — floored at 1e-300 to dodge an overflow bug. */
+  exponent: number
+  /** Max exponent the player can reach — floored value with the flat increase. */
+  maxexponent: number
+  /** The taxdivisor that scales coin production downward at high counts. */
+  taxdivisor: Decimal
+  /** Sibling check value — used by web_ui to detect "you're about to hit the cap". */
+  taxdivisorcheck: Decimal
+  /**
+   * True when the overtaxed achievement should be awarded — i.e. the player
+   * is in C13, has at least 1 c13eff completion, and their max-exponent gap
+   * is at most 99999. Web_ui calls awardUngroupedAchievement on this flag.
+   */
+  shouldAwardOvertaxed: boolean
+}
+
+// Hardcoded numerator of the maxexponent formula. Comes from the
+// underlying log-base-1.01 conversion of the 275-coin "ten billion to the
+// max-exponent power" target.
+const MAX_EXPONENT_NUMERATOR = 275
+// 1.01 is the base of every tax-divisor power. Pulled out so the two
+// log10(1.01) calls in maxexponent / taxdivisor share the same constant.
+const TAX_BASE = 1.01
+
+// Computes c13effcompletions — the count of challenge completions that
+// "really matter" inside C13. Filters out the high-tier (11-15) challenge
+// completions and the sing-15/20 bonuses (which xander apparently exploited).
+function computeC13EffCompletions (input: CalculateTaxInput): number {
+  return Math.max(
+    0,
+    input.totalChallengeCompletions
+      - input.c11Completions
+      - input.c12Completions
+      - input.c13Completions
+      - input.c14Completions
+      - input.c15Completions
+      - ((input.singularityCount >= 15) ? 4 : 0)
+      - ((input.singularityCount >= 20) ? 1 : 0)
+  )
+}
+
+// Picks the base `exp` value, applying challenge-specific overrides in
+// the same precedence order as the legacy code: reinc6 → reinc9 → asc15.
+// (Each later check overwrites the prior; if none fire, base is 1.)
+function computeBaseExp (input: CalculateTaxInput): number {
+  let exp = 1
+  if (input.inReinc6) {
+    exp = 3 * Math.pow(1 + input.c6Completions / 25, 2)
+  }
+  if (input.inReinc9) {
+    exp = 0.005
+  }
+  if (input.inAscension15) {
+    exp = 0.000005
+  }
+  return exp
+}
+
+/**
+ * Computes the tax exponent, max exponent, and the two taxdivisor values.
+ *
+ * Branching summary:
+ *   - Base exp picks one of {1, reinc6 formula, 0.005, 0.000005}
+ *   - C13 multiplies by 400 * (1 + c13/6) * 1.05^c13effcompletions
+ *   - C6 completions divide by 1.075
+ *   - Research / talisman / rune / cube reductions stack multiplicatively
+ *   - ascendShards log10 raised to (1 + c10/300*upgrade125 + 0.1*plat5 +
+ *     0.2*plat10 + taxPlatonicBlessing) divides
+ *   - rareFragments + research159 add a 0.98^... factor
+ *   - 281+ singularity + upgrade121 each halve
+ *   - taxmanLastStand stacks ×4 (asc unlocked) and ×5 (c14 done)
+ *   - Final clamp at 1e-300
+ *
+ * Then maxexponent = floor(275 / (log10(1.01) * exponent)) - 1 + flatIncrease,
+ * where flatIncrease = log10(fortunaeFormicidae) + log10(buildingPower).
+ *
+ * exponentForDivisor clamps log10(produceTotal+1) to [0, maxexponent] then
+ * subtracts flatIncrease. exponentForWarning is just maxexponent - flatIncrease.
+ * Both go through (1/550 * x^2) before becoming the taxdivisor exponent.
+ */
+export function calculateTax (input: CalculateTaxInput): CalculateTaxResult {
+  const c13eff = computeC13EffCompletions(input)
+
+  let exp = computeBaseExp(input)
+
+  if (input.inAscension13) {
+    exp *= 400 * (1 + 1 / 6 * input.c13Completions)
+    exp *= Math.pow(1.05, c13eff)
+  }
+  if (input.c6Completions > 0) {
+    exp /= 1.075
+  }
+
+  let exponent = 1
+  exponent *= exp
+  exponent *= 1 - 0.06 * input.research51
+  exponent *= 1 - 0.05 * input.research52
+  exponent *= 1 - 0.05 * input.research53
+  exponent *= 1 - 0.05 * input.research54
+  exponent *= 1 - 0.05 * input.research55
+  exponent *= input.taxReductionAchievement
+  exponent *= Math.pow(0.965, CalcECC('reincarnation', input.c6Completions))
+  exponent *= input.duplicationRuneTaxReduction
+  exponent *= input.thriftRuneTaxReduction
+  exponent *= input.antTaxReduction
+  // ascendShards log10 raised to a sum of platonic/upgrade contributions
+  exponent *= 1
+    / Math.pow(
+      1 + Decimal.log(input.ascendShards.add(1), 10),
+      1 + 1 / 300 * input.c10Completions * input.upgrade125 + 0.1 * input.platonicUpgrade5
+        + 0.2 * input.platonicUpgrade10 + input.taxPlatonicBlessing
+    )
+  exponent *= 1 + input.exemptionTalismanTaxReduction
+  exponent *= Math.pow(0.98, 3 / 5 * Decimal.log(input.rareFragments.add(1), 10) * input.research159)
+  exponent *= Math.pow(0.966, CalcECC('ascension', input.c13Completions))
+  exponent *= 1 - 0.666 * input.research200 / 100000
+  exponent *= 1 - 0.666 * input.cubeUpgrade50 / 100000
+  exponent *= input.challenge15TaxesReward
+  exponent *= input.campaignTaxMultiplier
+  if (input.upgrade121 > 0) {
+    exponent *= 0.5
+  }
+  if (input.highestSingularityCount >= 281) {
+    exponent *= 0.5
+  }
+  if (input.taxmanLastStandEnabled) {
+    if (input.ascensionsUnlocked) {
+      exponent *= 4
+    }
+    if (input.highestC14Completions > 0) {
+      exponent *= 5
+    }
+  }
+
+  // Overflow guard — exponent of zero would NaN every downstream pow.
+  if (exponent < 1e-300) {
+    exponent = 1e-300
+  }
+
+  const flatMaxExponentIncrease = Decimal.log(input.fortunaeFormicidaeCoinMultiplier, 10)
+    + Decimal.log(input.buildingPowerCoinMultiplier, 10)
+
+  const maxexponent = Math.floor(MAX_EXPONENT_NUMERATOR / (Decimal.log(TAX_BASE, 10) * exponent)) - 1
+    + flatMaxExponentIncrease
+
+  const exponentForDivisor = Math.max(
+    0,
+    Math.min(maxexponent, Math.floor(Decimal.log(input.produceTotal.add(1), 10))) - flatMaxExponentIncrease
+  )
+  const exponentForWarning = Math.max(0, maxexponent - flatMaxExponentIncrease)
+
+  const divisorExponent = 1 / 550 * Math.pow(exponentForDivisor, 2)
+  const checkExponent = 1 / 550 * Math.pow(exponentForWarning, 2)
+
+  const taxdivisor = Decimal.pow(TAX_BASE, divisorExponent * exponent)
+  const taxdivisorcheck = Decimal.pow(TAX_BASE, checkExponent * exponent)
+
+  // Overtaxed achievement: C13 active + at least one effective completion
+  // + max-exponent gap below 100000.
+  const shouldAwardOvertaxed = input.inAscension13
+    && (maxexponent - flatMaxExponentIncrease) <= 99999
+    && c13eff >= 1
+
+  return { exponent, maxexponent, taxdivisor, taxdivisorcheck, shouldAwardOvertaxed }
+}

--- a/packages/logic/test/parity/achievementLevels.parity.test.ts
+++ b/packages/logic/test/parity/achievementLevels.parity.test.ts
@@ -1,0 +1,102 @@
+// Parity tests for the achievement-level math, lifted from
+// packages/web_ui/src/Achievements.ts. Both `oldXxx` transcribe the
+// pre-migration bodies verbatim. The interesting threshold is 2500 points —
+// below it the level advances every 50 points, above it every 100 points.
+// At exactly 2500, both regimes agree (50). Sweep crosses the boundary in
+// both directions plus regime-midpoints to catch off-by-one errors.
+
+import { describe, expect, it } from 'vitest'
+import {
+  achievementLevelFromPoints as newLevelFromPoints,
+  toNextAchievementLevelEXP as newToNextEXP
+} from '../../src/mechanics/achievementLevels'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Achievements.ts) ─
+
+const oldLevelFromPoints = (achievementPoints: number): number => {
+  if (achievementPoints < 2500) {
+    return Math.floor(achievementPoints / 50)
+  } else {
+    return 50 + Math.floor((achievementPoints - 2500) / 100)
+  }
+}
+
+const oldToNextEXP = (achievementPoints: number): number => {
+  if (achievementPoints < 2500) {
+    return 50 - (achievementPoints % 50)
+  } else {
+    return 100 - (achievementPoints % 100)
+  }
+}
+
+// Sweep across the 2500 boundary plus every 50/100-point step on either side.
+// Includes points-at-exact-multiples to verify the modulo behavior at level
+// boundaries, plus a couple of large values to catch arithmetic-bug regressions.
+const pointsGrid = [
+  0,
+  1,
+  25,
+  49,
+  50,
+  51,
+  99,
+  100,
+  101,
+  149,
+  150,
+  199,
+  200,
+  499,
+  500,
+  999,
+  1000,
+  2449,
+  2450,
+  2499,
+  2500,
+  2501,
+  2549,
+  2550,
+  2599,
+  2600,
+  2601,
+  2999,
+  3000,
+  3001,
+  5000,
+  5099,
+  5100,
+  10000,
+  100000
+]
+
+describe('parity: achievementLevelFromPoints', () => {
+  it.each(pointsGrid)('points=%i', (points) => {
+    expect(newLevelFromPoints(points)).toBe(oldLevelFromPoints(points))
+  })
+})
+
+describe('parity: toNextAchievementLevelEXP', () => {
+  it.each(pointsGrid)('points=%i', (points) => {
+    expect(newToNextEXP(points)).toBe(oldToNextEXP(points))
+  })
+})
+
+// Sanity: the level should be 50 at exactly 2500 points, and 51 at 2600.
+// The old code's piecewise definition is contiguous here, so both functions
+// agree at 2500 — pinning that explicitly to catch regressions if someone
+// changes the threshold and forgets to update both branches.
+describe('regime boundary sanity', () => {
+  it('level is 50 at exactly 2500 points (both regimes agree)', () => {
+    expect(newLevelFromPoints(2500)).toBe(50)
+  })
+  it('level is 51 at 2600 points', () => {
+    expect(newLevelFromPoints(2600)).toBe(51)
+  })
+  it('toNext is 100 at exactly 2500 points', () => {
+    expect(newToNextEXP(2500)).toBe(100)
+  })
+  it('toNext is 50 at 2499 points', () => {
+    expect(newToNextEXP(2499)).toBe(1)
+  })
+})

--- a/packages/logic/test/parity/coinProduction.parity.test.ts
+++ b/packages/logic/test/parity/coinProduction.parity.test.ts
@@ -1,0 +1,202 @@
+// Parity tests for calculateCoinProduction, lifted from
+// packages/web_ui/src/Tax.ts. Each `oldXxx` transcribes the pre-migration
+// per-tier formula and noise-floor clamp verbatim. Sweeps cover: the
+// 0.0001 noise-floor boundary, the pre-clamp/post-clamp aggregation
+// difference, and the fifth-tier production formula at the high end.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import {
+  calculateCoinProduction as newCoinProd,
+  type CalculateCoinProductionInput,
+  type PerCoinTierInput
+} from '../../src/mechanics/coinProduction'
+
+// ─── Old implementation (verbatim from packages/web_ui/src/Tax.ts) ─────────
+
+const oldTierOutput = (tier: PerCoinTierInput, globalMult: Decimal): Decimal =>
+  tier.generated.add(tier.owned).times(globalMult).times(tier.coinMulti).times(tier.produceCoin)
+
+const oldCalculateCoinProduction = (input: CalculateCoinProductionInput) => {
+  let first = oldTierOutput(input.first, input.globalCoinMultiplier)
+  let second = oldTierOutput(input.second, input.globalCoinMultiplier)
+  let third = oldTierOutput(input.third, input.globalCoinMultiplier)
+  let fourth = oldTierOutput(input.fourth, input.globalCoinMultiplier)
+  let fifth = oldTierOutput(input.fifth, input.globalCoinMultiplier)
+  const total = first.add(second).add(third).add(fourth).add(fifth)
+
+  if (first.lte(0.0001)) first = new Decimal(0)
+  if (second.lte(0.0001)) second = new Decimal(0)
+  if (third.lte(0.0001)) third = new Decimal(0)
+  if (fourth.lte(0.0001)) fourth = new Decimal(0)
+  if (fifth.lte(0.0001)) fifth = new Decimal(0)
+
+  return { first, second, third, fourth, fifth, total, perSecond: total.times(40) }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+const expectAllEqual = (
+  next: ReturnType<typeof newCoinProd>,
+  old: ReturnType<typeof oldCalculateCoinProduction>
+) => {
+  expect(decimalEq(next.first, old.first)).toBe(true)
+  expect(decimalEq(next.second, old.second)).toBe(true)
+  expect(decimalEq(next.third, old.third)).toBe(true)
+  expect(decimalEq(next.fourth, old.fourth)).toBe(true)
+  expect(decimalEq(next.fifth, old.fifth)).toBe(true)
+  expect(decimalEq(next.total, old.total)).toBe(true)
+  expect(decimalEq(next.perSecond, old.perSecond)).toBe(true)
+}
+
+// Standard zeroed tier — for selectively setting one field at a time.
+const zeroTier: PerCoinTierInput = {
+  generated: new Decimal(0),
+  owned: 0,
+  coinMulti: new Decimal(1),
+  produceCoin: 1
+}
+
+describe('parity: calculateCoinProduction (all-zero baseline)', () => {
+  it('all tiers zero → 0 everywhere', () => {
+    const input: CalculateCoinProductionInput = {
+      first: zeroTier,
+      second: zeroTier,
+      third: zeroTier,
+      fourth: zeroTier,
+      fifth: zeroTier,
+      globalCoinMultiplier: new Decimal(1)
+    }
+    expectAllEqual(newCoinProd(input), oldCalculateCoinProduction(input))
+  })
+})
+
+describe('parity: calculateCoinProduction (noise-floor boundary)', () => {
+  // Tier output values around 0.0001 — verify the clamp fires correctly.
+  // Picking generated values that, after the multipliers, land just below
+  // and just above the threshold.
+  const cases = [
+    // generated=0.00005, owned=0, mult=1, produce=1 → 0.00005 (clamped to 0)
+    { generated: 0.00005, expectedClamp: true },
+    // generated=0.0001, owned=0 → 0.0001 (exactly at threshold; .lte → clamped)
+    { generated: 0.0001, expectedClamp: true },
+    // generated=0.0002 → > 0.0001 (kept)
+    { generated: 0.0002, expectedClamp: false },
+    // generated=1 → way above threshold
+    { generated: 1, expectedClamp: false }
+  ]
+  for (const c of cases) {
+    it(`generated=${c.generated} (clamp=${c.expectedClamp})`, () => {
+      const tier: PerCoinTierInput = { ...zeroTier, generated: new Decimal(c.generated) }
+      const input: CalculateCoinProductionInput = {
+        first: tier,
+        second: zeroTier,
+        third: zeroTier,
+        fourth: zeroTier,
+        fifth: zeroTier,
+        globalCoinMultiplier: new Decimal(1)
+      }
+      const next = newCoinProd(input)
+      const old = oldCalculateCoinProduction(input)
+      expectAllEqual(next, old)
+      // Sanity check: clamp expectation matches reality.
+      if (c.expectedClamp) {
+        expect(next.first.eq(0)).toBe(true)
+      } else {
+        expect(next.first.gt(0)).toBe(true)
+      }
+    })
+  }
+})
+
+describe('parity: calculateCoinProduction (one-tier-each)', () => {
+  // Test each of the five tier slots independently to verify the per-tier
+  // formula is identical (no accidental cross-tier copy-paste bug).
+  const tiers: ('first' | 'second' | 'third' | 'fourth' | 'fifth')[] = [
+    'first',
+    'second',
+    'third',
+    'fourth',
+    'fifth'
+  ]
+  const nonZeroTier: PerCoinTierInput = {
+    generated: new Decimal(100),
+    owned: 50,
+    coinMulti: new Decimal(2),
+    produceCoin: 3
+  }
+  for (const tierName of tiers) {
+    it(`only ${tierName} non-zero`, () => {
+      const input: CalculateCoinProductionInput = {
+        first: zeroTier,
+        second: zeroTier,
+        third: zeroTier,
+        fourth: zeroTier,
+        fifth: zeroTier,
+        globalCoinMultiplier: new Decimal(5),
+        [tierName]: nonZeroTier
+      }
+      expectAllEqual(newCoinProd(input), oldCalculateCoinProduction(input))
+    })
+  }
+})
+
+describe('parity: calculateCoinProduction (large values)', () => {
+  // Stress test — every tier active at scales where Decimal precision matters.
+  const cases: CalculateCoinProductionInput[] = [
+    {
+      first: { generated: new Decimal(1e10), owned: 100, coinMulti: new Decimal(2), produceCoin: 5 },
+      second: { generated: new Decimal(1e20), owned: 1000, coinMulti: new Decimal(3), produceCoin: 10 },
+      third: { generated: new Decimal(1e30), owned: 10000, coinMulti: new Decimal(4), produceCoin: 20 },
+      fourth: { generated: new Decimal(1e40), owned: 100000, coinMulti: new Decimal(5), produceCoin: 50 },
+      fifth: { generated: new Decimal(1e100), owned: 1000000, coinMulti: new Decimal('1e10'), produceCoin: 100 },
+      globalCoinMultiplier: new Decimal('1e5')
+    },
+    // Extreme global multiplier
+    {
+      first: { generated: new Decimal(1), owned: 0, coinMulti: new Decimal(1), produceCoin: 1 },
+      second: { generated: new Decimal(2), owned: 0, coinMulti: new Decimal(1), produceCoin: 1 },
+      third: { generated: new Decimal(3), owned: 0, coinMulti: new Decimal(1), produceCoin: 1 },
+      fourth: { generated: new Decimal(4), owned: 0, coinMulti: new Decimal(1), produceCoin: 1 },
+      fifth: { generated: new Decimal(5), owned: 0, coinMulti: new Decimal(1), produceCoin: 1 },
+      globalCoinMultiplier: new Decimal('1e200')
+    }
+  ]
+  for (let i = 0; i < cases.length; i++) {
+    it(`large-value mix #${i}`, () => {
+      expectAllEqual(newCoinProd(cases[i]), oldCalculateCoinProduction(cases[i]))
+    })
+  }
+})
+
+describe('parity: calculateCoinProduction (pre-clamp total)', () => {
+  // The aggregate uses PRE-clamp values. Verify a setup where some tiers
+  // are below the noise floor but contribute to total nonetheless.
+  it('tiny tier contributes to total despite clamp', () => {
+    const tiny: PerCoinTierInput = {
+      generated: new Decimal(0.00005),
+      owned: 0,
+      coinMulti: new Decimal(1),
+      produceCoin: 1
+    }
+    const large: PerCoinTierInput = {
+      generated: new Decimal(1000),
+      owned: 0,
+      coinMulti: new Decimal(1),
+      produceCoin: 1
+    }
+    const input: CalculateCoinProductionInput = {
+      first: tiny,
+      second: large,
+      third: tiny,
+      fourth: large,
+      fifth: tiny,
+      globalCoinMultiplier: new Decimal(1)
+    }
+    const next = newCoinProd(input)
+    const old = oldCalculateCoinProduction(input)
+    expectAllEqual(next, old)
+    // Sanity: total should be > 2000 (the two large tiers) + tiny contributions
+    expect(next.total.gt(2000)).toBe(true)
+  })
+})

--- a/packages/logic/test/parity/gqUpgradeCost.parity.test.ts
+++ b/packages/logic/test/parity/gqUpgradeCost.parity.test.ts
@@ -1,0 +1,178 @@
+// Parity tests for gqUpgradeCostTNL, lifted from
+// packages/web_ui/src/singularity.ts. Sweeps cover: each of the four
+// cost-form branches (Exponential2, Cubic, Quadratic, default), the
+// overcap multiplier kicking in past base maxLevel, the no-max-level
+// progression at 100/400 (default branch only), and the maxed-out
+// early-return.
+
+import { describe, expect, it } from 'vitest'
+import {
+  gqUpgradeCostTNL as newCostTNL,
+  type GQUpgradeCostTNLInput,
+  type GQUpgradeSpecialCostForm
+} from '../../src/mechanics/gqUpgradeCost'
+
+// ─── Old implementation (verbatim from packages/web_ui/src/singularity.ts) ─
+
+interface OldInput {
+  level: number
+  maxLevel: number
+  computedMaxLevel: number
+  costPerLevel: number
+  specialCostForm: GQUpgradeSpecialCostForm
+}
+
+const oldCostTNL = (input: OldInput): number => {
+  let costMultiplier = 1
+
+  if (input.computedMaxLevel === input.level) {
+    return 0
+  }
+
+  if (input.computedMaxLevel > input.maxLevel && input.level >= input.maxLevel) {
+    costMultiplier *= Math.pow(4, input.level - input.maxLevel + 1)
+  }
+
+  if (input.specialCostForm === 'Exponential2') {
+    return input.costPerLevel * Math.sqrt(costMultiplier) * Math.pow(2, input.level)
+  }
+
+  if (input.specialCostForm === 'Cubic') {
+    return input.costPerLevel * costMultiplier * (Math.pow(input.level + 1, 3) - Math.pow(input.level, 3))
+  }
+
+  if (input.specialCostForm === 'Quadratic') {
+    return input.costPerLevel * costMultiplier * (Math.pow(input.level + 1, 2) - Math.pow(input.level, 2))
+  }
+
+  costMultiplier *= input.maxLevel === -1 && input.level >= 100 ? input.level / 50 : 1
+  costMultiplier *= input.maxLevel === -1 && input.level >= 400 ? input.level / 100 : 1
+
+  return input.computedMaxLevel === input.level
+    ? 0
+    : Math.ceil(input.costPerLevel * (1 + input.level) * costMultiplier)
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── Per-branch tests ─────────────────────────────────────────────────────
+
+describe('parity: gqUpgradeCostTNL (Exponential2)', () => {
+  const levelGrid = [0, 1, 5, 10, 20, 30]
+  for (const level of levelGrid) {
+    for (const maxLevel of [10, 100]) {
+      // computedMaxLevel = maxLevel + overclock bonus
+      for (const computedExtra of [0, 5, 20]) {
+        const input: GQUpgradeCostTNLInput = {
+          level,
+          maxLevel,
+          computedMaxLevel: maxLevel + computedExtra,
+          costPerLevel: 100,
+          specialCostForm: 'Exponential2'
+        }
+        it(`level=${level} maxLevel=${maxLevel} extra=${computedExtra}`, () => {
+          expect(closeEnough(newCostTNL(input), oldCostTNL(input))).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+describe('parity: gqUpgradeCostTNL (Cubic)', () => {
+  const levelGrid = [0, 1, 5, 10, 100, 500]
+  for (const level of levelGrid) {
+    for (const maxLevel of [10, 100, 1000]) {
+      for (const computedExtra of [0, 1, 10]) {
+        const input: GQUpgradeCostTNLInput = {
+          level,
+          maxLevel,
+          computedMaxLevel: maxLevel + computedExtra,
+          costPerLevel: 50,
+          specialCostForm: 'Cubic'
+        }
+        it(`level=${level} maxLevel=${maxLevel} extra=${computedExtra}`, () => {
+          expect(closeEnough(newCostTNL(input), oldCostTNL(input))).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+describe('parity: gqUpgradeCostTNL (Quadratic)', () => {
+  const levelGrid = [0, 1, 5, 10, 100, 500]
+  for (const level of levelGrid) {
+    for (const maxLevel of [10, 100, 1000]) {
+      for (const computedExtra of [0, 1, 10]) {
+        const input: GQUpgradeCostTNLInput = {
+          level,
+          maxLevel,
+          computedMaxLevel: maxLevel + computedExtra,
+          costPerLevel: 50,
+          specialCostForm: 'Quadratic'
+        }
+        it(`level=${level} maxLevel=${maxLevel} extra=${computedExtra}`, () => {
+          expect(closeEnough(newCostTNL(input), oldCostTNL(input))).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+describe('parity: gqUpgradeCostTNL (default branch, finite maxLevel)', () => {
+  const levelGrid = [0, 1, 5, 10, 99, 100, 101, 400, 401, 500]
+  for (const level of levelGrid) {
+    for (const maxLevel of [1000, 5000]) {
+      for (const computedExtra of [0, 5]) {
+        const input: GQUpgradeCostTNLInput = {
+          level,
+          maxLevel,
+          computedMaxLevel: maxLevel + computedExtra,
+          costPerLevel: 100,
+          specialCostForm: null
+        }
+        it(`level=${level} maxLevel=${maxLevel} extra=${computedExtra}`, () => {
+          expect(closeEnough(newCostTNL(input), oldCostTNL(input))).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+describe('parity: gqUpgradeCostTNL (default branch, no-max-level progression)', () => {
+  // maxLevel = -1 triggers the level/50 (≥100) and level/100 (≥400)
+  // multipliers. Sweep across both boundaries.
+  const levelGrid = [0, 1, 50, 99, 100, 101, 200, 399, 400, 401, 800, 5000]
+  for (const level of levelGrid) {
+    // When maxLevel === -1, computedMaxLevel is also -1 (no overcap path
+    // applies); base case has level !== computedMaxLevel.
+    const input: GQUpgradeCostTNLInput = {
+      level,
+      maxLevel: -1,
+      computedMaxLevel: -1,
+      costPerLevel: 25,
+      specialCostForm: null
+    }
+    it(`level=${level} (no-max progression)`, () => {
+      expect(closeEnough(newCostTNL(input), oldCostTNL(input))).toBe(true)
+    })
+  }
+})
+
+describe('parity: gqUpgradeCostTNL (maxed-out → 0)', () => {
+  const inputs: GQUpgradeCostTNLInput[] = [
+    { level: 10, maxLevel: 10, computedMaxLevel: 10, costPerLevel: 100, specialCostForm: null },
+    { level: 100, maxLevel: 50, computedMaxLevel: 100, costPerLevel: 100, specialCostForm: 'Cubic' },
+    { level: 5, maxLevel: 5, computedMaxLevel: 5, costPerLevel: 100, specialCostForm: 'Exponential2' }
+  ]
+  for (const input of inputs) {
+    it(`level=${input.level} = computedMax`, () => {
+      expect(newCostTNL(input)).toBe(0)
+      expect(oldCostTNL(input)).toBe(0)
+    })
+  }
+})

--- a/packages/logic/test/parity/gqUpgradeLevels.parity.test.ts
+++ b/packages/logic/test/parity/gqUpgradeLevels.parity.test.ts
@@ -1,0 +1,272 @@
+// Parity tests for gqUpgradeLevels — `gqFreeLevelMultiplier`,
+// `gqUpgradeFreeLevelSoftcap`, `computeGQUpgradeMaxLevel`, and the gated
+// `actualGQUpgradeTotalLevels`, all lifted from
+// packages/web_ui/src/singularity.ts.
+//
+// Sweeps cover: the softcap kink at level == baseRealFreeLevels (where
+// `min(level, baseRealFree) + sqrt(max(0, baseRealFree - level))` transitions
+// from the linear branch to the sqrt branch), every overclock-perks
+// threshold for the max-level cap, all four challenge gates and the
+// platonicDelta-specific gate, the improvedFree polynomial path with several
+// exponents.
+
+import { describe, expect, it } from 'vitest'
+import {
+  actualGQUpgradeTotalLevels as newActualLevels,
+  computeGQUpgradeMaxLevel as newMaxLevel,
+  gqFreeLevelMultiplier as newFreeLevelMult,
+  gqUpgradeFreeLevelSoftcap as newFreeLevelSoftcap
+} from '../../src/mechanics/gqUpgradeLevels'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/singularity.ts) ─
+
+// Same array web_ui used. Sorted ascending; the loop bails at the first unmet
+// threshold.
+const oldOverclockPerks = [50, 60, 75, 100, 125, 150, 175, 200, 225, 250]
+
+const oldFreeLevelMult = (shopFreeUpgradeMult: number, cubeUpgrade75: number): number =>
+  shopFreeUpgradeMult + 0.3 / 100 * cubeUpgrade75
+
+const oldFreeLevelSoftcap = (freeLevel: number, level: number, freeLevelMult: number): number => {
+  const baseRealFreeLevels = freeLevelMult * freeLevel
+  return Math.min(level, baseRealFreeLevels) + Math.sqrt(Math.max(0, baseRealFreeLevels - level))
+}
+
+interface OldMaxLevelInput {
+  canExceedCap: boolean
+  maxLevel: number
+  highestSingularityCount: number
+  octeractSingUpgradeCapIncrease: number
+}
+
+const oldMaxLevel = (input: OldMaxLevelInput): number => {
+  if (!input.canExceedCap) {
+    return input.maxLevel
+  }
+  let cap = input.maxLevel
+  for (const perk of oldOverclockPerks) {
+    if (input.highestSingularityCount >= perk) {
+      cap += 1
+    } else {
+      break
+    }
+  }
+  cap += input.octeractSingUpgradeCapIncrease
+  return cap
+}
+
+interface OldActualLevelsInput {
+  level: number
+  freeLevel: number
+  qualityOfLife: boolean
+  isPlatonicDelta: boolean
+  inNoSingularityUpgrades: boolean
+  inSadisticPrequel: boolean
+  inLimitedAscensions: boolean
+  inLimitedTime: boolean
+  freeLevelMult: number
+  improvedFreeUnlocked: boolean
+  improvedFreeExponent: number
+}
+
+const oldActualLevels = (input: OldActualLevelsInput): number => {
+  if ((input.inNoSingularityUpgrades || input.inSadisticPrequel) && !input.qualityOfLife) {
+    return 0
+  }
+  if (
+    (input.inLimitedAscensions || input.inLimitedTime || input.inSadisticPrequel)
+    && input.isPlatonicDelta
+  ) {
+    return 0
+  }
+  const actualFreeLevels = oldFreeLevelSoftcap(input.freeLevel, input.level, input.freeLevelMult)
+  const linearLevels = input.level + actualFreeLevels
+  let polynomialLevels = 0
+  if (input.improvedFreeUnlocked) {
+    polynomialLevels = Math.pow(input.level * actualFreeLevels, input.improvedFreeExponent)
+  }
+  return Math.max(linearLevels, polynomialLevels)
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── gqFreeLevelMultiplier ─────────────────────────────────────────────────
+
+describe('parity: gqFreeLevelMultiplier', () => {
+  const shopGrid = [0, 0.5, 1, 1.5, 2]
+  const cubeGrid = [0, 1, 10, 100, 1000]
+  for (const shop of shopGrid) {
+    it.each(cubeGrid)(`shop=${shop} cube75=%i`, (cube) => {
+      expect(closeEnough(newFreeLevelMult(shop, cube), oldFreeLevelMult(shop, cube))).toBe(true)
+    })
+  }
+})
+
+// ─── gqUpgradeFreeLevelSoftcap (linear-to-sqrt boundary) ───────────────────
+
+describe('parity: gqUpgradeFreeLevelSoftcap (every regime)', () => {
+  // Pick freeLevel × mult combinations and sweep level around the kink at
+  // baseRealFreeLevels = freeLevel * mult — sub, equal, super.
+  const cases = [
+    { freeLevel: 0, mult: 1 },
+    { freeLevel: 10, mult: 1 },
+    { freeLevel: 100, mult: 1.5 },
+    { freeLevel: 50, mult: 2 },
+    { freeLevel: 1000, mult: 1 }
+  ]
+  for (const { freeLevel, mult } of cases) {
+    const base = freeLevel * mult
+    const levelSweep = [
+      0,
+      Math.floor(base / 2),
+      Math.max(0, Math.floor(base) - 1),
+      Math.floor(base),
+      Math.ceil(base),
+      Math.floor(base) + 1,
+      Math.floor(base * 2),
+      Math.floor(base * 10)
+    ]
+    for (const level of levelSweep) {
+      it(`freeLevel=${freeLevel} mult=${mult} level=${level}`, () => {
+        expect(closeEnough(newFreeLevelSoftcap(freeLevel, level, mult), oldFreeLevelSoftcap(freeLevel, level, mult)))
+          .toBe(true)
+      })
+    }
+  }
+})
+
+// ─── computeGQUpgradeMaxLevel (each overclock-perks threshold) ─────────────
+
+describe('parity: computeGQUpgradeMaxLevel', () => {
+  // Sweep every threshold in the overclock-perks array in both directions
+  // (perk-1, perk, perk+1) plus a few values past the last perk.
+  const singCountGrid = [
+    0,
+    49,
+    50,
+    51,
+    59,
+    60,
+    61,
+    74,
+    75,
+    76,
+    99,
+    100,
+    101,
+    124,
+    125,
+    149,
+    150,
+    174,
+    175,
+    199,
+    200,
+    224,
+    225,
+    249,
+    250,
+    251,
+    500
+  ]
+  const capIncreaseGrid = [0, 1, 5]
+  const baseMaxLevelGrid = [0, 10, 100, -1] // -1 sentinel covered too
+  for (const canExceedCap of [true, false]) {
+    for (const maxLevel of baseMaxLevelGrid) {
+      for (const capIncrease of capIncreaseGrid) {
+        it.each(singCountGrid)(
+          `canExceed=${canExceedCap} maxLevel=${maxLevel} capInc=${capIncrease} sing=%i`,
+          (sing) => {
+            const input = {
+              canExceedCap,
+              maxLevel,
+              highestSingularityCount: sing,
+              octeractSingUpgradeCapIncrease: capIncrease
+            }
+            expect(newMaxLevel(input)).toBe(oldMaxLevel(input))
+          }
+        )
+      }
+    }
+  }
+})
+
+// ─── actualGQUpgradeTotalLevels (gates + improvedFree path) ────────────────
+
+describe('parity: actualGQUpgradeTotalLevels (gate combinations, gates active)', () => {
+  // Pick a representative non-zero level / freeLevel and sweep the four
+  // challenge gates × the two upgrade flags. Verifies all eight gating
+  // truth-table cases produce the same gating decisions.
+  const level = 25
+  const freeLevel = 10
+  const freeLevelMult = 1.5
+  for (const inNoSingularityUpgrades of [true, false]) {
+    for (const inSadisticPrequel of [true, false]) {
+      for (const inLimitedAscensions of [true, false]) {
+        for (const inLimitedTime of [true, false]) {
+          for (const qualityOfLife of [true, false]) {
+            for (const isPlatonicDelta of [true, false]) {
+              const input = {
+                level,
+                freeLevel,
+                qualityOfLife,
+                isPlatonicDelta,
+                inNoSingularityUpgrades,
+                inSadisticPrequel,
+                inLimitedAscensions,
+                inLimitedTime,
+                freeLevelMult,
+                improvedFreeUnlocked: false,
+                improvedFreeExponent: 0
+              }
+              it(`gates: noSU=${inNoSingularityUpgrades} sadistic=${inSadisticPrequel} limAsc=${inLimitedAscensions} limTime=${inLimitedTime} qol=${qualityOfLife} plat=${isPlatonicDelta}`, () => {
+                expect(closeEnough(newActualLevels(input), oldActualLevels(input))).toBe(true)
+              })
+            }
+          }
+        }
+      }
+    }
+  }
+})
+
+describe('parity: actualGQUpgradeTotalLevels (improvedFree polynomial path)', () => {
+  // No gates active. Sweep across exponent values and softcap regimes to
+  // make sure the max(linear, polynomial) decision matches.
+  const exponentGrid = [0.5, 0.8, 1.0, 1.05, 1.1, 1.2]
+  const cases = [
+    { level: 0, freeLevel: 0, mult: 1 },
+    { level: 5, freeLevel: 10, mult: 1 },
+    { level: 10, freeLevel: 10, mult: 1 }, // exactly at kink
+    { level: 50, freeLevel: 10, mult: 1 },
+    { level: 100, freeLevel: 100, mult: 1.5 },
+    { level: 1000, freeLevel: 500, mult: 2 }
+  ]
+  for (const { level, freeLevel, mult } of cases) {
+    for (const exponent of exponentGrid) {
+      for (const improvedFreeUnlocked of [true, false]) {
+        const input = {
+          level,
+          freeLevel,
+          qualityOfLife: false,
+          isPlatonicDelta: false,
+          inNoSingularityUpgrades: false,
+          inSadisticPrequel: false,
+          inLimitedAscensions: false,
+          inLimitedTime: false,
+          freeLevelMult: mult,
+          improvedFreeUnlocked,
+          improvedFreeExponent: exponent
+        }
+        it(`lv=${level} free=${freeLevel} mult=${mult} exp=${exponent} improvedFree=${improvedFreeUnlocked}`, () => {
+          expect(closeEnough(newActualLevels(input), oldActualLevels(input))).toBe(true)
+        })
+      }
+    }
+  }
+})

--- a/packages/logic/test/parity/hepteractValues.parity.test.ts
+++ b/packages/logic/test/parity/hepteractValues.parity.test.ts
@@ -1,0 +1,122 @@
+// Parity tests for the hepteract effective/cap helpers, lifted from
+// packages/web_ui/src/Hepteracts.ts. Sweeps cover:
+//   - hepteractEffective: linear regime (≤ LIMIT), DR regime (> LIMIT),
+//     quark special-case pass-through, varying DR exponents
+//   - hepteractCap: TIMES_CAP_EXTENDED at 0/1/many
+//   - hepteractFinalCap: with and without Exalt 3 doubling
+
+import { describe, expect, it } from 'vitest'
+import {
+  hepteractCap as newCap,
+  hepteractEffective as newEffective,
+  type HepteractEffectiveInput,
+  hepteractFinalCap as newFinalCap
+} from '../../src/mechanics/hepteractValues'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Hepteracts.ts) ─
+
+const oldEffective = (input: HepteractEffectiveInput): number => {
+  if (input.isQuark) {
+    return input.rawAmount
+  }
+  let effectiveValue = Math.min(input.rawAmount, input.limit)
+  if (input.rawAmount > input.limit) {
+    effectiveValue *= Math.pow(input.rawAmount / input.limit, input.drExponent)
+  }
+  return effectiveValue
+}
+
+const oldCap = (baseCap: number, timesCapExtended: number): number => {
+  return Math.pow(2, timesCapExtended) * baseCap
+}
+
+const oldFinalCap = (baseCap: number, timesCapExtended: number, exalt3HepteractCap: boolean): number => {
+  const specialMultiplier = exalt3HepteractCap ? 2 : 1
+  return oldCap(baseCap, timesCapExtended) * specialMultiplier
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// ─── hepteractEffective ────────────────────────────────────────────────────
+
+describe('parity: hepteractEffective (linear regime, ≤ LIMIT)', () => {
+  for (const rawAmount of [0, 1, 100, 999, 1000]) {
+    for (const drExponent of [0.5, 1, 2]) {
+      const input: HepteractEffectiveInput = {
+        rawAmount,
+        limit: 1000,
+        drExponent,
+        isQuark: false
+      }
+      it(`raw=${rawAmount} limit=1000 dr=${drExponent}`, () => {
+        expect(closeEnough(newEffective(input), oldEffective(input))).toBe(true)
+      })
+    }
+  }
+})
+
+describe('parity: hepteractEffective (DR regime, > LIMIT)', () => {
+  // Sweep across the LIMIT boundary and into the DR regime. Different
+  // DR exponents: 0.5 (most hepts), 1 (no DR), 2 (extreme).
+  for (const rawAmount of [1001, 1500, 2000, 10000, 100000]) {
+    for (const drExponent of [0.1, 0.5, 0.75, 1, 1.5]) {
+      const input: HepteractEffectiveInput = {
+        rawAmount,
+        limit: 1000,
+        drExponent,
+        isQuark: false
+      }
+      it(`raw=${rawAmount} limit=1000 dr=${drExponent}`, () => {
+        expect(closeEnough(newEffective(input), oldEffective(input))).toBe(true)
+      })
+    }
+  }
+})
+
+describe('parity: hepteractEffective (quark special-case)', () => {
+  // isQuark === true → just returns rawAmount, ignoring limit/dr.
+  for (const rawAmount of [0, 100, 1e6, 1e20]) {
+    const input: HepteractEffectiveInput = {
+      rawAmount,
+      limit: 50, // irrelevant when isQuark
+      drExponent: 0.5, // irrelevant when isQuark
+      isQuark: true
+    }
+    it(`quark raw=${rawAmount}`, () => {
+      expect(newEffective(input)).toBe(oldEffective(input))
+      expect(newEffective(input)).toBe(rawAmount)
+    })
+  }
+})
+
+// ─── hepteractCap ──────────────────────────────────────────────────────────
+
+describe('parity: hepteractCap', () => {
+  // BASE_CAP * 2^TIMES_CAP_EXTENDED.
+  for (const baseCap of [10, 100, 1e5, 1e10]) {
+    for (const times of [0, 1, 5, 10, 20]) {
+      it(`base=${baseCap} times=${times}`, () => {
+        expect(newCap(baseCap, times)).toBe(oldCap(baseCap, times))
+      })
+    }
+  }
+})
+
+// ─── hepteractFinalCap (Exalt 3 doubling) ─────────────────────────────────
+
+describe('parity: hepteractFinalCap', () => {
+  for (const baseCap of [10, 1000, 1e6]) {
+    for (const times of [0, 1, 5]) {
+      for (const exalt3 of [true, false]) {
+        it(`base=${baseCap} times=${times} exalt3=${exalt3}`, () => {
+          expect(newFinalCap(baseCap, times, exalt3)).toBe(oldFinalCap(baseCap, times, exalt3))
+        })
+      }
+    }
+  }
+})

--- a/packages/logic/test/parity/levelMilestones.parity.test.ts
+++ b/packages/logic/test/parity/levelMilestones.parity.test.ts
@@ -1,0 +1,194 @@
+// Parity tests for the level-milestone effect formulas, lifted from
+// packages/web_ui/src/Levels.ts (the `synergismLevelMilestones.<key>.effect`
+// fields). Each `oldXxx` transcribes the pre-migration body verbatim.
+// Sweeps cover every documented levelReq boundary (5/6/7/9/12/15/20/40/60/65/
+// 80/100/130/160/180/225) plus mid-band values for the per-level scaling
+// rune/talisman milestones. The eight challenge-state combinations of
+// `salvageChallengeBuff` get their own enumerated test.
+
+import { describe, expect, it } from 'vitest'
+import {
+  achievementTalismanEnhancementEffect as newAchTalisman,
+  duplicationRuneMilestoneEffect as newDuplication,
+  getLevelMilestone as newGetLevelMilestone,
+  type LevelMilestoneKey,
+  levelMilestones as newLevelMilestones,
+  prismRuneMilestoneEffect as newPrism,
+  runeAutobuyImproverEffect as newRuneAuto,
+  salvageChallengeBuffEffect as newSalvageBuff,
+  siRuneMilestoneEffect as newSI,
+  speedRuneMilestoneEffect as newSpeed,
+  thriftRuneMilestoneEffect as newThrift
+} from '../../src/mechanics/levelMilestones'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Levels.ts) ─────
+
+const oldSpeedRune = (achievementLevel: number) => 0.5 * (achievementLevel - 19)
+const oldDuplicationRune = (achievementLevel: number) => 0.4 * (achievementLevel - 39)
+const oldPrismRune = (achievementLevel: number) => 0.3 * (achievementLevel - 59)
+const oldThriftRune = (achievementLevel: number) => 0.2 * (achievementLevel - 79)
+const oldSIRune = (achievementLevel: number) => 0.1 * (achievementLevel - 99)
+const oldRuneAutobuyImprover = (achievementLevel: number) => 1.1 + 0.01 * (achievementLevel - 130)
+const oldAchievementTalismanEnhancement = (achievementLevel: number) => achievementLevel
+
+const oldSalvageChallengeBuff = (
+  inAnyChallenge: boolean,
+  inAscension15: boolean,
+  insideSingularityChallenge: boolean
+): number => {
+  let baseVal = 25
+  if (inAnyChallenge) {
+    baseVal *= 2
+  }
+  if (inAscension15) {
+    baseVal *= 2
+  }
+  if (insideSingularityChallenge) {
+    baseVal *= 3
+  }
+  return baseVal
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Sweeps the achievement-level range covering every documented threshold:
+// 5/6/7/9/12/15/20/40/60/65/80/100/130/160/180/225 and a few mid-band.
+const levelGrid = [
+  0,
+  1,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  19,
+  20,
+  21,
+  39,
+  40,
+  41,
+  59,
+  60,
+  64,
+  65,
+  79,
+  80,
+  99,
+  100,
+  129,
+  130,
+  131,
+  159,
+  160,
+  179,
+  180,
+  224,
+  225,
+  226,
+  300
+]
+
+const allPureMilestoneKeys: LevelMilestoneKey[] = [
+  'offeringTimerScaling',
+  'autoPrestige',
+  'speedRune',
+  'duplicationRune',
+  'prismRune',
+  'thriftRune',
+  'SIRune',
+  'tier1CrystalAutobuy',
+  'tier2CrystalAutobuy',
+  'tier3CrystalAutobuy',
+  'tier4CrystalAutobuy',
+  'tier5CrystalAutobuy',
+  'achievementTalismanUnlock',
+  'runeAutobuyImprover',
+  'achievementTalismanEnhancement',
+  'antSpeed2Autobuyer',
+  'wowCubesAutobuyer',
+  'ascensionScoreAutobuyer',
+  'mortuus2Autobuyer'
+]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: speedRuneMilestoneEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newSpeed(lv), oldSpeedRune(lv))).toBe(true))
+})
+
+describe('parity: duplicationRuneMilestoneEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newDuplication(lv), oldDuplicationRune(lv))).toBe(true))
+})
+
+describe('parity: prismRuneMilestoneEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newPrism(lv), oldPrismRune(lv))).toBe(true))
+})
+
+describe('parity: thriftRuneMilestoneEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newThrift(lv), oldThriftRune(lv))).toBe(true))
+})
+
+describe('parity: siRuneMilestoneEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newSI(lv), oldSIRune(lv))).toBe(true))
+})
+
+describe('parity: runeAutobuyImproverEffect', () => {
+  it.each(levelGrid)(
+    'lv=%i',
+    (lv) => expect(closeEnough(newRuneAuto(lv), oldRuneAutobuyImprover(lv))).toBe(true)
+  )
+})
+
+describe('parity: achievementTalismanEnhancementEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(newAchTalisman(lv)).toBe(oldAchievementTalismanEnhancement(lv)))
+})
+
+// ─── salvageChallengeBuff: every state combination ─────────────────────────
+
+describe('parity: salvageChallengeBuffEffect (every state combo)', () => {
+  const booleanGrid = [true, false]
+  for (const inAnyChallenge of booleanGrid) {
+    for (const inAscension15 of booleanGrid) {
+      for (const insideSingularityChallenge of booleanGrid) {
+        it(`inAnyChallenge=${inAnyChallenge} inAscension15=${inAscension15} insideSing=${insideSingularityChallenge}`, () => {
+          const next = newSalvageBuff({ inAnyChallenge, inAscension15, insideSingularityChallenge })
+          const old = oldSalvageChallengeBuff(inAnyChallenge, inAscension15, insideSingularityChallenge)
+          expect(next).toBe(old)
+        })
+      }
+    }
+  }
+})
+
+// ─── getLevelMilestone: threshold gate ─────────────────────────────────────
+
+describe('getLevelMilestone: returns defaultValue below levelReq', () => {
+  for (const key of allPureMilestoneKeys) {
+    const data = newLevelMilestones[key]
+    if (data.levelReq <= 0) continue
+    it(`${key} at levelReq-1 = defaultValue (${data.defaultValue})`, () => {
+      expect(newGetLevelMilestone(key, data.levelReq - 1)).toBe(data.defaultValue)
+    })
+  }
+})
+
+describe('getLevelMilestone: returns effect at levelReq', () => {
+  for (const key of allPureMilestoneKeys) {
+    const data = newLevelMilestones[key]
+    it(`${key} at levelReq = effect(levelReq)`, () => {
+      expect(newGetLevelMilestone(key, data.levelReq)).toBe(data.effect(data.levelReq))
+    })
+  }
+})

--- a/packages/logic/test/parity/levelRewards.parity.test.ts
+++ b/packages/logic/test/parity/levelRewards.parity.test.ts
@@ -1,0 +1,236 @@
+// Parity tests for the level-reward effect formulas, lifted from
+// packages/web_ui/src/Levels.ts (the `synergismLevelRewards.<key>.effect`
+// fields). Each `oldXxx` transcribes the pre-migration body verbatim
+// (including the misspelled `salavePerLevel` variable from web_ui).
+// Sweeps cross every documented threshold per reward — band boundaries
+// at 100/200 (salvage, ants), the /20 step (quarks), the 100-level wow-cube
+// kink, the cube-tier minLevel boundaries, and the late-game post-209/229/259
+// luck thresholds.
+
+import { describe, expect, it } from 'vitest'
+import {
+  ambrosiaLuckEffect as newAmbrosiaLuck,
+  antsEffect as newAnts,
+  getLevelReward as newGetLevelReward,
+  type LevelRewardKey,
+  levelRewards as newLevelRewards,
+  obtainiumEffect as newObtainium,
+  offeringsEffect as newOfferings,
+  quarksEffect as newQuarks,
+  redAmbrosiaLuckEffect as newRedAmbrosiaLuck,
+  salvageEffect as newSalvage,
+  wowCubesEffect as newWowCubes,
+  wowHepteractCubesEffect as newWowHept,
+  wowHyperCubesEffect as newWowHyper,
+  wowOcteractsEffect as newWowOct,
+  wowPlatonicCubesEffect as newWowPlat,
+  wowTesseractsEffect as newWowTess
+} from '../../src/mechanics/levelRewards'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Levels.ts) ─────
+
+const oldSalvage = (lv: number) => {
+  let salvage = 0
+  let salavePerLevel = 1
+  let remainingLevels = lv
+  while (remainingLevels >= 100) {
+    salvage += salavePerLevel * 100
+    remainingLevels -= 100
+    salavePerLevel += 1
+  }
+  salvage += salavePerLevel * remainingLevels
+  return salvage
+}
+
+const oldQuarks = (lv: number) => Math.pow(1.01, Math.floor(lv / 20))
+const oldOfferings = (lv: number) => Math.pow(1.01, lv) * Math.pow(1.02, Math.max(0, lv - 100))
+const oldObtainium = (lv: number) => Math.pow(1.01, lv - 15) * Math.pow(1.02, Math.max(0, lv - 100))
+
+const oldAnts = (lv: number) => {
+  const first100Levels = Math.min(71, lv - 59) * 25
+  const next100Levels = Math.max(0, Math.min(100, lv - 100)) * 50
+  const remainingLevels = Math.max(0, lv - 200) * 100
+  return first100Levels + next100Levels + remainingLevels
+}
+
+const oldWowCubes = (lv: number) => (1 + (lv - 60) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 6)
+const oldWowTess = (lv: number) => (1 + (lv - 80) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 8)
+const oldWowHyper = (lv: number) => (1 + (lv - 100) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 10)
+const oldWowPlat = (lv: number) => (1 + (lv - 120) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 12)
+const oldWowHept = (lv: number) => (1 + (lv - 150) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 15)
+const oldWowOct = (lv: number) => (1 + (lv - 209) / 20) * Math.pow(1.02, lv - 209)
+const oldAmbrosiaLuck = (lv: number) => 4 * (lv - 229)
+const oldRedAmbrosiaLuck = (lv: number) => lv - 259
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Sweeps across every documented threshold:
+//   - 0 (defaultValue boundary for salvage/offerings)
+//   - 15 / 20 (obtainium / quarks minLevel)
+//   - 19 / 20 / 21 / 39 / 40 (quarks /20 step boundaries)
+//   - 60 / 70 (ants / wowCubes minLevel)
+//   - 80 / 90 / 99 / 100 / 101 (wowTesseracts minLevel, ants band)
+//   - 110 / 120 / 130 / 140 / 150 / 170 (each cube tier minLevel)
+//   - 199 / 200 / 201 (ants 100→remaining band)
+//   - 209 / 210 / 229 / 230 / 259 / 260 (wowOcteracts / ambrosia / redAmbrosia)
+//   - 300 / 500 (long-band scaling sanity)
+const levelGrid = [
+  0,
+  1,
+  10,
+  14,
+  15,
+  16,
+  19,
+  20,
+  21,
+  39,
+  40,
+  41,
+  59,
+  60,
+  61,
+  69,
+  70,
+  71,
+  79,
+  80,
+  81,
+  89,
+  90,
+  91,
+  99,
+  100,
+  101,
+  109,
+  110,
+  111,
+  119,
+  120,
+  121,
+  139,
+  140,
+  141,
+  149,
+  150,
+  151,
+  169,
+  170,
+  171,
+  199,
+  200,
+  201,
+  208,
+  209,
+  210,
+  211,
+  228,
+  229,
+  230,
+  231,
+  258,
+  259,
+  260,
+  261,
+  300,
+  500
+]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: salvageEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(newSalvage(lv)).toBe(oldSalvage(lv)))
+})
+
+describe('parity: quarksEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newQuarks(lv), oldQuarks(lv))).toBe(true))
+})
+
+describe('parity: offeringsEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newOfferings(lv), oldOfferings(lv))).toBe(true))
+})
+
+describe('parity: obtainiumEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newObtainium(lv), oldObtainium(lv))).toBe(true))
+})
+
+describe('parity: antsEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(newAnts(lv)).toBe(oldAnts(lv)))
+})
+
+describe('parity: wowCubesEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newWowCubes(lv), oldWowCubes(lv))).toBe(true))
+})
+
+describe('parity: wowTesseractsEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newWowTess(lv), oldWowTess(lv))).toBe(true))
+})
+
+describe('parity: wowHyperCubesEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newWowHyper(lv), oldWowHyper(lv))).toBe(true))
+})
+
+describe('parity: wowPlatonicCubesEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newWowPlat(lv), oldWowPlat(lv))).toBe(true))
+})
+
+describe('parity: wowHepteractCubesEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newWowHept(lv), oldWowHept(lv))).toBe(true))
+})
+
+describe('parity: wowOcteractsEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(closeEnough(newWowOct(lv), oldWowOct(lv))).toBe(true))
+})
+
+describe('parity: ambrosiaLuckEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(newAmbrosiaLuck(lv)).toBe(oldAmbrosiaLuck(lv)))
+})
+
+describe('parity: redAmbrosiaLuckEffect', () => {
+  it.each(levelGrid)('lv=%i', (lv) => expect(newRedAmbrosiaLuck(lv)).toBe(oldRedAmbrosiaLuck(lv)))
+})
+
+// ─── getLevelReward + threshold gate ───────────────────────────────────────
+
+// Tests that getLevelReward returns defaultValue below minLevel and the
+// formula's value at/above minLevel — the threshold behaviour that callers
+// rely on (Statistics.ts gates several stat lines off these).
+const allRewardKeys: LevelRewardKey[] = [
+  'salvage',
+  'quarks',
+  'offerings',
+  'obtainium',
+  'ants',
+  'wowCubes',
+  'wowTesseracts',
+  'wowHyperCubes',
+  'wowPlatonicCubes',
+  'wowHepteractCubes',
+  'wowOcteracts',
+  'ambrosiaLuck',
+  'redAmbrosiaLuck'
+]
+
+describe('getLevelReward: returns defaultValue below minLevel', () => {
+  for (const key of allRewardKeys) {
+    const data = newLevelRewards[key]
+    if (data.minLevel <= 0) continue
+    it(`${key} at minLevel-1 = defaultValue (${data.defaultValue})`, () => {
+      expect(newGetLevelReward(key, data.minLevel - 1)).toBe(data.defaultValue)
+    })
+  }
+})
+
+describe('getLevelReward: returns effect at minLevel', () => {
+  for (const key of allRewardKeys) {
+    const data = newLevelRewards[key]
+    it(`${key} at minLevel = effect(minLevel)`, () => {
+      expect(newGetLevelReward(key, data.minLevel)).toBe(data.effect(data.minLevel))
+    })
+  }
+})

--- a/packages/logic/test/parity/octeractUpgradeLevels.parity.test.ts
+++ b/packages/logic/test/parity/octeractUpgradeLevels.parity.test.ts
@@ -1,0 +1,94 @@
+// Parity tests for octeractUpgradeLevels — `octeractFreeLevelMultiplier`,
+// `octeractFreeLevelSoftcap`, and the gated `actualOcteractUpgradeTotalLevels`,
+// lifted from packages/web_ui/src/Octeracts.ts. Sweeps cover the softcap
+// boundary (level == actualFreeLevels), both gate combinations, and the
+// qualityOfLife escape hatch.
+
+import { describe, expect, it } from 'vitest'
+import {
+  actualOcteractUpgradeTotalLevels as newActualLevels,
+  octeractFreeLevelMultiplier as newFreeLevelMult,
+  octeractFreeLevelSoftcap as newFreeLevelSoftcap
+} from '../../src/mechanics/octeractUpgradeLevels'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Octeracts.ts) ───
+
+const oldFreeLevelMult = (cubeUpgrade78: number): number => 1 + 0.3 / 100 * cubeUpgrade78
+
+const oldFreeLevelSoftcap = (freeLevel: number, freeLevelMult: number): number => freeLevel * freeLevelMult
+
+interface OldActualLevelsInput {
+  level: number
+  freeLevel: number
+  qualityOfLife: boolean
+  cubeUpgrade78: number
+  inNoOcteracts: boolean
+  inSadisticPrequel: boolean
+}
+
+const oldActualLevels = (input: OldActualLevelsInput): number => {
+  if ((input.inNoOcteracts || input.inSadisticPrequel) && !input.qualityOfLife) {
+    return 0
+  }
+  const freeLevelMult = oldFreeLevelMult(input.cubeUpgrade78)
+  const actualFreeLevels = oldFreeLevelSoftcap(input.freeLevel, freeLevelMult)
+  if (input.level >= actualFreeLevels) {
+    return actualFreeLevels + input.level
+  }
+  return 2 * Math.sqrt(actualFreeLevels * input.level)
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+const cubeUpgrade78Grid = [0, 1, 10, 100, 1000]
+const levelGrid = [0, 1, 5, 10, 50, 100, 500, 1000]
+const freeLevelGrid = [0, 1, 5, 10, 50, 100, 500, 1000]
+const boolGrid = [true, false]
+
+describe('parity: octeractFreeLevelMultiplier', () => {
+  it.each(cubeUpgrade78Grid)('cubeUpgrade78=%i', (c) => {
+    expect(newFreeLevelMult(c)).toBe(oldFreeLevelMult(c))
+  })
+})
+
+describe('parity: octeractFreeLevelSoftcap', () => {
+  for (const freeLevel of freeLevelGrid) {
+    for (const cubeUpgrade78 of cubeUpgrade78Grid) {
+      const mult = oldFreeLevelMult(cubeUpgrade78)
+      it(`freeLevel=${freeLevel} mult=${mult}`, () => {
+        expect(closeEnough(newFreeLevelSoftcap(freeLevel, mult), oldFreeLevelSoftcap(freeLevel, mult))).toBe(true)
+      })
+    }
+  }
+})
+
+describe('parity: actualOcteractUpgradeTotalLevels', () => {
+  for (const inNoOcteracts of boolGrid) {
+    for (const inSadisticPrequel of boolGrid) {
+      for (const qualityOfLife of boolGrid) {
+        for (const cubeUpgrade78 of cubeUpgrade78Grid) {
+          for (const level of levelGrid) {
+            for (const freeLevel of freeLevelGrid) {
+              const input = {
+                level,
+                freeLevel,
+                qualityOfLife,
+                cubeUpgrade78,
+                inNoOcteracts,
+                inSadisticPrequel
+              }
+              it(`noOct=${inNoOcteracts} sadistic=${inSadisticPrequel} qol=${qualityOfLife} c78=${cubeUpgrade78} lv=${level} free=${freeLevel}`, () => {
+                expect(closeEnough(newActualLevels(input), oldActualLevels(input))).toBe(true)
+              })
+            }
+          }
+        }
+      }
+    }
+  }
+})

--- a/packages/logic/test/parity/runeEXPMultiplier.parity.test.ts
+++ b/packages/logic/test/parity/runeEXPMultiplier.parity.test.ts
@@ -1,0 +1,181 @@
+// Parity tests for universalRuneEXPMult, lifted from
+// packages/web_ui/src/Runes.ts. The function aggregates three input groups
+// (additive, multiplicative, recycle) — the sweep enumerates each input
+// in isolation (other inputs zero) to verify per-contribution arithmetic,
+// then combines several non-zero inputs to verify the sum × product
+// composition matches.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import { universalRuneEXPMult as newMult } from '../../src/mechanics/runeEXPMultiplier'
+
+// ─── Old implementation (verbatim from packages/web_ui/src/Runes.ts) ───────
+
+interface OldInput {
+  purchasedLevels: number
+  c1Completions: number
+  research22: number
+  research23: number
+  upgrade71: number
+  research91: number
+  research92: number
+  ascensionCounter: number
+  cubeUpgrade32: number
+  constantUpgrade8: number
+  challenge15RuneExpReward: number
+  salvageRuneEXPMultiplier: Decimal
+}
+
+const oldMult = (input: OldInput): Decimal => {
+  const allRuneExpAdditiveMultiplier = 1
+    + Math.min(1, input.c1Completions)
+    + (0.4 / 10) * input.c1Completions
+    + 0.6 * input.research22
+    + 0.3 * input.research23
+    + (input.upgrade71 * input.purchasedLevels) / 25
+
+  const allRuneExpMultiplier = [
+    1 + input.research91 / 20,
+    1 + input.research92 / 20,
+    1 + (input.ascensionCounter / 1000) * input.cubeUpgrade32,
+    1 + (1 / 10) * input.constantUpgrade8,
+    input.challenge15RuneExpReward
+  ].reduce((x, y) => x.times(y), new Decimal('1'))
+
+  return allRuneExpMultiplier.times(allRuneExpAdditiveMultiplier).times(input.salvageRuneEXPMultiplier)
+}
+
+const closeEnoughDecimal = (a: Decimal, b: Decimal, rel = 1e-12): boolean => {
+  if (a.eq(b)) return true
+  const an = Math.abs(Number(a.toString()))
+  const bn = Math.abs(Number(b.toString()))
+  if (an < 1 && bn < 1) return Math.abs(an - bn) < rel
+  return Math.abs(an - bn) / Math.max(an, bn) < rel
+}
+
+const baseZero: OldInput = {
+  purchasedLevels: 0,
+  c1Completions: 0,
+  research22: 0,
+  research23: 0,
+  upgrade71: 0,
+  research91: 0,
+  research92: 0,
+  ascensionCounter: 0,
+  cubeUpgrade32: 0,
+  constantUpgrade8: 0,
+  challenge15RuneExpReward: 1,
+  salvageRuneEXPMultiplier: new Decimal(1)
+}
+
+// ─── Per-input parity (other inputs zero) ──────────────────────────────────
+
+describe('parity: universalRuneEXPMult (per-input, others zero)', () => {
+  const cases: { name: string; mk: () => OldInput }[] = [
+    // c1Completions exercises the min(1, n) + 0.04 * n piecewise
+    ...[0, 1, 2, 5, 10, 100].map((n) => ({
+      name: `c1Completions=${n}`,
+      mk: () => ({ ...baseZero, c1Completions: n })
+    })),
+    ...[0, 1, 2, 3].map((n) => ({
+      name: `research22=${n}`,
+      mk: () => ({ ...baseZero, research22: n })
+    })),
+    ...[0, 1, 3].map((n) => ({
+      name: `research23=${n}`,
+      mk: () => ({ ...baseZero, research23: n })
+    })),
+    // upgrade71 scales with purchasedLevels — pair with non-zero pl
+    ...[0, 1].map((n) => ({
+      name: `upgrade71=${n} purchasedLevels=100`,
+      mk: () => ({ ...baseZero, upgrade71: n, purchasedLevels: 100 })
+    })),
+    ...[0, 5, 20].map((n) => ({
+      name: `research91=${n}`,
+      mk: () => ({ ...baseZero, research91: n })
+    })),
+    ...[0, 5, 20].map((n) => ({
+      name: `research92=${n}`,
+      mk: () => ({ ...baseZero, research92: n })
+    })),
+    // cubeUpgrade32 needs nonzero ascensionCounter to contribute
+    ...[0, 1, 5].map((n) => ({
+      name: `cubeUpgrade32=${n} ascCounter=10000`,
+      mk: () => ({ ...baseZero, cubeUpgrade32: n, ascensionCounter: 10000 })
+    })),
+    ...[0, 1, 5, 10].map((n) => ({
+      name: `constantUpgrade8=${n}`,
+      mk: () => ({ ...baseZero, constantUpgrade8: n })
+    })),
+    ...[1, 1.5, 5, 1e6].map((n) => ({
+      name: `challenge15Reward=${n}`,
+      mk: () => ({ ...baseZero, challenge15RuneExpReward: n })
+    })),
+    ...[new Decimal(1), new Decimal(2), new Decimal('1e10')].map((d) => ({
+      name: `salvage=${d.toString()}`,
+      mk: () => ({ ...baseZero, salvageRuneEXPMultiplier: d })
+    }))
+  ]
+
+  for (const { name, mk } of cases) {
+    it(name, () => {
+      const input = mk()
+      expect(closeEnoughDecimal(newMult(input), oldMult(input))).toBe(true)
+    })
+  }
+})
+
+// ─── Composition (all inputs simultaneously non-zero) ──────────────────────
+
+describe('parity: universalRuneEXPMult (composition)', () => {
+  const mixes: OldInput[] = [
+    {
+      purchasedLevels: 50,
+      c1Completions: 5,
+      research22: 2,
+      research23: 3,
+      upgrade71: 1,
+      research91: 10,
+      research92: 5,
+      ascensionCounter: 5000,
+      cubeUpgrade32: 3,
+      constantUpgrade8: 7,
+      challenge15RuneExpReward: 2.5,
+      salvageRuneEXPMultiplier: new Decimal(3)
+    },
+    {
+      purchasedLevels: 1000,
+      c1Completions: 50,
+      research22: 5,
+      research23: 5,
+      upgrade71: 1,
+      research91: 20,
+      research92: 20,
+      ascensionCounter: 100000,
+      cubeUpgrade32: 10,
+      constantUpgrade8: 20,
+      challenge15RuneExpReward: 100,
+      salvageRuneEXPMultiplier: new Decimal('1e5')
+    },
+    {
+      purchasedLevels: 0,
+      c1Completions: 1,
+      research22: 1,
+      research23: 1,
+      upgrade71: 0,
+      research91: 1,
+      research92: 1,
+      ascensionCounter: 1,
+      cubeUpgrade32: 1,
+      constantUpgrade8: 1,
+      challenge15RuneExpReward: 1.0001,
+      salvageRuneEXPMultiplier: new Decimal(1.5)
+    }
+  ]
+  for (let i = 0; i < mixes.length; i++) {
+    it(`mix #${i}`, () => {
+      const input = mixes[i]
+      expect(closeEnoughDecimal(newMult(input), oldMult(input))).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/runeLevels.parity.test.ts
+++ b/packages/logic/test/parity/runeLevels.parity.test.ts
@@ -1,0 +1,251 @@
+// Parity tests for the rune EXP/level math cluster, lifted from
+// packages/web_ui/src/Runes.ts. Each `oldXxx` transcribes the pre-migration
+// body verbatim. Sweeps cover: the EXP↔level closed-form invert at
+// representative levels per the in-game rune coefficients, the
+// max-affordable-purchase planner across budgets that span sub-1-level,
+// exactly-N-levels, and far-overshoot regimes, plus the "level 0 unowned"
+// edge case.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import {
+  maxRuneLevelPurchase as newMaxPurchase,
+  runeEXPLeftToLevel as newEXPLeft,
+  runeEXPToLevel as newEXPToLevel,
+  runeLevelFromEXP as newLevelFromEXP,
+  runeOfferingsToLevel as newOfferingsToLevel
+} from '../../src/mechanics/runeLevels'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Runes.ts) ─────
+
+const oldEXPToLevel = (costCoefficient: Decimal, level: number, levelsPerOOM: number): Decimal =>
+  costCoefficient.times(Decimal.pow(10, level / levelsPerOOM).minus(1))
+
+const oldEXPLeftToLevel = (
+  costCoefficient: Decimal,
+  targetLevel: number,
+  levelsPerOOM: number,
+  currentRuneEXP: Decimal
+): Decimal => Decimal.max(0, oldEXPToLevel(costCoefficient, targetLevel, levelsPerOOM).minus(currentRuneEXP))
+
+const oldOfferingsToLevel = (
+  costCoefficient: Decimal,
+  targetLevel: number,
+  levelsPerOOM: number,
+  currentRuneEXP: Decimal,
+  runeEXPPerOffering: Decimal
+): Decimal =>
+  Decimal.max(
+    1,
+    oldEXPLeftToLevel(costCoefficient, targetLevel, levelsPerOOM, currentRuneEXP)
+      .div(runeEXPPerOffering)
+      .ceil()
+  )
+
+const oldLevelFromEXP = (currentRuneEXP: Decimal, costCoefficient: Decimal, levelsPerOOM: number): number =>
+  Math.floor(levelsPerOOM * Decimal.log10(currentRuneEXP.div(costCoefficient).plus(1)))
+
+interface OldMaxPurchaseInput {
+  costCoefficient: Decimal
+  levelsPerOOM: number
+  currentLevel: number
+  currentRuneEXP: Decimal
+  runeEXPPerOffering: Decimal
+  budget: Decimal
+  isUnlocked: boolean
+}
+
+const oldMaxPurchase = (input: OldMaxPurchaseInput) => {
+  if (!input.isUnlocked || input.budget.lt(0)) {
+    return { levels: 0, expRequired: new Decimal(0), offerings: new Decimal(0) }
+  }
+  const totalEXPAvailable = input.budget.times(input.runeEXPPerOffering).add(input.currentRuneEXP)
+  const maxLevel = Math.floor(input.levelsPerOOM * Decimal.log10(totalEXPAvailable.div(input.costCoefficient).plus(1)))
+  const levelsGained = Math.max(0, maxLevel - input.currentLevel)
+  if (levelsGained === 0) {
+    const nextLevelEXP = oldEXPToLevel(input.costCoefficient, input.currentLevel + 1, input.levelsPerOOM)
+    const offeringsRequired = Decimal.max(
+      1,
+      nextLevelEXP.minus(input.currentRuneEXP).div(input.runeEXPPerOffering).ceil()
+    )
+    return { levels: 1, expRequired: nextLevelEXP, offerings: offeringsRequired }
+  }
+  const expRequired = oldEXPToLevel(input.costCoefficient, input.currentLevel + levelsGained, input.levelsPerOOM)
+  const offeringsRequired = Decimal.max(
+    1,
+    expRequired.minus(input.currentRuneEXP).div(input.runeEXPPerOffering).ceil()
+  )
+  return { levels: levelsGained, expRequired, offerings: offeringsRequired }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+// In-game rune coefficients (per packages/web_ui/src/Runes.ts) chosen to
+// represent the spectrum: speed=50/150, antiquities=1/100, infiniteAscent
+// = whatever its costCoefficient is. We use a couple of representative
+// (costCoeff, levelsPerOOM) pairs plus a wider sweep.
+const runeShapes = [
+  { name: 'speed', costCoefficient: new Decimal(50), levelsPerOOM: 150 },
+  { name: 'small-coeff', costCoefficient: new Decimal(1), levelsPerOOM: 100 },
+  { name: 'huge-coeff', costCoefficient: new Decimal('1e10'), levelsPerOOM: 200 }
+]
+
+const levelGrid = [0, 1, 10, 50, 100, 150, 500, 1000, 5000]
+
+// ─── runeEXPToLevel ────────────────────────────────────────────────────────
+
+describe('parity: runeEXPToLevel', () => {
+  for (const shape of runeShapes) {
+    for (const level of levelGrid) {
+      it(`${shape.name} level=${level}`, () => {
+        expect(decimalEq(
+          newEXPToLevel(shape.costCoefficient, level, shape.levelsPerOOM),
+          oldEXPToLevel(shape.costCoefficient, level, shape.levelsPerOOM)
+        )).toBe(true)
+      })
+    }
+  }
+})
+
+// ─── runeEXPLeftToLevel (clamps at zero when over-leveled) ─────────────────
+
+describe('parity: runeEXPLeftToLevel', () => {
+  const currentEXPGrid = [
+    new Decimal(0),
+    new Decimal(100),
+    new Decimal('1e9'),
+    new Decimal('1e100')
+  ]
+  for (const shape of runeShapes) {
+    for (const level of levelGrid) {
+      for (const currentRuneEXP of currentEXPGrid) {
+        it(`${shape.name} level=${level} currentEXP=${currentRuneEXP.toString()}`, () => {
+          expect(decimalEq(
+            newEXPLeft(shape.costCoefficient, level, shape.levelsPerOOM, currentRuneEXP),
+            oldEXPLeftToLevel(shape.costCoefficient, level, shape.levelsPerOOM, currentRuneEXP)
+          )).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+// ─── runeOfferingsToLevel (clamps at 1) ────────────────────────────────────
+
+describe('parity: runeOfferingsToLevel', () => {
+  const perOfferingGrid = [new Decimal(1), new Decimal(100), new Decimal('1e6')]
+  for (const shape of runeShapes) {
+    for (const level of [10, 100, 500]) {
+      for (const currentEXP of [new Decimal(0), new Decimal('1e5')]) {
+        for (const perOffering of perOfferingGrid) {
+          it(`${shape.name} level=${level} EXP=${currentEXP.toString()} perOff=${perOffering.toString()}`, () => {
+            expect(decimalEq(
+              newOfferingsToLevel(shape.costCoefficient, level, shape.levelsPerOOM, currentEXP, perOffering),
+              oldOfferingsToLevel(shape.costCoefficient, level, shape.levelsPerOOM, currentEXP, perOffering)
+            )).toBe(true)
+          })
+        }
+      }
+    }
+  }
+})
+
+// ─── runeLevelFromEXP (closed-form invert) ─────────────────────────────────
+
+describe('parity: runeLevelFromEXP', () => {
+  // Spread EXP values from sub-1-level (small EXP) to massive (Decimal range).
+  const expGrid = [
+    new Decimal(0),
+    new Decimal(1),
+    new Decimal(100),
+    new Decimal('1e3'),
+    new Decimal('1e6'),
+    new Decimal('1e10'),
+    new Decimal('1e30'),
+    new Decimal('1e100')
+  ]
+  for (const shape of runeShapes) {
+    for (const exp of expGrid) {
+      it(`${shape.name} exp=${exp.toString()}`, () => {
+        expect(newLevelFromEXP(exp, shape.costCoefficient, shape.levelsPerOOM))
+          .toBe(oldLevelFromEXP(exp, shape.costCoefficient, shape.levelsPerOOM))
+      })
+    }
+  }
+})
+
+// ─── maxRuneLevelPurchase (gate, sub-level budget, multi-level budget) ─────
+
+describe('parity: maxRuneLevelPurchase', () => {
+  const baseInputs = [
+    { costCoefficient: new Decimal(50), levelsPerOOM: 150 },
+    { costCoefficient: new Decimal(1), levelsPerOOM: 100 }
+  ]
+  // Span: locked → unlocked-but-broke, broke at high level, exact-next-level,
+  // few-levels-budget, massive overshoot.
+  const cases = [
+    // Locked rune — must return zero result.
+    {
+      currentLevel: 0,
+      currentRuneEXP: new Decimal(0),
+      runeEXPPerOffering: new Decimal(10),
+      budget: new Decimal('1e20'),
+      isUnlocked: false
+    },
+    // Negative budget — also zero result.
+    {
+      currentLevel: 5,
+      currentRuneEXP: new Decimal(100),
+      runeEXPPerOffering: new Decimal(10),
+      budget: new Decimal(-1),
+      isUnlocked: true
+    },
+    // Can't afford even one level (small budget at high current level)
+    {
+      currentLevel: 100,
+      currentRuneEXP: new Decimal(0),
+      runeEXPPerOffering: new Decimal(1),
+      budget: new Decimal(1),
+      isUnlocked: true
+    },
+    // Some affordable levels
+    {
+      currentLevel: 10,
+      currentRuneEXP: new Decimal(0),
+      runeEXPPerOffering: new Decimal(100),
+      budget: new Decimal('1e6'),
+      isUnlocked: true
+    },
+    // Big budget — should reach many levels
+    {
+      currentLevel: 0,
+      currentRuneEXP: new Decimal(0),
+      runeEXPPerOffering: new Decimal(10),
+      budget: new Decimal('1e20'),
+      isUnlocked: true
+    },
+    // Already-accumulated EXP plus budget
+    {
+      currentLevel: 50,
+      currentRuneEXP: new Decimal('1e8'),
+      runeEXPPerOffering: new Decimal(1000),
+      budget: new Decimal('1e10'),
+      isUnlocked: true
+    }
+  ]
+  for (const base of baseInputs) {
+    for (const c of cases) {
+      const input = { ...base, ...c }
+      it(
+        `coeff=${base.costCoefficient.toString()} oom=${base.levelsPerOOM} curLevel=${c.currentLevel} unlocked=${c.isUnlocked} budget=${c.budget.toString()}`,
+        () => {
+          const newRes = newMaxPurchase(input)
+          const oldRes = oldMaxPurchase(input)
+          expect(newRes.levels).toBe(oldRes.levels)
+          expect(decimalEq(newRes.expRequired, oldRes.expRequired)).toBe(true)
+          expect(decimalEq(newRes.offerings, oldRes.offerings)).toBe(true)
+        }
+      )
+    }
+  }
+})

--- a/packages/logic/test/parity/shopCosts.parity.test.ts
+++ b/packages/logic/test/parity/shopCosts.parity.test.ts
@@ -1,0 +1,73 @@
+// Parity tests for shopCost, lifted from packages/web_ui/src/Shop.ts.
+// Sweeps cover both branches: consumable / one-shot upgrades (flat price)
+// vs. stacked upgrades (linear-in-level scaling).
+
+import { describe, expect, it } from 'vitest'
+import { shopCost as newShopCost, type ShopCostInput } from '../../src/mechanics/shopCosts'
+
+// ─── Old implementation (verbatim from packages/web_ui/src/Shop.ts) ────────
+
+const oldShopCost = (input: ShopCostInput): number => {
+  if (input.isConsumable || input.maxLevel === 1) {
+    return input.price
+  }
+  return input.price + input.priceIncrease * input.currentLevel
+}
+
+describe('parity: shopCost (consumable branch)', () => {
+  // Consumables always return flat price regardless of currentLevel.
+  for (const currentLevel of [0, 1, 10, 100]) {
+    for (const price of [10, 100, 1000]) {
+      it(`consumable price=${price} level=${currentLevel}`, () => {
+        const input: ShopCostInput = {
+          isConsumable: true,
+          maxLevel: 100, // irrelevant for consumables
+          price,
+          priceIncrease: 50, // irrelevant for consumables
+          currentLevel
+        }
+        expect(newShopCost(input)).toBe(oldShopCost(input))
+        expect(newShopCost(input)).toBe(price)
+      })
+    }
+  }
+})
+
+describe('parity: shopCost (maxLevel=1 branch)', () => {
+  // One-shot upgrades also flat-price.
+  for (const currentLevel of [0, 1]) {
+    for (const price of [10, 1000]) {
+      it(`maxLevel=1 price=${price} level=${currentLevel}`, () => {
+        const input: ShopCostInput = {
+          isConsumable: false,
+          maxLevel: 1,
+          price,
+          priceIncrease: 25,
+          currentLevel
+        }
+        expect(newShopCost(input)).toBe(oldShopCost(input))
+        expect(newShopCost(input)).toBe(price)
+      })
+    }
+  }
+})
+
+describe('parity: shopCost (stacked-upgrade branch)', () => {
+  // Linear scaling: price + priceIncrease * currentLevel.
+  for (const price of [10, 100]) {
+    for (const priceIncrease of [5, 20, 100]) {
+      for (const currentLevel of [0, 1, 5, 10, 100]) {
+        it(`price=${price} incr=${priceIncrease} level=${currentLevel}`, () => {
+          const input: ShopCostInput = {
+            isConsumable: false,
+            maxLevel: 100,
+            price,
+            priceIncrease,
+            currentLevel
+          }
+          expect(newShopCost(input)).toBe(oldShopCost(input))
+        })
+      }
+    }
+  }
+})

--- a/packages/logic/test/parity/singularityChallenges.parity.test.ts
+++ b/packages/logic/test/parity/singularityChallenges.parity.test.ts
@@ -1,0 +1,325 @@
+// Parity tests for the SingularityChallenges per-challenge formulas, lifted
+// from packages/web_ui/src/SingularityChallenges.ts. Sweeps cover:
+//   - singularityRequirement: every piecewise boundary per challenge
+//     (the linear ones at 0/1/10 + max; the piecewise ones around their
+//     specific knees at 2/5/6, 9/10, 14, etc.)
+//   - achievementPointValue: all linear, sample at 0/1/max
+//   - effect: every reward key × representative completion counts
+//     (including the "is unlocked at N" boolean boundaries)
+
+import { describe, expect, it } from 'vitest'
+import {
+  limitedAscensionsAchievementPointValue as newLimAscAP,
+  limitedAscensionsEffect as newLimAscEffect,
+  limitedAscensionsSingularityRequirement as newLimAscSR,
+  limitedTimeAchievementPointValue as newLimTimeAP,
+  limitedTimeEffect as newLimTimeEffect,
+  limitedTimeSingularityRequirement as newLimTimeSR,
+  noAmbrosiaUpgradesAchievementPointValue as newNoAmbAP,
+  noAmbrosiaUpgradesEffect as newNoAmbEffect,
+  noAmbrosiaUpgradesSingularityRequirement as newNoAmbSR,
+  noOcteractsAchievementPointValue as newNoOctAP,
+  noOcteractsEffect as newNoOctEffect,
+  noOcteractsSingularityRequirement as newNoOctSR,
+  noQuarkUpgradesAchievementPointValue as newNoQuarkAP,
+  noQuarkUpgradesEffect as newNoQuarkEffect,
+  noQuarkUpgradesSingularityRequirement as newNoQuarkSR,
+  noSingularityUpgradesAchievementPointValue as newNoSingAP,
+  noSingularityUpgradesEffect as newNoSingEffect,
+  noSingularityUpgradesSingularityRequirement as newNoSingSR,
+  oneChallengeCapAchievementPointValue as newOneChalAP,
+  oneChallengeCapEffect as newOneChalEffect,
+  oneChallengeCapSingularityRequirement as newOneChalSR,
+  sadisticPrequelAchievementPointValue as newSadAP,
+  sadisticPrequelEffect as newSadEffect,
+  sadisticPrequelSingularityRequirement as newSadSR,
+  taxmanLastStandAchievementPointValue as newTaxAP,
+  taxmanLastStandEffect as newTaxEffect,
+  taxmanLastStandSingularityRequirement as newTaxSR
+} from '../../src/mechanics/singularityChallenges'
+
+// ─── Old implementations (verbatim from web_ui SingularityChallenges.ts) ───
+
+const oldNoSingSR = (baseReq: number, completions: number) =>
+  baseReq + 16 * completions + 8 * (completions >= 9 ? 1 : 0)
+
+const oldOneChalSR = (baseReq: number, completions: number) =>
+  baseReq + 19 * completions - 2 * (completions >= 14 ? 1 : 0)
+
+const oldNoOctSR = (baseReq: number, completions: number) => {
+  if (completions < 10) return baseReq + 13 * completions
+  return baseReq + 13 * 9 + 10 * (completions - 9)
+}
+
+const oldLimAscSR = (baseReq: number, completions: number) => baseReq + 27 * completions
+
+const oldNoAmbSR = (baseReq: number, completions: number) => {
+  if (completions < 10) return baseReq + 12 * completions
+  return baseReq + 12 * 9 + 4 * (completions - 9)
+}
+
+const oldNoQuarkSR = (baseReq: number, completions: number) => {
+  if (completions > 5) return baseReq + 185 + 8 * (completions - 6)
+  if (completions > 2) return baseReq + 70 + 9 * (completions - 6)
+  return baseReq + 15 * completions
+}
+
+const oldLimTimeSR = (baseReq: number, completions: number) => {
+  if (completions > 9) return 277 + 2 * (completions - 10)
+  return baseReq + 8 * completions
+}
+
+const oldSadSR = (baseReq: number, completions: number) => baseReq + 8 * completions
+const oldTaxSR = (baseReq: number, completions: number) => baseReq + 4 * completions
+
+const oldNoSingEffect = (n: number, key: string): number | boolean => {
+  if (key === 'cubes') return 1 + n
+  if (key === 'goldenQuarks') return 1 + 0.12 * +(n > 0)
+  if (key === 'blueberries') return +(n > 0)
+  if (key === 'shopUpgrade') return n >= 10
+  if (key === 'additiveLuckMult') return n >= 15 ? 0.05 : 0
+  return n >= 15 // shopUpgrade2
+}
+
+const oldOneChalEffect = (n: number, key: string): number | boolean => {
+  if (key === 'corrScoreIncrease') return 0.05 * n
+  if (key === 'blueberrySpeedMult') return 1 + n / 60
+  if (key === 'capIncrease') return 3 * +(n > 0)
+  if (key === 'freeCorruptionLevel') return +(n >= 12)
+  if (key === 'shopUpgrade') return n >= 12
+  if (key === 'reinCapIncrease2') return 7 * +(n >= 15)
+  return 2 * +(n >= 15) // ascCapIncrease2
+}
+
+const oldNoOctEffect = (n: number, key: string): number | boolean => {
+  if (key === 'octeractPow') return n <= 10 ? 0.02 * n : 0.2 + (n - 10) / 100
+  if (key === 'offeringBonus') return n > 0
+  if (key === 'obtainiumBonus') return n >= 10
+  return n >= 10 // shopUpgrade
+}
+
+const oldLimAscEffect = (n: number, key: string): number | boolean => {
+  if (key === 'ascensionSpeedMult') return 1 + 0.25 * n / 100
+  if (key === 'hepteractCap') return n > 0
+  if (key === 'shopUpgrade') return n >= 8
+  return n >= 10 // shopUpgrade2
+}
+
+const oldNoAmbEffect = (n: number, key: string): number | boolean => {
+  if (key === 'bonusAmbrosia') return +(n > 0)
+  if (key === 'blueberries') return Math.floor(n / 5) + +(n > 0)
+  if (key === 'additiveLuckMult') return n / 200
+  if (key === 'ambrosiaLuck') return 20 * n
+  if (key === 'redLuck') return 4 * n
+  if (key === 'blueberrySpeedMult') return 1 + n / 25
+  if (key === 'redSpeedMult') return 1 + 2 * n / 100
+  if (key === 'shopUpgrade') return n >= 8
+  return n >= 10 // shopUpgrade2
+}
+
+const oldNoQuarkEffect = (n: number, key: string): number | boolean => {
+  if (key === 'freeObtainiumLevels') return n
+  if (key === 'freeOfferingLevels') return n
+  if (key === 'freeSpeedLevels') return n
+  if (key === 'freeCubeLevels') return n
+  if (key === 'freeQuarkLevel') return n >= 5 ? 1 : 0
+  if (key === 'freeInfinityLevels') return n
+  if (key === 'shopUpgrade') return n >= 1
+  return n >= 10 // topHatUnlock
+}
+
+const oldLimTimeEffect = (n: number, key: string): number | boolean => {
+  if (key === 'preserveQuarks') return +(n > 0)
+  if (key === 'quarkMult') return 1 + 0.02 * n
+  if (key === 'globalSpeed') return 1 + 0.12 * n
+  if (key === 'ascensionSpeed') return 1 + 0.12 * n
+  if (key === 'barRequirementMultiplier') return 1 - 0.02 * n
+  if (key === 'shopUpgrade') return n >= 5
+  return n >= 10 // shopUpgrade2
+}
+
+const oldSadEffect = (n: number, key: string): number | boolean => {
+  if (key === 'extraFree') return 50 * +(n > 0)
+  if (key === 'quarkMult') return 1 + 0.06 * n
+  if (key === 'freeUpgradeMult') return 1 + 0.06 * n
+  if (key === 'shopUpgrade') return n >= 5
+  if (key === 'shopUpgrade2') return n >= 10
+  return n >= 15 // shopUpgrade3
+}
+
+const oldTaxEffect = (n: number, key: string): number | boolean => {
+  if (key === 'horseShoeUnlock') return n > 0
+  if (key === 'shopUpgrade') return n >= 5
+  if (key === 'talismanUnlock') return n >= 10
+  if (key === 'talismanFreeLevel') return 25 * n
+  if (key === 'talismanRuneEffect') return 0.03 * n
+  if (key === 'antiquityOOM') return 1 / 50 * n / 10
+  return 1 / 20 * n / 10 // horseShoeOOM
+}
+
+const closeEnough = (a: number | boolean, b: number | boolean): boolean => {
+  if (a === b) return true
+  if (typeof a === 'number' && typeof b === 'number') {
+    if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < 1e-12
+    return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < 1e-12
+  }
+  return false
+}
+
+// Completion grid covering 0, 1, every documented knee (2, 5, 8, 9, 10, 12,
+// 14, 15), and max+1 for each challenge.
+const completionsGrid = [0, 1, 2, 3, 5, 6, 8, 9, 10, 11, 12, 14, 15, 16]
+
+// ─── singularityRequirement (per-challenge piecewise knees) ────────────────
+
+describe('parity: singularityRequirement (all 9 challenges)', () => {
+  const cases: { name: string; baseReq: number; newFn: typeof oldNoSingSR; oldFn: typeof oldNoSingSR }[] = [
+    { name: 'noSingularityUpgrades', baseReq: 1, newFn: newNoSingSR, oldFn: oldNoSingSR },
+    { name: 'oneChallengeCap', baseReq: 10, newFn: newOneChalSR, oldFn: oldOneChalSR },
+    { name: 'noOcteracts', baseReq: 75, newFn: newNoOctSR, oldFn: oldNoOctSR },
+    { name: 'limitedAscensions', baseReq: 7, newFn: newLimAscSR, oldFn: oldLimAscSR },
+    { name: 'noAmbrosiaUpgrades', baseReq: 150, newFn: newNoAmbSR, oldFn: oldNoAmbSR },
+    { name: 'noQuarkUpgrades', baseReq: 20, newFn: newNoQuarkSR, oldFn: oldNoQuarkSR },
+    { name: 'limitedTime', baseReq: 203, newFn: newLimTimeSR, oldFn: oldLimTimeSR },
+    { name: 'sadisticPrequel', baseReq: 120, newFn: newSadSR, oldFn: oldSadSR },
+    { name: 'taxmanLastStand', baseReq: 240, newFn: newTaxSR, oldFn: oldTaxSR }
+  ]
+  for (const c of cases) {
+    for (const completions of completionsGrid) {
+      it(`${c.name} comp=${completions}`, () => {
+        expect(c.newFn(c.baseReq, completions)).toBe(c.oldFn(c.baseReq, completions))
+      })
+    }
+  }
+})
+
+// ─── achievementPointValue (all linear) ────────────────────────────────────
+
+describe('parity: achievementPointValue (all 9 challenges)', () => {
+  const cases: { name: string; newFn: (n: number) => number; oldFn: (n: number) => number }[] = [
+    { name: 'noSingularityUpgrades', newFn: newNoSingAP, oldFn: (n) => 15 * n },
+    { name: 'oneChallengeCap', newFn: newOneChalAP, oldFn: (n) => 15 * n },
+    { name: 'noOcteracts', newFn: newNoOctAP, oldFn: (n) => 20 * n },
+    { name: 'limitedAscensions', newFn: newLimAscAP, oldFn: (n) => 30 * n },
+    { name: 'noAmbrosiaUpgrades', newFn: newNoAmbAP, oldFn: (n) => 25 * n },
+    { name: 'noQuarkUpgrades', newFn: newNoQuarkAP, oldFn: (n) => 20 * n },
+    { name: 'limitedTime', newFn: newLimTimeAP, oldFn: (n) => 30 * n },
+    { name: 'sadisticPrequel', newFn: newSadAP, oldFn: (n) => 40 * n },
+    { name: 'taxmanLastStand', newFn: newTaxAP, oldFn: (n) => 50 * n }
+  ]
+  for (const c of cases) {
+    for (const n of [0, 1, 5, 10, 15]) {
+      it(`${c.name} n=${n}`, () => {
+        expect(c.newFn(n)).toBe(c.oldFn(n))
+      })
+    }
+  }
+})
+
+// ─── effect (per-challenge × per-reward-key) ──────────────────────────────
+
+// Helper to run a parity assertion across the cartesian product of completions
+// × keys for one challenge.
+const runEffectParity = <K extends string>(
+  challengeName: string,
+  newFn: (n: number, key: K) => number | boolean,
+  oldFn: (n: number, key: string) => number | boolean,
+  keys: K[]
+) => {
+  describe(`parity: ${challengeName}Effect`, () => {
+    for (const key of keys) {
+      for (const completions of completionsGrid) {
+        it(`key=${key} comp=${completions}`, () => {
+          const next = newFn(completions, key)
+          const old = oldFn(completions, key)
+          expect(closeEnough(next, old)).toBe(true)
+        })
+      }
+    }
+  })
+}
+
+runEffectParity('noSingularityUpgrades', newNoSingEffect, oldNoSingEffect, [
+  'cubes',
+  'goldenQuarks',
+  'blueberries',
+  'shopUpgrade',
+  'additiveLuckMult',
+  'shopUpgrade2'
+])
+
+runEffectParity('oneChallengeCap', newOneChalEffect, oldOneChalEffect, [
+  'corrScoreIncrease',
+  'blueberrySpeedMult',
+  'capIncrease',
+  'freeCorruptionLevel',
+  'shopUpgrade',
+  'reinCapIncrease2',
+  'ascCapIncrease2'
+])
+
+runEffectParity('noOcteracts', newNoOctEffect, oldNoOctEffect, [
+  'octeractPow',
+  'offeringBonus',
+  'obtainiumBonus',
+  'shopUpgrade'
+])
+
+runEffectParity('limitedAscensions', newLimAscEffect, oldLimAscEffect, [
+  'ascensionSpeedMult',
+  'hepteractCap',
+  'shopUpgrade',
+  'shopUpgrade2'
+])
+
+runEffectParity('noAmbrosiaUpgrades', newNoAmbEffect, oldNoAmbEffect, [
+  'bonusAmbrosia',
+  'blueberries',
+  'additiveLuckMult',
+  'ambrosiaLuck',
+  'redLuck',
+  'blueberrySpeedMult',
+  'redSpeedMult',
+  'shopUpgrade',
+  'shopUpgrade2'
+])
+
+runEffectParity('noQuarkUpgrades', newNoQuarkEffect, oldNoQuarkEffect, [
+  'freeObtainiumLevels',
+  'freeOfferingLevels',
+  'freeSpeedLevels',
+  'freeCubeLevels',
+  'freeQuarkLevel',
+  'freeInfinityLevels',
+  'shopUpgrade',
+  'topHatUnlock'
+])
+
+runEffectParity('limitedTime', newLimTimeEffect, oldLimTimeEffect, [
+  'preserveQuarks',
+  'quarkMult',
+  'globalSpeed',
+  'ascensionSpeed',
+  'barRequirementMultiplier',
+  'shopUpgrade',
+  'shopUpgrade2'
+])
+
+runEffectParity('sadisticPrequel', newSadEffect, oldSadEffect, [
+  'extraFree',
+  'quarkMult',
+  'freeUpgradeMult',
+  'shopUpgrade',
+  'shopUpgrade2',
+  'shopUpgrade3'
+])
+
+runEffectParity('taxmanLastStand', newTaxEffect, oldTaxEffect, [
+  'horseShoeUnlock',
+  'shopUpgrade',
+  'talismanUnlock',
+  'talismanFreeLevel',
+  'talismanRuneEffect',
+  'antiquityOOM',
+  'horseShoeOOM'
+])

--- a/packages/logic/test/parity/singularityHelpers.parity.test.ts
+++ b/packages/logic/test/parity/singularityHelpers.parity.test.ts
@@ -1,0 +1,153 @@
+// Parity tests for the three singularity helpers, lifted from
+// packages/web_ui/src/singularity.ts. Sweeps cover:
+//   - maxSingularityLookahead: nonZero false vs true × non-zero
+//     lookahead contributions
+//   - goldenQuarkCost: below / at / above the 10000-GQ baseline
+//   - calculateNextSpike: every singularityPenaltyThresholds boundary
+//     × reduction offset
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateNextSpike as newNextSpike,
+  goldenQuarkCost as newGqCost,
+  maxSingularityLookahead as newLookahead
+} from '../../src/mechanics/singularityHelpers'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/singularity.ts) ─
+
+const oldSingularityPenaltyThresholds = [11, 26, 37, 51, 101, 151, 201, 216, 230, 270]
+const OLD_GOLDEN_QUARK_BASE_COST = 10000
+
+interface OldLookaheadInput {
+  nonZero: boolean
+  singFastForwardLookahead: number
+  singFastForward2Lookahead: number
+  octeractFastForwardLookahead: number
+}
+
+const oldLookahead = (input: OldLookaheadInput): number => {
+  if (!input.nonZero) {
+    return 0
+  }
+  let maxLookahead = 1
+  maxLookahead += input.singFastForwardLookahead
+  maxLookahead += input.singFastForward2Lookahead
+  maxLookahead += input.octeractFastForwardLookahead
+  return maxLookahead
+}
+
+const oldGqCost = (cost: number) => ({
+  cost,
+  costReduction: Math.max(0, OLD_GOLDEN_QUARK_BASE_COST - cost)
+})
+
+interface OldNextSpikeInput {
+  singularityCount: number
+  singularityReductions: number
+}
+
+const oldNextSpike = (input: OldNextSpikeInput): number => {
+  for (const sing of oldSingularityPenaltyThresholds) {
+    if (sing + input.singularityReductions > input.singularityCount) {
+      return sing + input.singularityReductions
+    }
+  }
+  return -1
+}
+
+// ─── maxSingularityLookahead ──────────────────────────────────────────────
+
+describe('parity: maxSingularityLookahead', () => {
+  // nonZero=false short-circuits to 0 regardless of bonuses
+  for (const bonus of [[0, 0, 0], [1, 1, 1], [5, 3, 2]]) {
+    it(`nonZero=false bonuses=${bonus.join(',')}`, () => {
+      const input = {
+        nonZero: false,
+        singFastForwardLookahead: bonus[0],
+        singFastForward2Lookahead: bonus[1],
+        octeractFastForwardLookahead: bonus[2]
+      }
+      expect(newLookahead(input)).toBe(oldLookahead(input))
+    })
+  }
+  // nonZero=true sums everything
+  for (const fwd1 of [0, 1, 5]) {
+    for (const fwd2 of [0, 1, 5]) {
+      for (const oct of [0, 1, 3]) {
+        it(`nonZero=true fwd1=${fwd1} fwd2=${fwd2} oct=${oct}`, () => {
+          const input = {
+            nonZero: true,
+            singFastForwardLookahead: fwd1,
+            singFastForward2Lookahead: fwd2,
+            octeractFastForwardLookahead: oct
+          }
+          expect(newLookahead(input)).toBe(oldLookahead(input))
+        })
+      }
+    }
+  }
+})
+
+// ─── goldenQuarkCost ──────────────────────────────────────────────────────
+
+describe('parity: goldenQuarkCost', () => {
+  const costGrid = [0, 1, 100, 1000, 5000, 9999, 10000, 10001, 50000, 1e6]
+  for (const cost of costGrid) {
+    it(`cost=${cost}`, () => {
+      const next = newGqCost(cost)
+      const old = oldGqCost(cost)
+      expect(next.cost).toBe(old.cost)
+      expect(next.costReduction).toBe(old.costReduction)
+    })
+  }
+})
+
+// ─── calculateNextSpike ───────────────────────────────────────────────────
+
+describe('parity: calculateNextSpike', () => {
+  // Sweep every threshold boundary in both directions for several reduction
+  // values. -1 happens past the last threshold.
+  const singGrid = [
+    0,
+    10,
+    11,
+    12,
+    25,
+    26,
+    27,
+    36,
+    37,
+    38,
+    50,
+    51,
+    52,
+    100,
+    101,
+    102,
+    150,
+    151,
+    152,
+    200,
+    201,
+    202,
+    215,
+    216,
+    217,
+    229,
+    230,
+    231,
+    269,
+    270,
+    271,
+    300
+  ]
+  const reductionGrid = [0, 1, 5, 10]
+  for (const reductions of reductionGrid) {
+    for (const sing of singGrid) {
+      it(`sing=${sing} reductions=${reductions}`, () => {
+        const input = { singularityCount: sing, singularityReductions: reductions }
+        expect(newNextSpike(input)).toBe(oldNextSpike(input))
+      })
+    }
+  }
+})

--- a/packages/logic/test/parity/singularityPenalties.parity.test.ts
+++ b/packages/logic/test/parity/singularityPenalties.parity.test.ts
@@ -1,0 +1,390 @@
+// Parity tests for calculateEffectiveSingularities and calculateSingularityDebuff,
+// lifted from packages/web_ui/src/singularity.ts. Each `oldXxx` transcribes the
+// pre-migration body verbatim — including the local Exalt 4 helper that web_ui
+// composed inline. Sweeps cover every singularityCount threshold boundary
+// (10/25/36/50/100/150/200/215/230/269) and every debuff branch.
+
+import { describe, expect, it } from 'vitest'
+import {
+  calculateEffectiveSingularities as newEffectiveSings,
+  calculateSingularityDebuff as newSingDebuff,
+  type SingularityDebuff
+} from '../../src/mechanics/singularityPenalties'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/singularity.ts) ─
+
+// The web_ui calculateEffectiveSingularities composed
+// calculateExalt4EffectiveSingularityMultiplier(comps, false), and the
+// Calculate.ts shim for that fed inExalt4 = player.singularityChallenges.noOcteracts.enabled.
+// So the old behavior is `oldExalt4Mult(comps, false, inExalt4)`.
+const oldExalt4Mult = (comps: number, force: boolean, inExalt4: boolean): number =>
+  inExalt4 || force ? Math.pow(comps + 1, 3) : 1
+
+interface OldEffectiveSingsInput {
+  singularityCount: number
+  noOcteractsCompletions: number
+  inExalt4: boolean
+  taxmanLastStandEnabled: boolean
+  taxmanLastStandCompletions: number
+  platonicUpgrade15: number
+}
+
+const oldEffectiveSings = (input: OldEffectiveSingsInput): number => {
+  const singularityCount = input.singularityCount
+  let effectiveSingularities = singularityCount
+  effectiveSingularities *= Math.min(4.75, (0.75 * singularityCount) / 10 + 1)
+
+  effectiveSingularities *= oldExalt4Mult(
+    input.noOcteractsCompletions,
+    false,
+    input.inExalt4
+  )
+
+  if (singularityCount > 10) {
+    effectiveSingularities *= 1.5
+    effectiveSingularities *= Math.min(
+      4,
+      (1.25 * singularityCount) / 10 - 0.25
+    )
+  }
+  if (singularityCount > 25) {
+    effectiveSingularities *= 2.5
+    effectiveSingularities *= Math.min(6, (1.5 * singularityCount) / 25 - 0.5)
+  }
+  if (singularityCount > 36) {
+    effectiveSingularities *= 4
+    effectiveSingularities *= Math.min(5, singularityCount / 18 - 1)
+    effectiveSingularities *= Math.pow(
+      1.1,
+      Math.min(singularityCount - 36, 64)
+    )
+  }
+  if (singularityCount > 50) {
+    effectiveSingularities *= 5
+    effectiveSingularities *= Math.min(8, (2 * singularityCount) / 50 - 1)
+    effectiveSingularities *= Math.pow(
+      1.1,
+      Math.min(singularityCount - 50, 50)
+    )
+  }
+  if (singularityCount > 100) {
+    effectiveSingularities *= 2
+    effectiveSingularities *= singularityCount / 25
+    effectiveSingularities *= Math.pow(1.1, singularityCount - 100)
+  }
+  if (singularityCount > 150) {
+    effectiveSingularities *= 2
+    effectiveSingularities *= Math.pow(1.05, singularityCount - 150)
+  }
+  if (singularityCount > 200) {
+    effectiveSingularities *= 1.5
+    effectiveSingularities *= Math.pow(1.275, singularityCount - 200)
+  }
+  if (singularityCount > 215) {
+    effectiveSingularities *= 1.25
+    effectiveSingularities *= Math.pow(1.2, singularityCount - 215)
+  }
+  if (singularityCount > 230) {
+    effectiveSingularities *= 2
+  }
+  if (singularityCount > 269) {
+    effectiveSingularities *= 3
+    effectiveSingularities *= Math.pow(3, singularityCount - 269)
+  }
+
+  if (
+    input.taxmanLastStandEnabled
+    && input.taxmanLastStandCompletions >= 8
+    && input.platonicUpgrade15 === 0
+  ) {
+    effectiveSingularities = Math.pow(effectiveSingularities, 3 / 2)
+  }
+
+  return effectiveSingularities
+}
+
+interface OldSingDebuffInput {
+  debuff: SingularityDebuff
+  singularityCount: number
+  antiquitiesRuneActive: boolean
+  singularityReductions: number
+  horseShoeMult: number
+  noOcteractsCompletions: number
+  inExalt4: boolean
+  taxmanLastStandEnabled: boolean
+  taxmanLastStandCompletions: number
+  platonicUpgrade15: number
+}
+
+const oldSingDebuff = (input: OldSingDebuffInput): number => {
+  if (input.singularityCount === 0 || input.antiquitiesRuneActive) {
+    return (input.debuff === 'Salvage' || input.debuff === 'Ant ELO') ? 0 : 1
+  }
+
+  const constitutiveSingularityCount = input.singularityCount - input.singularityReductions
+  if (constitutiveSingularityCount < 1) {
+    return 1
+  }
+
+  const effectiveSingularities = oldEffectiveSings({
+    singularityCount: constitutiveSingularityCount,
+    noOcteractsCompletions: input.noOcteractsCompletions,
+    inExalt4: input.inExalt4,
+    taxmanLastStandEnabled: input.taxmanLastStandEnabled,
+    taxmanLastStandCompletions: input.taxmanLastStandCompletions,
+    platonicUpgrade15: input.platonicUpgrade15
+  })
+
+  let baseDebuffMultiplier = 1
+  baseDebuffMultiplier *= input.horseShoeMult
+
+  if (input.debuff === 'Offering') {
+    const extraMult = Math.pow(1.02, constitutiveSingularityCount)
+    return extraMult * baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 3 * (Math.sqrt(effectiveSingularities) + 1)
+      : Math.pow(effectiveSingularities, 2 / 3) / 400)
+  } else if (input.debuff === 'Salvage') {
+    return -(4 * constitutiveSingularityCount
+      + 4 * Math.max(0, constitutiveSingularityCount - 100)
+      + 4 * Math.max(0, constitutiveSingularityCount - 200)
+      + 3 * Math.max(0, constitutiveSingularityCount - 250)
+      + 3 * Math.max(0, constitutiveSingularityCount - 270)
+      + 2 * Math.max(0, constitutiveSingularityCount - 280))
+  } else if (input.debuff === 'Ant ELO') {
+    return -Math.min(1, 0.001 * constitutiveSingularityCount)
+  } else if (input.debuff === 'Global Speed') {
+    return baseDebuffMultiplier * (1 + Math.sqrt(effectiveSingularities) / 4)
+  } else if (input.debuff === 'Obtainium') {
+    const extraMult = Math.pow(1.02, constitutiveSingularityCount)
+    return extraMult * baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 3 * (Math.sqrt(effectiveSingularities) + 1)
+      : Math.pow(effectiveSingularities, 2 / 3) / 400)
+  } else if (input.debuff === 'Researches') {
+    return baseDebuffMultiplier * (1 + Math.sqrt(effectiveSingularities) / 2)
+  } else if (input.debuff === 'Ascension Speed') {
+    return baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 1 + Math.sqrt(effectiveSingularities) / 5
+      : 1 + Math.pow(effectiveSingularities, 0.75) / 10000)
+  } else if (input.debuff === 'Cubes') {
+    const extraMult = constitutiveSingularityCount > 100
+      ? 2 * Math.pow(1.03, constitutiveSingularityCount - 100)
+      : 2
+    return baseDebuffMultiplier * (constitutiveSingularityCount < 150
+      ? 3 * (1 + (Math.sqrt(effectiveSingularities) * extraMult) / 4)
+      : 1 + (Math.pow(effectiveSingularities, 0.75) * extraMult) / 1000)
+  } else if (input.debuff === 'Platonic Costs') {
+    return baseDebuffMultiplier * (constitutiveSingularityCount > 36
+      ? 1 + Math.pow(effectiveSingularities, 3 / 10) / 12
+      : 1)
+  } else if (input.debuff === 'Hepteract Costs') {
+    return baseDebuffMultiplier * (constitutiveSingularityCount > 50
+      ? 1 + Math.pow(effectiveSingularities, 11 / 50) / 25
+      : 1)
+  } else {
+    return baseDebuffMultiplier * Math.cbrt(effectiveSingularities + 1)
+  }
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-12): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+// Sweeps singularityCount across every step boundary (10, 25, 36, 50, 100,
+// 150, 200, 215, 230, 269) plus mid-band and below-zero edge values.
+const singGrid = [
+  0,
+  1,
+  5,
+  9,
+  10,
+  11,
+  25,
+  26,
+  30,
+  36,
+  37,
+  49,
+  50,
+  51,
+  99,
+  100,
+  101,
+  149,
+  150,
+  151,
+  199,
+  200,
+  201,
+  214,
+  215,
+  216,
+  229,
+  230,
+  231,
+  268,
+  269,
+  270,
+  285
+]
+
+const noOctCompsGrid = [0, 1, 3, 8]
+const platonic15Grid = [0, 1]
+
+const allDebuffs: SingularityDebuff[] = [
+  'Offering',
+  'Obtainium',
+  'Salvage',
+  'Global Speed',
+  'Researches',
+  'Ant ELO',
+  'Ascension Speed',
+  'Cubes',
+  'Cube Upgrades',
+  'Platonic Costs',
+  'Hepteract Costs'
+]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: calculateEffectiveSingularities (taxman OFF, exalt4 OFF)', () => {
+  it.each(singGrid)('sing=%i', (singularityCount) => {
+    const input = {
+      singularityCount,
+      noOcteractsCompletions: 0,
+      inExalt4: false,
+      taxmanLastStandEnabled: false,
+      taxmanLastStandCompletions: 0,
+      platonicUpgrade15: 0
+    }
+    const next = newEffectiveSings(input)
+    const old = oldEffectiveSings(input)
+    expect(closeEnough(next, old)).toBe(true)
+  })
+})
+
+describe('parity: calculateEffectiveSingularities (exalt4 active across comps)', () => {
+  for (const comps of noOctCompsGrid) {
+    it.each(singGrid)(`comps=${comps} sing=%i`, (singularityCount) => {
+      const input = {
+        singularityCount,
+        noOcteractsCompletions: comps,
+        inExalt4: true,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 0,
+        platonicUpgrade15: 0
+      }
+      const next = newEffectiveSings(input)
+      const old = oldEffectiveSings(input)
+      expect(closeEnough(next, old)).toBe(true)
+    })
+  }
+})
+
+describe('parity: calculateEffectiveSingularities (taxman override boundary)', () => {
+  // The taxman ^(3/2) override fires only when enabled AND comps ≥ 8 AND platonic15 == 0.
+  // Sweep both sides of those gates plus a few singularity values.
+  const taxmanGrid = [
+    { enabled: false, comps: 8, plat15: 0 }, // gate-off
+    { enabled: true, comps: 7, plat15: 0 }, // sub-threshold comps
+    { enabled: true, comps: 8, plat15: 1 }, // platonic15 suppresses
+    { enabled: true, comps: 8, plat15: 0 }, // fires
+    { enabled: true, comps: 50, plat15: 0 } // fires, big comps
+  ]
+  const localSings = [5, 50, 150, 250]
+  for (const taxman of taxmanGrid) {
+    for (const sing of localSings) {
+      it(`taxman.enabled=${taxman.enabled} comps=${taxman.comps} plat15=${taxman.plat15} sing=${sing}`, () => {
+        const input = {
+          singularityCount: sing,
+          noOcteractsCompletions: 0,
+          inExalt4: false,
+          taxmanLastStandEnabled: taxman.enabled,
+          taxmanLastStandCompletions: taxman.comps,
+          platonicUpgrade15: taxman.plat15
+        }
+        const next = newEffectiveSings(input)
+        const old = oldEffectiveSings(input)
+        expect(closeEnough(next, old)).toBe(true)
+      })
+    }
+  }
+})
+
+describe('parity: calculateSingularityDebuff (every branch × sweep)', () => {
+  const reductionsGrid = [0, 1, 5]
+  const horseShoeGrid = [1, 0.75]
+  for (const debuff of allDebuffs) {
+    for (const reductions of reductionsGrid) {
+      for (const horseShoe of horseShoeGrid) {
+        it.each(singGrid)(`${debuff} reductions=${reductions} hs=${horseShoe} sing=%i`, (sing) => {
+          const input = {
+            debuff,
+            singularityCount: sing,
+            antiquitiesRuneActive: false,
+            singularityReductions: reductions,
+            horseShoeMult: horseShoe,
+            noOcteractsCompletions: 0,
+            inExalt4: false,
+            taxmanLastStandEnabled: false,
+            taxmanLastStandCompletions: 0,
+            platonicUpgrade15: 0
+          }
+          const next = newSingDebuff(input)
+          const old = oldSingDebuff(input)
+          expect(closeEnough(next, old)).toBe(true)
+        })
+      }
+    }
+  }
+})
+
+describe('parity: calculateSingularityDebuff (antiquities gate)', () => {
+  for (const debuff of allDebuffs) {
+    it(`${debuff} returns no-penalty value when antiquities active`, () => {
+      const input = {
+        debuff,
+        singularityCount: 100,
+        antiquitiesRuneActive: true,
+        singularityReductions: 0,
+        horseShoeMult: 1,
+        noOcteractsCompletions: 0,
+        inExalt4: false,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 0,
+        platonicUpgrade15: 0
+      }
+      const next = newSingDebuff(input)
+      const old = oldSingDebuff(input)
+      expect(next).toBe(old)
+    })
+  }
+})
+
+describe('parity: calculateSingularityDebuff (taxman override propagates through)', () => {
+  // Exercises the rare path where the ^(3/2) effective override actually shows
+  // up in the final debuff multiplier.
+  for (const debuff of allDebuffs) {
+    for (const plat15 of platonic15Grid) {
+      it(`${debuff} taxman enabled+comps=10 platonic15=${plat15}`, () => {
+        const input = {
+          debuff,
+          singularityCount: 200,
+          antiquitiesRuneActive: false,
+          singularityReductions: 0,
+          horseShoeMult: 1,
+          noOcteractsCompletions: 0,
+          inExalt4: false,
+          taxmanLastStandEnabled: true,
+          taxmanLastStandCompletions: 10,
+          platonicUpgrade15: plat15
+        }
+        const next = newSingDebuff(input)
+        const old = oldSingDebuff(input)
+        expect(closeEnough(next, old)).toBe(true)
+      })
+    }
+  }
+})

--- a/packages/logic/test/parity/talismanCosts.parity.test.ts
+++ b/packages/logic/test/parity/talismanCosts.parity.test.ts
@@ -1,0 +1,204 @@
+// Parity tests for regularCostProgression and exponentialCostProgression,
+// lifted from packages/web_ui/src/Talismans.ts. Each `oldXxx` transcribes the
+// pre-migration body verbatim. Sweeps cover every fragment-tier threshold
+// (0/30/60/90/120/150/180) for the regular formula and the 30/60/90/120/150
+// thresholds × the four ratios (2/10/1e5/1e8) actually used in production
+// for the exponential formula.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import {
+  exponentialCostProgression as newExpCostProgression,
+  regularCostProgression as newRegCostProgression,
+  type TalismanCraftItems
+} from '../../src/mechanics/talismanCosts'
+
+// ─── Old implementations (verbatim from packages/web_ui/src/Talismans.ts) ───
+
+const oldRegularCostProgression = (
+  baseMult: Decimal,
+  level: number
+): Record<TalismanCraftItems, Decimal> => {
+  let priceMult = baseMult
+  if (level >= 120) {
+    priceMult = priceMult.times((level - 90) / 30)
+  }
+  if (level >= 150) {
+    priceMult = priceMult.times((level - 120) / 30)
+  }
+  if (level >= 180) {
+    priceMult = priceMult.times((level - 170) / 10)
+  }
+
+  const shardCost = Decimal.pow(level, 3).times(1 / 8).plus(1).floor().times(priceMult)
+  const commonCost = level >= 30
+    ? Decimal.pow(level - 30, 3).times(1 / 32).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const uncommonCost = level >= 60
+    ? Decimal.pow(level - 60, 3).times(1 / 384).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const rareCost = level >= 90
+    ? Decimal.pow(level - 90, 3).times(1 / 500).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const epicCost = level >= 120
+    ? Decimal.pow(level - 120, 3).times(1 / 375).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const legendaryCost = level >= 150
+    ? Decimal.pow(level - 150, 3).times(1 / 192).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+  const mythicalCost = level >= 150
+    ? Decimal.pow(level - 150, 3).times(1 / 1280).plus(1).floor().times(priceMult)
+    : new Decimal(0)
+
+  return {
+    'shard': Decimal.max(0, shardCost),
+    'commonFragment': Decimal.max(0, commonCost),
+    'uncommonFragment': Decimal.max(0, uncommonCost),
+    'rareFragment': Decimal.max(0, rareCost),
+    'epicFragment': Decimal.max(0, epicCost),
+    'legendaryFragment': Decimal.max(0, legendaryCost),
+    'mythicalFragment': Decimal.max(0, mythicalCost)
+  }
+}
+
+const oldExponentialCostProgression = (
+  baseMult: Decimal,
+  level: number,
+  ratio: number
+): Record<TalismanCraftItems, Decimal> => {
+  const baseMultDecimal = new Decimal(baseMult)
+
+  return {
+    shard: Decimal.pow(ratio, level).times(baseMultDecimal).times(100).floor(),
+    commonFragment: level >= 30
+      ? Decimal.pow(ratio, level - 30).times(baseMultDecimal).times(50).floor()
+      : new Decimal(0),
+    uncommonFragment: level >= 60
+      ? Decimal.pow(ratio, level - 60).times(baseMultDecimal).times(25).floor()
+      : new Decimal(0),
+    rareFragment: level >= 90
+      ? Decimal.pow(ratio, level - 90).times(baseMultDecimal).times(20).floor()
+      : new Decimal(0),
+    epicFragment: level >= 120
+      ? Decimal.pow(ratio, level - 120).times(baseMultDecimal).times(15).floor()
+      : new Decimal(0),
+    legendaryFragment: level >= 150
+      ? Decimal.pow(ratio, level - 150).times(baseMultDecimal).times(10).floor()
+      : new Decimal(0),
+    mythicalFragment: level >= 150
+      ? Decimal.pow(ratio, level - 150).times(baseMultDecimal).times(5).floor()
+      : new Decimal(0)
+  }
+}
+
+const tierKeys: TalismanCraftItems[] = [
+  'shard',
+  'commonFragment',
+  'uncommonFragment',
+  'rareFragment',
+  'epicFragment',
+  'legendaryFragment',
+  'mythicalFragment'
+]
+
+const expectMapsEqual = (
+  next: Record<TalismanCraftItems, Decimal>,
+  old: Record<TalismanCraftItems, Decimal>
+) => {
+  for (const k of tierKeys) {
+    // Decimal.eq returns true on identical magnitude regardless of internal
+    // representation — safer than .toString() comparisons across the
+    // base-2/base-10 boundary inside break_infinity.
+    expect(next[k].eq(old[k])).toBe(true)
+  }
+}
+
+// Sweep every fragment-tier boundary in both directions plus a few mid-band
+// values for the regular formula's piecewise priceMult multiplier (120/150/180).
+const regularLevelGrid = [
+  0,
+  1,
+  10,
+  29,
+  30,
+  31,
+  45,
+  59,
+  60,
+  61,
+  75,
+  89,
+  90,
+  91,
+  100,
+  119,
+  120,
+  121,
+  135,
+  149,
+  150,
+  151,
+  165,
+  179,
+  180,
+  181,
+  200,
+  250
+]
+const baseMultGrid = [new Decimal(1), new Decimal(10), new Decimal('1e6')]
+
+// Exponential formula production ratios — 2 (mortuus), 10 (plastic),
+// 1e5 (wowSquare), 1e8 (cookieGrandma). Mid-range ratios included for sanity.
+const exponentialRatioGrid = [2, 10, 1e5, 1e8]
+// Exponential growth blows past Decimal's range fast, so cap the sweep.
+const exponentialLevelGrid = [
+  0,
+  1,
+  10,
+  29,
+  30,
+  31,
+  45,
+  59,
+  60,
+  61,
+  75,
+  89,
+  90,
+  91,
+  100,
+  119,
+  120,
+  121,
+  130,
+  149,
+  150,
+  151
+]
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('parity: regularCostProgression (each tier threshold)', () => {
+  for (const baseMult of baseMultGrid) {
+    it.each(regularLevelGrid)(`baseMult=${baseMult.toString()} level=%i`, (level) => {
+      const next = newRegCostProgression(baseMult, level)
+      const old = oldRegularCostProgression(baseMult, level)
+      expectMapsEqual(next, old)
+    })
+  }
+})
+
+describe('parity: exponentialCostProgression (each ratio × tier threshold)', () => {
+  for (const ratio of exponentialRatioGrid) {
+    for (const baseMult of baseMultGrid) {
+      it.each(exponentialLevelGrid)(
+        `ratio=${ratio} baseMult=${baseMult.toString()} level=%i`,
+        (level) => {
+          const next = newExpCostProgression(baseMult, level, ratio)
+          const old = oldExponentialCostProgression(baseMult, level, ratio)
+          expectMapsEqual(next, old)
+        }
+      )
+    }
+  }
+})

--- a/packages/logic/test/parity/tax.parity.test.ts
+++ b/packages/logic/test/parity/tax.parity.test.ts
@@ -1,0 +1,419 @@
+// Parity tests for calculateTax, lifted from packages/web_ui/src/Tax.ts.
+// The function has dozens of inputs feeding a long multiplicative chain
+// plus several override branches (C13/C9/C15, taxmanLastStand, 1e-300
+// overflow guard). The sweep strategy:
+//   1. Build a `baseline` input that produces a known non-degenerate
+//      result. Verify parity.
+//   2. For each branch / override, perturb the relevant inputs and
+//      verify parity on the perturbed input.
+//   3. Smoke-test the overtaxed-achievement flag at its three gates.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import { CalcECC } from '../../src/mechanics/challenges'
+import { calculateTax as newCalcTax, type CalculateTaxInput } from '../../src/mechanics/tax'
+
+// ─── Old implementation (verbatim from packages/web_ui/src/Tax.ts) ─────────
+
+const oldCalcTax = (input: CalculateTaxInput) => {
+  let exp = 1
+
+  if (input.inReinc6) {
+    exp = 3 * Math.pow(1 + input.c6Completions / 25, 2)
+  }
+  if (input.inReinc9) {
+    exp = 0.005
+  }
+  if (input.inAscension15) {
+    exp = 0.000005
+  }
+
+  const c13effcompletions = Math.max(
+    0,
+    input.totalChallengeCompletions
+      - input.c11Completions
+      - input.c12Completions
+      - input.c13Completions
+      - input.c14Completions
+      - input.c15Completions
+      - ((input.singularityCount >= 15) ? 4 : 0)
+      - ((input.singularityCount >= 20) ? 1 : 0)
+  )
+
+  if (input.inAscension13) {
+    exp *= 400 * (1 + 1 / 6 * input.c13Completions)
+    exp *= Math.pow(1.05, c13effcompletions)
+  }
+  if (input.c6Completions > 0) {
+    exp /= 1.075
+  }
+
+  let exponent = 1
+  exponent *= exp
+  exponent *= 1 - 0.06 * input.research51
+  exponent *= 1 - 0.05 * input.research52
+  exponent *= 1 - 0.05 * input.research53
+  exponent *= 1 - 0.05 * input.research54
+  exponent *= 1 - 0.05 * input.research55
+  exponent *= input.taxReductionAchievement
+  exponent *= Math.pow(0.965, CalcECC('reincarnation', input.c6Completions))
+  exponent *= input.duplicationRuneTaxReduction
+  exponent *= input.thriftRuneTaxReduction
+  exponent *= input.antTaxReduction
+  exponent *= 1
+    / Math.pow(
+      1 + Decimal.log(input.ascendShards.add(1), 10),
+      1 + 1 / 300 * input.c10Completions * input.upgrade125 + 0.1 * input.platonicUpgrade5
+        + 0.2 * input.platonicUpgrade10 + input.taxPlatonicBlessing
+    )
+  exponent *= 1 + input.exemptionTalismanTaxReduction
+  exponent *= Math.pow(0.98, 3 / 5 * Decimal.log(input.rareFragments.add(1), 10) * input.research159)
+  exponent *= Math.pow(0.966, CalcECC('ascension', input.c13Completions))
+  exponent *= 1 - 0.666 * input.research200 / 100000
+  exponent *= 1 - 0.666 * input.cubeUpgrade50 / 100000
+  exponent *= input.challenge15TaxesReward
+  exponent *= input.campaignTaxMultiplier
+  if (input.upgrade121 > 0) {
+    exponent *= 0.5
+  }
+  if (input.highestSingularityCount >= 281) {
+    exponent *= 0.5
+  }
+  if (input.taxmanLastStandEnabled) {
+    if (input.ascensionsUnlocked) {
+      exponent *= 4
+    }
+    if (input.highestC14Completions > 0) {
+      exponent *= 5
+    }
+  }
+
+  if (exponent < 1e-300) {
+    exponent = 1e-300
+  }
+
+  let flatMaxExponentIncrease = Decimal.log(input.fortunaeFormicidaeCoinMultiplier, 10)
+  flatMaxExponentIncrease += Decimal.log(input.buildingPowerCoinMultiplier, 10)
+
+  const maxexponent = Math.floor(275 / (Decimal.log(1.01, 10) * exponent)) - 1 + flatMaxExponentIncrease
+
+  const exponentForDivisor = Math.max(
+    0,
+    Math.min(maxexponent, Math.floor(Decimal.log(input.produceTotal.add(1), 10))) - flatMaxExponentIncrease
+  )
+  const exponentForWarning = Math.max(0, maxexponent - flatMaxExponentIncrease)
+
+  const shouldAwardOvertaxed = input.inAscension13
+    && (maxexponent - flatMaxExponentIncrease) <= 99999
+    && c13effcompletions >= 1
+
+  const divisorExponent = 1 / 550 * Math.pow(exponentForDivisor, 2)
+  const checkExponent = 1 / 550 * Math.pow(exponentForWarning, 2)
+
+  const taxdivisor = Decimal.pow(1.01, divisorExponent * exponent)
+  const taxdivisorcheck = Decimal.pow(1.01, checkExponent * exponent)
+
+  return { exponent, maxexponent, taxdivisor, taxdivisorcheck, shouldAwardOvertaxed }
+}
+
+// ─── Baseline input ─────────────────────────────────────────────────────
+
+const baseline: CalculateTaxInput = {
+  inReinc6: false,
+  inReinc9: false,
+  inAscension15: false,
+  inAscension13: false,
+  c6Completions: 0,
+  c13Completions: 0,
+
+  totalChallengeCompletions: 0,
+  c11Completions: 0,
+  c12Completions: 0,
+  c14Completions: 0,
+  c15Completions: 0,
+  singularityCount: 0,
+
+  research51: 0,
+  research52: 0,
+  research53: 0,
+  research54: 0,
+  research55: 0,
+  research159: 0,
+  research200: 0,
+  cubeUpgrade50: 0,
+  platonicUpgrade5: 0,
+  platonicUpgrade10: 0,
+  taxPlatonicBlessing: 0,
+  upgrade121: 0,
+  upgrade125: 0,
+  c10Completions: 0,
+
+  highestSingularityCount: 0,
+  taxmanLastStandEnabled: false,
+  ascensionsUnlocked: false,
+  highestC14Completions: 0,
+
+  taxReductionAchievement: 1,
+  duplicationRuneTaxReduction: 1,
+  thriftRuneTaxReduction: 1,
+  antTaxReduction: 1,
+  exemptionTalismanTaxReduction: 0,
+  challenge15TaxesReward: 1,
+  campaignTaxMultiplier: 1,
+
+  ascendShards: new Decimal(0),
+  rareFragments: new Decimal(0),
+  fortunaeFormicidaeCoinMultiplier: new Decimal(1),
+  buildingPowerCoinMultiplier: new Decimal(1),
+
+  produceTotal: new Decimal(1)
+}
+
+const closeEnough = (a: number, b: number, rel = 1e-10): boolean => {
+  if (a === b) return true
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return a === b
+  if (Math.abs(a) < 1 && Math.abs(b) < 1) return Math.abs(a - b) < rel
+  return Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b)) < rel
+}
+
+const decimalClose = (a: Decimal, b: Decimal, rel = 1e-10): boolean => {
+  if (a.eq(b)) return true
+  if (a.eq(0) && b.eq(0)) return true
+  const diff = a.minus(b).abs()
+  const denom = Decimal.max(a.abs(), b.abs())
+  return diff.div(denom).lt(rel)
+}
+
+const expectResultsEqual = (
+  next: ReturnType<typeof newCalcTax>,
+  old: ReturnType<typeof oldCalcTax>
+) => {
+  expect(closeEnough(next.exponent, old.exponent)).toBe(true)
+  expect(closeEnough(next.maxexponent, old.maxexponent)).toBe(true)
+  expect(decimalClose(next.taxdivisor, old.taxdivisor)).toBe(true)
+  expect(decimalClose(next.taxdivisorcheck, old.taxdivisorcheck)).toBe(true)
+  expect(next.shouldAwardOvertaxed).toBe(old.shouldAwardOvertaxed)
+}
+
+// ─── Baseline + per-branch perturbations ───────────────────────────────────
+
+describe('parity: calculateTax (baseline)', () => {
+  it('all-default input', () => {
+    expectResultsEqual(newCalcTax(baseline), oldCalcTax(baseline))
+  })
+})
+
+describe('parity: calculateTax (challenge overrides)', () => {
+  // Each override completely replaces the base `exp`. Test all three.
+  const cases: { name: string; perturb: Partial<CalculateTaxInput> }[] = [
+    { name: 'inReinc6 base', perturb: { inReinc6: true, c6Completions: 0 } },
+    { name: 'inReinc6 c6=25', perturb: { inReinc6: true, c6Completions: 25 } },
+    { name: 'inReinc6 c6=100', perturb: { inReinc6: true, c6Completions: 100 } },
+    { name: 'inReinc9', perturb: { inReinc9: true } },
+    { name: 'inAscension15', perturb: { inAscension15: true } },
+    // Override precedence: reinc9 wins over reinc6
+    { name: 'inReinc6 + inReinc9 (reinc9 wins)', perturb: { inReinc6: true, c6Completions: 10, inReinc9: true } },
+    // asc15 wins over reinc9 (last branch in legacy precedence)
+    { name: 'inReinc9 + inAscension15 (asc15 wins)', perturb: { inReinc9: true, inAscension15: true } }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      const input = { ...baseline, ...c.perturb }
+      expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    })
+  }
+})
+
+describe('parity: calculateTax (C13 multiplier + c13effcompletions)', () => {
+  const cases: { name: string; perturb: Partial<CalculateTaxInput> }[] = [
+    { name: 'asc13 alone', perturb: { inAscension13: true, c13Completions: 0 } },
+    { name: 'asc13 c13=10', perturb: { inAscension13: true, c13Completions: 10 } },
+    {
+      name: 'asc13 c13effcompletions positive',
+      perturb: {
+        inAscension13: true,
+        c13Completions: 5,
+        totalChallengeCompletions: 200,
+        c11Completions: 10,
+        c12Completions: 10,
+        c14Completions: 5,
+        c15Completions: 5
+      }
+    },
+    {
+      name: 'asc13 + singularityCount > 20 reductions',
+      perturb: {
+        inAscension13: true,
+        totalChallengeCompletions: 50,
+        singularityCount: 25
+      }
+    },
+    // c13effcompletions clamped at 0
+    {
+      name: 'all-completions = high-tier (c13eff → 0)',
+      perturb: {
+        inAscension13: true,
+        totalChallengeCompletions: 30,
+        c11Completions: 10,
+        c12Completions: 10,
+        c13Completions: 10
+      }
+    }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      const input = { ...baseline, ...c.perturb }
+      expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    })
+  }
+})
+
+describe('parity: calculateTax (research / cube reductions)', () => {
+  // Each research stacks multiplicatively. Sweep representative values.
+  const cases: { name: string; perturb: Partial<CalculateTaxInput> }[] = [
+    { name: 'research51 max', perturb: { research51: 16 } }, // 1 - 0.06*16 ≈ 0.04
+    { name: 'research52..55 max', perturb: { research52: 20, research53: 20, research54: 20, research55: 20 } },
+    { name: 'research200 max', perturb: { research200: 100000 } },
+    { name: 'cubeUpgrade50 max', perturb: { cubeUpgrade50: 100000 } },
+    { name: 'research159 with rareFragments', perturb: { research159: 1, rareFragments: new Decimal('1e10') } }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      const input = { ...baseline, ...c.perturb }
+      expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    })
+  }
+})
+
+describe('parity: calculateTax (ascendShards divisor)', () => {
+  // Exponent on the ascendShards divisor changes with c10/upgrade125/platonic/
+  // taxPlatonicBlessing. Sweep across each contribution.
+  const cases: { name: string; perturb: Partial<CalculateTaxInput> }[] = [
+    { name: 'ascendShards alone', perturb: { ascendShards: new Decimal('1e50') } },
+    {
+      name: 'ascendShards + c10*upgrade125',
+      perturb: { ascendShards: new Decimal('1e50'), c10Completions: 300, upgrade125: 1 }
+    },
+    { name: 'ascendShards + platonic5', perturb: { ascendShards: new Decimal('1e50'), platonicUpgrade5: 1 } },
+    { name: 'ascendShards + platonic10', perturb: { ascendShards: new Decimal('1e50'), platonicUpgrade10: 1 } },
+    {
+      name: 'ascendShards + taxPlatonicBlessing',
+      perturb: { ascendShards: new Decimal('1e50'), taxPlatonicBlessing: 0.5 }
+    }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      const input = { ...baseline, ...c.perturb }
+      expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    })
+  }
+})
+
+describe('parity: calculateTax (late-game halving)', () => {
+  // upgrade121 and sing281 each halve. Verify in isolation and combined.
+  for (const upgrade121 of [0, 1]) {
+    for (const sing of [0, 280, 281, 500]) {
+      it(`upgrade121=${upgrade121} sing=${sing}`, () => {
+        const input = { ...baseline, upgrade121, highestSingularityCount: sing }
+        expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+      })
+    }
+  }
+})
+
+describe('parity: calculateTax (taxmanLastStand)', () => {
+  // Three on/off flags + the C14 completions gate. Eight cases total.
+  for (const enabled of [true, false]) {
+    for (const unlocked of [true, false]) {
+      for (const c14 of [0, 1]) {
+        it(`enabled=${enabled} ascUnlocked=${unlocked} c14=${c14}`, () => {
+          const input = {
+            ...baseline,
+            taxmanLastStandEnabled: enabled,
+            ascensionsUnlocked: unlocked,
+            highestC14Completions: c14
+          }
+          expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+        })
+      }
+    }
+  }
+})
+
+describe('parity: calculateTax (1e-300 overflow guard)', () => {
+  // Stack enough reductions to drive exponent below 1e-300.
+  it('extreme reduction inputs → clamped to 1e-300', () => {
+    const input = {
+      ...baseline,
+      inReinc9: true, // base exp = 0.005
+      research51: 16,
+      research52: 20,
+      research53: 20,
+      research54: 20,
+      research55: 20,
+      duplicationRuneTaxReduction: 1e-100,
+      thriftRuneTaxReduction: 1e-100
+    }
+    expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    expect(newCalcTax(input).exponent).toBe(1e-300)
+  })
+})
+
+describe('parity: calculateTax (flatMaxExponentIncrease)', () => {
+  // Ant Coins multiplier and building power both feed into the flat
+  // max-exponent increase.
+  const cases = [
+    { fortunae: new Decimal('1e10'), building: new Decimal(1) },
+    { fortunae: new Decimal(1), building: new Decimal('1e20') },
+    { fortunae: new Decimal('1e10'), building: new Decimal('1e20') }
+  ]
+  for (let i = 0; i < cases.length; i++) {
+    const c = cases[i]
+    it(`fortunae=${c.fortunae.toString()} building=${c.building.toString()}`, () => {
+      const input = {
+        ...baseline,
+        fortunaeFormicidaeCoinMultiplier: c.fortunae,
+        buildingPowerCoinMultiplier: c.building
+      }
+      expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    })
+  }
+})
+
+describe('parity: calculateTax (produceTotal feeds divisor)', () => {
+  // produceTotal log10 caps the divisor exponent. Verify across orders of
+  // magnitude.
+  for (const exp of [0, 5, 10, 50, 100, 200]) {
+    it(`produceTotal=1e${exp}`, () => {
+      const input = { ...baseline, produceTotal: new Decimal(`1e${exp}`) }
+      expectResultsEqual(newCalcTax(input), oldCalcTax(input))
+    })
+  }
+})
+
+describe('parity: calculateTax (overtaxed achievement gate)', () => {
+  // Three gates: inAscension13 + maxexp gap ≤ 99999 + c13eff ≥ 1.
+  // Build inputs that toggle each gate.
+  it('asc13 + c13eff=0 → no award', () => {
+    const input = { ...baseline, inAscension13: true }
+    const res = newCalcTax(input)
+    expect(res.shouldAwardOvertaxed).toBe(false)
+  })
+  it('asc13 + c13eff=1 + small maxexp gap → award', () => {
+    const input = {
+      ...baseline,
+      inAscension13: true,
+      c13Completions: 5,
+      totalChallengeCompletions: 200,
+      // Large exponent → small maxexp (since maxexp ~ 275 / exp).
+      // Default exponent here will be large from the C13 multiplier so
+      // maxexp comes out modest; let's check actual behavior matches.
+      // Build power small so flatMaxExponentIncrease is 0.
+      fortunaeFormicidaeCoinMultiplier: new Decimal(1),
+      buildingPowerCoinMultiplier: new Decimal(1)
+    }
+    const res = newCalcTax(input)
+    const old = oldCalcTax(input)
+    expect(res.shouldAwardOvertaxed).toBe(old.shouldAwardOvertaxed)
+  })
+})

--- a/packages/web_ui/src/Achievements.ts
+++ b/packages/web_ui/src/Achievements.ts
@@ -1,3 +1,7 @@
+import {
+  achievementLevelFromPoints as logicAchievementLevelFromPoints,
+  toNextAchievementLevelEXP as logicToNextAchievementLevelEXP
+} from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
@@ -3585,11 +3589,7 @@ export const updateProgressiveCache = (ach: ProgressiveAchievements, sourcedFrom
 
 const updateAchievementLevel = (fromUpdatePoints = false) => {
   const oldLevel = achievementLevel
-  if (achievementPoints < 2500) {
-    achievementLevel = Math.floor(achievementPoints / 50)
-  } else {
-    achievementLevel = 50 + Math.floor((achievementPoints - 2500) / 100)
-  }
+  achievementLevel = logicAchievementLevelFromPoints(achievementPoints)
   displayLevelStuff()
   if (oldLevel < achievementLevel) {
     if (player.toggles[34] && !fromUpdatePoints) {
@@ -3613,13 +3613,7 @@ export function computeAchievementPoints (
   return points
 }
 
-export const toNextAchievementLevelEXP = () => {
-  if (achievementPoints < 2500) {
-    return 50 - (achievementPoints % 50)
-  } else {
-    return 100 - (achievementPoints % 100)
-  }
-}
+export const toNextAchievementLevelEXP = () => logicToNextAchievementLevelEXP(achievementPoints)
 
 export const getAchievementReward = (rewardType: AchievementRewards): number | boolean => {
   return achRewards[rewardType]()

--- a/packages/web_ui/src/Hepteracts.ts
+++ b/packages/web_ui/src/Hepteracts.ts
@@ -1,14 +1,17 @@
-import Decimal from 'break_infinity.js'
 import {
   abyssHepteractEffects as logicAbyssEffects,
   acceleratorBoostHepteractEffects as logicAcceleratorBoostEffects,
   acceleratorHepteractEffects as logicAcceleratorEffects,
   challengeHepteractEffects as logicChallengeEffects,
   chronosHepteractEffects as logicChronosEffects,
+  hepteractCap as logicHepteractCap,
+  hepteractEffective as logicHepteractEffective,
+  hepteractFinalCap as logicHepteractFinalCap,
   hyperrealismHepteractEffects as logicHyperrealismEffects,
   multiplierHepteractEffects as logicMultiplierEffects,
   quarkHepteractEffects as logicQuarkEffects
 } from '@synergism/logic'
+import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import {
@@ -291,14 +294,17 @@ export const getHepteractEffects = <K extends HepteractKeys>(hept: K): Hepteract
   return hepteracts[hept].EFFECTS(heptAmount)
 }
 
-const getHepteractCap = (hept: HepteractKeys): number => {
-  return Math.pow(2, hepteracts[hept].TIMES_CAP_EXTENDED) * hepteracts[hept].BASE_CAP
-}
+// Thin shim — sources BASE_CAP and TIMES_CAP_EXTENDED off the hept data.
+const getHepteractCap = (hept: HepteractKeys): number =>
+  logicHepteractCap(hepteracts[hept].BASE_CAP, hepteracts[hept].TIMES_CAP_EXTENDED)
 
-export const getFinalHepteractCap = (hept: HepteractKeys): number => {
-  const specialMultiplier = getSingularityChallengeEffect('limitedAscensions', 'hepteractCap') ? 2 : 1
-  return getHepteractCap(hept) * specialMultiplier
-}
+// Thin shim — sources the Exalt 3 (limitedAscensions) hepteractCap reward flag.
+export const getFinalHepteractCap = (hept: HepteractKeys): number =>
+  logicHepteractFinalCap(
+    hepteracts[hept].BASE_CAP,
+    hepteracts[hept].TIMES_CAP_EXTENDED,
+    getSingularityChallengeEffect('limitedAscensions', 'hepteractCap')
+  )
 
 const getCraftableHepteractAmount = (hept: HepteractKeys) => {
   const craftCostMulti = calculateSingularityDebuff('Hepteract Costs')
@@ -603,25 +609,15 @@ export const resetHepteracts = (tier: keyof typeof resetTiers) => {
   }
 }
 
-export const hepteractEffective = (hept: HepteractKeys) => {
-  // Quark Hept now uses a custom (nonpolynomial) formula, so just return val
-  if (hept === 'quark') {
-    return hepteracts[hept].BAL
-  }
-
-  const rawHeptAmount = hepteracts[hept].BAL
-  let effectiveValue = Math.min(rawHeptAmount, hepteracts[hept].LIMIT)
-  const exponent = hepteracts[hept].DR + hepteracts[hept].DR_INCREASE()
-
-  if (rawHeptAmount > hepteracts[hept].LIMIT) {
-    effectiveValue *= Math.pow(
-      rawHeptAmount / hepteracts[hept].LIMIT,
-      exponent
-    )
-  }
-
-  return effectiveValue
-}
+// Thin shim — sources BAL/LIMIT/DR off the hept data and resolves
+// DR_INCREASE() into a scalar before calling logic.
+export const hepteractEffective = (hept: HepteractKeys) =>
+  logicHepteractEffective({
+    rawAmount: hepteracts[hept].BAL,
+    limit: hepteracts[hept].LIMIT,
+    drExponent: hepteracts[hept].DR + hepteracts[hept].DR_INCREASE(),
+    isQuark: hept === 'quark'
+  })
 
 export const hepteractDescriptions = (hept: HepteractKeys) => {
   DOMCacheGetOrSet('hepteractUnlockedText').style.display = 'block'

--- a/packages/web_ui/src/Levels.ts
+++ b/packages/web_ui/src/Levels.ts
@@ -1,23 +1,19 @@
+import {
+  getLevelMilestone as logicGetLevelMilestone,
+  getLevelReward as logicGetLevelReward,
+  type LevelMilestoneKey,
+  levelMilestones as logicLevelMilestones,
+  type LevelRewardKey,
+  levelRewards as logicLevelRewards,
+  salvageChallengeBuffEffect as logicSalvageChallengeBuffEffect
+} from '@synergism/logic'
 import i18next from 'i18next'
 import { achievementLevel } from './Achievements'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import { resetTimeThreshold } from './Calculate'
 import { format, formatAsPercentIncrease, player } from './Synergism'
 
-type SynergismLevelReward =
-  | 'quarks'
-  | 'salvage'
-  | 'obtainium'
-  | 'offerings'
-  | 'ants'
-  | 'wowCubes'
-  | 'wowTesseracts'
-  | 'wowHyperCubes'
-  | 'wowPlatonicCubes'
-  | 'wowHepteractCubes'
-  | 'wowOcteracts'
-  | 'ambrosiaLuck'
-  | 'redAmbrosiaLuck'
+type SynergismLevelReward = LevelRewardKey
 
 interface SynergismLevelRewardData {
   name: () => string
@@ -29,216 +25,75 @@ interface SynergismLevelRewardData {
   nameColor: string
 }
 
-export const synergismLevelRewards: Record<SynergismLevelReward, SynergismLevelRewardData> = {
-  salvage: {
-    name: () => i18next.t('achievements.levelRewards.salvage.name'),
-    description: () => i18next.t('achievements.levelRewards.salvage.description'),
-    effect: (lv: number) => {
-      let salvage = 0
-      let salavePerLevel = 1
-      let remainingLevels = lv
-      while (remainingLevels >= 100) {
-        salvage += salavePerLevel * 100
-        remainingLevels -= 100
-        salavePerLevel += 1
-      }
-      salvage += salavePerLevel * remainingLevels
-      return salvage
-    },
-    effectDescription: () => {
-      const salvage = getLevelReward('salvage')
-      return i18next.t('achievements.levelRewards.salvage.effect', {
-        salvage: format(salvage, 0, true)
-      })
-    },
-    minLevel: 0,
-    defaultValue: 0,
-    nameColor: 'green'
-  },
-  quarks: {
-    name: () => i18next.t('achievements.levelRewards.quarks.name'),
-    description: () => i18next.t('achievements.levelRewards.quarks.description'),
-    effect: (lv: number) => Math.pow(1.01, Math.floor(lv / 20)),
-    effectDescription: () => {
-      const multiplier = getLevelReward('quarks')
-      return i18next.t('achievements.levelRewards.quarks.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 20,
-    defaultValue: 1,
-    nameColor: 'cyan'
-  },
-  offerings: {
-    name: () => i18next.t('achievements.levelRewards.offerings.name'),
-    description: () => i18next.t('achievements.levelRewards.offerings.description'),
-    effect: (lv: number) => Math.pow(1.01, lv) * Math.pow(1.02, Math.max(0, lv - 100)),
-    effectDescription: () => {
-      const multiplier = getLevelReward('offerings')
-      return i18next.t('achievements.levelRewards.offerings.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 0,
-    defaultValue: 1,
-    nameColor: 'orange'
-  },
-  obtainium: {
-    name: () => i18next.t('achievements.levelRewards.obtainium.name'),
-    description: () => i18next.t('achievements.levelRewards.obtainium.description'),
-    effect: (lv: number) => Math.pow(1.01, lv - 15) * Math.pow(1.02, Math.max(0, lv - 100)),
-    effectDescription: () => {
-      const multiplier = getLevelReward('obtainium')
-      return i18next.t('achievements.levelRewards.obtainium.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 15,
-    defaultValue: 1,
-    nameColor: 'pink'
-  },
-  ants: {
-    name: () => i18next.t('achievements.levelRewards.ants.name'),
-    description: () => i18next.t('achievements.levelRewards.ants.description'),
-    effect: (lv: number) => {
-      const first100Levels = Math.min(71, lv - 59) * 25
-      const next100Levels = Math.max(0, Math.min(100, lv - 100)) * 50
-      const remainingLevels = Math.max(0, lv - 200) * 100
-      return first100Levels + next100Levels + remainingLevels
-    },
-    effectDescription: () => {
-      const elo = getLevelReward('ants')
-      return i18next.t('achievements.levelRewards.ants.effect', {
-        elo: format(elo, 0, true)
-      })
-    },
-    minLevel: 60,
-    defaultValue: 1,
-    nameColor: 'burlywood'
-  },
-  wowCubes: {
-    name: () => i18next.t('achievements.levelRewards.wowCubes.name'),
-    description: () => i18next.t('achievements.levelRewards.wowCubes.description'),
-    effect: (lv: number) => (1 + (lv - 60) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 6),
-    effectDescription: () => {
-      const multiplier = getLevelReward('wowCubes')
-      return i18next.t('achievements.levelRewards.wowCubes.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 70,
-    defaultValue: 1,
-    nameColor: 'lightgrey'
-  },
-  wowTesseracts: {
-    name: () => i18next.t('achievements.levelRewards.wowTesseracts.name'),
-    description: () => i18next.t('achievements.levelRewards.wowTesseracts.description'),
-    effect: (lv: number) => (1 + (lv - 80) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 8),
-    effectDescription: () => {
-      const multiplier = getLevelReward('wowTesseracts')
-      return i18next.t('achievements.levelRewards.wowTesseracts.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 90,
-    defaultValue: 1,
-    nameColor: 'orchid'
-  },
-  wowHyperCubes: {
-    name: () => i18next.t('achievements.levelRewards.wowHyperCubes.name'),
-    description: () => i18next.t('achievements.levelRewards.wowHyperCubes.description'),
-    effect: (lv: number) => (1 + (lv - 100) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 10),
-    effectDescription: () => {
-      const multiplier = getLevelReward('wowHyperCubes')
-      return i18next.t('achievements.levelRewards.wowHyperCubes.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 110,
-    defaultValue: 1,
-    nameColor: 'crimson'
-  },
-  wowPlatonicCubes: {
-    name: () => i18next.t('achievements.levelRewards.wowPlatonicCubes.name'),
-    description: () => i18next.t('achievements.levelRewards.wowPlatonicCubes.description'),
-    effect: (lv: number) => (1 + (lv - 120) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 12),
-    effectDescription: () => {
-      const multiplier = getLevelReward('wowPlatonicCubes')
-      return i18next.t('achievements.levelRewards.wowPlatonicCubes.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 140,
-    defaultValue: 1,
-    nameColor: 'lightgoldenrodyellow'
-  },
-  wowHepteractCubes: {
-    name: () => i18next.t('achievements.levelRewards.wowHepteractCubes.name'),
-    description: () => i18next.t('achievements.levelRewards.wowHepteractCubes.description'),
-    effect: (lv: number) => (1 + (lv - 150) / 20) * Math.pow(1.07, Math.floor(lv / 10) - 15),
-    effectDescription: () => {
-      const multiplier = getLevelReward('wowHepteractCubes')
-      return i18next.t('achievements.levelRewards.wowHepteractCubes.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 170,
-    defaultValue: 1,
-    nameColor: 'mediumpurple'
-  },
-  wowOcteracts: {
-    name: () => i18next.t('achievements.levelRewards.wowOcteracts.name'),
-    description: () => i18next.t('achievements.levelRewards.wowOcteracts.description'),
-    effect: (lv: number) => (1 + (lv - 209) / 20) * Math.pow(1.02, lv - 209),
-    effectDescription: () => {
-      const multiplier = getLevelReward('wowOcteracts')
-      return i18next.t('achievements.levelRewards.wowOcteracts.effect', {
-        mult: formatAsPercentIncrease(multiplier, 2)
-      })
-    },
-    minLevel: 210,
-    defaultValue: 1,
-    nameColor: 'turquoise'
-  },
-  ambrosiaLuck: {
-    name: () => i18next.t('achievements.levelRewards.ambrosiaLuck.name'),
-    description: () => i18next.t('achievements.levelRewards.ambrosiaLuck.description'),
-    effect: (lv: number) => 4 * (lv - 229),
-    effectDescription: () => {
-      const luck = getLevelReward('ambrosiaLuck')
-      return i18next.t('achievements.levelRewards.ambrosiaLuck.effect', {
-        luck: format(luck, 0, true)
-      })
-    },
-    minLevel: 230,
-    defaultValue: 0,
-    nameColor: 'lime'
-  },
-  redAmbrosiaLuck: {
-    name: () => i18next.t('achievements.levelRewards.redAmbrosiaLuck.name'),
-    description: () => i18next.t('achievements.levelRewards.redAmbrosiaLuck.description'),
-    effect: (lv: number) => lv - 259,
-    effectDescription: () => {
-      const luck = getLevelReward('redAmbrosiaLuck')
-      return i18next.t('achievements.levelRewards.redAmbrosiaLuck.effect', {
-        luck: format(luck, 0, true)
-      })
-    },
-    minLevel: 260,
-    defaultValue: 0,
-    nameColor: 'red'
+// Helper to assemble each reward entry: pure formula bits come from
+// @synergism/logic's levelRewards table, web_ui owns the i18n/colour-only
+// surface. The `effectDescription` closure reads `achievementLevel` indirectly
+// via the local getLevelReward shim below, so it always reflects the live
+// player state — matching the legacy behaviour.
+const mkRewardEntry = (
+  key: LevelRewardKey,
+  nameColor: string,
+  effectDescription: () => string
+): SynergismLevelRewardData => {
+  const logic = logicLevelRewards[key]
+  return {
+    name: () => i18next.t(`achievements.levelRewards.${key}.name`),
+    description: () => i18next.t(`achievements.levelRewards.${key}.description`),
+    effect: logic.effect,
+    effectDescription,
+    minLevel: logic.minLevel,
+    defaultValue: logic.defaultValue,
+    nameColor
   }
+}
+
+// Effect-description string for a percent-multiplier reward (1.23x → +23%).
+const percentIncreaseEffectDesc = (key: LevelRewardKey) => () =>
+  i18next.t(`achievements.levelRewards.${key}.effect`, {
+    mult: formatAsPercentIncrease(getLevelReward(key), 2)
+  })
+
+export const synergismLevelRewards: Record<SynergismLevelReward, SynergismLevelRewardData> = {
+  salvage: mkRewardEntry('salvage', 'green', () =>
+    i18next.t('achievements.levelRewards.salvage.effect', {
+      salvage: format(getLevelReward('salvage'), 0, true)
+    })),
+  quarks: mkRewardEntry('quarks', 'cyan', percentIncreaseEffectDesc('quarks')),
+  offerings: mkRewardEntry('offerings', 'orange', percentIncreaseEffectDesc('offerings')),
+  obtainium: mkRewardEntry('obtainium', 'pink', percentIncreaseEffectDesc('obtainium')),
+  ants: mkRewardEntry('ants', 'burlywood', () =>
+    i18next.t('achievements.levelRewards.ants.effect', {
+      elo: format(getLevelReward('ants'), 0, true)
+    })),
+  wowCubes: mkRewardEntry('wowCubes', 'lightgrey', percentIncreaseEffectDesc('wowCubes')),
+  wowTesseracts: mkRewardEntry('wowTesseracts', 'orchid', percentIncreaseEffectDesc('wowTesseracts')),
+  wowHyperCubes: mkRewardEntry('wowHyperCubes', 'crimson', percentIncreaseEffectDesc('wowHyperCubes')),
+  wowPlatonicCubes: mkRewardEntry(
+    'wowPlatonicCubes',
+    'lightgoldenrodyellow',
+    percentIncreaseEffectDesc('wowPlatonicCubes')
+  ),
+  wowHepteractCubes: mkRewardEntry('wowHepteractCubes', 'mediumpurple', percentIncreaseEffectDesc('wowHepteractCubes')),
+  wowOcteracts: mkRewardEntry('wowOcteracts', 'turquoise', percentIncreaseEffectDesc('wowOcteracts')),
+  ambrosiaLuck: mkRewardEntry('ambrosiaLuck', 'lime', () =>
+    i18next.t('achievements.levelRewards.ambrosiaLuck.effect', {
+      luck: format(getLevelReward('ambrosiaLuck'), 0, true)
+    })),
+  redAmbrosiaLuck: mkRewardEntry(
+    'redAmbrosiaLuck',
+    'red',
+    () =>
+      i18next.t('achievements.levelRewards.redAmbrosiaLuck.effect', {
+        luck: format(getLevelReward('redAmbrosiaLuck'), 0, true)
+      })
+  )
 }
 
 const synergismLevelReward = Object.keys(synergismLevelRewards) as SynergismLevelReward[]
 
-export const getLevelReward = (reward: SynergismLevelReward): number => {
-  if (achievementLevel >= synergismLevelRewards[reward].minLevel) {
-    return synergismLevelRewards[reward].effect(achievementLevel)
-  } else {
-    return synergismLevelRewards[reward].defaultValue
-  }
-}
+// Thin shim over @synergism/logic's getLevelReward — reads the live
+// `achievementLevel` and forwards.
+export const getLevelReward = (reward: SynergismLevelReward): number => logicGetLevelReward(reward, achievementLevel)
 
 const getLevelRewardDescription = (reward: SynergismLevelReward) => {
   const name = synergismLevelRewards[reward].name()
@@ -288,27 +143,11 @@ export const generateLevelRewardHTMLs = () => {
   }
 }
 
-type SynergismLevelMilestones =
-  | 'offeringTimerScaling'
-  | 'speedRune'
-  | 'duplicationRune'
-  | 'prismRune'
-  | 'thriftRune'
-  | 'SIRune'
-  | 'autoPrestige'
-  | 'tier1CrystalAutobuy'
-  | 'tier2CrystalAutobuy'
-  | 'tier3CrystalAutobuy'
-  | 'tier4CrystalAutobuy'
-  | 'tier5CrystalAutobuy'
-  | 'achievementTalismanUnlock'
-  | 'runeAutobuyImprover'
-  | 'achievementTalismanEnhancement'
-  | 'salvageChallengeBuff'
-  | 'antSpeed2Autobuyer'
-  | 'wowCubesAutobuyer'
-  | 'ascensionScoreAutobuyer'
-  | 'mortuus2Autobuyer'
+// Extends the logic-side `LevelMilestoneKey` with the one milestone whose
+// effect needs live player state (`salvageChallengeBuff`). All other entries
+// in the web_ui table delegate `effect` to logic; the salvage one calls into
+// `logicSalvageChallengeBuffEffect` with input sourced from `player`.
+type SynergismLevelMilestones = LevelMilestoneKey | 'salvageChallengeBuff'
 
 interface SynergismLevelMilestoneData {
   name: () => string
@@ -320,337 +159,179 @@ interface SynergismLevelMilestoneData {
   displayOrder: number
 }
 
+// Builds a milestone-table entry from the logic-side data. Web_ui supplies the
+// i18n closures (name/description/effectDescription) and the displayOrder; the
+// effect/levelReq/defaultValue come from the logic levelMilestones table. The
+// `effect` thunk wraps the pure formula with the live `achievementLevel`.
+const mkMilestoneEntry = (
+  key: LevelMilestoneKey,
+  displayOrder: number,
+  effectDescription: () => string
+): SynergismLevelMilestoneData => {
+  const logic = logicLevelMilestones[key]
+  return {
+    name: () => i18next.t(`achievements.levelMilestones.${key}.name`),
+    description: () => i18next.t(`achievements.levelMilestones.${key}.description`),
+    effect: () => logic.effect(achievementLevel),
+    defaultValue: logic.defaultValue,
+    effectDescription,
+    levelReq: logic.levelReq,
+    displayOrder
+  }
+}
+
+// Effect-description string for "is this milestone unlocked yet?" rewards.
+// Used by the 11 unlock-flag milestones (autoPrestige, tier1-5 crystal, etc.)
+// whose effect returns 1 when active.
+const unlockedFlagDesc = (key: LevelMilestoneKey) => () => {
+  const unlocked = getLevelMilestone(key) === 1
+  return i18next.t(`achievements.levelMilestones.${key}.effect`, {
+    unlocked: unlocked ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
+  })
+}
+
+// Sources the live player-challenge state for the one impure milestone.
+const salvageChallengeBuffEffect = () =>
+  logicSalvageChallengeBuffEffect({
+    inAnyChallenge: player.currentChallenge.transcension !== 0
+      || player.currentChallenge.reincarnation !== 0
+      || player.currentChallenge.ascension !== 0,
+    inAscension15: player.currentChallenge.ascension === 15,
+    insideSingularityChallenge: player.insideSingularityChallenge
+  })
+
 const synergismLevelMilestones: Record<SynergismLevelMilestones, SynergismLevelMilestoneData> = {
-  offeringTimerScaling: {
-    name: () => i18next.t('achievements.levelMilestones.offeringTimerScaling.name'),
-    description: () => i18next.t('achievements.levelMilestones.offeringTimerScaling.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const mult = getLevelMilestone('offeringTimerScaling') === 1
-        ? Math.max(1, player.prestigecounter / resetTimeThreshold())
-        : 1
-      return i18next.t('achievements.levelMilestones.offeringTimerScaling.effect', {
-        mult: formatAsPercentIncrease(mult, 2)
-      })
-    },
-    levelReq: 5,
-    displayOrder: 1
-  },
+  offeringTimerScaling: mkMilestoneEntry('offeringTimerScaling', 1, () => {
+    const mult = getLevelMilestone('offeringTimerScaling') === 1
+      ? Math.max(1, player.prestigecounter / resetTimeThreshold())
+      : 1
+    return i18next.t('achievements.levelMilestones.offeringTimerScaling.effect', {
+      mult: formatAsPercentIncrease(mult, 2)
+    })
+  }),
   autoPrestige: {
-    name: () => i18next.t('achievements.levelMilestones.autoPrestige.name'),
-    description: () => i18next.t('achievements.levelMilestones.autoPrestige.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
+    ...mkMilestoneEntry('autoPrestige', 2, () => {
       const autoPrestige = getLevelMilestone('autoPrestige') === 1
       return i18next.t('achievements.levelMilestones.autoPrestige.effect', {
         autoPrestige: autoPrestige
           ? i18next.t('achievements.rewardTypes.unlocked')
           : i18next.t('achievements.rewardTypes.locked')
       })
-    },
-    levelReq: 7,
-    displayOrder: 2
+    })
   },
-  speedRune: {
-    name: () => i18next.t('achievements.levelMilestones.speedRune.name'),
-    description: () => i18next.t('achievements.levelMilestones.speedRune.description'),
-    effect: () => {
-      return 0.5 * (achievementLevel - 19)
-    },
-    defaultValue: 0,
-    effectDescription: () => {
-      const speedRune = getLevelMilestone('speedRune')
-      return i18next.t('achievements.levelMilestones.speedRune.effect', {
-        speedRune: format(speedRune, 2, true)
+  speedRune: mkMilestoneEntry('speedRune', 3, () =>
+    i18next.t('achievements.levelMilestones.speedRune.effect', {
+      speedRune: format(getLevelMilestone('speedRune'), 2, true)
+    })),
+  duplicationRune: mkMilestoneEntry(
+    'duplicationRune',
+    4,
+    () =>
+      i18next.t('achievements.levelMilestones.duplicationRune.effect', {
+        duplicationRune: format(getLevelMilestone('duplicationRune'), 2, true)
       })
-    },
-    levelReq: 20,
-    displayOrder: 3
-  },
-  duplicationRune: {
-    name: () => i18next.t('achievements.levelMilestones.duplicationRune.name'),
-    description: () => i18next.t('achievements.levelMilestones.duplicationRune.description'),
-    effect: () => {
-      return 0.4 * (achievementLevel - 39)
-    },
-    defaultValue: 0,
-    effectDescription: () => {
-      const duplicationRune = getLevelMilestone('duplicationRune')
-      return i18next.t('achievements.levelMilestones.duplicationRune.effect', {
-        duplicationRune: format(duplicationRune, 2, true)
+  ),
+  prismRune: mkMilestoneEntry('prismRune', 5, () =>
+    i18next.t('achievements.levelMilestones.prismRune.effect', {
+      prismRune: format(getLevelMilestone('prismRune'), 2, true)
+    })),
+  thriftRune: mkMilestoneEntry('thriftRune', 6, () =>
+    i18next.t('achievements.levelMilestones.thriftRune.effect', {
+      thriftRune: format(getLevelMilestone('thriftRune'), 2, true)
+    })),
+  SIRune: mkMilestoneEntry('SIRune', 7, () =>
+    i18next.t('achievements.levelMilestones.SIRune.effect', {
+      siRune: format(getLevelMilestone('SIRune'), 2, true)
+    })),
+  // The five tier crystal autobuyers share the same `unlocked/locked` strings.
+  // They use the `autobuy` interpolation key (not `unlocked`), so they can't
+  // use the shared `unlockedFlagDesc` helper directly.
+  tier1CrystalAutobuy: mkMilestoneEntry('tier1CrystalAutobuy', 8, () => {
+    const autobuy = getLevelMilestone('tier1CrystalAutobuy') === 1
+    return i18next.t('achievements.levelMilestones.tier1CrystalAutobuy.effect', {
+      autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
+    })
+  }),
+  tier2CrystalAutobuy: mkMilestoneEntry('tier2CrystalAutobuy', 9, () => {
+    const autobuy = getLevelMilestone('tier2CrystalAutobuy') === 1
+    return i18next.t('achievements.levelMilestones.tier2CrystalAutobuy.effect', {
+      autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
+    })
+  }),
+  tier3CrystalAutobuy: mkMilestoneEntry('tier3CrystalAutobuy', 10, () => {
+    const autobuy = getLevelMilestone('tier3CrystalAutobuy') === 1
+    return i18next.t('achievements.levelMilestones.tier3CrystalAutobuy.effect', {
+      autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
+    })
+  }),
+  tier4CrystalAutobuy: mkMilestoneEntry('tier4CrystalAutobuy', 11, () => {
+    const autobuy = getLevelMilestone('tier4CrystalAutobuy') === 1
+    return i18next.t('achievements.levelMilestones.tier4CrystalAutobuy.effect', {
+      autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
+    })
+  }),
+  tier5CrystalAutobuy: mkMilestoneEntry('tier5CrystalAutobuy', 12, () => {
+    const autobuy = getLevelMilestone('tier5CrystalAutobuy') === 1
+    return i18next.t('achievements.levelMilestones.tier5CrystalAutobuy.effect', {
+      autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
+    })
+  }),
+  achievementTalismanUnlock: mkMilestoneEntry(
+    'achievementTalismanUnlock',
+    13,
+    unlockedFlagDesc('achievementTalismanUnlock')
+  ),
+  runeAutobuyImprover: mkMilestoneEntry(
+    'runeAutobuyImprover',
+    13.5,
+    () =>
+      i18next.t('achievements.levelMilestones.runeAutobuyImprover.effect', {
+        mult: formatAsPercentIncrease(getLevelMilestone('runeAutobuyImprover'), 0)
       })
-    },
-    levelReq: 40,
-    displayOrder: 4
-  },
-  prismRune: {
-    name: () => i18next.t('achievements.levelMilestones.prismRune.name'),
-    description: () => i18next.t('achievements.levelMilestones.prismRune.description'),
-    effect: () => {
-      return 0.3 * (achievementLevel - 59)
-    },
-    defaultValue: 0,
-    effectDescription: () => {
-      const prismRune = getLevelMilestone('prismRune')
-      return i18next.t('achievements.levelMilestones.prismRune.effect', {
-        prismRune: format(prismRune, 2, true)
+  ),
+  achievementTalismanEnhancement: mkMilestoneEntry(
+    'achievementTalismanEnhancement',
+    14,
+    () =>
+      i18next.t('achievements.levelMilestones.achievementTalismanEnhancement.effect', {
+        level: format(getLevelMilestone('achievementTalismanEnhancement'), 0, true)
       })
-    },
-    levelReq: 60,
-    displayOrder: 5
-  },
-  thriftRune: {
-    name: () => i18next.t('achievements.levelMilestones.thriftRune.name'),
-    description: () => i18next.t('achievements.levelMilestones.thriftRune.description'),
-    effect: () => {
-      return 0.2 * (achievementLevel - 79)
-    },
-    defaultValue: 0,
-    effectDescription: () => {
-      const thriftRune = getLevelMilestone('thriftRune')
-      return i18next.t('achievements.levelMilestones.thriftRune.effect', {
-        thriftRune: format(thriftRune, 2, true)
-      })
-    },
-    levelReq: 80,
-    displayOrder: 6
-  },
-  SIRune: {
-    name: () => i18next.t('achievements.levelMilestones.SIRune.name'),
-    description: () => i18next.t('achievements.levelMilestones.SIRune.description'),
-    effect: () => {
-      return 0.1 * (achievementLevel - 99)
-    },
-    defaultValue: 0,
-    effectDescription: () => {
-      const siRune = getLevelMilestone('SIRune')
-      return i18next.t('achievements.levelMilestones.SIRune.effect', {
-        siRune: format(siRune, 2, true)
-      })
-    },
-    levelReq: 100,
-    displayOrder: 7
-  },
-  tier1CrystalAutobuy: {
-    name: () => i18next.t('achievements.levelMilestones.tier1CrystalAutobuy.name'),
-    description: () => i18next.t('achievements.levelMilestones.tier1CrystalAutobuy.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const autobuy = getLevelMilestone('tier1CrystalAutobuy') === 1
-      return i18next.t('achievements.levelMilestones.tier1CrystalAutobuy.effect', {
-        autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 6,
-    displayOrder: 8
-  },
-  tier2CrystalAutobuy: {
-    name: () => i18next.t('achievements.levelMilestones.tier2CrystalAutobuy.name'),
-    description: () => i18next.t('achievements.levelMilestones.tier2CrystalAutobuy.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const autobuy = getLevelMilestone('tier2CrystalAutobuy') === 1
-      return i18next.t('achievements.levelMilestones.tier2CrystalAutobuy.effect', {
-        autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 9,
-    displayOrder: 9
-  },
-  tier3CrystalAutobuy: {
-    name: () => i18next.t('achievements.levelMilestones.tier3CrystalAutobuy.name'),
-    description: () => i18next.t('achievements.levelMilestones.tier3CrystalAutobuy.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const autobuy = getLevelMilestone('tier3CrystalAutobuy') === 1
-      return i18next.t('achievements.levelMilestones.tier3CrystalAutobuy.effect', {
-        autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 12,
-    displayOrder: 10
-  },
-  tier4CrystalAutobuy: {
-    name: () => i18next.t('achievements.levelMilestones.tier4CrystalAutobuy.name'),
-    description: () => i18next.t('achievements.levelMilestones.tier4CrystalAutobuy.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const autobuy = getLevelMilestone('tier4CrystalAutobuy') === 1
-      return i18next.t('achievements.levelMilestones.tier4CrystalAutobuy.effect', {
-        autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 15,
-    displayOrder: 11
-  },
-  tier5CrystalAutobuy: {
-    name: () => i18next.t('achievements.levelMilestones.tier5CrystalAutobuy.name'),
-    description: () => i18next.t('achievements.levelMilestones.tier5CrystalAutobuy.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const autobuy = getLevelMilestone('tier5CrystalAutobuy') === 1
-      return i18next.t('achievements.levelMilestones.tier5CrystalAutobuy.effect', {
-        autobuy: autobuy ? i18next.t('achievements.rewardTypes.unlocked') : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 20,
-    displayOrder: 12
-  },
-  achievementTalismanUnlock: {
-    name: () => i18next.t('achievements.levelMilestones.achievementTalismanUnlock.name'),
-    description: () => i18next.t('achievements.levelMilestones.achievementTalismanUnlock.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const unlocked = getLevelMilestone('achievementTalismanUnlock') === 1
-      return i18next.t('achievements.levelMilestones.achievementTalismanUnlock.effect', {
-        unlocked: unlocked
-          ? i18next.t('achievements.rewardTypes.unlocked')
-          : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 100,
-    displayOrder: 13
-  },
-  runeAutobuyImprover: {
-    name: () => i18next.t('achievements.levelMilestones.runeAutobuyImprover.name'),
-    description: () => i18next.t('achievements.levelMilestones.runeAutobuyImprover.description'),
-    effect: () => 1.1 + 0.01 * (achievementLevel - 130),
-    defaultValue: 1,
-    effectDescription: () => {
-      const mult = getLevelMilestone('runeAutobuyImprover')
-      return i18next.t('achievements.levelMilestones.runeAutobuyImprover.effect', {
-        mult: formatAsPercentIncrease(mult, 0)
-      })
-    },
-    levelReq: 130,
-    displayOrder: 13.5
-  },
-  achievementTalismanEnhancement: {
-    name: () => i18next.t('achievements.levelMilestones.achievementTalismanEnhancement.name'),
-    description: () => i18next.t('achievements.levelMilestones.achievementTalismanEnhancement.description'),
-    effect: () => achievementLevel,
-    defaultValue: 0,
-    effectDescription: () => {
-      const level = getLevelMilestone('achievementTalismanEnhancement')
-      return i18next.t('achievements.levelMilestones.achievementTalismanEnhancement.effect', {
-        level: format(level, 0, true)
-      })
-    },
-    levelReq: 160,
-    displayOrder: 14
-  },
+  ),
+  // salvageChallengeBuff is the one milestone whose effect needs player state.
+  // The structure mirrors mkMilestoneEntry but with the salvage-specific effect
+  // thunk inline.
   salvageChallengeBuff: {
     name: () => i18next.t('achievements.levelMilestones.salvageChallengeBuff.name'),
     description: () => i18next.t('achievements.levelMilestones.salvageChallengeBuff.description'),
-    effect: () => {
-      let baseVal = 25
-      if (
-        player.currentChallenge.transcension !== 0
-        || player.currentChallenge.reincarnation !== 0
-        || player.currentChallenge.ascension !== 0
-      ) {
-        baseVal *= 2
-      }
-      if (player.currentChallenge.ascension === 15) {
-        baseVal *= 2
-      }
-      if (player.insideSingularityChallenge) {
-        baseVal *= 3
-      }
-      return baseVal
-    },
+    effect: salvageChallengeBuffEffect,
     defaultValue: 0,
-    effectDescription: () => {
-      const salvage = getLevelMilestone('salvageChallengeBuff')
-      return i18next.t('achievements.levelMilestones.salvageChallengeBuff.effect', {
-        salvage: format(salvage, 0, true)
-      })
-    },
+    effectDescription: () =>
+      i18next.t('achievements.levelMilestones.salvageChallengeBuff.effect', {
+        salvage: format(getLevelMilestone('salvageChallengeBuff'), 0, true)
+      }),
     levelReq: 180,
     displayOrder: 15
   },
-  antSpeed2Autobuyer: {
-    name: () => i18next.t('achievements.levelMilestones.antSpeed2Autobuyer.name'),
-    description: () => i18next.t('achievements.levelMilestones.antSpeed2Autobuyer.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const unlocked = getLevelMilestone('antSpeed2Autobuyer') === 1
-      return i18next.t('achievements.levelMilestones.antSpeed2Autobuyer.effect', {
-        unlocked: unlocked
-          ? i18next.t('achievements.rewardTypes.unlocked')
-          : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 65,
-    displayOrder: 16
-  },
-  wowCubesAutobuyer: {
-    name: () => i18next.t('achievements.levelMilestones.wowCubesAutobuyer.name'),
-    description: () => i18next.t('achievements.levelMilestones.wowCubesAutobuyer.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const unlocked = getLevelMilestone('wowCubesAutobuyer') === 1
-      return i18next.t('achievements.levelMilestones.wowCubesAutobuyer.effect', {
-        unlocked: unlocked
-          ? i18next.t('achievements.rewardTypes.unlocked')
-          : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 80,
-    displayOrder: 17
-  },
-  ascensionScoreAutobuyer: {
-    name: () => i18next.t('achievements.levelMilestones.ascensionScoreAutobuyer.name'),
-    description: () => i18next.t('achievements.levelMilestones.ascensionScoreAutobuyer.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const unlocked = getLevelMilestone('ascensionScoreAutobuyer') === 1
-      return i18next.t('achievements.levelMilestones.ascensionScoreAutobuyer.effect', {
-        unlocked: unlocked
-          ? i18next.t('achievements.rewardTypes.unlocked')
-          : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 80,
-    displayOrder: 18
-  },
-  mortuus2Autobuyer: {
-    name: () => i18next.t('achievements.levelMilestones.mortuus2Autobuyer.name'),
-    description: () => i18next.t('achievements.levelMilestones.mortuus2Autobuyer.description'),
-    effect: () => 1,
-    defaultValue: 0,
-    effectDescription: () => {
-      const unlocked = getLevelMilestone('mortuus2Autobuyer') === 1
-      return i18next.t('achievements.levelMilestones.mortuus2Autobuyer.effect', {
-        unlocked: unlocked
-          ? i18next.t('achievements.rewardTypes.unlocked')
-          : i18next.t('achievements.rewardTypes.locked')
-      })
-    },
-    levelReq: 225,
-    displayOrder: 19
-  }
+  antSpeed2Autobuyer: mkMilestoneEntry('antSpeed2Autobuyer', 16, unlockedFlagDesc('antSpeed2Autobuyer')),
+  wowCubesAutobuyer: mkMilestoneEntry('wowCubesAutobuyer', 17, unlockedFlagDesc('wowCubesAutobuyer')),
+  ascensionScoreAutobuyer: mkMilestoneEntry(
+    'ascensionScoreAutobuyer',
+    18,
+    unlockedFlagDesc('ascensionScoreAutobuyer')
+  ),
+  mortuus2Autobuyer: mkMilestoneEntry('mortuus2Autobuyer', 19, unlockedFlagDesc('mortuus2Autobuyer'))
 }
 
 const synergismLevelMilestone = Object.keys(synergismLevelMilestones) as SynergismLevelMilestones[]
 
+// Thin shim over @synergism/logic's getLevelMilestone, with a special case
+// for salvageChallengeBuff which lives in web_ui because its effect needs
+// live player-challenge state.
 export const getLevelMilestone = (milestone: SynergismLevelMilestones): number => {
-  if (achievementLevel >= synergismLevelMilestones[milestone].levelReq) {
-    return synergismLevelMilestones[milestone].effect()
-  } else {
-    return synergismLevelMilestones[milestone].defaultValue
+  if (milestone === 'salvageChallengeBuff') {
+    return achievementLevel >= 180 ? salvageChallengeBuffEffect() : 0
   }
+  return logicGetLevelMilestone(milestone, achievementLevel)
 }
 
 const getLevelMilestoneDescription = (milestone: SynergismLevelMilestones) => {

--- a/packages/web_ui/src/Octeracts.ts
+++ b/packages/web_ui/src/Octeracts.ts
@@ -1,3 +1,8 @@
+import {
+  actualOcteractUpgradeTotalLevels as logicActualOcteractUpgradeTotalLevels,
+  octeractFreeLevelMultiplier as logicOcteractFreeLevelMultiplier,
+  octeractFreeLevelSoftcap as logicOcteractFreeLevelSoftcap
+} from '@synergism/logic'
 import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import { calculateOcteractMultiplier } from './Calculate'
@@ -1074,33 +1079,25 @@ export const getOcteractUpgradeCostTNL = (upgradeKey: OcteractUpgrades): number 
   return upgrade.costFormula(upgrade.level, upgrade.costPerLevel)
 }
 
-const computeFreeLevelMultiplier = (): number => {
-  return 1 + 0.3 / 100 * player.cubeUpgrades[78]
-}
+// Thin shim — sources cubeUpgrades[78] for the multiplier.
+const computeFreeLevelMultiplier = (): number => logicOcteractFreeLevelMultiplier(player.cubeUpgrades[78])
 
-export const computeOcteractFreeLevelSoftcap = (upgradeKey: OcteractUpgrades): number => {
-  const freeLevelMult = computeFreeLevelMultiplier()
-  const upgrade = octeractUpgrades[upgradeKey]
-  return upgrade.freeLevel * freeLevelMult
-}
+export const computeOcteractFreeLevelSoftcap = (upgradeKey: OcteractUpgrades): number =>
+  logicOcteractFreeLevelSoftcap(octeractUpgrades[upgradeKey].freeLevel, computeFreeLevelMultiplier())
 
+// Thin shim over @synergism/logic. Sources level / freeLevel / qualityOfLife
+// off the upgrade snapshot and the noOcteracts / sadisticPrequel gate flags
+// off the player.
 export const actualOcteractUpgradeTotalLevels = (upgradeKey: OcteractUpgrades): number => {
   const upgrade = octeractUpgrades[upgradeKey]
-
-  if (
-    (player.singularityChallenges.noOcteracts.enabled || player.singularityChallenges.sadisticPrequel.enabled)
-    && !upgrade.qualityOfLife
-  ) {
-    return 0
-  }
-
-  const actualFreeLevels = computeOcteractFreeLevelSoftcap(upgradeKey)
-
-  if (upgrade.level >= actualFreeLevels) {
-    return actualFreeLevels + upgrade.level
-  } else {
-    return 2 * Math.sqrt(actualFreeLevels * upgrade.level)
-  }
+  return logicActualOcteractUpgradeTotalLevels({
+    level: upgrade.level,
+    freeLevel: upgrade.freeLevel,
+    qualityOfLife: upgrade.qualityOfLife,
+    cubeUpgrade78: player.cubeUpgrades[78],
+    inNoOcteracts: player.singularityChallenges.noOcteracts.enabled,
+    inSadisticPrequel: player.singularityChallenges.sadisticPrequel.enabled
+  })
 }
 
 export const upgradeOcteractToString = (upgradeKey: OcteractUpgrades): string => {

--- a/packages/web_ui/src/Runes.ts
+++ b/packages/web_ui/src/Runes.ts
@@ -4,11 +4,17 @@ import {
   finiteDescentRuneEffects as logicFiniteDescentRuneEffects,
   horseShoeRuneEffects as logicHorseShoeRuneEffects,
   infiniteAscentRuneEffects as logicInfiniteAscentRuneEffects,
+  maxRuneLevelPurchase as logicMaxRuneLevelPurchase,
   prismRuneEffects as logicPrismRuneEffects,
+  runeEXPLeftToLevel as logicRuneEXPLeftToLevel,
+  runeEXPToLevel as logicRuneEXPToLevel,
+  runeLevelFromEXP as logicRuneLevelFromEXP,
+  runeOfferingsToLevel as logicRuneOfferingsToLevel,
   speedRuneEffects as logicSpeedRuneEffects,
   superiorIntellectRuneEffects as logicSuperiorIntellectRuneEffects,
   thriftRuneEffects as logicThriftRuneEffects,
-  topHatRuneEffects as logicTopHatRuneEffects
+  topHatRuneEffects as logicTopHatRuneEffects,
+  universalRuneEXPMult as logicUniversalRuneEXPMult
 } from '@synergism/logic'
 import { calculateOfferings, calculateSalvageRuneEXPMultiplier } from './Calculate'
 import { format, formatAsPercentIncrease, player } from './Synergism'
@@ -303,50 +309,22 @@ export const SIEffectiveRuneLevelMult = () => {
   return runeEffectivenessStatsSI.reduce((x, y) => x * y.stat(), 1)
 }
 
-const universalRuneEXPMult = (purchasedLevels: number): Decimal => {
-  // recycleMult accounted for all recycle chance, but inversed so it's a multiplier instead
-  const recycleMultiplier = calculateSalvageRuneEXPMultiplier()
-
-  // Rune multiplier that is summed instead of added
-  /* TODO: Replace the effects of these upgrades with new ones
-    const allRuneExpAdditiveMultiplier = sumContents([
-        // Challenge 3 completions
-        (1 / 100) * player.highestchallengecompletions[3],
-        // Reincarnation 2x1
-        1 * player.upgrades[66]
-      ])
-    }*/
-  const allRuneExpAdditiveMultiplier = (
-    // Base amount multiplied per offering
-    1
-    // +1 if C1 completion
-    + Math.min(1, player.highestchallengecompletions[1])
-    // +0.10 per C1 completion
-    + (0.4 / 10) * player.highestchallengecompletions[1]
-    // Research 5x2
-    + 0.6 * player.researches[22]
-    // Research 5x3
-    + 0.3 * player.researches[23]
-    // Particle upgrade 3x1
-    + (player.upgrades[71] * purchasedLevels) / 25
-  )
-
-  // Rune multiplier that gets applied to all runes
-  const allRuneExpMultiplier = [
-    // Research 4x16
-    1 + player.researches[91] / 20,
-    // Research 4x17
-    1 + player.researches[92] / 20,
-    // Cube Upgrade Bonus
-    1 + (player.ascensionCounter / 1000) * player.cubeUpgrades[32],
-    // Constant Upgrade Multiplier
-    1 + (1 / 10) * player.constantUpgrades[8],
-    // Challenge 15 reward multiplier
-    G.challenge15Rewards.runeExp.value
-  ].reduce((x, y) => x.times(y), new Decimal('1'))
-
-  return allRuneExpMultiplier.times(allRuneExpAdditiveMultiplier).times(recycleMultiplier)
-}
+// Thin shim over @synergism/logic — sources every player/G input.
+const universalRuneEXPMult = (purchasedLevels: number): Decimal =>
+  logicUniversalRuneEXPMult({
+    purchasedLevels,
+    c1Completions: player.highestchallengecompletions[1],
+    research22: player.researches[22],
+    research23: player.researches[23],
+    upgrade71: player.upgrades[71],
+    research91: player.researches[91],
+    research92: player.researches[92],
+    ascensionCounter: player.ascensionCounter,
+    cubeUpgrade32: player.cubeUpgrades[32],
+    constantUpgrade8: player.constantUpgrades[8],
+    challenge15RuneExpReward: G.challenge15Rewards.runeExp.value,
+    salvageRuneEXPMultiplier: calculateSalvageRuneEXPMultiplier()
+  })
 
 export const runes: { [K in RuneKeys]: RuneData<K, keyof RuneTypeMap[K]> } = {
   speed: {
@@ -761,49 +739,34 @@ const getRuneEXPPerOffering = (rune: RuneKeys): Decimal => {
   return runes[rune].runeEXPPerOffering(runes[rune].level)
 }
 
-const computeEXPToLevel = (rune: RuneKeys, level: number) => {
-  const levelPerOOM = getLevelsPerOOM(rune)
-  return runes[rune].costCoefficient.times(Decimal.pow(10, level / levelPerOOM).minus(1))
-}
+// Thin shims over @synergism/logic — source the rune's costCoefficient /
+// levelsPerOOM / runeEXP off the data table.
+const computeEXPToLevel = (rune: RuneKeys, level: number) =>
+  logicRuneEXPToLevel(runes[rune].costCoefficient, level, getLevelsPerOOM(rune))
 
-const computeEXPLeftToLevel = (rune: RuneKeys, level: number) => {
-  return Decimal.max(0, computeEXPToLevel(rune, level).minus(runes[rune].runeEXP))
-}
+const computeEXPLeftToLevel = (rune: RuneKeys, level: number) =>
+  logicRuneEXPLeftToLevel(runes[rune].costCoefficient, level, getLevelsPerOOM(rune), runes[rune].runeEXP)
 
-const computeOfferingsToLevel = (rune: RuneKeys, level: number) => {
-  return Decimal.max(1, computeEXPLeftToLevel(rune, level).div(getRuneEXPPerOffering(rune)).ceil())
-}
+const computeOfferingsToLevel = (rune: RuneKeys, level: number) =>
+  logicRuneOfferingsToLevel(
+    runes[rune].costCoefficient,
+    level,
+    getLevelsPerOOM(rune),
+    runes[rune].runeEXP,
+    getRuneEXPPerOffering(rune)
+  )
 
 // Gives levels to buy, total EXP to that level, and offerings required to reach that level
-const maxRuneLevelPurchaseInformation = (rune: RuneKeys, budget: Decimal) => {
-  if (!runes[rune].isUnlocked() || budget.lt(0)) {
-    return { levels: 0, expRequired: new Decimal(0), offerings: new Decimal(0) }
-  }
-
-  const runeEXPPerOffering = getRuneEXPPerOffering(rune)
-  const totalEXPAvailable = budget.times(runeEXPPerOffering).add(runes[rune].runeEXP)
-  const levelsPerOOM = getLevelsPerOOM(rune)
-  const costCoeff = runes[rune].costCoefficient
-
-  // Calculate max level we can reach with available EXP
-  // EXP formula: costCoeff * (10^(level/levelsPerOOM) - 1)
-  // Solving for level: level = levelsPerOOM * log10((EXP/costCoeff) + 1)
-  const maxLevel = Math.floor(levelsPerOOM * Decimal.log10(totalEXPAvailable.div(costCoeff).plus(1)))
-  const levelsGained = Math.max(0, maxLevel - runes[rune].level)
-
-  if (levelsGained === 0) {
-    // Can't afford any levels, return next level stuff
-    const nextLevelEXP = computeEXPToLevel(rune, runes[rune].level + 1)
-    const offeringsRequired = Decimal.max(1, nextLevelEXP.minus(runes[rune].runeEXP).div(runeEXPPerOffering).ceil())
-    return { levels: 1, expRequired: nextLevelEXP, offerings: offeringsRequired }
-  }
-
-  // Return the levels we can gain and the EXP required for that many levels
-  const expRequired = computeEXPToLevel(rune, runes[rune].level + levelsGained)
-  // Need to be recomputed since offerings required is not necessarily equal to budget.
-  const offeringsRequired = Decimal.max(1, expRequired.minus(runes[rune].runeEXP).div(runeEXPPerOffering).ceil())
-  return { levels: levelsGained, expRequired: expRequired, offerings: offeringsRequired }
-}
+const maxRuneLevelPurchaseInformation = (rune: RuneKeys, budget: Decimal) =>
+  logicMaxRuneLevelPurchase({
+    costCoefficient: runes[rune].costCoefficient,
+    levelsPerOOM: getLevelsPerOOM(rune),
+    currentLevel: runes[rune].level,
+    currentRuneEXP: runes[rune].runeEXP,
+    runeEXPPerOffering: getRuneEXPPerOffering(rune),
+    budget,
+    isUnlocked: runes[rune].isUnlocked()
+  })
 
 const levelRune = (rune: RuneKeys, timesLeveled: number, budget: Decimal) => {
   let budgetUsed: Decimal
@@ -833,9 +796,9 @@ const setRuneLevel = (rune: RuneKeys, level: number) => {
 }
 
 const updateLevelsFromEXP = (rune: RuneKeys) => {
-  const levelsPerOOM = getLevelsPerOOM(rune)
-  const levels = Math.floor(levelsPerOOM * Decimal.log10(runes[rune].runeEXP.div(runes[rune].costCoefficient).plus(1)))
-  // Floating point imprecision fix
+  const levels = logicRuneLevelFromEXP(runes[rune].runeEXP, runes[rune].costCoefficient, getLevelsPerOOM(rune))
+  // Floating point imprecision fix — the closed-form floor can undershoot
+  // by exactly one when runeEXP is sitting right on a level boundary.
   if (computeEXPLeftToLevel(rune, levels + 1).eq(0)) {
     runes[rune].level = levels + 1
   } else {

--- a/packages/web_ui/src/Shop.ts
+++ b/packages/web_ui/src/Shop.ts
@@ -1,3 +1,4 @@
+import { shopCost as logicShopCost } from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
 import { getAmbrosiaUpgradeEffects } from './BlueberryUpgrades'
@@ -237,7 +238,7 @@ interface IShopData<T extends ShopUpgradeNames, K extends keyof QuarkShopUpgrade
   maxLevel: number
   type: shopUpgradeTypes
   refundMinimumLevel: number
-  upgradeTypes: ShopUpgradeGroups[],
+  upgradeTypes: ShopUpgradeGroups[]
   freeUpgradeMultiplier?: number
 }
 
@@ -548,7 +549,7 @@ export const shopUpgrades: { [K in ShopUpgradeNames]: IShopData<K, keyof QuarkSh
     description: () => i18next.t('shop.upgradeDescriptions.cubeToQuark'),
     effects: (n) => {
       if (n >= 1) {
-        return 1.5 + 0.5 * (1 - Math.pow(0.9, n - 1)) 
+        return 1.5 + 0.5 * (1 - Math.pow(0.9, n - 1))
       } else {
         return 1 // cubeQuarkMult
       }
@@ -572,14 +573,16 @@ export const shopUpgrades: { [K in ShopUpgradeNames]: IShopData<K, keyof QuarkSh
     description: () => i18next.t('shop.upgradeDescriptions.tesseractToQuark'),
     effects: (n) => {
       if (n >= 1) {
-        return 1.5 + 0.5 * (1 - Math.pow(0.9, n - 1)) 
+        return 1.5 + 0.5 * (1 - Math.pow(0.9, n - 1))
       } else {
         return 1 // tesseractQuarkMult
       }
     },
     effectDescription () {
       const tesseractQuarkMult = getShopUpgradeEffects('tesseractToQuark', 'tesseractQuarkMult')
-      return i18next.t('shop.upgradeEffects.tesseractToQuark', { amount: formatAsPercentIncrease(tesseractQuarkMult, 1) })
+      return i18next.t('shop.upgradeEffects.tesseractToQuark', {
+        amount: formatAsPercentIncrease(tesseractQuarkMult, 1)
+      })
     },
     isUnlocked: () => player.highestchallengecompletions[11] > 0 || player.highestSingularityCount > 0,
     price: 3500,
@@ -596,14 +599,16 @@ export const shopUpgrades: { [K in ShopUpgradeNames]: IShopData<K, keyof QuarkSh
     description: () => i18next.t('shop.upgradeDescriptions.hypercubeToQuark'),
     effects: (n) => {
       if (n >= 1) {
-        return 1.5 + 0.5 * (1 - Math.pow(0.9, n - 1)) 
+        return 1.5 + 0.5 * (1 - Math.pow(0.9, n - 1))
       } else {
         return 1 // hypercubeQuarkMult
       }
     },
     effectDescription () {
       const hypercubeQuarkMult = getShopUpgradeEffects('hypercubeToQuark', 'hypercubeQuarkMult')
-      return i18next.t('shop.upgradeEffects.hypercubeToQuark', { amount: formatAsPercentIncrease(hypercubeQuarkMult, 1) })
+      return i18next.t('shop.upgradeEffects.hypercubeToQuark', {
+        amount: formatAsPercentIncrease(hypercubeQuarkMult, 1)
+      })
     },
     isUnlocked: () => player.highestchallengecompletions[13] > 0 || player.highestSingularityCount > 0,
     price: 5000,
@@ -1838,7 +1843,7 @@ export const shopUpgrades: { [K in ShopUpgradeNames]: IShopData<K, keyof QuarkSh
     resetOnSingularity: resetNever,
     refundMinimumLevel: 0,
     upgradeTypes: [ShopUpgradeGroups.RedAmbrosiaLuck],
-    freeUpgradeMultiplier: 2,
+    freeUpgradeMultiplier: 2
   },
   shopCashGrabUltra: {
     name: () => i18next.t('shop.names.shopCashGrabUltra'),
@@ -2250,19 +2255,16 @@ export const updateShopLevels = () => {
   }
 }
 
-export const getShopCosts = (input: ShopUpgradeNames) => {
-  if (
-    shopUpgrades[input].type === shopUpgradeTypes.CONSUMABLE
-    || shopUpgrades[input].maxLevel === 1
-  ) {
-    return shopUpgrades[input].price
-  } else {
-    const priceIncreaseMult = player.shopUpgrades[input]
-    return (
-      shopUpgrades[input].price + shopUpgrades[input].priceIncrease * priceIncreaseMult
-    )
-  }
-}
+// Thin shim — sources upgrade snapshot off the shop data table and the
+// player's currently-owned level.
+export const getShopCosts = (input: ShopUpgradeNames) =>
+  logicShopCost({
+    isConsumable: shopUpgrades[input].type === shopUpgradeTypes.CONSUMABLE,
+    maxLevel: shopUpgrades[input].maxLevel,
+    price: shopUpgrades[input].price,
+    priceIncrease: shopUpgrades[input].priceIncrease,
+    currentLevel: player.shopUpgrades[input]
+  })
 
 export const createShopHTML = (input: ShopUpgradeNames) => {
   const name = shopUpgrades[input].name()

--- a/packages/web_ui/src/SingularityChallenges.ts
+++ b/packages/web_ui/src/SingularityChallenges.ts
@@ -1,3 +1,34 @@
+import {
+  limitedAscensionsAchievementPointValue as logicLimitedAscensionsAP,
+  limitedAscensionsEffect as logicLimitedAscensionsEffect,
+  limitedAscensionsSingularityRequirement as logicLimitedAscensionsSR,
+  limitedTimeAchievementPointValue as logicLimitedTimeAP,
+  limitedTimeEffect as logicLimitedTimeEffect,
+  limitedTimeSingularityRequirement as logicLimitedTimeSR,
+  noAmbrosiaUpgradesAchievementPointValue as logicNoAmbrosiaAP,
+  noAmbrosiaUpgradesEffect as logicNoAmbrosiaEffect,
+  noAmbrosiaUpgradesSingularityRequirement as logicNoAmbrosiaSR,
+  noOcteractsAchievementPointValue as logicNoOcteractsAP,
+  noOcteractsEffect as logicNoOcteractsEffect,
+  noOcteractsSingularityRequirement as logicNoOcteractsSR,
+  noQuarkUpgradesAchievementPointValue as logicNoQuarkAP,
+  noQuarkUpgradesEffect as logicNoQuarkEffect,
+  noQuarkUpgradesSingularityRequirement as logicNoQuarkSR,
+  noSingularityUpgradesAchievementPointValue as logicNoSingAP,
+  noSingularityUpgradesEffect as logicNoSingEffect,
+  noSingularityUpgradesSingularityRequirement as logicNoSingSR,
+  oneChallengeCapAchievementPointValue as logicOneChalCapAP,
+  oneChallengeCapEffect as logicOneChalCapEffect,
+  oneChallengeCapSingularityRequirement as logicOneChalCapSR,
+  sadisticPrequelAchievementPointValue as logicSadisticAP,
+  sadisticPrequelEffect as logicSadisticEffect,
+  sadisticPrequelSingularityRequirement as logicSadisticSR,
+  type SingularityChallengeDataKeys as LogicSingularityChallengeDataKeys,
+  type SingularityChallengeRewards as LogicSingularityChallengeRewards,
+  taxmanLastStandAchievementPointValue as logicTaxmanAP,
+  taxmanLastStandEffect as logicTaxmanEffect,
+  taxmanLastStandSingularityRequirement as logicTaxmanSR
+} from '@synergism/logic'
 import i18next from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import {
@@ -14,86 +45,10 @@ import { Alert, Confirm } from './UpdateHTML'
 import { toOrdinal } from './Utility'
 import { Globals as G } from './Variables'
 
-export type SingularityChallengeRewards = {
-  noSingularityUpgrades: {
-    cubes: number
-    goldenQuarks: number
-    blueberries: number
-    shopUpgrade: boolean
-    additiveLuckMult: number
-    shopUpgrade2: boolean
-  }
-  oneChallengeCap: {
-    corrScoreIncrease: number
-    blueberrySpeedMult: number
-    capIncrease: number
-    freeCorruptionLevel: number
-    shopUpgrade: boolean
-    reinCapIncrease2: number
-    ascCapIncrease2: number
-  }
-  noOcteracts: {
-    octeractPow: number
-    offeringBonus: boolean
-    obtainiumBonus: boolean
-    shopUpgrade: boolean
-  }
-  limitedAscensions: {
-    ascensionSpeedMult: number
-    hepteractCap: boolean
-    shopUpgrade: boolean
-    shopUpgrade2: boolean
-  }
-  noAmbrosiaUpgrades: {
-    bonusAmbrosia: number
-    blueberries: number
-    additiveLuckMult: number
-    ambrosiaLuck: number
-    redLuck: number
-    blueberrySpeedMult: number
-    redSpeedMult: number
-    shopUpgrade: boolean
-    shopUpgrade2: boolean
-  }
-  noQuarkUpgrades: {
-    freeObtainiumLevels: number
-    freeOfferingLevels: number
-    freeSpeedLevels: number
-    freeCubeLevels: number
-    freeQuarkLevel: number
-    freeInfinityLevels: number
-    shopUpgrade: boolean
-    topHatUnlock: boolean
-  }
-  limitedTime: {
-    preserveQuarks: boolean
-    quarkMult: number
-    globalSpeed: number
-    ascensionSpeed: number
-    barRequirementMultiplier: number
-    shopUpgrade: boolean
-    shopUpgrade2: boolean
-  }
-  sadisticPrequel: {
-    extraFree: number
-    quarkMult: number
-    freeUpgradeMult: number
-    shopUpgrade: boolean
-    shopUpgrade2: boolean
-    shopUpgrade3: boolean
-  }
-  taxmanLastStand: {
-    horseShoeUnlock: boolean
-    shopUpgrade: boolean
-    talismanUnlock: boolean
-    talismanFreeLevel: number
-    talismanRuneEffect: number
-    antiquityOOM: number
-    horseShoeOOM: number
-  }
-}
-
-export type SingularityChallengeDataKeys = keyof SingularityChallengeRewards
+// Re-exported from @synergism/logic so existing call sites that import
+// these types from this module keep compiling unchanged.
+export type SingularityChallengeRewards = LogicSingularityChallengeRewards
+export type SingularityChallengeDataKeys = LogicSingularityChallengeDataKeys
 
 interface ISingularityChallengeData {
   baseReq: number
@@ -398,89 +353,33 @@ export const singularityChallengeData: {
     maxCompletions: 15,
     unlockSingularity: 25,
     HTMLTag: 'noSingularityUpgrades',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      return baseReq + 16 * completions + 8 * (completions >= 9 ? 1 : 0)
-    },
-    achievementPointValue: (n) => {
-      return 15 * n
-    },
+    singularityRequirement: logicNoSingSR,
+    achievementPointValue: logicNoSingAP,
     scalingrewardcount: 2,
     uniquerewardcount: 5,
-    effect: (n, key) => {
-      if (key === 'cubes') {
-        return 1 + n
-      } else if (key === 'goldenQuarks') {
-        return 1 + 0.12 * +(n > 0)
-      } else if (key === 'blueberries') {
-        return +(n > 0)
-      } else if (key === 'shopUpgrade') {
-        return n >= 10
-      } else if (key === 'additiveLuckMult') {
-        return n >= 15 ? 0.05 : 0
-      } else {
-        return n >= 15 // shopUpgrade2
-      }
-    }
+    effect: logicNoSingEffect
   },
   oneChallengeCap: {
     baseReq: 10,
     maxCompletions: 15,
     unlockSingularity: 40,
     HTMLTag: 'oneChallengeCap',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      return baseReq + 19 * completions - 2 * (completions >= 14 ? 1 : 0)
-    },
-    achievementPointValue: (n) => {
-      return 15 * n
-    },
+    singularityRequirement: logicOneChalCapSR,
+    achievementPointValue: logicOneChalCapAP,
     scalingrewardcount: 3,
     uniquerewardcount: 4,
-    effect: (n, key) => {
-      if (key === 'corrScoreIncrease') {
-        return 0.05 * n
-      } else if (key === 'blueberrySpeedMult') {
-        return (1 + n / 60)
-      } else if (key === 'capIncrease') {
-        return 3 * +(n > 0)
-      } else if (key === 'freeCorruptionLevel') {
-        return +(n >= 12)
-      } else if (key === 'shopUpgrade') {
-        return n >= 12
-      } else if (key === 'reinCapIncrease2') {
-        return 7 * +(n >= 15)
-      } else {
-        return 2 * +(n >= 15) // ascCapIncrease2
-      }
-    }
+    effect: logicOneChalCapEffect
   },
   noOcteracts: {
     baseReq: 75,
     maxCompletions: 15,
     unlockSingularity: 100,
-    achievementPointValue: (n) => {
-      return 20 * n
-    },
+    achievementPointValue: logicNoOcteractsAP,
     HTMLTag: 'noOcteracts',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      if (completions < 10) {
-        return baseReq + 13 * completions
-      } else {
-        return baseReq + 13 * 9 + 10 * (completions - 9)
-      }
-    },
+    singularityRequirement: logicNoOcteractsSR,
     scalingrewardcount: 2,
     uniquerewardcount: 3,
-    effect: (n, key) => {
-      if (key === 'octeractPow') {
-        return (n <= 10) ? 0.02 * n : 0.2 + (n - 10) / 100
-      } else if (key === 'offeringBonus') {
-        return n > 0
-      } else if (key === 'obtainiumBonus') {
-        return n >= 10
-      } else {
-        return n >= 10 // shopUpgrade
-      }
-    },
+    effect: logicNoOcteractsEffect,
     alternateDescription: () => {
       const completions = player.singularityChallenges.noOcteracts.completions
       let stringText = i18next.t('singularityChallenge.data.noOcteracts.description')
@@ -498,26 +397,12 @@ export const singularityChallengeData: {
     baseReq: 7,
     maxCompletions: 10,
     unlockSingularity: 50,
-    achievementPointValue: (n) => {
-      return 30 * n
-    },
+    achievementPointValue: logicLimitedAscensionsAP,
     HTMLTag: 'limitedAscensions',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      return baseReq + 27 * completions
-    },
+    singularityRequirement: logicLimitedAscensionsSR,
     scalingrewardcount: 2,
     uniquerewardcount: 3,
-    effect: (n, key) => {
-      if (key === 'ascensionSpeedMult') {
-        return 1 + 0.25 * n / 100
-      } else if (key === 'hepteractCap') {
-        return n > 0
-      } else if (key === 'shopUpgrade') {
-        return n >= 8
-      } else {
-        return n >= 10 // shopUpgrade2
-      }
-    },
+    effect: logicLimitedAscensionsEffect,
     alternateDescription: () => {
       const ascensionLimit = calculateExalt3AscensionLimit(player.singularityChallenges.limitedAscensions.completions)
       const baseDesc = i18next.t('singularityChallenge.data.limitedAscensions.description')
@@ -535,79 +420,23 @@ export const singularityChallengeData: {
     baseReq: 150,
     maxCompletions: 15,
     unlockSingularity: 166,
-    achievementPointValue: (n) => {
-      return 25 * n
-    },
+    achievementPointValue: logicNoAmbrosiaAP,
     HTMLTag: 'noAmbrosiaUpgrades',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      if (completions < 10) {
-        return baseReq + 12 * completions
-      } else {
-        return baseReq + 12 * 9 + 4 * (completions - 9)
-      }
-    },
+    singularityRequirement: logicNoAmbrosiaSR,
     scalingrewardcount: 5,
     uniquerewardcount: 8,
-    effect: (n, key) => {
-      if (key === 'bonusAmbrosia') {
-        return +(n > 0)
-      } else if (key === 'blueberries') {
-        return Math.floor(n / 5) + +(n > 0)
-      } else if (key === 'additiveLuckMult') {
-        return n / 200
-      } else if (key === 'ambrosiaLuck') {
-        return 20 * n
-      } else if (key === 'redLuck') {
-        return 4 * n
-      } else if (key === 'blueberrySpeedMult') {
-        return 1 + n / 25
-      } else if (key === 'redSpeedMult') {
-        return 1 + 2 * n / 100
-      } else if (key === 'shopUpgrade') {
-        return n >= 8
-      } else {
-        return n >= 10 // shopUpgrade2
-      }
-    }
+    effect: logicNoAmbrosiaEffect
   },
   noQuarkUpgrades: {
     baseReq: 20,
     maxCompletions: 10,
     unlockSingularity: 66,
-    achievementPointValue: (n) => {
-      return 20 * n
-    },
+    achievementPointValue: logicNoQuarkAP,
     HTMLTag: 'noQuarkUpgrades',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      if (completions > 5) {
-        return baseReq + 185 + 8 * (completions - 6)
-      } else if (completions > 2) {
-        return baseReq + 70 + 9 * (completions - 6)
-      } else {
-        return baseReq + 15 * completions
-      }
-    },
+    singularityRequirement: logicNoQuarkSR,
     scalingrewardcount: 6,
     uniquerewardcount: 3,
-    effect: (n, key) => {
-      if (key === 'freeObtainiumLevels') {
-        return n
-      } else if (key === 'freeOfferingLevels') {
-        return n
-      } else if (key === 'freeSpeedLevels') {
-        return n
-      } else if (key === 'freeCubeLevels') {
-        return n
-      } else if (key === 'freeQuarkLevel') {
-        return n >= 5 ? 1 : 0
-      } else if (key === 'freeInfinityLevels') {
-        return n
-      } else if (key === 'shopUpgrade') {
-        return n >= 1
-      } else {
-        return n >= 10 // topHatUnlock
-      }
-    },
+    effect: logicNoQuarkEffect,
     alternateDescription: () => {
       const introText = i18next.t('singularityChallenge.data.noQuarkUpgrades.description')
       const chalText = i18next.t('singularityChallenge.data.noQuarkUpgrades.challengeDesc')
@@ -618,36 +447,12 @@ export const singularityChallengeData: {
     baseReq: 203,
     maxCompletions: 15,
     unlockSingularity: 216,
-    achievementPointValue: (n) => {
-      return 30 * n
-    },
+    achievementPointValue: logicLimitedTimeAP,
     HTMLTag: 'limitedTime',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      if (completions > 9) {
-        return 277 + 2 * (completions - 10)
-      } else {
-        return baseReq + 8 * completions
-      }
-    },
+    singularityRequirement: logicLimitedTimeSR,
     scalingrewardcount: 5,
     uniquerewardcount: 3,
-    effect: (n, key) => {
-      if (key === 'preserveQuarks') {
-        return +(n > 0)
-      } else if (key === 'quarkMult') {
-        return 1 + 0.02 * n
-      } else if (key === 'globalSpeed') {
-        return 1 + 0.12 * n
-      } else if (key === 'ascensionSpeed') {
-        return 1 + 0.12 * n
-      } else if (key === 'barRequirementMultiplier') {
-        return 1 - 0.02 * n
-      } else if (key === 'shopUpgrade') {
-        return n >= 5
-      } else {
-        return n >= 10 // shopUpgrade2
-      }
-    },
+    effect: logicLimitedTimeEffect,
     alternateDescription: () => {
       const completions = player.singularityChallenges.limitedTime.completions
       const baseDesc = i18next.t('singularityChallenge.data.limitedTime.description')
@@ -669,61 +474,23 @@ export const singularityChallengeData: {
     baseReq: 120,
     maxCompletions: 15,
     unlockSingularity: 256,
-    achievementPointValue: (n) => {
-      return 40 * n
-    },
+    achievementPointValue: logicSadisticAP,
     HTMLTag: 'sadisticPrequel',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      return baseReq + 8 * completions
-    },
+    singularityRequirement: logicSadisticSR,
     scalingrewardcount: 3,
     uniquerewardcount: 4,
-    effect: (n, key) => {
-      if (key === 'extraFree') {
-        return 50 * +(n > 0)
-      } else if (key === 'quarkMult') {
-        return 1 + 0.06 * n
-      } else if (key === 'freeUpgradeMult') {
-        return 1 + 0.06 * n
-      } else if (key === 'shopUpgrade') {
-        return n >= 5
-      } else if (key === 'shopUpgrade2') {
-        return n >= 10
-      } else {
-        return n >= 15 // shopUpgrade3
-      }
-    }
+    effect: logicSadisticEffect
   },
   taxmanLastStand: {
     baseReq: 240,
     maxCompletions: 10,
     unlockSingularity: 281,
-    achievementPointValue: (n) => {
-      return 50 * n
-    },
+    achievementPointValue: logicTaxmanAP,
     HTMLTag: 'taxmanLastStand',
-    singularityRequirement: (baseReq: number, completions: number) => {
-      return baseReq + 4 * completions
-    },
+    singularityRequirement: logicTaxmanSR,
     scalingrewardcount: 5,
     uniquerewardcount: 3,
-    effect: (n, key) => {
-      if (key === 'horseShoeUnlock') {
-        return n > 0
-      } else if (key === 'shopUpgrade') {
-        return n >= 5
-      } else if (key === 'talismanUnlock') {
-        return n >= 10
-      } else if (key === 'talismanFreeLevel') {
-        return 25 * n
-      } else if (key === 'talismanRuneEffect') {
-        return 0.03 * n
-      } else if (key === 'antiquityOOM') {
-        return 1 / 50 * n / 10
-      } else {
-        return 1 / 20 * n / 10 // horseShoeOOM
-      }
-    },
+    effect: logicTaxmanEffect,
     alternateDescription: () => {
       const completions = player.singularityChallenges.taxmanLastStand.completions
       const baseDesc = i18next.t('singularityChallenge.data.taxmanLastStand.description')

--- a/packages/web_ui/src/Talismans.ts
+++ b/packages/web_ui/src/Talismans.ts
@@ -3,12 +3,15 @@ import {
   chronosTalismanEffects as logicChronosTalismanEffects,
   cookieGrandmaTalismanEffects as logicCookieGrandmaTalismanEffects,
   exemptionTalismanEffects as logicExemptionTalismanEffects,
+  exponentialCostProgression as logicExponentialCostProgression,
   horseShoeTalismanEffects as logicHorseShoeTalismanEffects,
   metaphysicsTalismanEffects as logicMetaphysicsTalismanEffects,
   midasTalismanEffects as logicMidasTalismanEffects,
   mortuusTalismanEffects as logicMortuusTalismanEffects,
   plasticTalismanEffects as logicPlasticTalismanEffects,
   polymathTalismanEffects as logicPolymathTalismanEffects,
+  regularCostProgression as logicRegularCostProgression,
+  type TalismanCraftItems as LogicTalismanCraftItems,
   wowSquareTalismanEffects as logicWowSquareTalismanEffects
 } from '@synergism/logic'
 import Decimal from 'break_infinity.js'
@@ -36,14 +39,9 @@ interface TalismanFragmentCost {
   offerings: number
 }
 
-export type TalismanCraftItems =
-  | 'shard'
-  | 'commonFragment'
-  | 'uncommonFragment'
-  | 'rareFragment'
-  | 'epicFragment'
-  | 'legendaryFragment'
-  | 'mythicalFragment'
+// Re-exported from @synergism/logic so existing call sites that import
+// `TalismanCraftItems` from this module keep compiling unchanged.
+export type TalismanCraftItems = LogicTalismanCraftItems
 
 const talismanResourceCosts: Record<TalismanCraftItems, TalismanFragmentCost> = {
   shard: {
@@ -138,78 +136,10 @@ interface TalismanData<K extends TalismanKeys> {
   fragmentsInvested: Record<TalismanCraftItems, Decimal>
 }
 
-const regularCostProgression = (baseMult: Decimal, level: number): Record<TalismanCraftItems, Decimal> => {
-  let priceMult = baseMult
-  if (level >= 120) {
-    priceMult = priceMult.times((level - 90) / 30)
-  }
-  if (level >= 150) {
-    priceMult = priceMult.times((level - 120) / 30)
-  }
-  if (level >= 180) {
-    priceMult = priceMult.times((level - 170) / 10)
-  }
-
-  const shardCost = Decimal.pow(level, 3).times(1 / 8).plus(1).floor().times(priceMult)
-  const commonCost = level >= 30
-    ? Decimal.pow(level - 30, 3).times(1 / 32).plus(1).floor().times(priceMult)
-    : new Decimal(0)
-  const uncommonCost = level >= 60
-    ? Decimal.pow(level - 60, 3).times(1 / 384).plus(1).floor().times(priceMult)
-    : new Decimal(0)
-  const rareCost = level >= 90
-    ? Decimal.pow(level - 90, 3).times(1 / 500).plus(1).floor().times(priceMult)
-    : new Decimal(0)
-  const epicCost = level >= 120
-    ? Decimal.pow(level - 120, 3).times(1 / 375).plus(1).floor().times(priceMult)
-    : new Decimal(0)
-  const legendaryCost = level >= 150
-    ? Decimal.pow(level - 150, 3).times(1 / 192).plus(1).floor().times(priceMult)
-    : new Decimal(0)
-  const mythicalCost = level >= 150
-    ? Decimal.pow(level - 150, 3).times(1 / 1280).plus(1).floor().times(priceMult)
-    : new Decimal(0)
-
-  return {
-    'shard': Decimal.max(0, shardCost),
-    'commonFragment': Decimal.max(0, commonCost),
-    'uncommonFragment': Decimal.max(0, uncommonCost),
-    'rareFragment': Decimal.max(0, rareCost),
-    'epicFragment': Decimal.max(0, epicCost),
-    'legendaryFragment': Decimal.max(0, legendaryCost),
-    'mythicalFragment': Decimal.max(0, mythicalCost)
-  }
-}
-
-const exponentialCostProgression = (
-  baseMult: Decimal,
-  level: number,
-  ratio: number
-): Record<TalismanCraftItems, Decimal> => {
-  const baseMultDecimal = new Decimal(baseMult)
-
-  return {
-    shard: Decimal.pow(ratio, level).times(baseMultDecimal).times(100).floor(),
-    commonFragment: level >= 30
-      ? Decimal.pow(ratio, level - 30).times(baseMultDecimal).times(50).floor()
-      : new Decimal(0),
-    uncommonFragment: level >= 60
-      ? Decimal.pow(ratio, level - 60).times(baseMultDecimal).times(25).floor()
-      : new Decimal(0),
-    rareFragment: level >= 90
-      ? Decimal.pow(ratio, level - 90).times(baseMultDecimal).times(20).floor()
-      : new Decimal(0),
-    epicFragment: level >= 120
-      ? Decimal.pow(ratio, level - 120).times(baseMultDecimal).times(15).floor()
-      : new Decimal(0),
-    legendaryFragment: level >= 150
-      ? Decimal.pow(ratio, level - 150).times(baseMultDecimal).times(10).floor()
-      : new Decimal(0),
-    mythicalFragment: level >= 150
-      ? Decimal.pow(ratio, level - 150).times(baseMultDecimal).times(5).floor()
-      : new Decimal(0)
-  }
-}
+// Cost-progression formulas moved into @synergism/logic — these two aliases
+// preserve the legacy local-name call sites in the talisman data block below.
+const regularCostProgression = logicRegularCostProgression
+const exponentialCostProgression = logicExponentialCostProgression
 
 const universalTalismanMaxLevelIncreasers = () => {
   return (

--- a/packages/web_ui/src/Tax.ts
+++ b/packages/web_ui/src/Tax.ts
@@ -1,164 +1,125 @@
+import {
+  calculateCoinProduction as logicCalculateCoinProduction,
+  calculateTax as logicCalculateTax
+} from '@synergism/logic'
 import { calculateBuildingPowerCoinMultiplier, player } from './Synergism'
 import { sumContents } from './Utility'
 import { Globals as G } from './Variables'
 
-import Decimal from 'break_infinity.js'
 import { awardUngroupedAchievement, getAchievementReward } from './Achievements'
-import { CalcECC } from './Challenges'
 import { getAntUpgradeEffect } from './Features/Ants/AntUpgrades/lib/upgrade-effects'
 import { AntUpgrades } from './Features/Ants/AntUpgrades/structs/structs'
 import { calculateTaxPlatonicBlessing } from './PlatonicCubes'
 import { getRuneEffects } from './Runes'
 import { getTalismanEffects } from './Talismans'
 
+// Thin shim over @synergism/logic. Sources every coin-tier / globalCoinMulti
+// input from player and G, calls into logic for the production aggregation
+// AND the tax exponent / divisor formula, then writes the results back to G
+// and fires the overtaxed achievement if the returned flag says to.
 export const calculatetax = () => {
-  let exp = 1
-  // To 2020 Platonic: Why the HELL is this done here???
-  G.produceFirst = (player.firstGeneratedCoin.add(player.firstOwnedCoin)).times(G.globalCoinMultiplier).times(
-    G.coinOneMulti
-  )
-    .times(player.firstProduceCoin)
-  G.produceSecond = (player.secondGeneratedCoin.add(player.secondOwnedCoin)).times(G.globalCoinMultiplier).times(
-    G.coinTwoMulti
-  )
-    .times(player.secondProduceCoin)
-  G.produceThird = (player.thirdGeneratedCoin.add(player.thirdOwnedCoin)).times(G.globalCoinMultiplier).times(
-    G.coinThreeMulti
-  )
-    .times(player.thirdProduceCoin)
-  G.produceFourth = (player.fourthGeneratedCoin.add(player.fourthOwnedCoin)).times(G.globalCoinMultiplier).times(
-    G.coinFourMulti
-  )
-    .times(player.fourthProduceCoin)
-  G.produceFifth = (player.fifthGeneratedCoin.add(player.fifthOwnedCoin)).times(G.globalCoinMultiplier).times(
-    G.coinFiveMulti
-  )
-    .times(player.fifthProduceCoin)
-  G.produceTotal = G.produceFirst.add(G.produceSecond).add(G.produceThird).add(G.produceFourth)
-    .add(G.produceFifth)
+  // Per-tier coin production — pure aggregation over five tiers + clamping.
+  const production = logicCalculateCoinProduction({
+    first: {
+      generated: player.firstGeneratedCoin,
+      owned: player.firstOwnedCoin,
+      coinMulti: G.coinOneMulti,
+      produceCoin: player.firstProduceCoin
+    },
+    second: {
+      generated: player.secondGeneratedCoin,
+      owned: player.secondOwnedCoin,
+      coinMulti: G.coinTwoMulti,
+      produceCoin: player.secondProduceCoin
+    },
+    third: {
+      generated: player.thirdGeneratedCoin,
+      owned: player.thirdOwnedCoin,
+      coinMulti: G.coinThreeMulti,
+      produceCoin: player.thirdProduceCoin
+    },
+    fourth: {
+      generated: player.fourthGeneratedCoin,
+      owned: player.fourthOwnedCoin,
+      coinMulti: G.coinFourMulti,
+      produceCoin: player.fourthProduceCoin
+    },
+    fifth: {
+      generated: player.fifthGeneratedCoin,
+      owned: player.fifthOwnedCoin,
+      coinMulti: G.coinFiveMulti,
+      produceCoin: player.fifthProduceCoin
+    },
+    globalCoinMultiplier: G.globalCoinMultiplier
+  })
 
-  if (G.produceFirst.lte(.0001)) {
-    G.produceFirst = new Decimal(0)
-  }
-  if (G.produceSecond.lte(.0001)) {
-    G.produceSecond = new Decimal(0)
-  }
-  if (G.produceThird.lte(.0001)) {
-    G.produceThird = new Decimal(0)
-  }
-  if (G.produceFourth.lte(.0001)) {
-    G.produceFourth = new Decimal(0)
-  }
-  if (G.produceFifth.lte(.0001)) {
-    G.produceFifth = new Decimal(0)
-  }
+  G.produceFirst = production.first
+  G.produceSecond = production.second
+  G.produceThird = production.third
+  G.produceFourth = production.fourth
+  G.produceFifth = production.fifth
+  G.produceTotal = production.total
+  G.producePerSecond = production.perSecond
 
-  G.producePerSecond = G.produceTotal.times(40)
+  // Tax exponent / divisor / overtaxed-achievement flag.
+  const tax = logicCalculateTax({
+    inReinc6: player.currentChallenge.reincarnation === 6,
+    inReinc9: player.currentChallenge.reincarnation === 9,
+    inAscension15: player.currentChallenge.ascension === 15,
+    inAscension13: player.currentChallenge.ascension === 13,
+    c6Completions: player.challengecompletions[6],
+    c13Completions: player.challengecompletions[13],
 
-  if (player.currentChallenge.reincarnation === 6) {
-    exp = 3 * Math.pow(1 + player.challengecompletions[6] / 25, 2)
+    totalChallengeCompletions: sumContents(player.challengecompletions),
+    c11Completions: player.challengecompletions[11],
+    c12Completions: player.challengecompletions[12],
+    c14Completions: player.challengecompletions[14],
+    c15Completions: player.challengecompletions[15],
+    singularityCount: player.singularityCount,
+
+    research51: player.researches[51],
+    research52: player.researches[52],
+    research53: player.researches[53],
+    research54: player.researches[54],
+    research55: player.researches[55],
+    research159: player.researches[159],
+    research200: player.researches[200],
+    cubeUpgrade50: player.cubeUpgrades[50],
+    platonicUpgrade5: player.platonicUpgrades[5],
+    platonicUpgrade10: player.platonicUpgrades[10],
+    taxPlatonicBlessing: calculateTaxPlatonicBlessing(),
+    upgrade121: player.upgrades[121],
+    upgrade125: player.upgrades[125],
+    c10Completions: player.challengecompletions[10],
+
+    highestSingularityCount: player.highestSingularityCount,
+    taxmanLastStandEnabled: player.singularityChallenges.taxmanLastStand.enabled,
+    ascensionsUnlocked: player.unlocks.ascensions,
+    highestC14Completions: player.highestchallengecompletions[14],
+
+    taxReductionAchievement: +getAchievementReward('taxReduction'),
+    duplicationRuneTaxReduction: getRuneEffects('duplication', 'taxReduction'),
+    thriftRuneTaxReduction: getRuneEffects('thrift', 'taxReduction'),
+    antTaxReduction: getAntUpgradeEffect(AntUpgrades.Taxes).taxReduction,
+    exemptionTalismanTaxReduction: getTalismanEffects('exemption').taxReduction,
+    challenge15TaxesReward: G.challenge15Rewards.taxes.value,
+    campaignTaxMultiplier: player.campaigns.taxMultiplier,
+
+    ascendShards: player.ascendShards,
+    rareFragments: player.rareFragments,
+    fortunaeFormicidaeCoinMultiplier: getAntUpgradeEffect(AntUpgrades.Coins).coinMultiplier,
+    buildingPowerCoinMultiplier: calculateBuildingPowerCoinMultiplier(),
+
+    produceTotal: production.total
+  })
+
+  G.maxexponent = tax.maxexponent
+  G.taxdivisor = tax.taxdivisor
+  G.taxdivisorcheck = tax.taxdivisorcheck
+
+  // Side-effect: overtaxed achievement — logic returns the gate condition,
+  // we fire the achievement call here so logic stays free of UI hooks.
+  if (tax.shouldAwardOvertaxed) {
+    awardUngroupedAchievement('overtaxed')
   }
-  if (player.currentChallenge.reincarnation === 9) {
-    exp = 0.005
-  }
-  if (player.currentChallenge.ascension === 15) {
-    exp = 0.000005
-  }
-  // im doing this to spite xander, basically changes w5x9 to not impact tax scaling in c13 || Sean#7236
-  const c13effcompletions = Math.max(
-    0,
-    sumContents(player.challengecompletions) - player.challengecompletions[11] - player.challengecompletions[12]
-      - player.challengecompletions[13] - player.challengecompletions[14] - player.challengecompletions[15]
-      - ((player.singularityCount >= 15) ? 4 : 0)
-      - ((player.singularityCount >= 20) ? 1 : 0)
-  )
-  if (player.currentChallenge.ascension === 13) {
-    exp *= 400 * (1 + 1 / 6 * player.challengecompletions[13])
-    exp *= Math.pow(1.05, c13effcompletions)
-  }
-  if (player.challengecompletions[6] > 0) {
-    exp /= 1.075
-  }
-  let exponent = 1
-  exponent *= exp
-  exponent *= 1 - 0.06 * player.researches[51]
-  exponent *= 1 - 0.05 * player.researches[52]
-  exponent *= 1 - 0.05 * player.researches[53]
-  exponent *= 1 - 0.05 * player.researches[54]
-  exponent *= 1 - 0.05 * player.researches[55]
-  exponent *= +getAchievementReward('taxReduction')
-  exponent *= Math.pow(0.965, CalcECC('reincarnation', player.challengecompletions[6]))
-  exponent *= getRuneEffects('duplication', 'taxReduction')
-  exponent *= getRuneEffects('thrift', 'taxReduction')
-  exponent *= getAntUpgradeEffect(AntUpgrades.Taxes).taxReduction
-  exponent *= 1
-    / Math.pow(
-      1 + Decimal.log(player.ascendShards.add(1), 10),
-      1 + 1 / 300 * player.challengecompletions[10] * player.upgrades[125] + 0.1 * player.platonicUpgrades[5]
-        + 0.2 * player.platonicUpgrades[10] + calculateTaxPlatonicBlessing()
-    )
-  exponent *= 1 + getTalismanEffects('exemption').taxReduction
-  exponent *= Math.pow(0.98, 3 / 5 * Decimal.log(player.rareFragments.add(1), 10) * player.researches[159])
-  exponent *= Math.pow(0.966, CalcECC('ascension', player.challengecompletions[13]))
-  exponent *= 1 - 0.666 * player.researches[200] / 100000
-  exponent *= 1 - 0.666 * player.cubeUpgrades[50] / 100000
-  exponent *= G.challenge15Rewards.taxes.value
-  exponent *= player.campaigns.taxMultiplier
-  if (player.upgrades[121] > 0) {
-    exponent *= 0.5
-  }
-
-  if (player.highestSingularityCount >= 281) {
-    exponent *= 0.5
-  }
-
-  if (player.singularityChallenges.taxmanLastStand.enabled) {
-    if (player.unlocks.ascensions) {
-      exponent *= 4
-    }
-    if (player.highestchallengecompletions[14] > 0) {
-      exponent *= 5
-    }
-  }
-
-  // Cap the calculation overflow bug || httpsnet
-  if (exponent < 1e-300) {
-    exponent = 1e-300
-  }
-
-  // Ant Upgrade "Fortunae Formicidae" gives a flat max exponent increase equal to its coin multi
-  // It multiplies the coin production but is also tax-exempt, which we do by increasing the tax cap
-  // While also deducting the log value from `exponentForDivisor`.
-  // Implementing this was much more difficult than it needed to be.
-  let flatMaxExponentIncrease = Decimal.log(getAntUpgradeEffect(AntUpgrades.Coins).coinMultiplier, 10)
-  flatMaxExponentIncrease += Decimal.log(calculateBuildingPowerCoinMultiplier(), 10)
-
-  G.maxexponent = Math.floor(275 / (Decimal.log(1.01, 10) * exponent)) - 1 + flatMaxExponentIncrease
-
-  const exponentForDivisor = Math.max(
-    0,
-    Math.min(G.maxexponent, Math.floor(Decimal.log(G.produceTotal.add(1), 10))) - flatMaxExponentIncrease
-  )
-  const exponentForWarning = Math.max(0, G.maxexponent - flatMaxExponentIncrease)
-
-  if (player.currentChallenge.ascension === 13 && (G.maxexponent - flatMaxExponentIncrease) <= 99999) {
-    // i don't think it makes sense to give the achievement as soon as the challenge is opened
-    // as soon as the challenge is opened you don't have enough tax reducers to have max exponent above 100000
-    // so for the achievement description to make sense i think it should require at least 1 challenge completion || Dorijanko
-    if (c13effcompletions >= 1) {
-      awardUngroupedAchievement('overtaxed')
-    }
-  }
-
-  const divisorExponent = 1 / 550 * Math.pow(exponentForDivisor, 2)
-  // Not exactly clear why this is needed?
-  const checkExponent = 1 / 550 * Math.pow(exponentForWarning, 2)
-
-  // After the ants update, I really should get rid of these bad globals
-
-  // November 11, 2025: Platonic re-derived these equations to understand why this works.
-  // If you write this value out, you end up getting a function whose log is O(exponent^-1),
-  // Which is intentional.
-  G.taxdivisor = Decimal.pow(1.01, divisorExponent * exponent)
-  G.taxdivisorcheck = Decimal.pow(1.01, checkExponent * exponent)
 }

--- a/packages/web_ui/src/singularity.ts
+++ b/packages/web_ui/src/singularity.ts
@@ -1,10 +1,15 @@
 import {
   actualGQUpgradeTotalLevels as logicActualGQUpgradeTotalLevels,
   calculateEffectiveSingularities as logicCalcEffectiveSingularities,
+  calculateNextSpike as logicCalculateNextSpike,
   calculateSingularityDebuff as logicCalcSingularityDebuff,
   computeGQUpgradeMaxLevel as logicComputeGQUpgradeMaxLevel,
+  goldenQuarkCost as logicGoldenQuarkCost,
   gqFreeLevelMultiplier as logicGqFreeLevelMultiplier,
+  gqUpgradeCostTNL as logicGqUpgradeCostTNL,
   gqUpgradeFreeLevelSoftcap as logicGqUpgradeFreeLevelSoftcap,
+  type GQUpgradeSpecialCostForm,
+  maxSingularityLookahead as logicMaxSingularityLookahead,
   type SingularityDebuff
 } from '@synergism/logic'
 import i18next from 'i18next'
@@ -150,7 +155,6 @@ type GoldenQuarkUpgradeRewards = {
 export type SingularityDataKeys = keyof GoldenQuarkUpgradeRewards
 
 const tokenInheritanceTokens = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
-const singularityPenaltyThresholds = [11, 26, 37, 51, 101, 151, 201, 216, 230, 270]
 
 export const updateSingularityPenalties = (): void => {
   const singularityCount = player.singularityCount
@@ -2349,49 +2353,19 @@ export function updateMobileGQHTML (k: SingularityDataKeys) {
 }
 
 /**
- * Get the cost for upgrading once. Returns 0 if maxed.
+ * Get the cost for upgrading once. Returns 0 if maxed. Thin shim over
+ * @synergism/logic's gqUpgradeCostTNL — sources the upgrade snapshot off
+ * the data table and the computed-max-level off the matching shim.
  */
 export function getGQUpgradeCostTNL (upgradeKey: SingularityDataKeys): number {
   const upgrade = goldenQuarkUpgrades[upgradeKey]
-  let costMultiplier = 1
-
-  if (computeGQUpgradeMaxLevel(upgradeKey) === upgrade.level) {
-    return 0
-  }
-
-  // Overcap
-  if (computeGQUpgradeMaxLevel(upgradeKey) > upgrade.maxLevel && upgrade.level >= upgrade.maxLevel) {
-    costMultiplier *= Math.pow(4, upgrade.level - upgrade.maxLevel + 1)
-  }
-
-  if (upgrade.specialCostForm === 'Exponential2') {
-    return (
-      upgrade.costPerLevel * Math.sqrt(costMultiplier) * Math.pow(2, upgrade.level)
-    )
-  }
-
-  if (upgrade.specialCostForm === 'Cubic') {
-    return (
-      upgrade.costPerLevel
-      * costMultiplier
-      * (Math.pow(upgrade.level + 1, 3) - Math.pow(upgrade.level, 3))
-    )
-  }
-
-  if (upgrade.specialCostForm === 'Quadratic') {
-    return (
-      upgrade.costPerLevel
-      * costMultiplier
-      * (Math.pow(upgrade.level + 1, 2) - Math.pow(upgrade.level, 2))
-    )
-  }
-
-  costMultiplier *= upgrade.maxLevel === -1 && upgrade.level >= 100 ? upgrade.level / 50 : 1
-  costMultiplier *= upgrade.maxLevel === -1 && upgrade.level >= 400 ? upgrade.level / 100 : 1
-
-  return computeGQUpgradeMaxLevel(upgradeKey) === upgrade.level
-    ? 0
-    : Math.ceil(upgrade.costPerLevel * (1 + upgrade.level) * costMultiplier)
+  return logicGqUpgradeCostTNL({
+    level: upgrade.level,
+    maxLevel: upgrade.maxLevel,
+    computedMaxLevel: computeGQUpgradeMaxLevel(upgradeKey),
+    costPerLevel: upgrade.costPerLevel,
+    specialCostForm: (upgrade.specialCostForm ?? null) as GQUpgradeSpecialCostForm
+  })
 }
 
 /**
@@ -3548,30 +3522,17 @@ const handlePerks = (singularityCount: number) => {
   }
 }
 
-export const calculateMaxSingularityLookahead = (nonZero: boolean): number => {
-  if (!nonZero) {
-    return 0
-  } else {
-    let maxLookahead = 1
-    maxLookahead += getGQUpgradeEffect('singFastForward', 'lookahead')
-    maxLookahead += getGQUpgradeEffect('singFastForward2', 'lookahead')
-    maxLookahead += getOcteractUpgradeEffect('octeractFastForward', 'lookahead')
-    return maxLookahead
-  }
-}
+// Thin shim — sources the three lookahead effects off GQ / octeract upgrades.
+export const calculateMaxSingularityLookahead = (nonZero: boolean): number =>
+  logicMaxSingularityLookahead({
+    nonZero,
+    singFastForwardLookahead: getGQUpgradeEffect('singFastForward', 'lookahead'),
+    singFastForward2Lookahead: getGQUpgradeEffect('singFastForward2', 'lookahead'),
+    octeractFastForwardLookahead: getOcteractUpgradeEffect('octeractFastForward', 'lookahead')
+  })
 
-export const getGoldenQuarkCost = (): {
-  cost: number
-  costReduction: number
-} => {
-  const cost = calculateGoldenQuarkCost()
-  const baseCost = 10000
-
-  return {
-    cost: cost,
-    costReduction: Math.max(0, baseCost - cost)
-  }
-}
+// Thin shim — sources the live GQ cost from Calculate.
+export const getGoldenQuarkCost = () => logicGoldenQuarkCost(calculateGoldenQuarkCost())
 
 export async function buyGoldenQuarks (): Promise<void> {
   const goldenQuarkCost = getGoldenQuarkCost()
@@ -3659,18 +3620,14 @@ export const calculateEffectiveSingularities = (
     platonicUpgrade15: player.platonicUpgrades[15]
   })
 
+// Thin shim — sources the singularity-reduction sum off the local helper.
 const calculateNextSpike = (
   singularityCount: number = player.singularityCount
-): number => {
-  const penaltyDebuff = calculateSingularityReductions()
-
-  for (const sing of singularityPenaltyThresholds) {
-    if (sing + penaltyDebuff > singularityCount) {
-      return sing + penaltyDebuff
-    }
-  }
-  return -1
-}
+): number =>
+  logicCalculateNextSpike({
+    singularityCount,
+    singularityReductions: calculateSingularityReductions()
+  })
 
 // Thin shim over @synergism/logic's pure singularity-debuff calculator.
 // Sources the antiquities-rune toggle, the shop / ambrosia reductions, and

--- a/packages/web_ui/src/singularity.ts
+++ b/packages/web_ui/src/singularity.ts
@@ -1,11 +1,16 @@
+import {
+  actualGQUpgradeTotalLevels as logicActualGQUpgradeTotalLevels,
+  calculateEffectiveSingularities as logicCalcEffectiveSingularities,
+  calculateSingularityDebuff as logicCalcSingularityDebuff,
+  computeGQUpgradeMaxLevel as logicComputeGQUpgradeMaxLevel,
+  gqFreeLevelMultiplier as logicGqFreeLevelMultiplier,
+  gqUpgradeFreeLevelSoftcap as logicGqUpgradeFreeLevelSoftcap,
+  type SingularityDebuff
+} from '@synergism/logic'
 import i18next from 'i18next'
 import { getAmbrosiaUpgradeEffects } from './BlueberryUpgrades'
 import { DOMCacheGetOrSet } from './Cache/DOM'
-import {
-  calculateExalt4EffectiveSingularityMultiplier,
-  calculateGoldenQuarkCost,
-  calculateImmaculateAlchemyBonus
-} from './Calculate'
+import { calculateGoldenQuarkCost, calculateImmaculateAlchemyBonus } from './Calculate'
 import { updateMaxTokens, updateTokens } from './Campaign'
 import { getOcteractUpgradeEffect, octeractUpgrades } from './Octeracts'
 import { getGlobalBonus, getPersonalBonus, getQuarkBonus } from './Quark'
@@ -144,7 +149,6 @@ type GoldenQuarkUpgradeRewards = {
 
 export type SingularityDataKeys = keyof GoldenQuarkUpgradeRewards
 
-const overclockPerks = [50, 60, 75, 100, 125, 150, 175, 200, 225, 250]
 const tokenInheritanceTokens = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
 const singularityPenaltyThresholds = [11, 26, 37, 51, 101, 151, 201, 216, 230, 270]
 
@@ -2486,70 +2490,58 @@ export async function buyGQUpgradeLevel (
   revealStuff()
 }
 
+// Thin shim — sources the shop / cubeUpgrades[75] inputs.
 function computeFreeLevelMultiplier (): number {
-  return getShopUpgradeEffects('shopSingularityPotency', 'freeUpgradeMult') + 0.3 / 100 * player.cubeUpgrades[75]
+  return logicGqFreeLevelMultiplier(
+    getShopUpgradeEffects('shopSingularityPotency', 'freeUpgradeMult'),
+    player.cubeUpgrades[75]
+  )
 }
 
 export function computeGQUpgradeFreeLevelSoftcap (upgradeKey: SingularityDataKeys): number {
   const upgrade = goldenQuarkUpgrades[upgradeKey]
-  const freeLevelMult = computeFreeLevelMultiplier()
-  const baseRealFreeLevels = freeLevelMult * upgrade.freeLevel
-  return (
-    Math.min(upgrade.level, baseRealFreeLevels)
-    + Math.sqrt(Math.max(0, baseRealFreeLevels - upgrade.level))
-  )
+  return logicGqUpgradeFreeLevelSoftcap(upgrade.freeLevel, upgrade.level, computeFreeLevelMultiplier())
 }
 
 export function computeGQUpgradeMaxLevel (upgradeKey: SingularityDataKeys): number {
   const upgrade = goldenQuarkUpgrades[upgradeKey]
-  if (!upgrade.canExceedCap) {
-    return upgrade.maxLevel
-  } else {
-    let cap = upgrade.maxLevel
-    for (const perk of overclockPerks) {
-      if (player.highestSingularityCount >= perk) {
-        cap += 1
-      } else {
-        break
-      }
-    }
-    cap += getOcteractUpgradeEffect('octeractSingUpgradeCap', 'goldenQuarkUpgradeCapIncrease')
-    return cap
-  }
+  return logicComputeGQUpgradeMaxLevel({
+    canExceedCap: upgrade.canExceedCap,
+    maxLevel: upgrade.maxLevel,
+    highestSingularityCount: player.highestSingularityCount,
+    octeractSingUpgradeCapIncrease: getOcteractUpgradeEffect(
+      'octeractSingUpgradeCap',
+      'goldenQuarkUpgradeCapIncrease'
+    )
+  })
 }
 
 export function actualGQUpgradeTotalLevels (upgradeKey: SingularityDataKeys): number {
   const upgrade = goldenQuarkUpgrades[upgradeKey]
+  const improvedFreeUnlocked = getOcteractUpgradeEffect('octeractImprovedFree', 'unlocked')
+  // Sum the four improved-free exponents only when the gate is unlocked.
+  // Avoids paying for getOcteractUpgradeEffect lookups whose values logic
+  // wouldn't use anyway.
+  const improvedFreeExponent = improvedFreeUnlocked
+    ? getOcteractUpgradeEffect('octeractImprovedFree', 'freeLevelPower')
+      + getOcteractUpgradeEffect('octeractImprovedFree2', 'freeLevelPowerIncrease')
+      + getOcteractUpgradeEffect('octeractImprovedFree3', 'freeLevelPowerIncrease')
+      + getOcteractUpgradeEffect('octeractImprovedFree4', 'freeLevelPowerIncrease')
+    : 0
 
-  if (
-    (player.singularityChallenges.noSingularityUpgrades.enabled
-      || player.singularityChallenges.sadisticPrequel.enabled)
-    && !upgrade.qualityOfLife
-  ) {
-    return 0
-  }
-
-  if (
-    (player.singularityChallenges.limitedAscensions.enabled || player.singularityChallenges.limitedTime.enabled
-      || player.singularityChallenges.sadisticPrequel.enabled)
-    && upgradeKey === 'platonicDelta'
-  ) {
-    return 0
-  }
-
-  const actualFreeLevels = computeGQUpgradeFreeLevelSoftcap(upgradeKey)
-  const linearLevels = upgrade.level + actualFreeLevels
-  let polynomialLevels = 0
-
-  if (getOcteractUpgradeEffect('octeractImprovedFree', 'unlocked')) {
-    let exponent = getOcteractUpgradeEffect('octeractImprovedFree', 'freeLevelPower')
-    exponent += getOcteractUpgradeEffect('octeractImprovedFree2', 'freeLevelPowerIncrease')
-    exponent += getOcteractUpgradeEffect('octeractImprovedFree3', 'freeLevelPowerIncrease')
-    exponent += getOcteractUpgradeEffect('octeractImprovedFree4', 'freeLevelPowerIncrease')
-    polynomialLevels = Math.pow(upgrade.level * actualFreeLevels, exponent)
-  }
-
-  return Math.max(linearLevels, polynomialLevels)
+  return logicActualGQUpgradeTotalLevels({
+    level: upgrade.level,
+    freeLevel: upgrade.freeLevel,
+    qualityOfLife: upgrade.qualityOfLife,
+    isPlatonicDelta: upgradeKey === 'platonicDelta',
+    inNoSingularityUpgrades: player.singularityChallenges.noSingularityUpgrades.enabled,
+    inSadisticPrequel: player.singularityChallenges.sadisticPrequel.enabled,
+    inLimitedAscensions: player.singularityChallenges.limitedAscensions.enabled,
+    inLimitedTime: player.singularityChallenges.limitedTime.enabled,
+    freeLevelMult: computeFreeLevelMultiplier(),
+    improvedFreeUnlocked,
+    improvedFreeExponent
+  })
 }
 
 /**
@@ -3639,19 +3631,6 @@ export async function buyGoldenQuarks (): Promise<void> {
   )
 }
 
-type SingularityDebuffs =
-  | 'Offering'
-  | 'Obtainium'
-  | 'Salvage'
-  | 'Global Speed'
-  | 'Researches'
-  | 'Ant ELO'
-  | 'Ascension Speed'
-  | 'Cubes'
-  | 'Cube Upgrades'
-  | 'Platonic Costs'
-  | 'Hepteract Costs'
-
 const calculateSingularityReductions = () => {
   return (
     getShopUpgradeEffects('shopSingularityPenaltyDebuff', 'singularityPenaltyReducers')
@@ -3661,79 +3640,24 @@ const calculateSingularityReductions = () => {
   )
 }
 
+// Thin shim over @synergism/logic's pure effective-singularity formula. Reads
+// the noOcteracts / taxmanLastStand challenge state and platonic[15] off
+// player; the formula itself lives in mechanics/singularityPenalties.ts.
+//
+// `inExalt4` mirrors the legacy `calculateExalt4EffectiveSingularityMultiplier`
+// shim in Calculate.ts — `force` was hardcoded false at the original call site,
+// but `inExalt4` was sourced from player.singularityChallenges.noOcteracts.enabled.
 export const calculateEffectiveSingularities = (
   singularityCount: number = player.singularityCount
-): number => {
-  let effectiveSingularities = singularityCount
-  effectiveSingularities *= Math.min(4.75, (0.75 * singularityCount) / 10 + 1)
-
-  effectiveSingularities *= calculateExalt4EffectiveSingularityMultiplier(
-    player.singularityChallenges.noOcteracts.completions,
-    false
-  )
-
-  if (singularityCount > 10) {
-    effectiveSingularities *= 1.5
-    effectiveSingularities *= Math.min(
-      4,
-      (1.25 * singularityCount) / 10 - 0.25
-    )
-  }
-  if (singularityCount > 25) {
-    effectiveSingularities *= 2.5
-    effectiveSingularities *= Math.min(6, (1.5 * singularityCount) / 25 - 0.5)
-  }
-  if (singularityCount > 36) {
-    effectiveSingularities *= 4
-    effectiveSingularities *= Math.min(5, singularityCount / 18 - 1)
-    effectiveSingularities *= Math.pow(
-      1.1,
-      Math.min(singularityCount - 36, 64)
-    )
-  }
-  if (singularityCount > 50) {
-    effectiveSingularities *= 5
-    effectiveSingularities *= Math.min(8, (2 * singularityCount) / 50 - 1)
-    effectiveSingularities *= Math.pow(
-      1.1,
-      Math.min(singularityCount - 50, 50)
-    )
-  }
-  if (singularityCount > 100) {
-    effectiveSingularities *= 2
-    effectiveSingularities *= singularityCount / 25
-    effectiveSingularities *= Math.pow(1.1, singularityCount - 100)
-  }
-  if (singularityCount > 150) {
-    effectiveSingularities *= 2
-    effectiveSingularities *= Math.pow(1.05, singularityCount - 150)
-  }
-  if (singularityCount > 200) {
-    effectiveSingularities *= 1.5
-    effectiveSingularities *= Math.pow(1.275, singularityCount - 200)
-  }
-  if (singularityCount > 215) {
-    effectiveSingularities *= 1.25
-    effectiveSingularities *= Math.pow(1.2, singularityCount - 215)
-  }
-  if (singularityCount > 230) {
-    effectiveSingularities *= 2
-  }
-  if (singularityCount > 269) {
-    effectiveSingularities *= 3
-    effectiveSingularities *= Math.pow(3, singularityCount - 269)
-  }
-
-  if (
-    player.singularityChallenges.taxmanLastStand.enabled
-    && player.singularityChallenges.taxmanLastStand.completions >= 8
-    && player.platonicUpgrades[15] === 0
-  ) {
-    effectiveSingularities = Math.pow(effectiveSingularities, 3 / 2)
-  }
-
-  return effectiveSingularities
-}
+): number =>
+  logicCalcEffectiveSingularities({
+    singularityCount,
+    noOcteractsCompletions: player.singularityChallenges.noOcteracts.completions,
+    inExalt4: player.singularityChallenges.noOcteracts.enabled,
+    taxmanLastStandEnabled: player.singularityChallenges.taxmanLastStand.enabled,
+    taxmanLastStandCompletions: player.singularityChallenges.taxmanLastStand.completions,
+    platonicUpgrade15: player.platonicUpgrades[15]
+  })
 
 const calculateNextSpike = (
   singularityCount: number = player.singularityCount
@@ -3747,73 +3671,27 @@ const calculateNextSpike = (
   }
   return -1
 }
+
+// Thin shim over @synergism/logic's pure singularity-debuff calculator.
+// Sources the antiquities-rune toggle, the shop / ambrosia reductions, and
+// the horseshoe multiplier from the live web_ui state. `inExalt4` mirrors
+// the legacy Calculate.ts shim — sourced from player.singularityChallenges.noOcteracts.enabled.
 export const calculateSingularityDebuff = (
-  debuff: SingularityDebuffs,
+  debuff: SingularityDebuff,
   singularityCount: number = player.singularityCount
-) => {
-  if (singularityCount === 0 || runes.antiquities.level > 0) {
-    return (debuff === 'Salvage' || debuff === 'Ant ELO') ? 0 : 1
-  }
-
-  const constitutiveSingularityCount = singularityCount - calculateSingularityReductions()
-  if (constitutiveSingularityCount < 1) {
-    return 1
-  }
-
-  const effectiveSingularities = calculateEffectiveSingularities(
-    constitutiveSingularityCount
-  )
-
-  let baseDebuffMultiplier = 1
-  baseDebuffMultiplier *= getShopUpgradeEffects('shopHorseShoe', 'singularityPenaltyMult')
-
-  if (debuff === 'Offering') {
-    const extraMult = Math.pow(1.02, constitutiveSingularityCount)
-    return extraMult * baseDebuffMultiplier * (constitutiveSingularityCount < 150
-      ? 3 * (Math.sqrt(effectiveSingularities) + 1)
-      : Math.pow(effectiveSingularities, 2 / 3) / 400)
-  } else if (debuff === 'Salvage') {
-    return -(4 * constitutiveSingularityCount
-      + 4 * Math.max(0, constitutiveSingularityCount - 100)
-      + 4 * Math.max(0, constitutiveSingularityCount - 200)
-      + 3 * Math.max(0, constitutiveSingularityCount - 250)
-      + 3 * Math.max(0, constitutiveSingularityCount - 270)
-      + 2 * Math.max(0, constitutiveSingularityCount - 280))
-  } else if (debuff === 'Ant ELO') {
-    return -Math.min(1, 0.001 * constitutiveSingularityCount)
-  } else if (debuff === 'Global Speed') {
-    return baseDebuffMultiplier * (1 + Math.sqrt(effectiveSingularities) / 4)
-  } else if (debuff === 'Obtainium') {
-    const extraMult = Math.pow(1.02, constitutiveSingularityCount)
-    return extraMult * baseDebuffMultiplier * (constitutiveSingularityCount < 150
-      ? 3 * (Math.sqrt(effectiveSingularities) + 1)
-      : Math.pow(effectiveSingularities, 2 / 3) / 400)
-  } else if (debuff === 'Researches') {
-    return baseDebuffMultiplier * (1 + Math.sqrt(effectiveSingularities) / 2)
-  } else if (debuff === 'Ascension Speed') {
-    return baseDebuffMultiplier * (constitutiveSingularityCount < 150
-      ? 1 + Math.sqrt(effectiveSingularities) / 5
-      : 1 + Math.pow(effectiveSingularities, 0.75) / 10000)
-  } else if (debuff === 'Cubes') {
-    const extraMult = constitutiveSingularityCount > 100
-      ? 2 * Math.pow(1.03, constitutiveSingularityCount - 100)
-      : 2
-    return baseDebuffMultiplier * (constitutiveSingularityCount < 150
-      ? 3 * (1 + (Math.sqrt(effectiveSingularities) * extraMult) / 4)
-      : 1 + (Math.pow(effectiveSingularities, 0.75) * extraMult) / 1000)
-  } else if (debuff === 'Platonic Costs') {
-    return baseDebuffMultiplier * (constitutiveSingularityCount > 36
-      ? 1 + Math.pow(effectiveSingularities, 3 / 10) / 12
-      : 1)
-  } else if (debuff === 'Hepteract Costs') {
-    return baseDebuffMultiplier * (constitutiveSingularityCount > 50
-      ? 1 + Math.pow(effectiveSingularities, 11 / 50) / 25
-      : 1)
-  } else {
-    // Cube upgrades
-    return baseDebuffMultiplier * Math.cbrt(effectiveSingularities + 1)
-  }
-}
+) =>
+  logicCalcSingularityDebuff({
+    debuff,
+    singularityCount,
+    antiquitiesRuneActive: runes.antiquities.level > 0,
+    singularityReductions: calculateSingularityReductions(),
+    horseShoeMult: getShopUpgradeEffects('shopHorseShoe', 'singularityPenaltyMult'),
+    noOcteractsCompletions: player.singularityChallenges.noOcteracts.completions,
+    inExalt4: player.singularityChallenges.noOcteracts.enabled,
+    taxmanLastStandEnabled: player.singularityChallenges.taxmanLastStand.enabled,
+    taxmanLastStandCompletions: player.singularityChallenges.taxmanLastStand.completions,
+    platonicUpgrade15: player.platonicUpgrades[15]
+  })
 
 export const updateSingularityElevatorVisibility = (): void => {
   if (player.highestSingularityCount < 10) {


### PR DESCRIPTION
## Summary

Continues the `@synergism/logic` migration with **16 pure-math clusters** lifted out of web_ui across 6 commits. Logic-only refactor — every public web_ui surface keeps its old signature via thin shims, and every formula has parity tests against a verbatim transcription of the pre-migration body.

## Commits

| Commit | Migration | New tests |
|---|---|---:|
| `9fd7010e` | 7 clusters: singularity penalties, talisman costs, level rewards, level milestones, achievement levels, octeract upgrade levels, GQ upgrade levels | 7,476 |
| `0d456a95` | rune EXP/level math + universalRuneEXPMult | 263 |
| `869decaa` | gqUpgradeCostTNL + singularity helpers (lookahead / GQ cost wrapper / calculateNextSpike) | 367 |
| `7a5f5436` | Tax.ts: coin production aggregation + tax exponent/divisor formula | 64 |
| `22b69b24` | hepteract values + shop cost | 128 |
| `4443dc5e` | SingularityChallenge formulas (all 9 challenges × 3 helpers) | 983 |

## What stays in web_ui

Per the package boundary in `CLAUDE.md`, anything touching DOM / i18next / player mutation / Decimal cross-tier wrappers stays in web_ui. Each shim sources the inputs from `player` / `G` / pre-evaluated effect lookups (rune / talisman / ant / shop / GQ / octeract / challenge), calls into logic, and writes results back where the original code did.

## Caught while migrating

- **Tax CalcECC**: initially inlined wrong threshold-sum versions; the actual CalcECC is piecewise linear. Parity tests caught it before shipping — tax now imports from logic's `challenges.ts`.
- **Exalt 4 inExalt4 sourcing**: the original `calculateEffectiveSingularities` call hardcoded `force=false` but the existing Calculate.ts shim sources `inExalt4` from `player.singularityChallenges.noOcteracts.enabled`. The new shim mirrors that.
- **Coin tier types**: `player.<tier>OwnedCoin` / `<tier>ProduceCoin` are `number`, not `Decimal`. The original `.add(number)` / `.times(number)` calls worked because Decimal accepts both, but the logic input types needed to reflect reality.
- **G.challenge15Rewards.runeExp.value**: similarly a `number`, not `Decimal`.

## Verification

- Logic suite: 14,864 → **24,051 tests** (+62%, +9,187 assertions). All parity tests transcribe the pre-migration body verbatim and sweep every documented threshold / regime boundary.
- Web_ui suite: 2 infra tests still passing.
- `npm run lint`, `npm run check:tsc`, `npm run build:esbuild` clean on every commit (pre-commit hook enforces all three).

## Test plan

- [ ] In-game smoke: load an existing save and verify tax / coin production / GQ cost / rune levels / singularity-challenge entry all render the same numbers as before
- [ ] Buy a few shop upgrades — verify cost and bonus-level scaling unchanged
- [ ] Craft hepteracts above their LIMIT — verify the DR formula still produces expected output
- [ ] Enter a singularity challenge — verify the \`singularityRequirement\` and \`effect\` values match the pre-PR baseline
- [ ] Spot-check the GQ upgrade buy flow — verify cost-to-next-level and max-level cap (especially overclock-perks-extended upgrades) behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)