### PR TITLE
refactor: migrate corruption / talisman-rarity / achievement-points formulas into @synergism/logic

### DIFF
--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -23,6 +23,21 @@ export { calculateAcceleratorMultiplier, calculateTotalAcceleratorBoost } from '
 export type { BuyAcceleratorInput, GetCostAcceleratorInput } from './mechanics/accelerators'
 export { buyAccelerator, getCostAccelerator } from './mechanics/accelerators'
 export { achievementLevelFromPoints, toNextAchievementLevelEXP } from './mechanics/achievementLevels'
+export type { ComputeAchievementPointsInput } from './mechanics/achievementPoints'
+export {
+  ambrosiaCountPoints,
+  antMasteryPoints,
+  computeAchievementPoints,
+  exaltPoints,
+  freeRuneLevelPoints,
+  getAchievementQuarks,
+  maxedUpgradeFamilyPoints,
+  rebornELOPoints,
+  redAmbrosiaCountPoints,
+  runeLevelPoints,
+  singularityCountPoints,
+  talismanRarityPoints
+} from './mechanics/achievementPoints'
 export type {
   AmbrosiaMultInput,
   CalculateRequiredBlueberryTimeInput,
@@ -241,6 +256,7 @@ export type {
 } from './mechanics/coinProduction'
 export { calculateCoinProduction } from './mechanics/coinProduction'
 export type {
+  CorruptionRawMultiplierInput,
   DroughtEffectInput,
   HyperchallengeEffectInput,
   IlliteracyEffectInput,
@@ -248,6 +264,10 @@ export type {
   ViscosityEffectInput
 } from './mechanics/corruptions'
 export {
+  calculateCorruptionDifficultyScore,
+  calculateCorruptionRawMultiplier,
+  clipCorruptionLevel,
+  corruptionScoreMults,
   droughtEffect,
   hyperchallengeEffect,
   illiteracyEffect,
@@ -872,6 +892,18 @@ export type {
 export { calculateEffectiveSingularities, calculateSingularityDebuff } from './mechanics/singularityPenalties'
 export type { TalismanCraftCosts, TalismanCraftItems } from './mechanics/talismanCosts'
 export { exponentialCostProgression, regularCostProgression } from './mechanics/talismanCosts'
+export type {
+  AffordableTalismanLevelInput,
+  ComputeTalismanRarityInput,
+  LevelsUntilTalismanRarityIncreaseInput
+} from './mechanics/talismanLevels'
+export {
+  affordableTalismanLevel,
+  computeTalismanRarity,
+  levelsUntilTalismanRarityIncrease,
+  rarityValues,
+  sumOfTalismanRarities
+} from './mechanics/talismanLevels'
 export type {
   AchievementTalismanEffects,
   ChronosTalismanEffects,

--- a/packages/logic/src/mechanics/achievementPoints.ts
+++ b/packages/logic/src/mechanics/achievementPoints.ts
@@ -1,0 +1,213 @@
+// Achievement points math, lifted from packages/web_ui/src/Achievements.ts.
+// The web_ui side keeps the achievements data table (i18n descriptions,
+// unlock predicates, group classifications) and the progressiveAchievements
+// dispatch map; this module owns the pure formulas that convert per-progressive
+// cached values + the aggregated points sum.
+//
+// Each `<x>Points` function corresponds to one progressive achievement's
+// `pointsAwarded` body. Inputs are pre-extracted from player state by the
+// caller — antMasteries gets the per-ant highestMastery array, exalts gets
+// the rewardAP[] from singularityChallenges, etc.
+
+// ─── Progressive achievement: rune levels ──────────────────────────────────
+
+/**
+ * Points from the cumulative rune-level progressive achievement. Three-knee
+ * staircase: 1pt per 1000 (cap 200) + 1pt per 2500 (cap 400) + 1pt per 12500
+ * (cap 400). Theoretical max: 1000.
+ */
+export function runeLevelPoints (sumOfRuneLevels: number): number {
+  return Math.min(200, Math.floor(sumOfRuneLevels / 1000))
+    + Math.min(400, Math.floor(sumOfRuneLevels / 2500))
+    + Math.min(400, Math.floor(sumOfRuneLevels / 12500))
+}
+
+/**
+ * Points from the cumulative free-rune-level progressive achievement.
+ * Three-knee staircase: 1pt per 250 (cap 100) + 1pt per 750 (cap 200) +
+ * 1pt per 2500 (cap 200). Theoretical max: 500.
+ */
+export function freeRuneLevelPoints (sumOfFreeRuneLevels: number): number {
+  return Math.min(100, Math.floor(sumOfFreeRuneLevels / 250))
+    + Math.min(200, Math.floor(sumOfFreeRuneLevels / 750))
+    + Math.min(200, Math.floor(sumOfFreeRuneLevels / 2500))
+}
+
+// ─── Progressive achievement: ant masteries ────────────────────────────────
+
+/**
+ * Points from the ant-masteries progressive achievement. For each ant
+ * producer's `highestMastery`, awards `3 * mastery` + an extra +4 when mastery
+ * reaches 12. Theoretical max: 360 (12 ants × 30 + 12 × 4 = 360 + 48 = 408,
+ * but maxPointValue is set to 360 so the displayed cap doesn't match the
+ * formula's actual peak).
+ */
+export function antMasteryPoints (highestMasteries: readonly number[]): number {
+  let pointValue = 0
+  for (const mastery of highestMasteries) {
+    pointValue += 3 * mastery
+    if (mastery >= 12) {
+      pointValue += 4
+    }
+  }
+  return pointValue
+}
+
+// ─── Progressive achievement: reborn ELO ───────────────────────────────────
+
+/**
+ * Points from the reborn-ELO progressive achievement. Five-knee staircase
+ * over the leaderboard value: 1pt per 100 (cap 100) + 1pt per 1000 (cap 150)
+ * + 1pt per 9000 (cap 150) + 1pt per 75000 (cap 200) + 1pt per 150000 (cap
+ * 400). Theoretical max: 1000.
+ *
+ * The caller resolves `leaderboardELO` via `calculateLeaderboardValue(player.
+ * ants.highestRebornELOEver)` since that helper depends on the
+ * antSacrifice-domain leaderboard structure.
+ */
+export function rebornELOPoints (leaderboardELO: number): number {
+  return Math.min(100, Math.floor(leaderboardELO / 100))
+    + Math.min(150, Math.floor(leaderboardELO / 1000))
+    + Math.min(150, Math.floor(leaderboardELO / 9000))
+    + Math.min(200, Math.floor(leaderboardELO / 75000))
+    + Math.min(400, Math.floor(leaderboardELO / 150000))
+}
+
+// ─── Progressive achievement: singularity count ────────────────────────────
+
+/**
+ * Points from the singularity-count progressive achievement. Three-knee
+ * accumulator: 9 per singularity, +3 per singularity above 100, +3 per
+ * singularity above 200. Theoretical max stated as 3600 in the data table.
+ */
+export function singularityCountPoints (highestSingularityCount: number): number {
+  return 9 * highestSingularityCount
+    + 3 * Math.max(0, highestSingularityCount - 100)
+    + 3 * Math.max(0, highestSingularityCount - 200)
+}
+
+// ─── Progressive achievement: ambrosia counts ──────────────────────────────
+
+/**
+ * Points from the lifetime-ambrosia progressive achievement. Three-knee
+ * staircase: 1pt per 100 (cap 200) + 1pt per 10000 (cap 200) + sqrt-tail
+ * `floor(400 * sqrt(cached / 1e8))` (cap 400). Theoretical max: 800.
+ */
+export function ambrosiaCountPoints (lifetimeAmbrosia: number): number {
+  return Math.min(200, Math.floor(lifetimeAmbrosia / 100))
+    + Math.min(200, Math.floor(lifetimeAmbrosia / 10000))
+    + Math.min(400, Math.floor(400 * Math.sqrt(lifetimeAmbrosia / 1e8)))
+}
+
+/**
+ * Points from the lifetime-red-ambrosia progressive achievement. Four-knee
+ * staircase: 1pt per 25 (cap 200) + 1pt per 2500 (cap 200) + `400 * cached
+ * / 5e6` floored (cap 400) + `200 * cached / 1.25e7` floored (cap 200).
+ * Theoretical max: 1000.
+ */
+export function redAmbrosiaCountPoints (lifetimeRedAmbrosia: number): number {
+  return Math.min(200, Math.floor(lifetimeRedAmbrosia / 25))
+    + Math.min(200, Math.floor(lifetimeRedAmbrosia / 2500))
+    + Math.min(400, Math.floor(400 * lifetimeRedAmbrosia / 5e6))
+    + Math.min(200, Math.floor(200 * lifetimeRedAmbrosia / 1.25e7))
+}
+
+// ─── Progressive achievement: talisman rarities ────────────────────────────
+
+/**
+ * Points from the talisman-rarities progressive achievement. Trivial 5×
+ * multiplier over the cached sum-of-rarities. Theoretical max: 50 × number
+ * of talismans.
+ */
+export function talismanRarityPoints (sumOfRarities: number): number {
+  return 5 * sumOfRarities
+}
+
+// ─── Progressive achievement: exalts ───────────────────────────────────────
+
+/**
+ * Points from the exalt-achievement progressive entry. Just the sum of
+ * `rewardAP` across all singularity challenges — callers extract the values
+ * from `player.singularityChallenges[chal].rewardAP`.
+ */
+export function exaltPoints (rewardAPs: readonly number[]): number {
+  let pointValue = 0
+  for (const ap of rewardAPs) {
+    pointValue += ap
+  }
+  return pointValue
+}
+
+// ─── Progressive achievement: fully-maxed upgrade families ─────────────────
+
+/**
+ * Generic "count of maxed upgrades × point multiplier" formula. Used by the
+ * three upgrade-family progressives:
+ *   - singularityUpgrades: pointsPerMaxed = 5
+ *   - octeractUpgrades: pointsPerMaxed = 8
+ *   - redAmbrosiaUpgrades: pointsPerMaxed = 10
+ *
+ * The caller computes `maxedCount` by walking the upgrade table — for GQ /
+ * octeract upgrades that means `upgrade.maxLevel !== -1 && upgrade.level >=
+ * upgrade.maxLevel`; for red-ambrosia upgrades the `-1` sentinel doesn't
+ * exist so the inequality alone suffices.
+ */
+export function maxedUpgradeFamilyPoints (maxedCount: number, pointsPerMaxed: number): number {
+  return maxedCount * pointsPerMaxed
+}
+
+// ─── Achievement-completion quark reward ───────────────────────────────────
+
+/**
+ * Quarks awarded for completing a brand-new achievement. Starts at `5 *
+ * globalQuarkMultiplier`; above a 100× multiplier, applies a softcap of
+ * `100^0.6 * mult^0.4` so the bonus stays meaningful at high multipliers
+ * without blowing up. Final result is floored.
+ *
+ * `globalQuarkMultiplier` is `player.worlds.applyBonus(1)` in web_ui — the
+ * full multiplicative quark bonus including patreon / shop / etc.
+ */
+export function getAchievementQuarks (globalQuarkMultiplier: number): number {
+  let actualMultiplier = globalQuarkMultiplier
+  if (actualMultiplier > 100) {
+    actualMultiplier = Math.pow(100, 0.6) * Math.pow(actualMultiplier, 0.4)
+  }
+  return Math.floor(5 * actualMultiplier)
+}
+
+// ─── Total achievement points ──────────────────────────────────────────────
+
+export interface ComputeAchievementPointsInput {
+  /** Per-achievement `pointValue` from the achievements data table. */
+  pointValues: readonly number[]
+  /**
+   * Per-achievement unlocked flag. Truthy (typically 1) when awarded.
+   * Indices align with `pointValues`. The reduce treats any truthy value as
+   * unlocked to match the legacy `savedAchievements[index] ? ach.pointValue
+   * : 0` shape.
+   */
+  savedAchievements: readonly number[]
+  /**
+   * Per-progressive-achievement awarded points. Caller assembles this by
+   * calling each progressive's `pointsAwarded` (the per-progressive formulas
+   * above) and dropping the result into the array in any order.
+   */
+  progressivePointsAwarded: readonly number[]
+}
+
+/**
+ * Total achievement points: sum of per-achievement point values for unlocked
+ * achievements, plus the sum of per-progressive awarded points.
+ */
+export function computeAchievementPoints (input: ComputeAchievementPointsInput): number {
+  let points = 0
+  for (let i = 0; i < input.pointValues.length; i++) {
+    if (input.savedAchievements[i]) {
+      points += input.pointValues[i]
+    }
+  }
+  for (const awarded of input.progressivePointsAwarded) {
+    points += awarded
+  }
+  return points
+}

--- a/packages/logic/src/mechanics/corruptions.ts
+++ b/packages/logic/src/mechanics/corruptions.ts
@@ -140,3 +140,105 @@ export function hyperchallengeEffect(input: HyperchallengeEffectInput): number {
   const divisor = 1 + 2 / 5 * input.platonicUpgrade8
   return Math.max(1, input.baseEffect / divisor)
 }
+
+// ─── Per-corruption score multiplier ───────────────────────────────────────
+
+/**
+ * Score-multiplier table indexed by total corruption level (level + bonus
+ * levels). For total levels at or beyond the last index, the formula
+ * extrapolates with a 1.2^x geometric tail.
+ */
+export const corruptionScoreMults: readonly number[] = [
+  1,
+  3,
+  4,
+  5,
+  6,
+  7,
+  7.75,
+  8.5,
+  9.25,
+  10,
+  10.75,
+  11.5,
+  12.25,
+  13,
+  16,
+  20,
+  25,
+  33,
+  35
+] as const
+
+export interface CorruptionRawMultiplierInput {
+  /** Per-corruption level + bonus levels (cookieGrandma + GQ corruption15 + SC oneChallengeCap + finiteDescent rune). */
+  totalLevel: number
+  /**
+   * Additive score increase applied inside the power base. Sum of:
+   *   - getGQUpgradeEffect('advancedPack', 'corruptionScoreIncrease')
+   *   - getSingularityChallengeEffect('oneChallengeCap', 'corrScoreIncrease')
+   *   - 0.3 * player.cubeUpgrades[74]
+   */
+  bonusVal: number
+  /**
+   * Exponent applied to the result. Equal to 1 in the common case. When
+   * `player.platonicUpgrades[17] > 0` AND the corruption is `viscosity` AND
+   * `levels.viscosity >= 10`, callers pass `3 + 0.04 * platonicUpgrades[17]`
+   * (the P4x2 "exponent" buff).
+   */
+  viscosityPower: number
+}
+
+/**
+ * Per-corruption score multiplier. Interpolates the static score-mults table
+ * for total levels under the table length, then extrapolates with a 1.2^x
+ * geometric tail for higher levels. Both branches raised to viscosityPower.
+ */
+export function calculateCorruptionRawMultiplier(input: CorruptionRawMultiplierInput): number {
+  const scoreMultLength = corruptionScoreMults.length
+  const { totalLevel, bonusVal, viscosityPower } = input
+
+  if (totalLevel < scoreMultLength - 1) {
+    const portionAboveLevel = Math.ceil(totalLevel) - totalLevel
+    return Math.pow(
+      corruptionScoreMults[Math.floor(totalLevel)] + bonusVal
+        + portionAboveLevel
+          * (corruptionScoreMults[Math.ceil(totalLevel)] - corruptionScoreMults[Math.floor(totalLevel)]),
+      viscosityPower
+    )
+  } else {
+    return Math.pow(
+      (corruptionScoreMults[scoreMultLength - 1] + bonusVal)
+        * Math.pow(1.2, totalLevel - scoreMultLength + 1),
+      viscosityPower
+    )
+  }
+}
+
+// ─── Difficulty score ──────────────────────────────────────────────────────
+
+/**
+ * Total corruption difficulty score. Starts at 400 and adds `16 * (total
+ * level)²` per corruption. Callers pass the per-corruption total levels
+ * (level + bonus levels), in any order.
+ */
+export function calculateCorruptionDifficultyScore(totalLevels: readonly number[]): number {
+  let basePoints = 400
+  for (const lvl of totalLevels) {
+    basePoints += 16 * lvl * lvl
+  }
+  return basePoints
+}
+
+// ─── Level clipping / validation ───────────────────────────────────────────
+
+/**
+ * Clip a single corruption level to a valid stored value. Returns 0 if the
+ * input isn't a finite integer; otherwise clamps to `[0, maxLevel]`.
+ */
+export function clipCorruptionLevel(level: number, maxLevel: number): number {
+  if (!Number.isFinite(level) || Number.isNaN(level) || !Number.isInteger(level)) {
+    return 0
+  }
+  return Math.max(0, Math.min(maxLevel, level))
+}

--- a/packages/logic/src/mechanics/talismanLevels.ts
+++ b/packages/logic/src/mechanics/talismanLevels.ts
@@ -1,0 +1,143 @@
+// Talisman rarity / level math, migrated from packages/web_ui/src/Talismans.ts.
+// The talisman data table (i18n closures, isUnlocked predicates, baseMult/
+// maxLevel constants) stays in web_ui — this module owns the pure formulas
+// that map (level, maxLevel, rarity) → display rarity, the levels-until-next-
+// rarity counter, and the per-level affordability check.
+
+import type { Decimal } from '../math/bignum'
+import type { TalismanCraftCosts, TalismanCraftItems } from './talismanCosts'
+
+// ─── Rarity value table ────────────────────────────────────────────────────
+
+/**
+ * Rune-bonus multipliers applied per rarity tier. Rarity 0 means "talisman
+ * locked" and contributes nothing; rarities 1–10 are the displayed rarity
+ * tiers (Common → Mythic), with stacking bonuses above rarity 7 awarded by
+ * crossing 2x, 4x, 8x the talisman's `maxLevel`.
+ */
+export const rarityValues: Readonly<Record<number, number>> = Object.freeze({
+  0: 0,
+  1: 1,
+  2: 1.2,
+  3: 1.5,
+  4: 1.8,
+  5: 2.1,
+  6: 2.5,
+  7: 3,
+  8: 3.25,
+  9: 3.5,
+  10: 4
+})
+
+// ─── Rarity from level ─────────────────────────────────────────────────────
+
+export interface ComputeTalismanRarityInput {
+  /** `talismans[t].isUnlocked()`. When false, rarity is forced to 0. */
+  isUnlocked: boolean
+  /** `talismans[t].level`. */
+  level: number
+  /**
+   * `talismans[t].maxLevel`. NOT the cap including levelCapIncrease — the
+   * raw `maxLevel` constant on the talisman data table. The rarity tier
+   * formula uses ratios of this value (level / maxLevel ≥ 1, 2, 4, 8).
+   */
+  maxLevel: number
+}
+
+/**
+ * Display rarity for a talisman, 0–10. Locked talismans get 0. Unlocked
+ * talismans get `1 + min(6, floor(6 * level / maxLevel)) + extraRarity`,
+ * where `extraRarity` adds +1 for each of the 2×, 4×, and 8× `maxLevel`
+ * thresholds the talisman has crossed.
+ */
+export function computeTalismanRarity (input: ComputeTalismanRarityInput): number {
+  if (!input.isUnlocked) {
+    return 0
+  }
+  const levelRatio = input.level / input.maxLevel
+  let extraRarity = 0
+  if (levelRatio >= 1) {
+    if (levelRatio >= 2) extraRarity += 1
+    if (levelRatio >= 4) extraRarity += 1
+    if (levelRatio >= 8) extraRarity += 1
+  }
+  return 1 + Math.min(6, Math.floor(6 * levelRatio)) + extraRarity
+}
+
+// ─── Levels until next rarity tier ─────────────────────────────────────────
+
+export interface LevelsUntilTalismanRarityIncreaseInput {
+  /** `talismans[t].level`. */
+  level: number
+  /** `talismans[t].maxLevel`. */
+  maxLevel: number
+  /** `talismans[t].rarity` — current rarity tier. */
+  currentRarity: number
+  /** `getTalismanLevelCap(t)` — `maxLevel + levelCapIncrease()`. */
+  levelCap: number
+}
+
+/**
+ * Levels remaining until the next rarity tier triggers. Once `level` reaches
+ * `maxLevel` the rarity stops ratcheting via the level-ratio thresholds (the
+ * 2×/4×/8× extras still fire, but this helper ignores them — UI just buys
+ * up to the cap once you're past the maxLevel mark).
+ */
+export function levelsUntilTalismanRarityIncrease (
+  input: LevelsUntilTalismanRarityIncreaseInput
+): number {
+  if (input.level >= input.maxLevel) {
+    return input.levelCap - input.level
+  }
+  const levelReq = Math.ceil(input.maxLevel * input.currentRarity / 6)
+  return levelReq - input.level
+}
+
+// ─── Affordability check ───────────────────────────────────────────────────
+
+export interface AffordableTalismanLevelInput {
+  /** Per-item cost for the next level — output of the talisman's cost progression. */
+  costs: TalismanCraftCosts
+  /**
+   * Per-item budget available. Same keys as `costs`. For real purchases this
+   * is the player's owned fragments; during save-loading it's the saved
+   * `fragmentsInvested` snapshot.
+   */
+  budget: Record<TalismanCraftItems, Decimal>
+  /**
+   * Floating-point cushion applied to the budget. The web_ui caller uses
+   * 1.0001 when re-deriving level from invested fragments after a save load
+   * (compensating for Decimal round-trip imprecision); 1 for live purchases.
+   */
+  bufferMult: number
+}
+
+/**
+ * Returns true iff every item in `costs` is ≤ `budget[item] * bufferMult`.
+ * Walks the cost map directly so unused keys (e.g. tier-locked fragments at
+ * zero cost) don't affect the result — they're trivially satisfied.
+ */
+export function affordableTalismanLevel (input: AffordableTalismanLevelInput): boolean {
+  for (const item in input.costs) {
+    const key = item as TalismanCraftItems
+    if (input.costs[key].gt(input.budget[key].times(input.bufferMult))) {
+      return false
+    }
+  }
+  return true
+}
+
+// ─── Sum of rarities ───────────────────────────────────────────────────────
+
+/**
+ * Sum of all talisman rarities. Used by the achievement-points formula for
+ * the rarity-based progressive achievement. Trivial reduce, lifted to logic
+ * so the web_ui side doesn't have to iterate the talismans map every time.
+ */
+export function sumOfTalismanRarities (rarities: readonly number[]): number {
+  let sum = 0
+  for (const r of rarities) {
+    sum += r
+  }
+  return sum
+}

--- a/packages/logic/test/parity/achievementPoints.parity.test.ts
+++ b/packages/logic/test/parity/achievementPoints.parity.test.ts
@@ -1,0 +1,309 @@
+// Parity tests for the achievement-points pure math migrated from
+// packages/web_ui/src/Achievements.ts. The OLD implementations are
+// transcribed below; the originals read `player.*` or closed over the
+// `cached` parameter the dispatch map fed them — the migration takes the
+// already-extracted player inputs as named arguments.
+
+import { describe, expect, it } from 'vitest'
+import {
+  ambrosiaCountPoints as newAmbrosia,
+  antMasteryPoints as newAntMastery,
+  type ComputeAchievementPointsInput,
+  computeAchievementPoints as newComputePoints,
+  exaltPoints as newExalt,
+  freeRuneLevelPoints as newFreeRune,
+  getAchievementQuarks as newAchQuarks,
+  maxedUpgradeFamilyPoints as newMaxedFamily,
+  rebornELOPoints as newRebornELO,
+  redAmbrosiaCountPoints as newRedAmbrosia,
+  runeLevelPoints as newRuneLevel,
+  singularityCountPoints as newSingCount,
+  talismanRarityPoints as newTalismanRarity
+} from '../../src/mechanics/achievementPoints'
+
+// ─── runeLevelPoints ───────────────────────────────────────────────────────
+
+const oldRuneLevel = (cached: number): number => {
+  return Math.min(200, Math.floor(cached / 1000)) + Math.min(400, Math.floor(cached / 2500))
+    + Math.min(400, Math.floor(cached / 12500))
+}
+
+describe('parity: runeLevelPoints', () => {
+  const cases = [0, 1, 999, 1000, 2499, 2500, 12499, 12500, 100_000, 200_000, 500_000, 5_000_000, 10_000_000]
+  for (const cached of cases) {
+    it(`cached=${cached}`, () => {
+      expect(newRuneLevel(cached)).toBe(oldRuneLevel(cached))
+    })
+  }
+})
+
+// ─── freeRuneLevelPoints ───────────────────────────────────────────────────
+
+const oldFreeRune = (cached: number): number => {
+  return Math.min(100, Math.floor(cached / 250)) + Math.min(200, Math.floor(cached / 750))
+    + Math.min(200, Math.floor(cached / 2500))
+}
+
+describe('parity: freeRuneLevelPoints', () => {
+  const cases = [0, 249, 250, 749, 750, 2499, 2500, 25_000, 50_000, 150_000, 500_000, 1_000_000]
+  for (const cached of cases) {
+    it(`cached=${cached}`, () => {
+      expect(newFreeRune(cached)).toBe(oldFreeRune(cached))
+    })
+  }
+})
+
+// ─── antMasteryPoints ──────────────────────────────────────────────────────
+
+const oldAntMastery = (masteries: readonly number[]): number => {
+  let pointValue = 0
+  for (const m of masteries) {
+    pointValue += 3 * m
+    if (m >= 12) {
+      pointValue += 4
+    }
+  }
+  return pointValue
+}
+
+describe('parity: antMasteryPoints', () => {
+  const cases: number[][] = [
+    [],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // 36
+    [11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11], // 12 * 33 = 396, no +4s
+    [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12], // 12 * (36 + 4) = 480
+    [13, 14, 15, 12, 11, 10, 5, 6, 7, 8, 9, 0], // mixed
+    [100] // single big
+  ]
+  for (const [idx, masteries] of cases.entries()) {
+    it(`case ${idx} (n=${masteries.length})`, () => {
+      expect(newAntMastery(masteries)).toBe(oldAntMastery(masteries))
+    })
+  }
+})
+
+// ─── rebornELOPoints ───────────────────────────────────────────────────────
+
+const oldRebornELO = (leaderboardELO: number): number => {
+  return Math.min(100, Math.floor(leaderboardELO / 100))
+    + Math.min(150, Math.floor(leaderboardELO / 1000))
+    + Math.min(150, Math.floor(leaderboardELO / 9000))
+    + Math.min(200, Math.floor(leaderboardELO / 75000))
+    + Math.min(400, Math.floor(leaderboardELO / 150000))
+}
+
+describe('parity: rebornELOPoints', () => {
+  const cases = [
+    0,
+    99,
+    100,
+    999,
+    1000,
+    8999,
+    9000,
+    74_999,
+    75_000,
+    149_999,
+    150_000,
+    1_000_000,
+    10_000_000,
+    100_000_000
+  ]
+  for (const elo of cases) {
+    it(`elo=${elo}`, () => {
+      expect(newRebornELO(elo)).toBe(oldRebornELO(elo))
+    })
+  }
+})
+
+// ─── singularityCountPoints ────────────────────────────────────────────────
+
+const oldSingCount = (h: number): number => {
+  return 9 * h + 3 * Math.max(0, h - 100) + 3 * Math.max(0, h - 200)
+}
+
+describe('parity: singularityCountPoints', () => {
+  const cases = [0, 1, 50, 99, 100, 101, 150, 199, 200, 201, 250, 300, 500, 1000]
+  for (const h of cases) {
+    it(`highest=${h}`, () => {
+      expect(newSingCount(h)).toBe(oldSingCount(h))
+    })
+  }
+})
+
+// ─── ambrosiaCountPoints ───────────────────────────────────────────────────
+
+const oldAmbrosia = (cached: number): number => {
+  return Math.min(200, Math.floor(cached / 100))
+    + Math.min(200, Math.floor(cached / 10000))
+    + Math.min(400, Math.floor(400 * Math.sqrt(cached / 1e8)))
+}
+
+describe('parity: ambrosiaCountPoints', () => {
+  const cases = [0, 99, 100, 9999, 10_000, 99_999, 100_000, 1e6, 1e7, 1e8, 1e9, 1e10, 1e12]
+  for (const cached of cases) {
+    it(`cached=${cached}`, () => {
+      expect(newAmbrosia(cached)).toBe(oldAmbrosia(cached))
+    })
+  }
+})
+
+// ─── redAmbrosiaCountPoints ────────────────────────────────────────────────
+
+const oldRedAmbrosia = (cached: number): number => {
+  return Math.min(200, Math.floor(cached / 25))
+    + Math.min(200, Math.floor(cached / 2500))
+    + Math.min(400, Math.floor(400 * cached / 5e6))
+    + Math.min(200, Math.floor(200 * cached / 1.25e7))
+}
+
+describe('parity: redAmbrosiaCountPoints', () => {
+  const cases = [0, 24, 25, 2499, 2500, 250_000, 5e6, 1.25e7, 5e7, 1e8, 1e9]
+  for (const cached of cases) {
+    it(`cached=${cached}`, () => {
+      expect(newRedAmbrosia(cached)).toBe(oldRedAmbrosia(cached))
+    })
+  }
+})
+
+// ─── talismanRarityPoints ──────────────────────────────────────────────────
+
+describe('parity: talismanRarityPoints', () => {
+  const cases = [0, 1, 7, 50, 100, 1000]
+  for (const cached of cases) {
+    it(`cached=${cached}`, () => {
+      expect(newTalismanRarity(cached)).toBe(5 * cached)
+    })
+  }
+})
+
+// ─── exaltPoints ───────────────────────────────────────────────────────────
+
+const oldExalt = (rewardAPs: readonly number[]): number => {
+  let pointValue = 0
+  for (const ap of rewardAPs) pointValue += ap
+  return pointValue
+}
+
+describe('parity: exaltPoints', () => {
+  const cases: number[][] = [
+    [],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [10, 20, 30, 40, 50, 60, 70, 80, 90], // 450
+    [100, 100, 100, 100, 100, 100, 100, 100, 100], // 900
+    [25, 0, 50, 75, 0, 100, 125, 0, 25] // partial completion
+  ]
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx}`, () => {
+      expect(newExalt(c)).toBe(oldExalt(c))
+    })
+  }
+})
+
+// ─── maxedUpgradeFamilyPoints ──────────────────────────────────────────────
+
+describe('parity: maxedUpgradeFamilyPoints', () => {
+  const cases: Array<[number, number]> = [
+    [0, 5],
+    [10, 5], // GQ side: 50
+    [80, 5], // 400
+    [0, 8],
+    [50, 8], // octeract: 400
+    [0, 10],
+    [20, 10], // red ambrosia: 200
+    [100, 10] // 1000
+  ]
+  for (const [count, points] of cases) {
+    it(`count=${count} pts=${points}`, () => {
+      expect(newMaxedFamily(count, points)).toBe(count * points)
+    })
+  }
+})
+
+// ─── getAchievementQuarks ──────────────────────────────────────────────────
+
+const oldAchQuarks = (globalQuarkMultiplier: number): number => {
+  let actualMultiplier = globalQuarkMultiplier
+  if (actualMultiplier > 100) {
+    actualMultiplier = Math.pow(100, 0.6) * Math.pow(actualMultiplier, 0.4)
+  }
+  return Math.floor(5 * actualMultiplier)
+}
+
+describe('parity: getAchievementQuarks', () => {
+  const cases = [1, 5, 10, 50, 99.99, 100, 100.01, 500, 1000, 10_000, 1e6, 1e9]
+  for (const mult of cases) {
+    it(`mult=${mult}`, () => {
+      expect(newAchQuarks(mult)).toBe(oldAchQuarks(mult))
+    })
+  }
+})
+
+// ─── computeAchievementPoints ──────────────────────────────────────────────
+//
+// The old aggregator walks the achievements array plus the progressive map.
+// The new signature takes pre-extracted parallel arrays.
+
+const oldComputePoints = (input: ComputeAchievementPointsInput): number => {
+  let points = 0
+  for (let i = 0; i < input.pointValues.length; i++) {
+    if (input.savedAchievements[i]) points += input.pointValues[i]
+  }
+  for (const a of input.progressivePointsAwarded) points += a
+  return points
+}
+
+describe('parity: computeAchievementPoints', () => {
+  const cases: Array<{ name: string, input: ComputeAchievementPointsInput }> = [
+    {
+      name: 'empty',
+      input: { pointValues: [], savedAchievements: [], progressivePointsAwarded: [] }
+    },
+    {
+      name: 'all locked',
+      input: {
+        pointValues: [5, 10, 15, 20, 25],
+        savedAchievements: [0, 0, 0, 0, 0],
+        progressivePointsAwarded: []
+      }
+    },
+    {
+      name: 'all unlocked',
+      input: {
+        pointValues: [5, 10, 15, 20, 25], // sum 75
+        savedAchievements: [1, 1, 1, 1, 1],
+        progressivePointsAwarded: []
+      }
+    },
+    {
+      name: 'partial + progressives',
+      input: {
+        pointValues: [5, 10, 15, 20, 25],
+        savedAchievements: [1, 0, 1, 0, 1], // 5 + 15 + 25 = 45
+        progressivePointsAwarded: [100, 200, 50] // 350
+      }
+    },
+    {
+      name: 'savedAchievements truthy non-1 still counts',
+      input: {
+        pointValues: [5, 10, 15],
+        savedAchievements: [2, 0, 5],
+        progressivePointsAwarded: []
+      }
+    },
+    {
+      name: 'realistic-shaped (subset)',
+      input: {
+        pointValues: Array.from({ length: 100 }, (_, i) => 5 + i % 30),
+        savedAchievements: Array.from({ length: 100 }, (_, i) => (i % 3 === 0 ? 1 : 0)),
+        progressivePointsAwarded: [800, 1000, 360, 1000, 3600, 500, 800, 1000]
+      }
+    }
+  ]
+  for (const { name, input } of cases) {
+    it(name, () => {
+      expect(newComputePoints(input)).toBe(oldComputePoints(input))
+    })
+  }
+})

--- a/packages/logic/test/parity/corruptions.parity.test.ts
+++ b/packages/logic/test/parity/corruptions.parity.test.ts
@@ -5,6 +5,11 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  calculateCorruptionDifficultyScore as newDifficultyScore,
+  calculateCorruptionRawMultiplier as newRawMult,
+  clipCorruptionLevel as newClipLevel,
+  type CorruptionRawMultiplierInput,
+  corruptionScoreMults,
   droughtEffect as newDrought,
   hyperchallengeEffect as newHyperchallenge,
   illiteracyEffect as newIlliteracy,
@@ -215,6 +220,139 @@ describe('parity: hyperchallengeEffect', () => {
       const divisor = 1 + 2 / 5 * c.platonicUpgrade8
       const oldVal = Math.max(1, c.baseEffect / divisor)
       expect(newHyperchallenge(c)).toBe(oldVal)
+    })
+  }
+})
+
+// ─── calculateCorruptionRawMultiplier ──────────────────────────────────────
+//
+// Old (in-class) implementation transcribed below, using the
+// corruptionScoreMults table as #corruptionScoreMults. bonusMult was always 1
+// in the original code, so we drop it from the new signature.
+
+const oldScoreMults = [1, 3, 4, 5, 6, 7, 7.75, 8.5, 9.25, 10, 10.75, 11.5, 12.25, 13, 16, 20, 25, 33, 35]
+
+const oldRawMult = (i: CorruptionRawMultiplierInput): number => {
+  const scoreMultLength = oldScoreMults.length
+  if (i.totalLevel < scoreMultLength - 1) {
+    const portionAboveLevel = Math.ceil(i.totalLevel) - i.totalLevel
+    return Math.pow(
+      oldScoreMults[Math.floor(i.totalLevel)] + i.bonusVal
+        + portionAboveLevel
+          * (oldScoreMults[Math.ceil(i.totalLevel)] - oldScoreMults[Math.floor(i.totalLevel)]),
+      i.viscosityPower
+    )
+  } else {
+    return Math.pow(
+      (oldScoreMults[scoreMultLength - 1] + i.bonusVal)
+        * Math.pow(1.2, i.totalLevel - scoreMultLength + 1),
+      i.viscosityPower
+    )
+  }
+}
+
+describe('parity: corruptionScoreMults', () => {
+  it('matches the legacy table values', () => {
+    expect([...corruptionScoreMults]).toEqual(oldScoreMults)
+  })
+})
+
+describe('parity: calculateCorruptionRawMultiplier', () => {
+  const cases: CorruptionRawMultiplierInput[] = [
+    // Integer levels below table length, no bonus, no viscosity exponent
+    { totalLevel: 0, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 5, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 13, bonusVal: 0, viscosityPower: 1 },
+    // Interpolation between table entries
+    { totalLevel: 0.5, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 5.25, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 12.5, bonusVal: 0, viscosityPower: 1 },
+    // Boundary: totalLevel = scoreMultLength - 1 (= 18) → tail branch
+    { totalLevel: 17.99, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 18, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 18.5, bonusVal: 0, viscosityPower: 1 },
+    // Far tail with 1.2^x extrapolation
+    { totalLevel: 30, bonusVal: 0, viscosityPower: 1 },
+    { totalLevel: 100, bonusVal: 0, viscosityPower: 1 },
+    // bonusVal contributions
+    { totalLevel: 3, bonusVal: 2.5, viscosityPower: 1 },
+    { totalLevel: 12.4, bonusVal: 10, viscosityPower: 1 },
+    { totalLevel: 25, bonusVal: 5, viscosityPower: 1 },
+    // viscosityPower != 1 (P4x2 path)
+    { totalLevel: 10, bonusVal: 0, viscosityPower: 3 },
+    { totalLevel: 10, bonusVal: 0, viscosityPower: 3.4 }, // 3 + 0.04 * 10
+    { totalLevel: 15.5, bonusVal: 3, viscosityPower: 3.2 },
+    { totalLevel: 25, bonusVal: 7, viscosityPower: 3.8 }
+  ]
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx} (level=${c.totalLevel} bonus=${c.bonusVal} vp=${c.viscosityPower})`, () => {
+      expect(newRawMult(c)).toBeCloseTo(oldRawMult(c), 10)
+    })
+  }
+})
+
+// ─── calculateCorruptionDifficultyScore ────────────────────────────────────
+
+const oldDifficultyScore = (levels: number[]): number => {
+  let basePoints = 400
+  for (const lvl of levels) {
+    basePoints += 16 * Math.pow(lvl, 2)
+  }
+  return basePoints
+}
+
+describe('parity: calculateCorruptionDifficultyScore', () => {
+  const cases: number[][] = [
+    [], // empty (just 400)
+    [0, 0, 0, 0, 0, 0, 0, 0], // all zeros
+    [1, 1, 1, 1, 1, 1, 1, 1], // each contributing 16
+    [11, 11, 11, 11, 11, 11, 11, 11], // c15 loadout
+    [5, 3, 7, 0, 0, 9, 12, 4], // mixed
+    [100, 0, 0, 0, 0, 0, 0, 0], // one large
+    [25, 13, 18, 22, 30, 8, 16, 19] // varied with bonuses applied
+  ]
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx} (sum=${c.reduce((a, b) => a + b, 0)})`, () => {
+      expect(newDifficultyScore(c)).toBe(oldDifficultyScore(c))
+    })
+  }
+})
+
+// ─── clipCorruptionLevel ───────────────────────────────────────────────────
+//
+// Old behavior: validateNonnegativeInteger reset to 0 on non-integer/NaN/etc,
+// then Math.max(0, x) then Math.min(maxLevel, x). Equivalent to:
+
+const oldClip = (level: number, maxLevel: number): number => {
+  let v = level
+  if (!Number.isFinite(v) || Number.isNaN(v) || !Number.isInteger(v)) {
+    v = 0
+  }
+  v = Math.max(0, v)
+  v = Math.min(maxLevel, v)
+  return v
+}
+
+describe('parity: clipCorruptionLevel', () => {
+  const cases: Array<[number, number]> = [
+    [0, 13],
+    [5, 13],
+    [13, 13],
+    [14, 13], // clamps to max
+    [-1, 13], // negative integer clamps to 0
+    [-100, 13],
+    [3.5, 13], // non-integer → 0
+    [Number.NaN, 13],
+    [Number.POSITIVE_INFINITY, 13],
+    [Number.NEGATIVE_INFINITY, 13],
+    [0, 0],
+    [5, 0], // maxLevel = 0
+    [11, 11], // exactly at max
+    [100, 20]
+  ]
+  for (const [level, maxLevel] of cases) {
+    it(`level=${level} maxLevel=${maxLevel}`, () => {
+      expect(newClipLevel(level, maxLevel)).toBe(oldClip(level, maxLevel))
     })
   }
 })

--- a/packages/logic/test/parity/talismanLevels.parity.test.ts
+++ b/packages/logic/test/parity/talismanLevels.parity.test.ts
@@ -1,0 +1,252 @@
+// Parity tests for the talisman rarity / level math migrated from
+// packages/web_ui/src/Talismans.ts. The OLD implementations are transcribed
+// below; the originals read `talismans[t].*` and `player.*` directly, the
+// migration takes those as named-field inputs.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import type { TalismanCraftCosts, TalismanCraftItems } from '../../src/mechanics/talismanCosts'
+import {
+  affordableTalismanLevel as newAffordable,
+  type AffordableTalismanLevelInput,
+  computeTalismanRarity as newComputeRarity,
+  type ComputeTalismanRarityInput,
+  levelsUntilTalismanRarityIncrease as newLevelsUntilRarity,
+  type LevelsUntilTalismanRarityIncreaseInput,
+  rarityValues,
+  sumOfTalismanRarities as newSumRarities
+} from '../../src/mechanics/talismanLevels'
+
+// ─── rarityValues ──────────────────────────────────────────────────────────
+
+describe('parity: rarityValues', () => {
+  it('matches the legacy table values', () => {
+    const oldTable: Record<number, number> = {
+      0: 0,
+      1: 1,
+      2: 1.2,
+      3: 1.5,
+      4: 1.8,
+      5: 2.1,
+      6: 2.5,
+      7: 3,
+      8: 3.25,
+      9: 3.5,
+      10: 4
+    }
+    for (const k of Object.keys(oldTable).map(Number)) {
+      expect(rarityValues[k]).toBe(oldTable[k])
+    }
+  })
+})
+
+// ─── computeTalismanRarity ─────────────────────────────────────────────────
+
+const oldComputeRarity = (input: ComputeTalismanRarityInput): number => {
+  if (!input.isUnlocked) return 0
+  const levelRatio = input.level / input.maxLevel
+  let extraRarity = 0
+  if (levelRatio >= 1) {
+    if (levelRatio >= 2) extraRarity += 1
+    if (levelRatio >= 4) extraRarity += 1
+    if (levelRatio >= 8) extraRarity += 1
+  }
+  return 1 + Math.min(6, Math.floor(6 * levelRatio)) + extraRarity
+}
+
+describe('parity: computeTalismanRarity', () => {
+  const cases: ComputeTalismanRarityInput[] = [
+    // Locked
+    { isUnlocked: false, level: 0, maxLevel: 180 },
+    { isUnlocked: false, level: 180, maxLevel: 180 },
+    { isUnlocked: false, level: 1440, maxLevel: 180 },
+    // Unlocked, below tier thresholds (rarity 1 territory: levelRatio < 1/6)
+    { isUnlocked: true, level: 0, maxLevel: 180 },
+    { isUnlocked: true, level: 5, maxLevel: 180 },
+    { isUnlocked: true, level: 29, maxLevel: 180 }, // 29/180 < 1/6 → 1
+    // Rarity tier knees on a 180-cap talisman
+    { isUnlocked: true, level: 30, maxLevel: 180 }, // 30/180 = 1/6 → 2
+    { isUnlocked: true, level: 60, maxLevel: 180 }, // 60/180 = 2/6 → 3
+    { isUnlocked: true, level: 90, maxLevel: 180 }, // 90/180 = 3/6 → 4
+    { isUnlocked: true, level: 120, maxLevel: 180 }, // 120/180 = 4/6 → 5
+    { isUnlocked: true, level: 150, maxLevel: 180 }, // 150/180 = 5/6 → 6
+    { isUnlocked: true, level: 180, maxLevel: 180 }, // level = max, ratio = 1 → 7
+    // 2x / 4x / 8x extra-rarity thresholds
+    { isUnlocked: true, level: 359, maxLevel: 180 }, // < 2x → 7
+    { isUnlocked: true, level: 360, maxLevel: 180 }, // = 2x → 8
+    { isUnlocked: true, level: 719, maxLevel: 180 }, // < 4x → 8
+    { isUnlocked: true, level: 720, maxLevel: 180 }, // = 4x → 9
+    { isUnlocked: true, level: 1439, maxLevel: 180 }, // < 8x → 9
+    { isUnlocked: true, level: 1440, maxLevel: 180 }, // = 8x → 10
+    { isUnlocked: true, level: 5000, maxLevel: 180 }, // far past 8x → 10
+    // Different maxLevel base (some talismans have different caps)
+    { isUnlocked: true, level: 90, maxLevel: 90 }, // ratio = 1 → 7
+    { isUnlocked: true, level: 45, maxLevel: 90 } // ratio = 0.5 = 3/6 → 4
+  ]
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx} (unlocked=${c.isUnlocked} level=${c.level}/${c.maxLevel})`, () => {
+      expect(newComputeRarity(c)).toBe(oldComputeRarity(c))
+    })
+  }
+})
+
+// ─── levelsUntilTalismanRarityIncrease ─────────────────────────────────────
+
+const oldLevelsUntilRarity = (input: LevelsUntilTalismanRarityIncreaseInput): number => {
+  if (input.level >= input.maxLevel) {
+    return input.levelCap - input.level
+  }
+  const levelReq = Math.ceil(input.maxLevel * input.currentRarity / 6)
+  return levelReq - input.level
+}
+
+describe('parity: levelsUntilTalismanRarityIncrease', () => {
+  const cases: LevelsUntilTalismanRarityIncreaseInput[] = [
+    // Below maxLevel — uses ceil(maxLevel * rarity / 6) threshold
+    { level: 0, maxLevel: 180, currentRarity: 1, levelCap: 200 }, // ceil(30) - 0 = 30
+    { level: 5, maxLevel: 180, currentRarity: 1, levelCap: 200 }, // ceil(30) - 5 = 25
+    { level: 30, maxLevel: 180, currentRarity: 2, levelCap: 200 }, // ceil(60) - 30 = 30
+    { level: 60, maxLevel: 180, currentRarity: 3, levelCap: 200 }, // ceil(90) - 60 = 30
+    { level: 90, maxLevel: 180, currentRarity: 4, levelCap: 200 }, // ceil(120) - 90 = 30
+    { level: 120, maxLevel: 180, currentRarity: 5, levelCap: 200 }, // ceil(150) - 120 = 30
+    { level: 150, maxLevel: 180, currentRarity: 6, levelCap: 200 }, // ceil(180) - 150 = 30
+    // Non-divisible maxLevel for ceil() coverage
+    { level: 0, maxLevel: 100, currentRarity: 1, levelCap: 120 }, // ceil(16.67) - 0 = 17
+    { level: 17, maxLevel: 100, currentRarity: 2, levelCap: 120 }, // ceil(33.33) - 17 = 17
+    // Level >= maxLevel: levelCap - level branch
+    { level: 180, maxLevel: 180, currentRarity: 7, levelCap: 200 }, // 200 - 180 = 20
+    { level: 195, maxLevel: 180, currentRarity: 7, levelCap: 200 }, // 200 - 195 = 5
+    { level: 200, maxLevel: 180, currentRarity: 8, levelCap: 200 }, // 0
+    // levelCap === maxLevel (no levelCapIncrease)
+    { level: 180, maxLevel: 180, currentRarity: 7, levelCap: 180 } // 0
+  ]
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx} (level=${c.level} maxLevel=${c.maxLevel} rarity=${c.currentRarity} cap=${c.levelCap})`, () => {
+      expect(newLevelsUntilRarity(c)).toBe(oldLevelsUntilRarity(c))
+    })
+  }
+})
+
+// ─── affordableTalismanLevel ───────────────────────────────────────────────
+
+const oldAffordable = (input: AffordableTalismanLevelInput): boolean => {
+  for (const item in input.costs) {
+    if (input.costs[item as TalismanCraftItems].gt(input.budget[item as TalismanCraftItems].times(input.bufferMult))) {
+      return false
+    }
+  }
+  return true
+}
+
+const allZeroBudget = (): Record<TalismanCraftItems, Decimal> => ({
+  shard: new Decimal(0),
+  commonFragment: new Decimal(0),
+  uncommonFragment: new Decimal(0),
+  rareFragment: new Decimal(0),
+  epicFragment: new Decimal(0),
+  legendaryFragment: new Decimal(0),
+  mythicalFragment: new Decimal(0)
+})
+
+const fullCostMap = (n: number): TalismanCraftCosts => ({
+  shard: new Decimal(n),
+  commonFragment: new Decimal(n),
+  uncommonFragment: new Decimal(n),
+  rareFragment: new Decimal(n),
+  epicFragment: new Decimal(n),
+  legendaryFragment: new Decimal(n),
+  mythicalFragment: new Decimal(n)
+})
+
+describe('parity: affordableTalismanLevel', () => {
+  const cases: Array<{ name: string, input: AffordableTalismanLevelInput }> = [
+    // Zero cost: always affordable
+    {
+      name: 'zero cost / zero budget',
+      input: { costs: fullCostMap(0), budget: allZeroBudget(), bufferMult: 1 }
+    },
+    // All affordable
+    {
+      name: 'budget > cost',
+      input: {
+        costs: fullCostMap(100),
+        budget: fullCostMap(1000),
+        bufferMult: 1
+      }
+    },
+    // Exactly affordable: cost equals budget * bufferMult
+    {
+      name: 'cost exactly equal to budget',
+      input: {
+        costs: fullCostMap(100),
+        budget: fullCostMap(100),
+        bufferMult: 1
+      }
+    },
+    // One item over budget
+    {
+      name: 'shard over budget',
+      input: {
+        costs: { ...fullCostMap(50), shard: new Decimal(200) },
+        budget: fullCostMap(100),
+        bufferMult: 1
+      }
+    },
+    // bufferMult = 1.0001 lets a tiny imprecision through
+    {
+      name: 'loading buffer covers tiny imprecision',
+      input: {
+        costs: fullCostMap(100.005),
+        budget: fullCostMap(100),
+        bufferMult: 1.0001
+      }
+    },
+    // bufferMult = 1.0001 still rejects significant over-cost
+    {
+      name: 'loading buffer rejects 1% over',
+      input: {
+        costs: fullCostMap(101),
+        budget: fullCostMap(100),
+        bufferMult: 1.0001
+      }
+    },
+    // Tier-locked costs (zero in upper tiers, only shard cost set)
+    {
+      name: 'only shard cost, upper tiers zero',
+      input: {
+        costs: { ...allZeroBudget(), shard: new Decimal(50) },
+        budget: { ...allZeroBudget(), shard: new Decimal(100) },
+        bufferMult: 1
+      }
+    }
+  ]
+  for (const { name, input } of cases) {
+    it(name, () => {
+      expect(newAffordable(input)).toBe(oldAffordable(input))
+    })
+  }
+})
+
+// ─── sumOfTalismanRarities ─────────────────────────────────────────────────
+
+const oldSumRarities = (rarities: readonly number[]): number => {
+  let sum = 0
+  for (const r of rarities) sum += r
+  return sum
+}
+
+describe('parity: sumOfTalismanRarities', () => {
+  const cases: readonly number[][] = [
+    [],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], // 10 unlocked at rarity 1 → 10
+    [7, 7, 7, 7, 7, 7, 7, 7, 7, 7], // all maxed-out → 70
+    [10, 10, 10, 10, 10, 10, 10, 10, 10, 10], // all overcapped → 100
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] // mixed
+  ]
+  for (const [idx, c] of cases.entries()) {
+    it(`case ${idx} (n=${c.length})`, () => {
+      expect(newSumRarities(c)).toBe(oldSumRarities(c))
+    })
+  }
+})

--- a/packages/web_ui/src/Achievements.ts
+++ b/packages/web_ui/src/Achievements.ts
@@ -1,5 +1,17 @@
 import {
   achievementLevelFromPoints as logicAchievementLevelFromPoints,
+  ambrosiaCountPoints as logicAmbrosiaCountPoints,
+  antMasteryPoints as logicAntMasteryPoints,
+  computeAchievementPoints as logicComputeAchievementPoints,
+  exaltPoints as logicExaltPoints,
+  freeRuneLevelPoints as logicFreeRuneLevelPoints,
+  getAchievementQuarks as logicGetAchievementQuarks,
+  maxedUpgradeFamilyPoints as logicMaxedUpgradeFamilyPoints,
+  rebornELOPoints as logicRebornELOPoints,
+  redAmbrosiaCountPoints as logicRedAmbrosiaCountPoints,
+  runeLevelPoints as logicRuneLevelPoints,
+  singularityCountPoints as logicSingularityCountPoints,
+  talismanRarityPoints as logicTalismanRarityPoints,
   toNextAchievementLevelEXP as logicToNextAchievementLevelEXP
 } from '@synergism/logic'
 import Decimal from 'break_infinity.js'
@@ -122,15 +134,7 @@ export const buildingAchievementCheck = () => {
   awardAchievementGroup('fifthOwnedCoin')
 }
 
-const getAchievementQuarks = () => {
-  const globalQuarkMultiplier = player.worlds.applyBonus(1)
-  let actualMultiplier = globalQuarkMultiplier
-  if (actualMultiplier > 100) {
-    actualMultiplier = Math.pow(100, 0.6) * Math.pow(actualMultiplier, 0.4)
-  }
-
-  return Math.floor(5 * actualMultiplier)
-}
+const getAchievementQuarks = () => logicGetAchievementQuarks(player.worlds.applyBonus(1))
 
 /* June 9, 2025 Achievements System Rewrite */
 export type AchievementGroups =
@@ -285,10 +289,7 @@ export type ProgressiveAchievements =
 export const progressiveAchievements: Record<ProgressiveAchievements, ProgressiveAchievement> = {
   runeLevel: {
     maxPointValue: 1000,
-    pointsAwarded: (cached: number) => {
-      return Math.min(200, Math.floor(cached / 1000)) + Math.min(400, Math.floor(cached / 2500))
-        + Math.min(400, Math.floor(cached / 12500))
-    },
+    pointsAwarded: (cached: number) => logicRuneLevelPoints(cached),
     updateValue: () => {
       return sumOfRuneLevels()
     },
@@ -299,10 +300,7 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   },
   freeRuneLevel: {
     maxPointValue: 500,
-    pointsAwarded: (cached: number) => {
-      return Math.min(100, Math.floor(cached / 250)) + Math.min(200, Math.floor(cached / 750))
-        + Math.min(200, Math.floor(cached / 2500))
-    },
+    pointsAwarded: (cached: number) => logicFreeRuneLevelPoints(cached),
     updateValue: () => {
       return sumOfFreeRuneLevels()
     },
@@ -314,14 +312,11 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   antMasteries: {
     maxPointValue: 360,
     pointsAwarded: (_cached: number) => {
-      let pointValue = 0
+      const masteries: number[] = []
       for (let ant = AntProducers.Workers; ant <= LAST_ANT_PRODUCER; ant++) {
-        pointValue += 3 * player.ants.masteries[ant].highestMastery
-        if (player.ants.masteries[ant].highestMastery >= 12) {
-          pointValue += 4
-        }
+        masteries.push(player.ants.masteries[ant].highestMastery)
       }
-      return pointValue
+      return logicAntMasteryPoints(masteries)
     },
     updateValue: () => {
       let numMasteries = 0
@@ -337,14 +332,8 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   },
   rebornELO: {
     maxPointValue: 1000,
-    pointsAwarded: (_cached: number) => {
-      const leaderboardELO = calculateLeaderboardValue(player.ants.highestRebornELOEver)
-      return Math.min(100, Math.floor(leaderboardELO / 100))
-        + Math.min(150, Math.floor(leaderboardELO / 1000))
-        + Math.min(150, Math.floor(leaderboardELO / 9000))
-        + Math.min(200, Math.floor(leaderboardELO / 75000))
-        + Math.min(400, Math.floor(leaderboardELO / 150000))
-    },
+    pointsAwarded: (_cached: number) =>
+      logicRebornELOPoints(calculateLeaderboardValue(player.ants.highestRebornELOEver)),
     updateValue: () => {
       return calculateLeaderboardValue(player.ants.highestRebornELOEver)
     },
@@ -355,11 +344,7 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   },
   singularityCount: {
     maxPointValue: 3600,
-    pointsAwarded: (_cached: number) => {
-      return 9 * player.highestSingularityCount
-        + 3 * Math.max(0, player.highestSingularityCount - 100)
-        + 3 * Math.max(0, player.highestSingularityCount - 200)
-    },
+    pointsAwarded: (_cached: number) => logicSingularityCountPoints(player.highestSingularityCount),
     updateValue: () => {
       return player.highestSingularityCount
     },
@@ -370,11 +355,7 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   },
   ambrosiaCount: {
     maxPointValue: 800,
-    pointsAwarded: (cached: number) => {
-      return Math.min(200, Math.floor(cached / 100))
-        + Math.min(200, Math.floor(cached / 10000))
-        + Math.min(400, Math.floor(400 * Math.sqrt(cached / 1e8)))
-    },
+    pointsAwarded: (cached: number) => logicAmbrosiaCountPoints(cached),
     updateValue: () => {
       return player.lifetimeAmbrosia
     },
@@ -385,12 +366,7 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   },
   redAmbrosiaCount: {
     maxPointValue: 1000,
-    pointsAwarded: (cached: number) => {
-      return Math.min(200, Math.floor(cached / 25))
-        + Math.min(200, Math.floor(cached / 2500))
-        + Math.min(400, Math.floor(400 * cached / 5e6))
-        + Math.min(200, Math.floor(200 * cached / 1.25e7))
-    },
+    pointsAwarded: (cached: number) => logicRedAmbrosiaCountPoints(cached),
     updateValue: () => {
       return player.lifetimeRedAmbrosia
     },
@@ -402,11 +378,11 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   exalts: {
     maxPointValue: maxAPFromChallenges,
     pointsAwarded: (_cached: number) => {
-      let pointValue = 0
+      const rewardAPs: number[] = []
       for (const chal of Object.keys(player.singularityChallenges) as SingularityChallengeDataKeys[]) {
-        pointValue += player.singularityChallenges[chal].rewardAP
+        rewardAPs.push(player.singularityChallenges[chal].rewardAP)
       }
-      return pointValue
+      return logicExaltPoints(rewardAPs)
     },
     updateValue: () => {
       return 0
@@ -441,14 +417,13 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   singularityUpgrades: {
     maxPointValue: maxGoldenQuarkUpgradeAP,
     pointsAwarded: (_cached: number) => {
-      let pointValue = 0
-      // Go through all sing upgrades. if the max level is NOT -1, add 5 points if the upgrade level equals max level
+      let maxedCount = 0
       for (const upgrade of Object.values(goldenQuarkUpgrades)) {
         if (upgrade.maxLevel !== -1 && upgrade.level >= upgrade.maxLevel) {
-          pointValue += 5
+          maxedCount += 1
         }
       }
-      return pointValue
+      return logicMaxedUpgradeFamilyPoints(maxedCount, 5)
     },
     updateValue: () => {
       return 0
@@ -461,14 +436,13 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   octeractUpgrades: {
     maxPointValue: maxOcteractUpgradeAP,
     pointsAwarded: (_cached: number) => {
-      let pointValue = 0
-      // Go through all octeract upgrades. if the max level is NOT -1, add 8 points if the upgrade level equals max level
+      let maxedCount = 0
       for (const upgrade of Object.values(octeractUpgrades)) {
         if (upgrade.maxLevel !== -1 && upgrade.level >= upgrade.maxLevel) {
-          pointValue += 8
+          maxedCount += 1
         }
       }
-      return pointValue
+      return logicMaxedUpgradeFamilyPoints(maxedCount, 8)
     },
     updateValue: () => {
       return 0
@@ -481,13 +455,13 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   redAmbrosiaUpgrades: {
     maxPointValue: maxRedAmbrosiaUpgradeAP,
     pointsAwarded: () => {
-      let pointValue = 0
+      let maxedCount = 0
       for (const upgrade of Object.values(redAmbrosiaUpgrades)) {
         if (upgrade.level >= upgrade.maxLevel) {
-          pointValue += 10
+          maxedCount += 1
         }
       }
-      return pointValue
+      return logicMaxedUpgradeFamilyPoints(maxedCount, 10)
     },
     updateValue: () => {
       return 0
@@ -499,9 +473,7 @@ export const progressiveAchievements: Record<ProgressiveAchievements, Progressiv
   },
   talismanRarities: {
     maxPointValue: maxTalismansRarityAP,
-    pointsAwarded: (cached: number) => {
-      return 5 * cached
-    },
+    pointsAwarded: (cached: number) => logicTalismanRarityPoints(cached),
     updateValue: () => {
       return Object.values(talismans).reduce((acc, talisman) => {
         acc += talisman.rarity
@@ -3602,15 +3574,14 @@ export function computeAchievementPoints (
   savedAchievements: number[],
   savedProgressiveAchievements: Record<string, number>
 ): number {
-  let points = achievements.reduce((sum, ach, index) => {
-    return sum + (savedAchievements[index] ? ach.pointValue : 0)
-  }, 0)
-
-  for (const k of Object.keys(progressiveAchievements) as ProgressiveAchievements[]) {
-    points += progressiveAchievements[k].pointsAwarded(savedProgressiveAchievements[k] ?? 0)
-  }
-
-  return points
+  const progressiveKeys = Object.keys(progressiveAchievements) as ProgressiveAchievements[]
+  return logicComputeAchievementPoints({
+    pointValues: achievements.map((ach) => ach.pointValue),
+    savedAchievements,
+    progressivePointsAwarded: progressiveKeys.map((k) =>
+      progressiveAchievements[k].pointsAwarded(savedProgressiveAchievements[k] ?? 0)
+    )
+  })
 }
 
 export const toNextAchievementLevelEXP = () => logicToNextAchievementLevelEXP(achievementPoints)

--- a/packages/web_ui/src/Corruptions.ts
+++ b/packages/web_ui/src/Corruptions.ts
@@ -1,4 +1,7 @@
 import {
+  calculateCorruptionDifficultyScore as logicCorruptionDifficultyScore,
+  calculateCorruptionRawMultiplier as logicCorruptionRawMultiplier,
+  clipCorruptionLevel as logicClipCorruptionLevel,
   droughtEffect as logicDroughtEffect,
   hyperchallengeEffect as logicHyperchallengeEffect,
   illiteracyEffect as logicIlliteracyEffect,
@@ -19,7 +22,7 @@ import { getTalismanEffects } from './Talismans'
 import { IconSets } from './Themes'
 import { toggleCorruptionLevel } from './Toggles'
 import { Alert, Notification, Prompt } from './UpdateHTML'
-import { getElementById, productContents, sumContents, validateNonnegativeInteger } from './Utility'
+import { getElementById, productContents, sumContents } from './Utility'
 import { Globals as G } from './Variables'
 
 enum CorruptionIndices {
@@ -87,7 +90,6 @@ export const c15Corruptions: Corruptions = {
 
 export class CorruptionLoadout {
   #totalScoreMult = 1
-  #corruptionScoreMults = [1, 3, 4, 5, 6, 7, 7.75, 8.5, 9.25, 10, 10.75, 11.5, 12.25, 13, 16, 20, 25, 33, 35]
   #levels: Corruptions = {
     viscosity: 0,
     drought: 0,
@@ -127,19 +129,11 @@ export class CorruptionLoadout {
   }
 
   public clipCorruptionLevels () {
-    const minLevel = 0
     const maxLevel = maxCorruptionLevel()
 
     for (const [corr, level] of Object.entries(this.#levels)) {
       const corruption = corr as keyof Corruptions
-
-      // Standard Validation
-      if (!validateNonnegativeInteger(level)) {
-        this.#levels[corruption] = 0
-      }
-
-      this.#levels[corruption] = Math.max(minLevel, this.#levels[corruption])
-      this.#levels[corruption] = Math.min(maxLevel, this.#levels[corruption])
+      this.#levels[corruption] = logicClipCorruptionLevel(level, maxLevel)
     }
   }
 
@@ -148,32 +142,17 @@ export class CorruptionLoadout {
     bonusVal += getSingularityChallengeEffect('oneChallengeCap', 'corrScoreIncrease')
     bonusVal += 0.3 * player.cubeUpgrades[74]
 
-    const bonusMult = 1
-
     // player.platonicUpgrades[17] is the 17th platonic upgrade, known usually as P4x2, makes
     // Exponent 3 + 0.04 * level if the corr is viscosity and it is set at least level 10.
     const viscosityPower = (player.platonicUpgrades[17] > 0 && this.#levels.viscosity >= 10 && corr === 'viscosity')
       ? 3 + 0.04 * player.platonicUpgrades[17]
       : 1
 
-    const totalLevel = this.#levels[corr] + this.bonusLevels
-    const scoreMultLength = this.#corruptionScoreMults.length
-
-    if (totalLevel < scoreMultLength - 1) {
-      const portionAboveLevel = Math.ceil(totalLevel) - totalLevel
-      return Math.pow(
-        this.#corruptionScoreMults[Math.floor(totalLevel)] + bonusVal
-          + portionAboveLevel
-            * (this.#corruptionScoreMults[Math.ceil(totalLevel)] - this.#corruptionScoreMults[Math.floor(totalLevel)]),
-        viscosityPower
-      ) * bonusMult
-    } else {
-      return Math.pow(
-        (this.#corruptionScoreMults[scoreMultLength - 1] + bonusVal)
-          * Math.pow(1.2, totalLevel - scoreMultLength + 1),
-        viscosityPower
-      ) * bonusMult
-    }
+    return logicCorruptionRawMultiplier({
+      totalLevel: this.#levels[corr] + this.bonusLevels,
+      bonusVal,
+      viscosityPower
+    })
   }
 
   #viscosityEffect () {
@@ -270,11 +249,8 @@ export class CorruptionLoadout {
   }
 
   get totalCorruptionDifficultyScore () {
-    let basePoints = 400
-    Object.keys(this.#levels).forEach((key) => {
-      basePoints += 16 * Math.pow(this.getTotalLevel(key as keyof Corruptions), 2)
-    })
-    return basePoints
+    const bonus = this.bonusLevels
+    return logicCorruptionDifficultyScore(Object.values(this.#levels).map((lvl) => lvl + bonus))
   }
 
   get totalCorruptionDifficultyMultiplier () {

--- a/packages/web_ui/src/Talismans.ts
+++ b/packages/web_ui/src/Talismans.ts
@@ -1,16 +1,21 @@
 import {
   achievementTalismanEffects as logicAchievementTalismanEffects,
+  affordableTalismanLevel as logicAffordableTalismanLevel,
   chronosTalismanEffects as logicChronosTalismanEffects,
+  computeTalismanRarity as logicComputeTalismanRarity,
   cookieGrandmaTalismanEffects as logicCookieGrandmaTalismanEffects,
   exemptionTalismanEffects as logicExemptionTalismanEffects,
   exponentialCostProgression as logicExponentialCostProgression,
   horseShoeTalismanEffects as logicHorseShoeTalismanEffects,
+  levelsUntilTalismanRarityIncrease as logicLevelsUntilTalismanRarityIncrease,
   metaphysicsTalismanEffects as logicMetaphysicsTalismanEffects,
   midasTalismanEffects as logicMidasTalismanEffects,
   mortuusTalismanEffects as logicMortuusTalismanEffects,
   plasticTalismanEffects as logicPlasticTalismanEffects,
   polymathTalismanEffects as logicPolymathTalismanEffects,
+  rarityValues as logicRarityValues,
   regularCostProgression as logicRegularCostProgression,
+  sumOfTalismanRarities as logicSumOfTalismanRarities,
   type TalismanCraftItems as LogicTalismanCraftItems,
   wowSquareTalismanEffects as logicWowSquareTalismanEffects
 } from '@synergism/logic'
@@ -102,19 +107,7 @@ export const noTalismanFragments: Record<TalismanCraftItems, Decimal> = {
   mythicalFragment: new Decimal(0)
 }
 
-const rarityValues: Record<number, number> = {
-  0: 0,
-  1: 1,
-  2: 1.2,
-  3: 1.5,
-  4: 1.8,
-  5: 2.1,
-  6: 2.5,
-  7: 3,
-  8: 3.25,
-  9: 3.5,
-  10: 4
-}
+const rarityValues = logicRarityValues
 
 interface TalismanData<K extends TalismanKeys> {
   level: number
@@ -615,64 +608,34 @@ export const getTalismanLevelCap = (t: TalismanKeys) => {
 }
 
 const setTalismanRarity = (t: TalismanKeys) => {
-  if (!talismans[t].isUnlocked()) {
-    talismans[t].rarity = 0
-    return
-  }
-
-  // Since the actual level cap depends on
-  // level cap increasers, this can be greater than 1
-  const levelRatio = talismans[t].level / talismans[t].maxLevel
-
-  let extraRarity = 0
-  if (levelRatio >= 1) {
-    if (levelRatio >= 2) {
-      extraRarity += 1
-    }
-    if (levelRatio >= 4) {
-      extraRarity += 1
-    }
-    if (levelRatio >= 8) {
-      extraRarity += 1
-    }
-  }
-
-  talismans[t].rarity = 1 + Math.min(6, Math.floor(6 * levelRatio)) + extraRarity
+  talismans[t].rarity = logicComputeTalismanRarity({
+    isUnlocked: talismans[t].isUnlocked(),
+    level: talismans[t].level,
+    maxLevel: talismans[t].maxLevel
+  })
 }
 
-const levelsUntilRarityIncrease = (t: TalismanKeys) => {
-  const level = talismans[t].level
-  const maxLevel = talismans[t].maxLevel
-  if (level >= maxLevel) {
-    // This ignores rarity above 7...
-    // And just tries to level to cap
-    return getTalismanLevelCap(t) - level
-  } else {
-    const currentRarity = talismans[t].rarity
-    const levelReq = Math.ceil(maxLevel * currentRarity / 6)
-    return levelReq - level
-  }
-}
+const levelsUntilRarityIncrease = (t: TalismanKeys) =>
+  logicLevelsUntilTalismanRarityIncrease({
+    level: talismans[t].level,
+    maxLevel: talismans[t].maxLevel,
+    currentRarity: talismans[t].rarity,
+    levelCap: getTalismanLevelCap(t)
+  })
 
 const affordableNextLevel = (
   t: TalismanKeys,
   budget: Record<TalismanCraftItems, Decimal>,
   level: number,
   loadingTalismans = false
-): boolean => {
-  const costs = talismans[t].costs(talismans[t].baseMult, level)
-  // This fixes a bug where imprecisions cause Talismans to be one level lower after loading
-  // Talismans might need a redesign in terms of leveling, to make it more in line with Runes/Spirits/Blessings
-  const smallBufferMult = loadingTalismans ? 1.0001 : 1
-
-  for (const item in costs) {
-    if (costs[item as TalismanCraftItems].gt(budget[item as TalismanCraftItems].times(smallBufferMult))) {
-      return false
-    }
-  }
-
-  return true
-}
+): boolean =>
+  // The 1.0001 cushion when loadingTalismans is true fixes a save-load bug
+  // where Decimal imprecision dropped talismans by one level on import.
+  logicAffordableTalismanLevel({
+    costs: talismans[t].costs(talismans[t].baseMult, level),
+    budget,
+    bufferMult: loadingTalismans ? 1.0001 : 1
+  })
 
 export const updateTalismanLevelAndSpentFromInvested = (t: TalismanKeys): void => {
   let level = 0
@@ -1122,13 +1085,10 @@ export const resetTalismanData = (tier: keyof typeof resetTiers) => {
   player.mythicalFragments = new Decimal(0)
 }
 
-export const sumOfTalismanRarities = (): number => {
-  let sum = 0
-  for (const t of Object.keys(talismans) as TalismanKeys[]) {
-    sum += talismans[t].rarity
-  }
-  return sum
-}
+export const sumOfTalismanRarities = (): number =>
+  logicSumOfTalismanRarities(
+    (Object.keys(talismans) as TalismanKeys[]).map((t) => talismans[t].rarity)
+  )
 
 /**
  * Updates legacy talisman data (player.talismanLevels[i]) to the

--- a/packages/web_ui/src/Utility.ts
+++ b/packages/web_ui/src/Utility.ts
@@ -273,9 +273,6 @@ export function memoize<Args extends unknown[], Ret> (fn: (...args: Args) => Ret
   }
 }
 
-export const validateNonnegativeInteger = (n: number | string): boolean => {
-  return Number.isFinite(n) && !Number.isNaN(n) && Number.isInteger(n)
-}
 /**
  * Finds the highest (index + 1) where array[index] is less than or equal to the target number,
  * but array[index + 1] is greater than the target number.


### PR DESCRIPTION
## Summary

Three migrations into `packages/logic`, all following the established pattern: `web_ui` keeps the data table (UI fields, i18n closures, player adapters); logic owns the pure-formula portion.

- **Corruptions** — `corruptionScoreMults` table + `calculateCorruptionRawMultiplier` (interpolation + 1.2^x tail) + `calculateCorruptionDifficultyScore` + `clipCorruptionLevel`. `CorruptionLoadout`'s in-class formulas collapse to one-line shims. Unused `validateNonnegativeInteger` helper deleted.
- **Talisman rarity / level** — new `talismanLevels.ts` module: `rarityValues` table, `computeTalismanRarity` (with 2×/4×/8× extra-rarity thresholds), `levelsUntilTalismanRarityIncrease`, `affordableTalismanLevel` (Decimal-aware with save-load buffer), `sumOfTalismanRarities`.
- **Achievement points** — new `achievementPoints.ts` module covering all 12 progressive `pointsAwarded` formulas (rune levels, ant masteries, reborn ELO, singularity count, ambrosia counts, talisman rarities, exalts, maxed upgrade families), plus `getAchievementQuarks` and the `computeAchievementPoints` aggregator.

Adds **236 parity assertions** total (67 + 48 + 121).

## Test plan

- [x] `npm test` — 29,669 tests pass
- [x] `npm run check:tsc` — clean across logic + web_ui + desktop_ui
- [x] `npm run lint` — no new warnings (14 pre-existing in untouched files)
- [x] `npx madge --circular` — no new circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)