### PR TITLE
refactor: migrate tick body foundation into @synergism/logic

### DIFF
--- a/packages/logic/src/events/types.ts
+++ b/packages/logic/src/events/types.ts
@@ -64,3 +64,62 @@ export type CoreEvent =
       /** wowTesseracts spent (plain number — WowTesseracts wrapper stays in web_ui). */
       spent: number
     }
+  // ─── Tick events ──────────────────────────────────────────────────────────
+  // Emitted by the migrated tick body. UI subscribers translate these into the
+  // side effects the legacy in-place tick performed directly (revealStuff,
+  // achievement notifications, visual research/ant/octeract refreshes, etc.).
+  | {
+      kind: 'resources-gained'
+      /** Per-tick coin gain (after taxdivisor + maxexponent clamp). Zero if produceTotal < 0.001. */
+      coins: Decimal
+      /** Per-tick prestige-point gain from upgrade 93 (zero otherwise). */
+      prestigePoints: Decimal
+      /** Per-tick transcend-point gain from upgrade 100 (zero otherwise). */
+      transcendPoints: Decimal
+      /** Per-tick reincarnation-point gain from cubeUpgrade 28 (zero otherwise). */
+      reincarnationPoints: Decimal
+      /** Per-tick prestigeShard gain from diamond production (zero in t-chal 3 / r-chal 10). */
+      prestigeShards: Decimal
+      /** Per-tick transcendShard gain from mythos production (zero in t-chal 3 / r-chal 10). */
+      transcendShards: Decimal
+      /** Per-tick reincarnationShard gain from particle production. */
+      reincarnationShards: Decimal
+      /** Per-tick ascendShard gain from the first ascension building. */
+      ascendShards: Decimal
+    }
+  | {
+      kind: 'auto-reset-triggered'
+      /** Which reset tier auto-fired this tick. */
+      tier: 'prestige' | 'transcension' | 'reincarnation' | 'ascension'
+      /** Whether the threshold check was point-amount based or wall-clock based. */
+      mode: 'amount' | 'time'
+    }
+  | {
+      kind: 'achievement-group-awarded'
+      /** Group key passed to awardAchievementGroup() — e.g. 'constant', 'antCrumbs'. */
+      group: string
+    }
+  | {
+      kind: 'auto-tool-fired'
+      /** Which automaticTools branch fired. */
+      tool: 'runeSacrifice' | 'antSacrifice' | 'addObtainium' | 'addOfferings'
+    }
+  | {
+      kind: 'challenge-sweep-transitioned'
+      /** SweepState kind transitioned out of. */
+      from: string
+      /** SweepState kind transitioned into. */
+      to: string
+    }
+  | {
+      kind: 'reveal-needed'
+      /** Which legacy revealStuff() trigger fired — names mirror the four checks in resourceGain. */
+      trigger: 'coinone' | 'cointwo' | 'cointhree' | 'coinfour'
+    }
+  | {
+      kind: 'challenge-auto-completed'
+      /** challengecompletions index that was just incremented (1..5). */
+      challengeIndex: 1 | 2 | 3 | 4 | 5
+      /** New completion count after increment. */
+      newCompletions: number
+    }

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -886,6 +886,26 @@ export {
   resetTimeThreshold
 } from './mechanics/resetTimeAndAutoObtainium'
 export type {
+  ResetCurrencyInput,
+  ResetCurrencyResult
+} from './mechanics/resetCurrency'
+export { resetCurrency } from './mechanics/resetCurrency'
+export type {
+  UpdateAllTickInput,
+  UpdateAllTickResult
+} from './mechanics/updateAllTick'
+export { updateAllTick } from './mechanics/updateAllTick'
+export type {
+  UpdateAllMultiplierInput,
+  UpdateAllMultiplierResult
+} from './mechanics/updateAllMultiplier'
+export { updateAllMultiplier } from './mechanics/updateAllMultiplier'
+export type {
+  GlobalMultipliersInput,
+  GlobalMultipliersResult
+} from './mechanics/globalMultipliers'
+export { computeGlobalMultipliers } from './mechanics/globalMultipliers'
+export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,
   SpeedRuneBlessingEffects,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -906,6 +906,11 @@ export type {
 } from './mechanics/globalMultipliers'
 export { computeGlobalMultipliers } from './mechanics/globalMultipliers'
 export type {
+  ResourceGainInput,
+  ResourceGainResult
+} from './mechanics/resourceGain'
+export { resourceGain } from './mechanics/resourceGain'
+export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,
   SpeedRuneBlessingEffects,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -911,6 +911,21 @@ export type {
 } from './mechanics/resourceGain'
 export { resourceGain } from './mechanics/resourceGain'
 export type {
+  AdvanceAscensionTimerInput,
+  AdvanceAscensionTimerResult,
+  AdvanceGoldenQuarksTimerInput,
+  AdvanceQuarksTimerInput,
+  AdvanceSingularityTimerInput,
+  AdvanceSingularityTimerResult
+} from './tick/timers'
+export {
+  advanceAscensionTimer,
+  advanceGoldenQuarksTimer,
+  advanceQuarksTimer,
+  advanceResetCounter,
+  advanceSingularityTimer
+} from './tick/timers'
+export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,
   SpeedRuneBlessingEffects,

--- a/packages/logic/src/mechanics/globalMultipliers.ts
+++ b/packages/logic/src/mechanics/globalMultipliers.ts
@@ -1,0 +1,591 @@
+// Per-tick global multiplier aggregator. Lifted from
+// packages/web_ui/src/Synergism.ts (multipliers).
+//
+// Populates the 17 G.* multiplier fields the rest of the tick reads.
+// Largest single migration of Phase 2 — composes ~30 pre-evaluated calls plus
+// 50+ player.* / G.* reads. Web_ui pre-evaluates everything; this stays a
+// pure (state, inputs) → result function.
+
+import { Decimal } from '../math/bignum'
+import { CalcECC } from './challenges'
+
+export interface GlobalMultipliersInput {
+  // ─── Direct player state — upgrades 1-60 (coin tier perks) ────────────
+
+  /** player.upgrades[1] — gates coinOneMulti × first6CoinUp. */
+  upgrade1: number
+  /** player.upgrades[2] — gates coinTwoMulti × first6CoinUp. */
+  upgrade2: number
+  /** player.upgrades[3] — gates coinThreeMulti × first6CoinUp. */
+  upgrade3: number
+  /** player.upgrades[4] — gates coinFourMulti × first6CoinUp. */
+  upgrade4: number
+  /** player.upgrades[5] — gates coinFiveMulti × first6CoinUp. */
+  upgrade5: number
+  /** player.upgrades[6] — adds first6CoinUp to the main s multiplier. */
+  upgrade6: number
+  /** player.upgrades[10] — coinOneMulti × `2 ^ min(50, secondOwnedCoin/15)`. */
+  upgrade10: number
+  /** player.upgrades[12] — s × min(1e4, 1.01^prestigeCount). */
+  upgrade12: number
+  /** player.upgrades[13] — coinTwoMulti × min(1e50, (firstGenMythos+firstOwnMythos+1)^(4/3) * 1e22). */
+  upgrade13: number
+  /** player.upgrades[17] — coinFourMulti × 1e100. */
+  upgrade17: number
+  /** player.upgrades[18] — coinThreeMulti × min(1e125, transcendShards+1). */
+  upgrade18: number
+  /** player.upgrades[19] — coinTwoMulti × min(1e200, transcendPoints*1e30 + 1). */
+  upgrade19: number
+  /** player.upgrades[20] — s × (totalCoinOwned/4 + 1)^10. */
+  upgrade20: number
+  /** player.upgrades[41] — s × min(1e30, (transcendPoints+4)^0.5). */
+  upgrade41: number
+  /** player.upgrades[43] — s × min(1e30, 1.01^transcendCount). */
+  upgrade43: number
+  /** player.upgrades[48] — s × ((totalMultiplier*totalAccelerator)/1000 + 1)^8. */
+  upgrade48: number
+  /** player.upgrades[56] — coinOneMulti × 1e5000. */
+  upgrade56: number
+  /** player.upgrades[57] — coinTwoMulti × 1e7500. */
+  upgrade57: number
+  /** player.upgrades[58] — coinThreeMulti × 1e15000. */
+  upgrade58: number
+  /** player.upgrades[59] — coinFourMulti × 1e25000. */
+  upgrade59: number
+  /** player.upgrades[60] — coinFiveMulti × 1e35000. */
+  upgrade60: number
+
+  // ─── upgrades 36-67 (crystal / mythos tier) ───────────────────────────
+
+  /** player.upgrades[36] — globalCrystalMultiplier × min(1e5000, prestigePoints^(1/500)). */
+  upgrade36: number
+  /** player.upgrades[37] — globalMythosMultiplier × log10(prestigePoints+10)^2. */
+  upgrade37: number
+  /** player.upgrades[42] — globalMythosMultiplier × min(1e50, (prestigePoints+1)^(1/50)/2.5 + 1). */
+  upgrade42: number
+  /** player.upgrades[47] — globalMythosMultiplier × 1.01^aP × (aP/5 + 1). */
+  upgrade47: number
+  /** player.upgrades[51] — globalMythosMultiplier × totalAcceleratorBoost^2. */
+  upgrade51: number
+  /** player.upgrades[52] — globalMythosMultiplier × itself^0.025 (idempotent-ish). */
+  upgrade52: number
+  /** player.upgrades[53] — mythosupgrade13 × min(1e1250, acceleratorEffect^(1/125)). */
+  upgrade53: number
+  /** player.upgrades[54] — mythosupgrade14 × min(1e2000, multiplierEffect^(1/180)). */
+  upgrade54: number
+  /** player.upgrades[55] — mythosupgrade15 × 1e1000 ^ min(1000, buildingPower-1). */
+  upgrade55: number
+  /** player.upgrades[63] — globalCrystalMultiplier × min(1e6000, (reincarnationPoints+1)^6). */
+  upgrade63: number
+  /** player.upgrades[64] — globalMythosMultiplier × (reincarnationPoints+1)^2. */
+  upgrade64: number
+  /** player.upgrades[123] — additional `1 + 0.025n` exponent on c. */
+  upgrade123: number
+
+  // ─── Researches ───────────────────────────────────────────────────────
+
+  /** player.researches[5] — globalCrystalMultiplier × 1e4 ^ (n * (1 + ECC(asc, c14)/2)). */
+  research5: number
+  /** player.researches[17] — `1 + 0.001n` exponent on s for c. */
+  research17: number
+  /** player.researches[26] — globalCrystalMultiplier × 2.5^n. */
+  research26: number
+  /** player.researches[27] — globalCrystalMultiplier × 2.5^n. */
+  research27: number
+  /** player.researches[39] — globalCrystalMultiplier × buildingPowerMult^(1/50). */
+  research39: number
+  /** player.researches[40] — globalMythosMultiplier × buildingPowerMult^(1/250). */
+  research40: number
+  /** player.researches[139] — globalConstantMult × (1 + 0.02n). */
+  research139: number
+  /** player.researches[154] — globalConstantMult × (1 + 0.03n). */
+  research154: number
+  /** player.researches[184] — globalConstantMult × (1 + 0.05n). */
+  research184: number
+  /** player.researches[199] — globalConstantMult × (1 + 0.10n). */
+  research199: number
+
+  // ─── Crystal / constant / platonic upgrades ───────────────────────────
+
+  /** player.crystalUpgrades[0] — exponent base for the achievementPoints-fueled bonus. */
+  crystalUpgrade0: number
+  /** player.crystalUpgrades[1] — feeds the log10(coins+1) bonus + its log2 exponent. */
+  crystalUpgrade1: number
+  /** player.crystalUpgrades[4] — exponent base for the c1-c5 completion sum bonus. */
+  crystalUpgrade4: number
+  /** player.constantUpgrades[1] — globalConstantMult ^ `1.05 + constUpgrade1Buff + 0.001*plat18`. */
+  constantUpgrade1: number
+  /** player.constantUpgrades[2] — bounded percentage bump fed into globalConstantMult. */
+  constantUpgrade2: number
+  /** player.platonicUpgrades[5] — × 2 when > 0. */
+  platonicUpgrade5: number
+  /** player.platonicUpgrades[10] — × 10 when > 0. */
+  platonicUpgrade10: number
+  /** player.platonicUpgrades[14] — a-chal 15 reincarnation-corrupted log10-coin exponent term. */
+  platonicUpgrade14: number
+  /** player.platonicUpgrades[15] — a-chal 15: ^1.1 on lol + globalConstantMult ×1e250 when > 0. */
+  platonicUpgrade15: number
+  /** player.platonicUpgrades[16] — `overfluxPowder+1 ^ 10*plat16` multiplied into globalConstantMult. */
+  platonicUpgrade16: number
+  /** player.platonicUpgrades[18] — adds to constUpgrade1 base + bounded contribution to constUpgrade2 percent. */
+  platonicUpgrade18: number
+
+  // ─── Resources / counters ─────────────────────────────────────────────
+
+  /** player.coins — log10 base for crystalUpgrade1 bonus + plat14 r-corruption term. */
+  coins: Decimal
+  /** player.prestigePoints — feeds upgrade-36, upgrade-37, upgrade-42 multipliers. */
+  prestigePoints: Decimal
+  /** player.transcendPoints — feeds upgrade-19, upgrade-41 multipliers. */
+  transcendPoints: Decimal
+  /** player.reincarnationPoints — feeds upgrade-63, upgrade-64 multipliers. */
+  reincarnationPoints: Decimal
+  /** player.transcendShards — feeds upgrade-18 coinThree multiplier. */
+  transcendShards: Decimal
+  /** player.prestigeCount — exponent for upgrade-12. */
+  prestigeCount: number
+  /** player.transcendCount — exponent for upgrade-43. */
+  transcendCount: number
+  /** player.highestSingularityCount — gates the singularity s multiplier when > 0. */
+  highestSingularityCount: number
+  /** player.goldenQuarks — base for `(goldenQuarks+1)^1.5` singularity bonus. */
+  goldenQuarks: number
+  /** player.overfluxPowder — base for plat16 globalConstantMult bonus. */
+  overfluxPowder: number
+
+  // ─── Coin tier owned counts (for derived totals) ──────────────────────
+
+  /** player.secondOwnedCoin — used in upgrade-10 (`2 ^ min(50, n/15)`). */
+  secondOwnedCoin: number
+  /** player.firstGeneratedMythos — feeds upgrade-13. */
+  firstGeneratedMythos: Decimal
+  /** player.firstOwnedMythos — feeds upgrade-13 + globalMythosOwned. */
+  firstOwnedMythos: number
+  /** player.secondOwnedMythos — feeds totalMythosOwned. */
+  secondOwnedMythos: number
+  /** player.thirdOwnedMythos — feeds totalMythosOwned. */
+  thirdOwnedMythos: number
+  /** player.fourthOwnedMythos — feeds totalMythosOwned. */
+  fourthOwnedMythos: number
+  /** player.fifthOwnedMythos — feeds totalMythosOwned. */
+  fifthOwnedMythos: number
+
+  // ─── Challenge state ──────────────────────────────────────────────────
+
+  /** player.challengecompletions[1..5] — sum feeds crystalUpgrade4 exponent. */
+  c1Completions: number
+  c2Completions: number
+  c3Completions: number
+  c4Completions: number
+  c5Completions: number
+  /** player.challengecompletions[14] — fed through CalcECC for ecc14a. */
+  c14Completions: number
+  /** player.currentChallenge.reincarnation — r-chal 6/7/9 each divide s by a constant. */
+  reincarnationChallenge: number
+  /** player.currentChallenge.ascension — gates platonicUpgrade 5/14/15 lol exponent terms. */
+  ascensionChallenge: number
+  /** player.corruptions.used.recession — feeds recessionPower lookup + plat14 exponent. */
+  recessionCorruptionLevel: number
+
+  // ─── Pre-evaluated values (already-migrated callers) ──────────────────
+
+  /** `calculateCrystalCoinMultiplier()` — multiplied into s. */
+  crystalMult: Decimal
+  /** `calculateBuildingPower()` — used in upgrade-55 `min(1000, buildingPower-1)`. */
+  buildingPower: number
+  /** `calculateBuildingPowerCoinMultiplier(buildingPower)` — multiplied into s, also feeds research-39/40. */
+  buildingPowerMult: Decimal
+  /** `calculateTotalCoinOwned()` — used in first6CoinUp + upgrade-20. */
+  totalCoinOwned: number
+  /** `getAntUpgradeEffect(AntUpgrades.Coins).coinMultiplier` — multiplied into s, also surfaced as antMultiplier output. */
+  antMultiplier: Decimal
+  /** `crystalUpgrade3CrystalMultiplier()` — multiplied into globalCrystalMultiplier. */
+  crystalUpgrade3Multiplier: Decimal
+  /** Module-level `achievementPoints` from Achievements.ts — feeds crystalUpgrade0 exponent + upgrade-47. */
+  achievementPoints: number
+  /** `+getAchievementReward('crystalMultiplier')` — multiplied into globalCrystalMultiplier. */
+  crystalMultiplierAchievement: number
+  /** `+getAchievementReward('constUpgrade1Buff')` — added to constUpgrade1 exponent base. */
+  constUpgrade1BuffAchievement: number
+  /** `+getAchievementReward('constUpgrade2Buff')` — bounded coefficient inside constUpgrade2. */
+  constUpgrade2BuffAchievement: number
+  /** `getRuneEffects('prism', 'productionLog10')` — exponent of 10 multiplied into globalCrystalMultiplier. */
+  prismProductionLog10: number
+  /** `getShopUpgradeEffects('constantEX', 'maxPercentIncrease')` — added into constUpgrade2 bounded percentage. */
+  constantEXMaxPercentIncrease: number
+  /** `ascendBuildingDR()` — exponent applied to constUpgrade2 contribution. */
+  ascendBuildingDRValue: number
+
+  // ─── G inputs (pre-extracted by web_ui) ───────────────────────────────
+
+  /** G.multiplierEffect — multiplied into s (set by updateAllMultiplier earlier this tick). */
+  multiplierEffect: Decimal
+  /** G.acceleratorEffect — multiplied into s (set by updateAllTick earlier this tick) + mythosupgrade13. */
+  acceleratorEffect: Decimal
+  /** G.totalMultiplier — feeds upgrade-48 (×totalAccelerator/1000+1). */
+  totalMultiplier: number
+  /** G.totalAccelerator — feeds upgrade-48. */
+  totalAccelerator: number
+  /** G.totalAcceleratorBoost — exponent base for upgrade-51. */
+  totalAcceleratorBoost: number
+  /** G.challenge15Rewards.coinExponent.value — exponent of lol → globalCoinMultiplier. */
+  challenge15CoinExponent: number
+  /** G.challenge15Rewards.exponent.value — `(exponent-1)*1000` is bounded into constUpgrade2 percent. */
+  challenge15ExponentValue: number
+  /** G.challenge15Rewards.constantBonus.value — multiplied into globalConstantMult. */
+  challenge15ConstantBonus: number
+  /** G.recessionPower[player.corruptions.used.recession] — exponent applied to globalCoinMultiplier. */
+  recessionPower: number
+}
+
+export interface GlobalMultipliersResult {
+  globalCoinMultiplier: Decimal
+  coinOneMulti: Decimal
+  coinTwoMulti: Decimal
+  coinThreeMulti: Decimal
+  coinFourMulti: Decimal
+  coinFiveMulti: Decimal
+  globalCrystalMultiplier: Decimal
+  globalMythosMultiplier: Decimal
+  grandmasterMultiplier: Decimal
+  totalMythosOwned: number
+  mythosBuildingPower: number
+  challengeThreeMultiplier: Decimal
+  mythosupgrade13: Decimal
+  mythosupgrade14: Decimal
+  mythosupgrade15: Decimal
+  globalConstantMult: Decimal
+  /** Surfaced for parity even though it equals input.antMultiplier — legacy
+   * sets G.antMultiplier inside multipliers() so the shim must too. */
+  antMultiplier: Decimal
+}
+
+/**
+ * Per-tick global-multiplier aggregator. Direct transcription of the legacy
+ * multipliers() body with input/output substitution; preserves the exact
+ * computation order so parity holds across every code path.
+ */
+export function computeGlobalMultipliers (input: GlobalMultipliersInput): GlobalMultipliersResult {
+  let s = new Decimal(1)
+  let c = new Decimal(1)
+
+  s = s.times(input.multiplierEffect)
+  s = s.times(input.acceleratorEffect)
+  s = s.times(input.crystalMult)
+  s = s.times(input.buildingPowerMult)
+  s = s.times(input.antMultiplier)
+
+  const first6CoinUp = new Decimal(input.totalCoinOwned + 1).times(
+    Decimal.min(1e30, Decimal.pow(1.008, input.totalCoinOwned))
+  )
+
+  if (input.highestSingularityCount > 0) {
+    s = s.times(
+      Math.pow(input.goldenQuarks + 1, 1.5)
+        * Math.pow(input.highestSingularityCount + 1, 2)
+    )
+  }
+  if (input.upgrade6 > 0.5) {
+    s = s.times(first6CoinUp)
+  }
+  if (input.upgrade12 > 0.5) {
+    s = s.times(Decimal.min(1e4, Decimal.pow(1.01, input.prestigeCount)))
+  }
+  if (input.upgrade20 > 0.5) {
+    s = s.times(Decimal.pow(input.totalCoinOwned / 4 + 1, 10))
+  }
+  if (input.upgrade41 > 0.5) {
+    s = s.times(Decimal.min(1e30, Decimal.pow(input.transcendPoints.add(4), 1 / 2)))
+  }
+  if (input.upgrade43 > 0.5) {
+    s = s.times(Decimal.min(1e30, Decimal.pow(1.01, input.transcendCount)))
+  }
+  if (input.upgrade48 > 0.5) {
+    s = s.times(
+      Decimal.pow((input.totalMultiplier * input.totalAccelerator) / 1000 + 1, 8)
+    )
+  }
+  if (input.reincarnationChallenge === 6) {
+    s = s.dividedBy(1e250)
+  }
+  if (input.reincarnationChallenge === 7) {
+    s = s.dividedBy('1e1250')
+  }
+  if (input.reincarnationChallenge === 9) {
+    s = s.dividedBy('1e2000000')
+  }
+  c = Decimal.pow(s, 1 + 0.001 * input.research17)
+  let lol = Decimal.pow(c, 1 + 0.025 * input.upgrade123)
+  if (input.ascensionChallenge === 15 && input.platonicUpgrade5 > 0) {
+    lol = Decimal.pow(lol, 1.1)
+  }
+  if (input.ascensionChallenge === 15 && input.platonicUpgrade14 > 0) {
+    lol = Decimal.pow(
+      lol,
+      1
+        + ((1 / 20)
+            * input.recessionCorruptionLevel
+            * Decimal.log(input.coins.add(1), 10))
+          / (1e7 + Decimal.log(input.coins.add(1), 10))
+    )
+  }
+  if (input.ascensionChallenge === 15 && input.platonicUpgrade15 > 0) {
+    lol = Decimal.pow(lol, 1.1)
+  }
+  lol = Decimal.pow(lol, input.challenge15CoinExponent)
+  let globalCoinMultiplier = lol
+  globalCoinMultiplier = Decimal.pow(globalCoinMultiplier, input.recessionPower)
+
+  let coinOneMulti = new Decimal(1)
+  if (input.upgrade1 > 0.5) {
+    coinOneMulti = coinOneMulti.times(first6CoinUp)
+  }
+  if (input.upgrade10 > 0.5) {
+    coinOneMulti = coinOneMulti.times(
+      Decimal.pow(2, Math.min(50, input.secondOwnedCoin / 15))
+    )
+  }
+  if (input.upgrade56 > 0.5) {
+    coinOneMulti = coinOneMulti.times('1e5000')
+  }
+
+  let coinTwoMulti = new Decimal(1)
+  if (input.upgrade2 > 0.5) {
+    coinTwoMulti = coinTwoMulti.times(first6CoinUp)
+  }
+  if (input.upgrade13 > 0.5) {
+    coinTwoMulti = coinTwoMulti.times(
+      Decimal.min(
+        1e50,
+        Decimal.pow(input.firstGeneratedMythos.add(input.firstOwnedMythos).add(1), 4 / 3)
+          .times(1e22)
+      )
+    )
+  }
+  if (input.upgrade19 > 0.5) {
+    coinTwoMulti = coinTwoMulti.times(
+      Decimal.min(1e200, input.transcendPoints.times(1e30).add(1))
+    )
+  }
+  if (input.upgrade57 > 0.5) {
+    coinTwoMulti = coinTwoMulti.times('1e7500')
+  }
+
+  let coinThreeMulti = new Decimal(1)
+  if (input.upgrade3 > 0.5) {
+    coinThreeMulti = coinThreeMulti.times(first6CoinUp)
+  }
+  if (input.upgrade18 > 0.5) {
+    coinThreeMulti = coinThreeMulti.times(
+      Decimal.min(1e125, input.transcendShards.add(1))
+    )
+  }
+  if (input.upgrade58 > 0.5) {
+    coinThreeMulti = coinThreeMulti.times('1e15000')
+  }
+
+  let coinFourMulti = new Decimal(1)
+  if (input.upgrade4 > 0.5) {
+    coinFourMulti = coinFourMulti.times(first6CoinUp)
+  }
+  if (input.upgrade17 > 0.5) {
+    coinFourMulti = coinFourMulti.times(1e100)
+  }
+  if (input.upgrade59 > 0.5) {
+    coinFourMulti = coinFourMulti.times('1e25000')
+  }
+
+  let coinFiveMulti = new Decimal(1)
+  if (input.upgrade5 > 0.5) {
+    coinFiveMulti = coinFiveMulti.times(first6CoinUp)
+  }
+  if (input.upgrade60 > 0.5) {
+    coinFiveMulti = coinFiveMulti.times('1e35000')
+  }
+
+  let globalCrystalMultiplier = new Decimal(1)
+  globalCrystalMultiplier = globalCrystalMultiplier.times(input.crystalMultiplierAchievement)
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(10, input.prismProductionLog10)
+  )
+  if (input.upgrade36 > 0.5) {
+    globalCrystalMultiplier = globalCrystalMultiplier.times(
+      Decimal.min('1e5000', Decimal.pow(input.prestigePoints, 1 / 500))
+    )
+  }
+  if (input.upgrade63 > 0.5) {
+    globalCrystalMultiplier = globalCrystalMultiplier.times(
+      Decimal.min('1e6000', Decimal.pow(input.reincarnationPoints.add(1), 6))
+    )
+  }
+  if (input.research39 > 0.5) {
+    globalCrystalMultiplier = globalCrystalMultiplier.times(
+      Decimal.pow(input.buildingPowerMult, 1 / 50)
+    )
+  }
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(1 + 0.01 * input.crystalUpgrade0, input.achievementPoints)
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(
+      1 + input.crystalUpgrade1 * Decimal.log(input.coins.add(1), 10) / 100,
+      2 + Math.log2(input.crystalUpgrade1 + 1)
+    )
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(input.crystalUpgrade3Multiplier)
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(
+      1 + 0.05 * input.crystalUpgrade4,
+      input.c1Completions
+        + input.c2Completions
+        + input.c3Completions
+        + input.c4Completions
+        + input.c5Completions
+    )
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(10, CalcECC('transcend', input.c5Completions))
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(
+      1e4,
+      input.research5 * (1 + (1 / 2) * CalcECC('ascension', input.c14Completions))
+    )
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(Decimal.pow(2.5, input.research26))
+  globalCrystalMultiplier = globalCrystalMultiplier.times(Decimal.pow(2.5, input.research27))
+
+  let globalMythosMultiplier = new Decimal(1)
+
+  if (input.upgrade37 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(Decimal.log(input.prestigePoints.add(10), 10), 2)
+    )
+  }
+  if (input.upgrade42 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.min(
+        1e50,
+        Decimal.pow(input.prestigePoints.add(1), 1 / 50).dividedBy(2.5).add(1)
+      )
+    )
+  }
+  if (input.upgrade47 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier
+      .times(Decimal.pow(1.01, input.achievementPoints))
+      .times(input.achievementPoints / 5 + 1)
+  }
+  if (input.upgrade51 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(input.totalAcceleratorBoost, 2)
+    )
+  }
+  if (input.upgrade52 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(globalMythosMultiplier, 0.025)
+    )
+  }
+  if (input.upgrade64 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(input.reincarnationPoints.add(1), 2)
+    )
+  }
+  if (input.research40 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(input.buildingPowerMult, 1 / 250)
+    )
+  }
+
+  let grandmasterMultiplier = new Decimal(1)
+  const totalMythosOwned = input.firstOwnedMythos
+    + input.secondOwnedMythos
+    + input.thirdOwnedMythos
+    + input.fourthOwnedMythos
+    + input.fifthOwnedMythos
+
+  const mythosBuildingPower = 1 + CalcECC('transcend', input.c3Completions) / 200
+  const challengeThreeMultiplier = Decimal.pow(mythosBuildingPower, totalMythosOwned)
+
+  grandmasterMultiplier = grandmasterMultiplier.times(challengeThreeMultiplier)
+
+  let mythosupgrade13 = new Decimal(1)
+  let mythosupgrade14 = new Decimal(1)
+  let mythosupgrade15 = new Decimal(1)
+  if (input.upgrade53 === 1) {
+    mythosupgrade13 = mythosupgrade13.times(
+      Decimal.min('1e1250', Decimal.pow(input.acceleratorEffect, 1 / 125))
+    )
+  }
+  if (input.upgrade54 === 1) {
+    mythosupgrade14 = mythosupgrade14.times(
+      Decimal.min('1e2000', Decimal.pow(input.multiplierEffect, 1 / 180))
+    )
+  }
+  if (input.upgrade55 === 1) {
+    mythosupgrade15 = mythosupgrade15.times(
+      Decimal.pow('1e1000', Math.min(1000, input.buildingPower - 1))
+    )
+  }
+
+  let globalConstantMult = new Decimal('1')
+  globalConstantMult = globalConstantMult.times(
+    Decimal.pow(
+      1.05
+        + input.constUpgrade1BuffAchievement
+        + 0.001 * input.platonicUpgrade18,
+      input.constantUpgrade1
+    )
+  )
+  globalConstantMult = globalConstantMult.times(
+    Decimal.pow(
+      1
+        + 0.001
+          * Math.min(
+            100
+              + 1000 * input.constUpgrade2BuffAchievement
+              + 10 * input.constantEXMaxPercentIncrease
+              + 1000 * (input.challenge15ExponentValue - 1)
+              + 3 * input.platonicUpgrade18,
+            input.constantUpgrade2
+          ),
+      input.ascendBuildingDRValue
+    )
+  )
+  globalConstantMult = globalConstantMult.times(1 + (2 / 100) * input.research139)
+  globalConstantMult = globalConstantMult.times(1 + (3 / 100) * input.research154)
+  globalConstantMult = globalConstantMult.times(1 + (5 / 100) * input.research184)
+  globalConstantMult = globalConstantMult.times(1 + (10 / 100) * input.research199)
+  globalConstantMult = globalConstantMult.times(input.challenge15ConstantBonus)
+  if (input.platonicUpgrade5 > 0) {
+    globalConstantMult = globalConstantMult.times(2)
+  }
+  if (input.platonicUpgrade10 > 0) {
+    globalConstantMult = globalConstantMult.times(10)
+  }
+  if (input.platonicUpgrade15 > 0) {
+    globalConstantMult = globalConstantMult.times(1e250)
+  }
+  globalConstantMult = globalConstantMult.times(
+    Decimal.pow(input.overfluxPowder + 1, 10 * input.platonicUpgrade16)
+  )
+
+  return {
+    globalCoinMultiplier,
+    coinOneMulti,
+    coinTwoMulti,
+    coinThreeMulti,
+    coinFourMulti,
+    coinFiveMulti,
+    globalCrystalMultiplier,
+    globalMythosMultiplier,
+    grandmasterMultiplier,
+    totalMythosOwned,
+    mythosBuildingPower,
+    challengeThreeMultiplier,
+    mythosupgrade13,
+    mythosupgrade14,
+    mythosupgrade15,
+    globalConstantMult,
+    antMultiplier: input.antMultiplier
+  }
+}

--- a/packages/logic/src/mechanics/resetCurrency.ts
+++ b/packages/logic/src/mechanics/resetCurrency.ts
@@ -1,0 +1,133 @@
+// Per-tick prestige / transcend / reincarnation point-gain calculator. Lifted
+// from packages/web_ui/src/Synergism.ts (resetCurrency).
+//
+// Three independent point formulas with shared challenge-overrides:
+//   - Transcension Challenge 5 forces prestigePow to 0.01.
+//   - Reincarnation Challenge 10 forces prestigePow to 1e-4 and
+//     transcendPow to 0.001.
+//   - Ascension Challenge 12 zeroes reincarnationPointGain.
+//
+// Caller pre-evaluates CalcECC('transcend', challengecompletions[5]) as
+// `ecc5`, the deflation table lookup as `deflationMultiplier`, the
+// particleGain achievement reward as `particleGainReward`, and passes the
+// G.acceleratorEffect Decimal through directly.
+
+import { Decimal } from '../math/bignum'
+
+export interface ResetCurrencyInput {
+  /** Pre-evaluated `CalcECC('transcend', player.challengecompletions[5])` —
+   * contributes `+ ecc5 / 100` to the base prestigePow of 0.5. */
+  ecc5: number
+  /** player.currentChallenge.transcension — when === 5, forces prestigePow
+   * to 0.01 and disables the upgrade-16 multiplier. */
+  transcensionChallenge: number
+  /** player.currentChallenge.reincarnation — when === 10, forces prestigePow
+   * to 1e-4, transcendPow to 0.001, and disables both upgrade multipliers.
+   * When non-zero, also re-exponents reincarnationPointGain by 0.01. */
+  reincarnationChallenge: number
+  /** player.currentChallenge.ascension — when === 12, zeroes
+   * reincarnationPointGain after all other calculations. */
+  ascensionChallenge: number
+  /** Pre-evaluated `G.deflationMultiplier[player.corruptions.used.deflation]`
+   * — multiplies prestigePow, and used as the upgrade-16 acceleratorEffect
+   * exponent scaler (1/3 * deflationMultiplier). */
+  deflationMultiplier: number
+  /** player.coinsThisPrestige — base for the prestige-point formula
+   * `floor((coinsThisPrestige / 1e12) ^ prestigePow)`. */
+  coinsThisPrestige: Decimal
+  /** player.coinsThisTranscension — base for the transcend-point formula
+   * `floor((coinsThisTranscension / 1e100) ^ transcendPow)`. */
+  coinsThisTranscension: Decimal
+  /** player.transcendShards — base for the reincarnation-point formula
+   * `floor((transcendShards / 1e300) ^ 0.01)`. */
+  transcendShards: Decimal
+  /** player.upgrades[16] — when > 0.5 and outside t-chal 5 / r-chal 10,
+   * multiplies prestigePointGain by min(10^1e33, acceleratorEffect ^
+   * (deflationMultiplier / 3)). */
+  upgrade16: number
+  /** player.upgrades[44] — when > 0.5 and outside t-chal 5 / r-chal 10,
+   * multiplies transcendPointGain by min(1e6, 1.01 ^ transcendCount). */
+  upgrade44: number
+  /** player.upgrades[65] — when > 0.5, multiplies reincarnationPointGain by 5. */
+  upgrade65: number
+  /** player.transcendCount — exponent base for the upgrade-44 multiplier. */
+  transcendCount: number
+  /** G.acceleratorEffect — Decimal base for the upgrade-16 prestige multiplier. */
+  acceleratorEffect: Decimal
+  /** Pre-evaluated `+getAchievementReward('particleGain')` — multiplied into
+   * reincarnationPointGain (unconditional). */
+  particleGainReward: number
+}
+
+export interface ResetCurrencyResult {
+  prestigePointGain: Decimal
+  transcendPointGain: Decimal
+  reincarnationPointGain: Decimal
+}
+
+/**
+ * Compute the three per-tick reset-currency point-gain values. Pure: no
+ * mutation of the input; returns a fresh result the caller writes back
+ * to `G.prestigePointGain` / `G.transcendPointGain` / `G.reincarnationPointGain`.
+ */
+export function resetCurrency (input: ResetCurrencyInput): ResetCurrencyResult {
+  let prestigePow = 0.5 + input.ecc5 / 100
+  let transcendPow = 0.03
+
+  if (input.transcensionChallenge === 5) {
+    prestigePow = 0.01
+  }
+  if (input.reincarnationChallenge === 10) {
+    prestigePow = 1e-4
+    transcendPow = 0.001
+  }
+  prestigePow *= input.deflationMultiplier
+
+  let prestigePointGain = Decimal.floor(
+    Decimal.pow(input.coinsThisPrestige.dividedBy(1e12), prestigePow)
+  )
+  if (
+    input.upgrade16 > 0.5
+    && input.transcensionChallenge !== 5
+    && input.reincarnationChallenge !== 10
+  ) {
+    prestigePointGain = prestigePointGain.times(
+      Decimal.min(
+        Decimal.pow(10, 1e33),
+        Decimal.pow(
+          input.acceleratorEffect,
+          (1 / 3) * input.deflationMultiplier
+        )
+      )
+    )
+  }
+
+  let transcendPointGain = Decimal.floor(
+    Decimal.pow(input.coinsThisTranscension.dividedBy(1e100), transcendPow)
+  )
+  if (
+    input.upgrade44 > 0.5
+    && input.transcensionChallenge !== 5
+    && input.reincarnationChallenge !== 10
+  ) {
+    transcendPointGain = transcendPointGain.times(
+      Decimal.min(1e6, Decimal.pow(1.01, input.transcendCount))
+    )
+  }
+
+  let reincarnationPointGain = Decimal.floor(
+    Decimal.pow(input.transcendShards.dividedBy(1e300), 0.01)
+  )
+  if (input.reincarnationChallenge !== 0) {
+    reincarnationPointGain = Decimal.pow(reincarnationPointGain, 0.01)
+  }
+  reincarnationPointGain = reincarnationPointGain.times(input.particleGainReward)
+  if (input.upgrade65 > 0.5) {
+    reincarnationPointGain = reincarnationPointGain.times(5)
+  }
+  if (input.ascensionChallenge === 12) {
+    reincarnationPointGain = new Decimal('0')
+  }
+
+  return { prestigePointGain, transcendPointGain, reincarnationPointGain }
+}

--- a/packages/logic/src/mechanics/resourceGain.ts
+++ b/packages/logic/src/mechanics/resourceGain.ts
@@ -1,0 +1,609 @@
+// Per-tick resource generation. Lifted from packages/web_ui/src/Synergism.ts
+// (resourceGain), minus the terminal challenge `resetCheck` dispatch which
+// is async + modal-aware and stays in web_ui.
+//
+// Computes:
+//   1. Coin gain (5 coin counters when produceTotal ≥ 0.001).
+//   2. Per-tier point gains from upgrade-93 / upgrade-100 / cubeUpgrade-28.
+//   3. Four producer cascades (Diamonds, Mythos, Particles, AscendBuildings)
+//      — each computes its 5 G.produce*Tier fields then advances 4 generated
+//      counters from the next tier's production.
+//   4. Shard accumulation (prestige/transcend/reincarnation/ascend).
+//   5. `awardAchievementGroup('constant')` gate (ascensionCount > 0).
+//   6. Challenge 1-5 auto-completion (research-gated coin thresholds).
+//
+// Side effects surface as CoreEvents:
+//   - achievement-group-awarded ('constant')
+//   - challenge-auto-completed (one per c1-c5 increment)
+//
+// The caller orchestrates the pre-tick functions (calculateTotalAcceleratorBoost,
+// updateAllTick, updateAllMultiplier, multipliers, calculatetax, resetCurrency)
+// before invoking this so all G inputs are fresh.
+
+import type { CoreEvent } from '../events/types'
+import { Decimal } from '../math/bignum'
+
+export interface ResourceGainInput {
+  /** Tick delta in seconds (already scaled by globalSpeedMult by the caller). */
+  dt: number
+
+  // ─── Coin gain inputs (G.produceTotal / taxdivisor / maxexponent set by Phase 2) ─
+
+  produceTotal: Decimal
+  taxdivisor: Decimal
+  taxdivisorcheck: Decimal
+  maxexponent: number
+  coins: Decimal
+  coinsThisPrestige: Decimal
+  coinsThisTranscension: Decimal
+  coinsThisReincarnation: Decimal
+  coinsTotal: Decimal
+
+  // ─── Point gain inputs ──────────────────────────────────────────────
+
+  /** player.upgrades[93] — when === 1 and coinsThisPrestige ≥ 1e16, drips prestigePoints. */
+  upgrade93: number
+  /** player.upgrades[100] — when === 1 and coinsThisTranscension ≥ 1e100, drips transcendPoints. */
+  upgrade100: number
+  /** player.cubeUpgrades[28] — when > 0 and transcendShards ≥ 1e300, drips reincarnationPoints. */
+  cubeUpgrade28: number
+  prestigePoints: Decimal
+  transcendPoints: Decimal
+  reincarnationPoints: Decimal
+  /** Pre-evaluated G.prestigePointGain (set by resetCurrency earlier this tick). */
+  prestigePointGain: Decimal
+  /** Pre-evaluated G.transcendPointGain (set by resetCurrency earlier this tick). */
+  transcendPointGain: Decimal
+  /** Pre-evaluated G.reincarnationPointGain (set by resetCurrency earlier this tick). */
+  reincarnationPointGain: Decimal
+
+  // ─── Diamond cascade (5 generated + 5 owned + 5 produce values) ─────
+
+  firstGeneratedDiamonds: Decimal
+  secondGeneratedDiamonds: Decimal
+  thirdGeneratedDiamonds: Decimal
+  fourthGeneratedDiamonds: Decimal
+  fifthGeneratedDiamonds: Decimal
+  firstOwnedDiamonds: number
+  secondOwnedDiamonds: number
+  thirdOwnedDiamonds: number
+  fourthOwnedDiamonds: number
+  fifthOwnedDiamonds: number
+  firstProduceDiamonds: number
+  secondProduceDiamonds: number
+  thirdProduceDiamonds: number
+  fourthProduceDiamonds: number
+  fifthProduceDiamonds: number
+  /** Pre-evaluated G.globalCrystalMultiplier — multiplied into every diamond tier. */
+  globalCrystalMultiplier: Decimal
+
+  // ─── Mythos cascade (5 generated + 5 owned + 5 produce, plus 3 G mult inputs) ─
+
+  firstGeneratedMythos: Decimal
+  secondGeneratedMythos: Decimal
+  thirdGeneratedMythos: Decimal
+  fourthGeneratedMythos: Decimal
+  fifthGeneratedMythos: Decimal
+  firstOwnedMythos: number
+  secondOwnedMythos: number
+  thirdOwnedMythos: number
+  fourthOwnedMythos: number
+  fifthOwnedMythos: number
+  firstProduceMythos: number
+  secondProduceMythos: number
+  thirdProduceMythos: number
+  fourthProduceMythos: number
+  fifthProduceMythos: number
+  /** Pre-evaluated G.globalMythosMultiplier — base for every mythos tier. */
+  globalMythosMultiplier: Decimal
+  /** Pre-evaluated G.grandmasterMultiplier — only the fifth tier multiplies by this. */
+  grandmasterMultiplier: Decimal
+  /** Pre-evaluated G.mythosupgrade13 — only the first tier multiplies by this. */
+  mythosupgrade13: Decimal
+  /** Pre-evaluated G.mythosupgrade14 — only the third tier multiplies by this. */
+  mythosupgrade14: Decimal
+  /** Pre-evaluated G.mythosupgrade15 — only the fifth tier multiplies by this. */
+  mythosupgrade15: Decimal
+
+  // ─── Particle cascade (5 generated + 5 owned + 5 produce + upgrade67 gate) ─
+
+  firstGeneratedParticles: Decimal
+  secondGeneratedParticles: Decimal
+  thirdGeneratedParticles: Decimal
+  fourthGeneratedParticles: Decimal
+  fifthGeneratedParticles: Decimal
+  firstOwnedParticles: number
+  secondOwnedParticles: number
+  thirdOwnedParticles: number
+  fourthOwnedParticles: number
+  fifthOwnedParticles: number
+  firstProduceParticles: number
+  secondProduceParticles: number
+  thirdProduceParticles: number
+  fourthProduceParticles: number
+  fifthProduceParticles: number
+  /** player.upgrades[67] — when > 0.5, applies pm = 1.03 ^ totalOwnedParticles to the first tier. */
+  upgrade67: number
+
+  // ─── Shards ─────────────────────────────────────────────────────────
+
+  prestigeShards: Decimal
+  transcendShards: Decimal
+  reincarnationShards: Decimal
+  ascendShards: Decimal
+
+  // ─── AscendBuildings (5 generated + 5 owned, plus globalConstantMult) ─
+
+  ascendBuilding1Generated: Decimal
+  ascendBuilding2Generated: Decimal
+  ascendBuilding3Generated: Decimal
+  ascendBuilding4Generated: Decimal
+  ascendBuilding5Generated: Decimal
+  ascendBuilding1Owned: number
+  ascendBuilding2Owned: number
+  ascendBuilding3Owned: number
+  ascendBuilding4Owned: number
+  ascendBuilding5Owned: number
+  /** Pre-evaluated G.globalConstantMult (set by multipliers earlier this tick). */
+  globalConstantMult: Decimal
+
+  // ─── Achievement + challenge auto-completion inputs ─────────────────
+
+  /** player.ascensionCount — gates the awardAchievementGroup('constant') event. */
+  ascensionCount: number
+  /** player.currentChallenge.transcension — disables prestigeShards / transcendShards gains when === 3. */
+  transcensionChallenge: number
+  /** player.currentChallenge.reincarnation — also disables both shards branches when === 10. */
+  reincarnationChallenge: number
+
+  // Challenge 1-5 auto-completion gates
+  research66: number
+  research67_: number  // research[67] — name disambiguated from upgrade67
+  research68: number
+  research69: number
+  research70: number
+  research71: number
+  research72: number
+  research73: number
+  research74: number
+  research75: number
+  research105: number
+  c1Completions: number
+  c2Completions: number
+  c3Completions: number
+  c4Completions: number
+  c5Completions: number
+  highestC1: number
+  highestC2: number
+  highestC3: number
+  highestC4: number
+  highestC5: number
+  /** G.challengeBaseRequirements — 5-element array; passed by reference (read-only). */
+  challengeBaseRequirements: readonly number[]
+}
+
+export interface ResourceGainResult {
+  // ─── Player updates (every field is the post-tick value, even if unchanged) ─
+  coins: Decimal
+  coinsThisPrestige: Decimal
+  coinsThisTranscension: Decimal
+  coinsThisReincarnation: Decimal
+  coinsTotal: Decimal
+  prestigePoints: Decimal
+  transcendPoints: Decimal
+  reincarnationPoints: Decimal
+  prestigeShards: Decimal
+  transcendShards: Decimal
+  reincarnationShards: Decimal
+  ascendShards: Decimal
+  firstGeneratedDiamonds: Decimal
+  secondGeneratedDiamonds: Decimal
+  thirdGeneratedDiamonds: Decimal
+  fourthGeneratedDiamonds: Decimal
+  firstGeneratedMythos: Decimal
+  secondGeneratedMythos: Decimal
+  thirdGeneratedMythos: Decimal
+  fourthGeneratedMythos: Decimal
+  firstGeneratedParticles: Decimal
+  secondGeneratedParticles: Decimal
+  thirdGeneratedParticles: Decimal
+  fourthGeneratedParticles: Decimal
+  /** Only first-fourth ascendBuilding generated values can change (5th doesn't have a "next tier" to feed it). */
+  ascendBuilding1Generated: Decimal
+  ascendBuilding2Generated: Decimal
+  ascendBuilding3Generated: Decimal
+  ascendBuilding4Generated: Decimal
+  c1Completions: number
+  c2Completions: number
+  c3Completions: number
+  c4Completions: number
+  c5Completions: number
+
+  // ─── G cache updates ────────────────────────────────────────────────
+  produceFirstDiamonds: Decimal
+  produceSecondDiamonds: Decimal
+  produceThirdDiamonds: Decimal
+  produceFourthDiamonds: Decimal
+  produceFifthDiamonds: Decimal
+  produceDiamonds: Decimal
+  produceFirstMythos: Decimal
+  produceSecondMythos: Decimal
+  produceThirdMythos: Decimal
+  produceFourthMythos: Decimal
+  produceFifthMythos: Decimal
+  produceMythos: Decimal
+  producePerSecondMythos: Decimal
+  produceFirstParticles: Decimal
+  produceSecondParticles: Decimal
+  produceThirdParticles: Decimal
+  produceFourthParticles: Decimal
+  produceFifthParticles: Decimal
+  produceParticles: Decimal
+  producePerSecondParticles: Decimal
+  /** G.ascendBuildingProduction — { first, second, third, fourth, fifth } Decimal values. */
+  ascendBuildingProduction: {
+    first: Decimal
+    second: Decimal
+    third: Decimal
+    fourth: Decimal
+    fifth: Decimal
+  }
+
+  /** Events for the UI tier to dispatch (achievement notifications, challenge-auto-completion UI updates). */
+  events: CoreEvent[]
+}
+
+/**
+ * Per-tick resource generation. Pure given the input bundle; returns the
+ * full post-tick player + G slice plus an event list.
+ */
+export function resourceGain (input: ResourceGainInput): ResourceGainResult {
+  const dt = input.dt
+  const events: CoreEvent[] = []
+
+  // ─── Coin gain ─────────────────────────────────────────────────────
+  let coins = input.coins
+  let coinsThisPrestige = input.coinsThisPrestige
+  let coinsThisTranscension = input.coinsThisTranscension
+  let coinsThisReincarnation = input.coinsThisReincarnation
+  let coinsTotal = input.coinsTotal
+  if (input.produceTotal.gte(0.001)) {
+    const addcoin = Decimal.min(
+      input.produceTotal.dividedBy(input.taxdivisor),
+      Decimal.pow(10, input.maxexponent - Decimal.log(input.taxdivisorcheck, 10))
+    ).times(dt / 0.025)
+    coins = coins.add(addcoin)
+    coinsThisPrestige = coinsThisPrestige.add(addcoin)
+    coinsThisTranscension = coinsThisTranscension.add(addcoin)
+    coinsThisReincarnation = coinsThisReincarnation.add(addcoin)
+    coinsTotal = coinsTotal.add(addcoin)
+  }
+
+  // ─── Point gains ───────────────────────────────────────────────────
+  let prestigePoints = input.prestigePoints
+  let transcendPoints = input.transcendPoints
+  let reincarnationPoints = input.reincarnationPoints
+  if (input.upgrade93 === 1 && coinsThisPrestige.gte(1e16)) {
+    prestigePoints = prestigePoints.add(
+      Decimal.floor(input.prestigePointGain.dividedBy(4000).times(dt / 0.025))
+    )
+  }
+  if (input.upgrade100 === 1 && coinsThisTranscension.gte(1e100)) {
+    transcendPoints = transcendPoints.add(
+      Decimal.floor(input.transcendPointGain.dividedBy(4000).times(dt / 0.025))
+    )
+  }
+  if (input.cubeUpgrade28 > 0 && input.transcendShards.gte(1e300)) {
+    reincarnationPoints = reincarnationPoints.add(
+      Decimal.floor(input.reincarnationPointGain.dividedBy(4000).times(dt / 0.025))
+    )
+  }
+
+  // ─── Diamond cascade ───────────────────────────────────────────────
+  const produceFirstDiamonds = input.firstGeneratedDiamonds
+    .add(input.firstOwnedDiamonds)
+    .times(input.firstProduceDiamonds)
+    .times(input.globalCrystalMultiplier)
+  const produceSecondDiamonds = input.secondGeneratedDiamonds
+    .add(input.secondOwnedDiamonds)
+    .times(input.secondProduceDiamonds)
+    .times(input.globalCrystalMultiplier)
+  const produceThirdDiamonds = input.thirdGeneratedDiamonds
+    .add(input.thirdOwnedDiamonds)
+    .times(input.thirdProduceDiamonds)
+    .times(input.globalCrystalMultiplier)
+  const produceFourthDiamonds = input.fourthGeneratedDiamonds
+    .add(input.fourthOwnedDiamonds)
+    .times(input.fourthProduceDiamonds)
+    .times(input.globalCrystalMultiplier)
+  const produceFifthDiamonds = input.fifthGeneratedDiamonds
+    .add(input.fifthOwnedDiamonds)
+    .times(input.fifthProduceDiamonds)
+    .times(input.globalCrystalMultiplier)
+
+  const fourthGeneratedDiamonds = input.fourthGeneratedDiamonds.add(
+    produceFifthDiamonds.times(dt / 0.025)
+  )
+  const thirdGeneratedDiamonds = input.thirdGeneratedDiamonds.add(
+    produceFourthDiamonds.times(dt / 0.025)
+  )
+  const secondGeneratedDiamonds = input.secondGeneratedDiamonds.add(
+    produceThirdDiamonds.times(dt / 0.025)
+  )
+  const firstGeneratedDiamonds = input.firstGeneratedDiamonds.add(
+    produceSecondDiamonds.times(dt / 0.025)
+  )
+  const produceDiamonds = produceFirstDiamonds
+
+  let prestigeShards = input.prestigeShards
+  if (input.transcensionChallenge !== 3 && input.reincarnationChallenge !== 10) {
+    prestigeShards = prestigeShards.add(produceDiamonds.times(dt / 0.025))
+  }
+
+  // ─── Mythos cascade ────────────────────────────────────────────────
+  const produceFifthMythos = input.fifthGeneratedMythos
+    .add(input.fifthOwnedMythos)
+    .times(input.fifthProduceMythos)
+    .times(input.globalMythosMultiplier)
+    .times(input.grandmasterMultiplier)
+    .times(input.mythosupgrade15)
+  const produceFourthMythos = input.fourthGeneratedMythos
+    .add(input.fourthOwnedMythos)
+    .times(input.fourthProduceMythos)
+    .times(input.globalMythosMultiplier)
+  const produceThirdMythos = input.thirdGeneratedMythos
+    .add(input.thirdOwnedMythos)
+    .times(input.thirdProduceMythos)
+    .times(input.globalMythosMultiplier)
+    .times(input.mythosupgrade14)
+  const produceSecondMythos = input.secondGeneratedMythos
+    .add(input.secondOwnedMythos)
+    .times(input.secondProduceMythos)
+    .times(input.globalMythosMultiplier)
+  const produceFirstMythos = input.firstGeneratedMythos
+    .add(input.firstOwnedMythos)
+    .times(input.firstProduceMythos)
+    .times(input.globalMythosMultiplier)
+    .times(input.mythosupgrade13)
+  const fourthGeneratedMythos = input.fourthGeneratedMythos.add(
+    produceFifthMythos.times(dt / 0.025)
+  )
+  const thirdGeneratedMythos = input.thirdGeneratedMythos.add(
+    produceFourthMythos.times(dt / 0.025)
+  )
+  const secondGeneratedMythos = input.secondGeneratedMythos.add(
+    produceThirdMythos.times(dt / 0.025)
+  )
+  const firstGeneratedMythos = input.firstGeneratedMythos.add(
+    produceSecondMythos.times(dt / 0.025)
+  )
+
+  // produceMythos: recomputed after mutations using post-tick firstGeneratedMythos
+  const produceMythos = firstGeneratedMythos
+    .add(input.firstOwnedMythos)
+    .times(input.firstProduceMythos)
+    .times(input.globalMythosMultiplier)
+    .times(input.mythosupgrade13)
+  const producePerSecondMythos = produceMythos.times(40)
+
+  // ─── Particle cascade ──────────────────────────────────────────────
+  let pm = new Decimal('1')
+  if (input.upgrade67 > 0.5) {
+    pm = pm.times(
+      Decimal.pow(
+        1.03,
+        input.firstOwnedParticles
+          + input.secondOwnedParticles
+          + input.thirdOwnedParticles
+          + input.fourthOwnedParticles
+          + input.fifthOwnedParticles
+      )
+    )
+  }
+  const produceFifthParticles = input.fifthGeneratedParticles
+    .add(input.fifthOwnedParticles)
+    .times(input.fifthProduceParticles)
+  const produceFourthParticles = input.fourthGeneratedParticles
+    .add(input.fourthOwnedParticles)
+    .times(input.fourthProduceParticles)
+  const produceThirdParticles = input.thirdGeneratedParticles
+    .add(input.thirdOwnedParticles)
+    .times(input.thirdProduceParticles)
+  const produceSecondParticles = input.secondGeneratedParticles
+    .add(input.secondOwnedParticles)
+    .times(input.secondProduceParticles)
+  const produceFirstParticles = input.firstGeneratedParticles
+    .add(input.firstOwnedParticles)
+    .times(input.firstProduceParticles)
+    .times(pm)
+  const fourthGeneratedParticles = input.fourthGeneratedParticles.add(
+    produceFifthParticles.times(dt / 0.025)
+  )
+  const thirdGeneratedParticles = input.thirdGeneratedParticles.add(
+    produceFourthParticles.times(dt / 0.025)
+  )
+  const secondGeneratedParticles = input.secondGeneratedParticles.add(
+    produceThirdParticles.times(dt / 0.025)
+  )
+  const firstGeneratedParticles = input.firstGeneratedParticles.add(
+    produceSecondParticles.times(dt / 0.025)
+  )
+
+  // produceParticles: recomputed after mutations using post-tick firstGeneratedParticles
+  const produceParticles = firstGeneratedParticles
+    .add(input.firstOwnedParticles)
+    .times(input.firstProduceParticles)
+    .times(pm)
+  const producePerSecondParticles = produceParticles.times(40)
+
+  // ─── Transcend / reincarnation shards ──────────────────────────────
+  let transcendShards = input.transcendShards
+  if (input.transcensionChallenge !== 3 && input.reincarnationChallenge !== 10) {
+    transcendShards = transcendShards.add(produceMythos.times(dt / 0.025))
+  }
+  const reincarnationShards = input.reincarnationShards.add(produceParticles.times(dt / 0.025))
+
+  // ─── AscendBuildings cascade (note: dt unscaled — legacy uses raw dt, not dt/0.025) ─
+  const ascendOwned: readonly number[] = [
+    input.ascendBuilding1Owned,
+    input.ascendBuilding2Owned,
+    input.ascendBuilding3Owned,
+    input.ascendBuilding4Owned,
+    input.ascendBuilding5Owned
+  ]
+  const ascendGenerated: Decimal[] = [
+    input.ascendBuilding1Generated,
+    input.ascendBuilding2Generated,
+    input.ascendBuilding3Generated,
+    input.ascendBuilding4Generated,
+    input.ascendBuilding5Generated
+  ]
+  const ascendProd: Decimal[] = [
+    new Decimal(0),
+    new Decimal(0),
+    new Decimal(0),
+    new Decimal(0),
+    new Decimal(0)
+  ]
+  for (let j = 4; j >= 0; j--) {
+    ascendProd[j] = ascendGenerated[j]
+      .add(ascendOwned[j])
+      .times(0.05)
+      .times(input.globalConstantMult)
+
+    if (j !== 0) {
+      ascendGenerated[j - 1] = ascendGenerated[j - 1].add(ascendProd[j].times(dt))
+    }
+  }
+
+  const ascendShards = input.ascendShards.add(ascendProd[0].times(dt))
+
+  // ─── awardAchievementGroup('constant') gate ────────────────────────
+  if (input.ascensionCount > 0) {
+    events.push({ kind: 'achievement-group-awarded', group: 'constant' })
+  }
+
+  // ─── Challenge 1-5 auto-completion ─────────────────────────────────
+  let c1Completions = input.c1Completions
+  let c2Completions = input.c2Completions
+  let c3Completions = input.c3Completions
+  let c4Completions = input.c4Completions
+  let c5Completions = input.c5Completions
+
+  if (
+    input.research71 > 0.5
+    && c1Completions < Math.min(input.highestC1, 25 + 5 * input.research66 + 925 * input.research105)
+    && coins.gte(
+      Decimal.pow(10, 1.25 * input.challengeBaseRequirements[0] * Math.pow(1 + c1Completions, 2))
+    )
+  ) {
+    c1Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 1, newCompletions: c1Completions })
+  }
+  if (
+    input.research72 > 0.5
+    && c2Completions < Math.min(input.highestC2, 25 + 5 * input.research67_ + 925 * input.research105)
+    && coins.gte(
+      Decimal.pow(10, 1.6 * input.challengeBaseRequirements[1] * Math.pow(1 + c2Completions, 2))
+    )
+  ) {
+    c2Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 2, newCompletions: c2Completions })
+  }
+  if (
+    input.research73 > 0.5
+    && c3Completions < Math.min(input.highestC3, 25 + 5 * input.research68 + 925 * input.research105)
+    && coins.gte(
+      Decimal.pow(10, 1.7 * input.challengeBaseRequirements[2] * Math.pow(1 + c3Completions, 2))
+    )
+  ) {
+    c3Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 3, newCompletions: c3Completions })
+  }
+  if (
+    input.research74 > 0.5
+    && c4Completions < Math.min(input.highestC4, 25 + 5 * input.research69 + 925 * input.research105)
+    && coins.gte(
+      Decimal.pow(10, 1.45 * input.challengeBaseRequirements[3] * Math.pow(1 + c4Completions, 2))
+    )
+  ) {
+    c4Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 4, newCompletions: c4Completions })
+  }
+  if (
+    input.research75 > 0.5
+    && c5Completions < Math.min(input.highestC5, 25 + 5 * input.research70 + 925 * input.research105)
+    && coins.gte(
+      Decimal.pow(10, 2 * input.challengeBaseRequirements[4] * Math.pow(1 + c5Completions, 2))
+    )
+  ) {
+    c5Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 5, newCompletions: c5Completions })
+  }
+
+  return {
+    coins,
+    coinsThisPrestige,
+    coinsThisTranscension,
+    coinsThisReincarnation,
+    coinsTotal,
+    prestigePoints,
+    transcendPoints,
+    reincarnationPoints,
+    prestigeShards,
+    transcendShards,
+    reincarnationShards,
+    ascendShards,
+    firstGeneratedDiamonds,
+    secondGeneratedDiamonds,
+    thirdGeneratedDiamonds,
+    fourthGeneratedDiamonds,
+    firstGeneratedMythos,
+    secondGeneratedMythos,
+    thirdGeneratedMythos,
+    fourthGeneratedMythos,
+    firstGeneratedParticles,
+    secondGeneratedParticles,
+    thirdGeneratedParticles,
+    fourthGeneratedParticles,
+    ascendBuilding1Generated: ascendGenerated[0],
+    ascendBuilding2Generated: ascendGenerated[1],
+    ascendBuilding3Generated: ascendGenerated[2],
+    ascendBuilding4Generated: ascendGenerated[3],
+    c1Completions,
+    c2Completions,
+    c3Completions,
+    c4Completions,
+    c5Completions,
+
+    produceFirstDiamonds,
+    produceSecondDiamonds,
+    produceThirdDiamonds,
+    produceFourthDiamonds,
+    produceFifthDiamonds,
+    produceDiamonds,
+    produceFirstMythos,
+    produceSecondMythos,
+    produceThirdMythos,
+    produceFourthMythos,
+    produceFifthMythos,
+    produceMythos,
+    producePerSecondMythos,
+    produceFirstParticles,
+    produceSecondParticles,
+    produceThirdParticles,
+    produceFourthParticles,
+    produceFifthParticles,
+    produceParticles,
+    producePerSecondParticles,
+    ascendBuildingProduction: {
+      first: ascendProd[0],
+      second: ascendProd[1],
+      third: ascendProd[2],
+      fourth: ascendProd[3],
+      fifth: ascendProd[4]
+    },
+
+    events
+  }
+}

--- a/packages/logic/src/mechanics/updateAllMultiplier.ts
+++ b/packages/logic/src/mechanics/updateAllMultiplier.ts
@@ -1,0 +1,274 @@
+// Per-tick multiplier-state aggregator. Lifted from
+// packages/web_ui/src/Synergism.ts (updateAllMultiplier).
+//
+// Computes the full multiplier stack for the current tick:
+//   - freeUpgradeMultiplier (intermediate snapshot)
+//   - freeMultiplier / totalMultiplier
+//   - challengeOneLog (constant 3, surfaced for parity)
+//   - totalMultiplierBoost
+//   - multiplierPower / multiplierEffect
+//
+// Same pattern as updateAllTick — web_ui pre-evaluates every rune /
+// hepteract / cube-blessing / achievement-reward / ant-effect input and
+// passes plain values in.
+
+import { Decimal } from '../math/bignum'
+import { CalcECC } from './challenges'
+
+export interface UpdateAllMultiplierInput {
+  // ─── Direct player state ──────────────────────────────────────────────
+
+  /** player.upgrades[7] — when > 0, adds min(4, 1 + log10(fifthOwnedCoin+1)). */
+  upgrade7: number
+  /** player.upgrades[9] — when > 0, adds floor(acceleratorBought / 10). */
+  upgrade9: number
+  /** player.upgrades[21..25] — each contributes +1 when > 0 and feeds the 1.01^count factor. */
+  upgrade21: number
+  upgrade22: number
+  upgrade23: number
+  upgrade24: number
+  upgrade25: number
+  /** player.upgrades[33] — when > 0, adds totalAcceleratorBoost. */
+  upgrade33: number
+  /** player.upgrades[34] — adds +0.03 per level to a multiplier. */
+  upgrade34: number
+  /** player.upgrades[35] — adds +0.02 per level to a multiplier. */
+  upgrade35: number
+  /** player.upgrades[49] — when > 0, adds min(50, log1e10(transcendPoints+1)). */
+  upgrade49: number
+  /** player.upgrades[50] — when > 0.5 inside a transcension/reincarnation challenge, multiplies by 1.25. */
+  upgrade50: number
+  /** player.upgrades[68] — when > 0, adds min(2500, floor(log10(taxdivisor)/1000)). */
+  upgrade68: number
+  /** player.acceleratorBought — feeds upgrade-9 contribution. */
+  acceleratorBought: number
+  /** player.multiplierBought — added directly to freeMultiplier for totalMultiplier. */
+  multiplierBought: number
+  /** player.fifthOwnedCoin — log10 base for upgrade-7. */
+  fifthOwnedCoin: number
+  /** player.challengecompletions[1] — adds +1 when > 0; fed through CalcECC for ecc1tr. */
+  c1Completions: number
+  /** player.challengecompletions[7] — fed through CalcECC for ecc7r; triggers c7 = 1.25 when > 0.5. */
+  c7Completions: number
+  /** player.challengecompletions[14] — fed through CalcECC for ecc14a. */
+  c14Completions: number
+  /** player.transcendPoints — log1e10 base for upgrade-49. */
+  transcendPoints: Decimal
+  /** player.transcendShards — log3 base for the b accumulator. */
+  transcendShards: Decimal
+  /** player.researches[2] — adds (1/5 * n * (1 + 1/2 * ecc14a)) to a multiplier. */
+  research2: number
+  /** player.researches[11..15] — additive bumps to a multiplier (1/20, 1/25, 1/40, 3/200, 1/200 per level). */
+  research11: number
+  research12: number
+  research13: number
+  research14: number
+  research15: number
+  /** player.researches[33..35] — each adds (11n/100) to b multiplier. */
+  research33: number
+  research34: number
+  research35: number
+  /** player.researches[87] — adds (1/20 * n) to a multiplier. */
+  research87: number
+  /** player.researches[89] — adds (n/5) to b multiplier. */
+  research89: number
+  /** player.researches[94] — multiplies the "20 * floor(sumOfRuneLevels/8)" additive. */
+  research94: number
+  /** player.researches[128, 143, 158, 173, 188, 200] — additive bumps to a multiplier. */
+  research128: number
+  research143: number
+  research158: number
+  research173: number
+  research188: number
+  research200: number
+  /** player.cubeUpgrades[50] — adds (0.01/100 * n) to a multiplier. */
+  cubeUpgrade50: number
+  /** player.platonicUpgrades[6] — contributes (1 + n/30) to the exponent on `a`. */
+  platonicUpgrade6: number
+  /** player.currentChallenge.transcension — controls upgrade-50 gate + t-chal 1/2 multiplierPower overrides. */
+  transcensionChallenge: number
+  /** player.currentChallenge.reincarnation — controls upgrade-50 gate + r-chal 7/10 multiplierPower overrides. */
+  reincarnationChallenge: number
+  /** player.corruptions.used.viscosity — triggers >=15 / >=16 cuts on a. */
+  viscosityCorruptionLevel: number
+
+  // ─── Pre-evaluated effects / rewards / blessings ──────────────────────
+
+  /** `+getAchievementReward('multipliers')` — added to base a. */
+  multipliersAchievement: number
+  /** `sumOfRuneLevels()` — used as `20 * research94 * floor(n/8)` additive. */
+  sumOfRuneLevels: number
+  /** `getRuneEffects('duplication', 'multiplicativeMultipliers')` — multiplies a. */
+  multiplicativeMultipliersRune: number
+  /** `getRuneEffects('duplication', 'multiplierBoosts')` — added to b accumulator. */
+  multiplierBoostsRune: number
+  /** `getRuneBlessingEffect('duplication').multiplierBoosts` — multiplies b. */
+  multiplierBoostsRuneBlessing: number
+  /** `getAntUpgradeEffect(AntUpgrades.Multipliers).multiplierMult` — multiplies a. */
+  antMultiplierMult: number
+  /** `calculateMultiplierCubeBlessing()` — multiplies a. */
+  multiplierCubeBlessing: number
+  /** `getHepteractEffects('multiplier').multiplier` — added to a after the viscosity-pow step. */
+  hepteractMultiplier: number
+  /** `getHepteractEffects('multiplier').multiplierMultiplier` — multiplies a after the additive. */
+  hepteractMultiplierMult: number
+
+  // ─── G inputs (pre-extracted by web_ui) ───────────────────────────────
+
+  /** G.totalAcceleratorBoost — added via upgrade-33. */
+  totalAcceleratorBoost: number
+  /** G.taxdivisor — log10 base for the upgrade-68 contribution. */
+  taxdivisor: Decimal
+  /** G.viscosityPower[player.corruptions.used.viscosity] — exponent factor on a. */
+  viscosityPower: number
+  /** G.challenge15Rewards.multiplier.value — multiplies a after the hepteract additive. */
+  challenge15RewardMultiplier: number
+}
+
+export interface UpdateAllMultiplierResult {
+  /** G.freeUpgradeMultiplier — `a` snapshot right after upgrades/achievements are folded in. */
+  freeUpgradeMultiplier: number
+  /** G.freeMultiplier — final floored `a` after all multiplicative + corruption gating. */
+  freeMultiplier: number
+  /** G.totalMultiplier — freeMultiplier + multiplierBought. */
+  totalMultiplier: number
+  /** G.challengeOneLog — constant 3, surfaced for parity. */
+  challengeOneLog: number
+  /** G.totalMultiplierBoost — pow(floor(b), 1 + 0.04 * ecc7r). */
+  totalMultiplierBoost: number
+  /** G.multiplierPower — `2 + 0.02 * totalMultiplierBoost * c7` (with challenge overrides). */
+  multiplierPower: number
+  /** G.multiplierEffect — Decimal.pow(multiplierPower, totalMultiplier). */
+  multiplierEffect: Decimal
+}
+
+/**
+ * Per-tick multiplier-state aggregator. Mirrors the legacy updateAllMultiplier
+ * body verbatim aside from input/output shape.
+ */
+export function updateAllMultiplier (input: UpdateAllMultiplierInput): UpdateAllMultiplierResult {
+  let a = 0
+
+  if (input.upgrade7 > 0) {
+    a += Math.min(4, 1 + Math.floor(Decimal.log(input.fifthOwnedCoin + 1, 10)))
+  }
+  if (input.upgrade9 > 0) {
+    a += Math.floor(input.acceleratorBought / 10)
+  }
+  if (input.upgrade21 > 0) a += 1
+  if (input.upgrade22 > 0) a += 1
+  if (input.upgrade23 > 0) a += 1
+  if (input.upgrade24 > 0) a += 1
+  if (input.upgrade25 > 0) a += 1
+  if (input.upgrade33 > 0) {
+    a += input.totalAcceleratorBoost
+  }
+  if (input.upgrade49 > 0) {
+    a += Math.min(50, Math.floor(Decimal.log(input.transcendPoints.add(1), 1e10)))
+  }
+  if (input.upgrade68 > 0) {
+    a += Math.min(2500, Math.floor((Decimal.log(input.taxdivisor, 10) * 1) / 1000))
+  }
+  if (input.c1Completions > 0) {
+    a += 1
+  }
+
+  a += input.multipliersAchievement
+  a += 20 * input.research94 * Math.floor(input.sumOfRuneLevels / 8)
+
+  const freeUpgradeMultiplier = Math.min(1e100, a)
+
+  const ecc14a = CalcECC('ascension', input.c14Completions)
+  const ecc1tr = CalcECC('transcend', input.c1Completions)
+  const ecc7r = CalcECC('reincarnation', input.c7Completions)
+
+  a *= Math.pow(
+    1.01,
+    input.upgrade21 + input.upgrade22 + input.upgrade23 + input.upgrade24 + input.upgrade25
+  )
+  a *= 1 + 0.03 * input.upgrade34 + 0.02 * input.upgrade35
+  a *= 1 + (1 / 5) * input.research2 * (1 + (1 / 2) * ecc14a)
+  a *= 1
+    + (1 / 20) * input.research11
+    + (1 / 25) * input.research12
+    + (1 / 40) * input.research13
+    + (3 / 200) * input.research14
+    + (1 / 200) * input.research15
+  a *= input.multiplicativeMultipliersRune
+  a *= 1 + (1 / 20) * input.research87
+  a *= 1 + (1 / 100) * input.research128
+  a *= 1 + (0.8 / 100) * input.research143
+  a *= 1 + (0.6 / 100) * input.research158
+  a *= 1 + (0.4 / 100) * input.research173
+  a *= 1 + (0.2 / 100) * input.research188
+  a *= 1 + (0.01 / 100) * input.research200
+  a *= 1 + (0.01 / 100) * input.cubeUpgrade50
+  a *= input.antMultiplierMult
+  a *= input.multiplierCubeBlessing
+
+  if (
+    (input.transcensionChallenge !== 0 || input.reincarnationChallenge !== 0)
+    && input.upgrade50 > 0.5
+  ) {
+    a *= 1.25
+  }
+  a = Math.pow(
+    a,
+    Math.min(1, (1 + input.platonicUpgrade6 / 30) * input.viscosityPower)
+  )
+  a += input.hepteractMultiplier
+  a *= input.challenge15RewardMultiplier
+  a *= input.hepteractMultiplierMult
+  a = Math.floor(Math.min(1e100, a))
+
+  if (input.viscosityCorruptionLevel >= 15) a = Math.pow(a, 0.2)
+  if (input.viscosityCorruptionLevel >= 16) a = 1
+
+  const freeMultiplier = a
+  const totalMultiplier = freeMultiplier + input.multiplierBought
+  const challengeOneLog = 3
+
+  let b = 0
+  b += Decimal.log(input.transcendShards.add(1), 3)
+  b += input.multiplierBoostsRune
+  b += 2 * ecc1tr
+  b *= 1 + (11 * input.research33) / 100
+  b *= 1 + (11 * input.research34) / 100
+  b *= 1 + (11 * input.research35) / 100
+  b *= 1 + input.research89 / 5
+  b *= input.multiplierBoostsRuneBlessing
+
+  const totalMultiplierBoost = Math.pow(Math.floor(b), 1 + ecc7r * 0.04)
+
+  const c7 = input.c7Completions > 0.5 ? 1.25 : 1
+
+  let multiplierPower = 2 + 0.02 * totalMultiplierBoost * c7
+
+  if (
+    input.reincarnationChallenge !== 7
+    && input.reincarnationChallenge !== 10
+  ) {
+    if (input.transcensionChallenge === 1) {
+      multiplierPower = 1
+    }
+    if (input.transcensionChallenge === 2) {
+      multiplierPower = 1.25 + 0.0012 * b * c7
+    }
+  }
+  multiplierPower = Math.min(1e300, multiplierPower)
+
+  if (input.reincarnationChallenge === 7) multiplierPower = 1
+  if (input.reincarnationChallenge === 10) multiplierPower = 1
+
+  const multiplierEffect = Decimal.pow(multiplierPower, totalMultiplier)
+
+  return {
+    freeUpgradeMultiplier,
+    freeMultiplier,
+    totalMultiplier,
+    challengeOneLog,
+    totalMultiplierBoost,
+    multiplierPower,
+    multiplierEffect
+  }
+}

--- a/packages/logic/src/mechanics/updateAllTick.ts
+++ b/packages/logic/src/mechanics/updateAllTick.ts
@@ -1,0 +1,274 @@
+// Per-tick accelerator-state aggregator. Lifted from
+// packages/web_ui/src/Synergism.ts (updateAllTick).
+//
+// Computes the full accelerator stack for the current tick:
+//   - totalAccelerator / costDivisor (bookkeeping)
+//   - freeUpgradeAccelerator (intermediate snapshot used elsewhere)
+//   - freeAccelerator (from upgrades + boosts + runes + cubes + multipliers
+//     + hepteracts + corruptions)
+//   - acceleratorPower / acceleratorEffect / acceleratorEffectDisplay
+//   - generatorPower
+//
+// All "effect" inputs (achievement rewards, rune effects, cube blessings,
+// hepteract effects, viscosity power, challenge 15 reward) are pre-evaluated
+// by web_ui and passed in. G.acceleratorMultiplier is also pre-evaluated —
+// the web_ui shim calls calculateAcceleratorMultiplier() before invoking
+// updateAllTick so this slot is fresh.
+
+import { Decimal } from '../math/bignum'
+import { CalcECC } from './challenges'
+
+export interface UpdateAllTickInput {
+  // ─── Direct player state ──────────────────────────────────────────────
+
+  /** player.acceleratorBought — base for totalAccelerator. */
+  acceleratorBought: number
+  /** player.multiplierBought — feeds upgrade-8's `floor(mult/7)`. */
+  multiplierBought: number
+  /** player.upgrades[8] — non-zero enables the multiplier-bought-derived bonus. */
+  upgrade8: number
+  /** player.upgrades[11] — when > 0.5 and r-chal ≠ 7, enables generatorPower formula. */
+  upgrade11: number
+  /** player.upgrades[21] — non-zero adds +5. */
+  upgrade21: number
+  /** player.upgrades[22] — non-zero adds +4. */
+  upgrade22: number
+  /** player.upgrades[23] — non-zero adds +3. */
+  upgrade23: number
+  /** player.upgrades[24] — non-zero adds +2. */
+  upgrade24: number
+  /** player.upgrades[25] — non-zero adds +1. */
+  upgrade25: number
+  /** player.upgrades[32] — non-zero adds min(500, floor(log1e25(prestigePoints+1))). */
+  upgrade32: number
+  /** player.upgrades[45] — non-zero adds min(2500, floor(log10(transcendShards+1))). */
+  upgrade45: number
+  /** player.upgrades[46] — when > 0.5, sets tuSevenMulti to 1.05 (else 1). */
+  upgrade46: number
+  /** player.prestigePoints — log-base argument for upgrade-32. */
+  prestigePoints: Decimal
+  /** player.transcendShards — log-base argument for upgrade-45. */
+  transcendShards: Decimal
+  /** player.challengecompletions[1] — used in t-chal 1 acceleratorPower formula. */
+  c1Completions: number
+  /** player.challengecompletions[2] — fed through CalcECC by caller (transcend) for ecc2tr. */
+  c2Completions: number
+  /** player.challengecompletions[7] — fed through CalcECC by caller (reincarnation) for ecc7r. */
+  c7Completions: number
+  /** player.currentChallenge.transcension — controls acceleratorPower overrides for 1/2/3. */
+  transcensionChallenge: number
+  /** player.currentChallenge.reincarnation — controls acceleratorPower / acceleratorEffect overrides for 7/10. */
+  reincarnationChallenge: number
+  /** player.researches[18] — adds +2 per level to the totalAcceleratorBoost factor. */
+  research18: number
+  /** player.researches[19] — adds +2 per level to the totalAcceleratorBoost factor. */
+  research19: number
+  /** player.researches[20] — adds +3 per level to the totalAcceleratorBoost factor. */
+  research20: number
+  /** player.platonicUpgrades[6] — contributes (1 + n/30) to the exponent on `a`. */
+  platonicUpgrade6: number
+  /** player.unlocks.prestige — gates the multiplicative-accelerators rune effect. */
+  prestigeUnlocked: boolean
+  /** player.corruptions.used.viscosity — sources viscosityPower and triggers >=15 / >=16 cuts. */
+  viscosityCorruptionLevel: number
+
+  // ─── Pre-evaluated effects / rewards / blessings ──────────────────────
+
+  /** `+getAchievementReward('accelerators')` — added to base `a` (after upgrades). */
+  acceleratorsAchievement: number
+  /** `+getAchievementReward('acceleratorPower')` — additive term inside acceleratorPower. */
+  acceleratorPowerAchievement: number
+  /** `getRuneEffects('speed', 'multiplicativeAccelerators')` — multiplies `a` when prestige unlocked. */
+  multiplicativeAcceleratorsRune: number
+  /** `getRuneEffects('speed', 'acceleratorPower')` — additive term inside acceleratorPower. */
+  acceleratorPowerRune: number
+  /** `calculateAcceleratorCubeBlessing()` — adds to the totalAcceleratorBoost factor. */
+  acceleratorCubeBlessing: number
+  /** `getHepteractEffects('accelerator').accelerators` — added to `a` after rune+multiplier+power steps. */
+  hepteractAccelerators: number
+  /** `getHepteractEffects('accelerator').acceleratorMultiplier` — multiplies `a` after the additive step. */
+  hepteractAcceleratorMult: number
+
+  // ─── G inputs (pre-extracted by web_ui) ───────────────────────────────
+
+  /** G.totalAcceleratorBoost (set by calculateTotalAcceleratorBoost prior to this call). */
+  totalAcceleratorBoost: number
+  /** G.acceleratorMultiplier (set by calculateAcceleratorMultiplier prior to this call). */
+  acceleratorMultiplier: number
+  /** G.viscosityPower[player.corruptions.used.viscosity] — viscosity-corruption exponent factor. */
+  viscosityPower: number
+  /** G.challenge15Rewards.accelerator.value — multiplied into `a` after the hepteract additive. */
+  challenge15RewardAccelerator: number
+}
+
+export interface UpdateAllTickResult {
+  /** G.totalAccelerator (= acceleratorBought + freeAccelerator). */
+  totalAccelerator: number
+  /** G.costDivisor — always set to 1 here, surfaced for parity. */
+  costDivisor: number
+  /** G.freeUpgradeAccelerator — `a` snapshot right after upgrades/achievements/ECC are folded in. */
+  freeUpgradeAccelerator: number
+  /** G.freeAccelerator — final floored `a` after all multiplicative + corruption gating. */
+  freeAccelerator: number
+  /** G.tuSevenMulti — 1.05 when upgrade46 > 0.5, else 1. */
+  tuSevenMulti: number
+  /** G.acceleratorPower — used as exponent base for acceleratorEffect. */
+  acceleratorPower: number
+  /** G.acceleratorEffect — Decimal pow result; reads totalAccelerator (+ totalMultiplier when t-chal 1). */
+  acceleratorEffect: Decimal
+  /** G.acceleratorEffectDisplay — `acceleratorPower * 100 - 100` wrapped in Decimal. */
+  acceleratorEffectDisplay: Decimal
+  /** G.generatorPower — `1.02 ^ totalAccelerator` when upgrade11 active outside r-chal 7; 1 otherwise. */
+  generatorPower: Decimal
+}
+
+/**
+ * Per-tick accelerator-state aggregator. See file-level comment for the
+ * computation sequence; mirrors the legacy updateAllTick body verbatim aside
+ * from input/output shape.
+ *
+ * @param totalMultiplier  G.totalMultiplier at call time — read only for the
+ *                         t-chal 1 acceleratorEffect exponent
+ *                         (`acceleratorPower ^ (totalAccelerator + totalMultiplier)`).
+ *                         Separate from `input` because it's set by updateAllMultiplier
+ *                         in the legacy ordering and we want the parity test to
+ *                         exercise both with/without that completed.
+ */
+export function updateAllTick (
+  input: UpdateAllTickInput,
+  totalMultiplier: number
+): UpdateAllTickResult {
+  let a = 0
+
+  const totalAcceleratorInit = input.acceleratorBought
+  const costDivisor = 1
+
+  if (input.upgrade8 !== 0) {
+    a += Math.floor(input.multiplierBought / 7)
+  }
+  if (input.upgrade21 !== 0) {
+    a += 5
+  }
+  if (input.upgrade22 !== 0) {
+    a += 4
+  }
+  if (input.upgrade23 !== 0) {
+    a += 3
+  }
+  if (input.upgrade24 !== 0) {
+    a += 2
+  }
+  if (input.upgrade25 !== 0) {
+    a += 1
+  }
+  if (input.upgrade32 !== 0) {
+    a += Math.min(500, Math.floor(Decimal.log(input.prestigePoints.add(1), 1e25)))
+  }
+  if (input.upgrade45 !== 0) {
+    a += Math.min(2500, Math.floor(Decimal.log(input.transcendShards.add(1), 10)))
+  }
+  a += input.acceleratorsAchievement
+
+  const ecc2tr = CalcECC('transcend', input.c2Completions)
+  const ecc7r = CalcECC('reincarnation', input.c7Completions)
+
+  a += 5 * ecc2tr
+  const freeUpgradeAccelerator = a
+
+  a += input.totalAcceleratorBoost
+    * (5
+      + 2 * input.research18
+      + 2 * input.research19
+      + 3 * input.research20
+      + input.acceleratorCubeBlessing)
+
+  if (input.prestigeUnlocked) {
+    a *= input.multiplicativeAcceleratorsRune
+  }
+
+  a *= input.acceleratorMultiplier
+  a = Math.pow(
+    a,
+    Math.min(1, (1 + input.platonicUpgrade6 / 30) * input.viscosityPower)
+  )
+  a += input.hepteractAccelerators
+  a *= input.challenge15RewardAccelerator
+  a *= input.hepteractAcceleratorMult
+  a = Math.floor(Math.min(1e100, a))
+
+  if (input.viscosityCorruptionLevel >= 15) {
+    a = Math.pow(a, 0.2)
+  }
+  if (input.viscosityCorruptionLevel >= 16) {
+    a = 1
+  }
+
+  const freeAccelerator = a
+  const totalAccelerator = totalAcceleratorInit + freeAccelerator
+
+  const tuSevenMulti = input.upgrade46 > 0.5 ? 1.05 : 1
+
+  let acceleratorPower = Math.pow(
+    1.1
+      + input.acceleratorPowerRune
+      + 1 / 400 * ecc2tr
+      + input.acceleratorPowerAchievement
+      + tuSevenMulti
+        * (input.totalAcceleratorBoost / 100)
+        * (1 + ecc2tr / 20),
+    1 + 0.04 * ecc7r
+  )
+
+  // No-MA and Sadistic challenges overwrite the transcension overrides
+  if (
+    input.reincarnationChallenge !== 7
+    && input.reincarnationChallenge !== 10
+  ) {
+    if (input.transcensionChallenge === 1) {
+      acceleratorPower *= 25 / (50 + input.c1Completions)
+      acceleratorPower += 0.55
+      acceleratorPower = Math.max(1, acceleratorPower)
+    }
+    if (input.transcensionChallenge === 2) {
+      acceleratorPower = 1
+    }
+    if (input.transcensionChallenge === 3) {
+      acceleratorPower = 1 + acceleratorPower / 2
+    }
+  }
+  acceleratorPower = Math.min(1e300, acceleratorPower)
+  if (input.reincarnationChallenge === 7) {
+    acceleratorPower = 1
+  }
+  if (input.reincarnationChallenge === 10) {
+    acceleratorPower = 1
+  }
+
+  let acceleratorEffect: Decimal
+  if (input.transcensionChallenge !== 1) {
+    acceleratorEffect = Decimal.pow(acceleratorPower, totalAccelerator)
+  } else {
+    acceleratorEffect = Decimal.pow(acceleratorPower, totalAccelerator + totalMultiplier)
+  }
+  const acceleratorEffectDisplay = new Decimal(acceleratorPower * 100 - 100)
+  if (input.reincarnationChallenge === 10) {
+    acceleratorEffect = new Decimal(1)
+  }
+
+  let generatorPower = new Decimal(1)
+  if (input.upgrade11 > 0.5 && input.reincarnationChallenge !== 7) {
+    generatorPower = Decimal.pow(1.02, totalAccelerator)
+  }
+
+  return {
+    totalAccelerator,
+    costDivisor,
+    freeUpgradeAccelerator,
+    freeAccelerator,
+    tuSevenMulti,
+    acceleratorPower,
+    acceleratorEffect,
+    acceleratorEffectDisplay,
+    generatorPower
+  }
+}

--- a/packages/logic/src/tick/timers.ts
+++ b/packages/logic/src/tick/timers.ts
@@ -1,0 +1,141 @@
+// Per-tick reset/quark/singularity counter advancement. Lifted from
+// packages/web_ui/src/Helper.ts (addTimers, simple counter cases).
+//
+// Covers the 7 cases of addTimers that are pure counter math with no
+// side effects, no RNG, and no consumable orchestration:
+//   prestige, transcension, reincarnation (shared shape: counter += time × mult)
+//   ascension (dual counter + ascensionSpeedMulti)
+//   singularity (triple counter + singularitySpeedMulti + challenge timer)
+//   quarks (capped at maxQuarkTimer)
+//   goldenQuarks (capped at 168 hours, gated by exportGQPerHour > 0)
+//
+// The four complex cases (octeracts, autoPotion, ambrosia, redAmbrosia)
+// stay in web_ui for now — each involves modal/consumable side effects or
+// the seededRandom RNG, which need their own migration scaffolding.
+//
+// Caller pre-evaluates the per-tick globalTimeMultiplier
+// (`getGQUpgradeEffect('halfMind', 'unlocked') ? 10 : calculateGlobalSpeedMult()`)
+// and per-case speed multipliers (`ascensionSpeedMulti`, `singularitySpeedMulti`)
+// and the various caps (`maxQuarkTimer`, `exportGQPerHour`).
+
+// Shared counter advancement for prestige / transcension / reincarnation.
+// Each of these three timers uses the same shape:
+//   counter += time * globalTimeMultiplier
+// — no caps, no conditional speed multipliers.
+export function advanceResetCounter (
+  counter: number,
+  time: number,
+  globalTimeMultiplier: number
+): number {
+  return counter + time * globalTimeMultiplier
+}
+
+export interface AdvanceAscensionTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** player.ascensionCounter — advances by time × ascensionSpeedMulti. */
+  ascensionCounter: number
+  /** player.ascensionCounterReal — advances by time only (unaffected by ascension speed). */
+  ascensionCounterReal: number
+  /** Pre-evaluated ascension speed: `getGQUpgradeEffect('oneMind', 'unlocked') ? 10 : calculateAscensionSpeedMult()`. */
+  ascensionSpeedMulti: number
+}
+
+export interface AdvanceAscensionTimerResult {
+  ascensionCounter: number
+  ascensionCounterReal: number
+}
+
+/**
+ * Advance the ascension dual-counter. ascensionCounter scales with the
+ * pre-evaluated `ascensionSpeedMulti`; ascensionCounterReal is raw wall
+ * time. The ascension timer case in legacy addTimers passes `timeMultiplier
+ * = 1` (not globalTimeMultiplier), so we don't take it as input.
+ */
+export function advanceAscensionTimer (input: AdvanceAscensionTimerInput): AdvanceAscensionTimerResult {
+  return {
+    ascensionCounter: input.ascensionCounter + input.time * input.ascensionSpeedMulti,
+    ascensionCounterReal: input.ascensionCounterReal + input.time
+  }
+}
+
+export interface AdvanceSingularityTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** player.ascensionCounterRealReal — advances by raw `time`. */
+  ascensionCounterRealReal: number
+  /** player.singularityCounter — advances by time × singularitySpeedMulti. */
+  singularityCounter: number
+  /** player.singChallengeTimer — advances by time × singularitySpeedMulti
+   * when insideSingularityChallenge, else reset to 0. */
+  singChallengeTimer: number
+  /** player.insideSingularityChallenge — gates the singChallengeTimer
+   * accumulation vs. reset. */
+  insideSingularityChallenge: boolean
+  /** Pre-evaluated `getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'singularitySpeedMult')`. */
+  singularitySpeedMulti: number
+}
+
+export interface AdvanceSingularityTimerResult {
+  ascensionCounterRealReal: number
+  singularityCounter: number
+  singChallengeTimer: number
+}
+
+/**
+ * Advance the singularity tri-counter. Same `time` input feeds all three.
+ * `singChallengeTimer` accumulates only when `insideSingularityChallenge`,
+ * otherwise it resets to 0 every tick.
+ */
+export function advanceSingularityTimer (input: AdvanceSingularityTimerInput): AdvanceSingularityTimerResult {
+  const ascensionCounterRealReal = input.ascensionCounterRealReal + input.time
+  const singularityCounter = input.singularityCounter + input.time * input.singularitySpeedMulti
+  const singChallengeTimer = input.insideSingularityChallenge
+    ? input.singChallengeTimer + input.time * input.singularitySpeedMulti
+    : 0
+  return { ascensionCounterRealReal, singularityCounter, singChallengeTimer }
+}
+
+export interface AdvanceQuarksTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** player.quarkstimer — advances by raw `time`, clamped to `maxQuarkTimer`. */
+  quarkstimer: number
+  /** Pre-evaluated `quarkHandler().maxTime` — upper bound on quarkstimer. */
+  maxQuarkTimer: number
+}
+
+/**
+ * Advance the quark export timer, clamped at `maxQuarkTimer` (~25 hours,
+ * extended by Research 8x20). Legacy uses `timeMultiplier = 1` here.
+ */
+export function advanceQuarksTimer (input: AdvanceQuarksTimerInput): number {
+  const advanced = input.quarkstimer + input.time
+  return advanced > input.maxQuarkTimer ? input.maxQuarkTimer : advanced
+}
+
+export interface AdvanceGoldenQuarksTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** player.goldenQuarksTimer — advances by raw `time`, clamped to 168 hours
+   * (`3600 * 168`). */
+  goldenQuarksTimer: number
+  /** Pre-evaluated `getGQUpgradeEffect('goldenQuarks3', 'exportGQPerHour')` —
+   * when 0, the timer doesn't advance at all (return value === current value). */
+  exportGQPerHour: number
+}
+
+const GOLDEN_QUARKS_TIMER_CAP_SECONDS = 3600 * 168
+
+/**
+ * Advance the golden-quark export timer, gated by the `goldenQuarks3`
+ * GQ upgrade. When `exportGQPerHour === 0`, the timer is untouched.
+ * Otherwise it accumulates raw `time` and clamps to the 168-hour cap.
+ */
+export function advanceGoldenQuarksTimer (input: AdvanceGoldenQuarksTimerInput): number {
+  if (input.exportGQPerHour === 0) {
+    return input.goldenQuarksTimer
+  }
+  const advanced = input.goldenQuarksTimer + input.time
+  return advanced > GOLDEN_QUARKS_TIMER_CAP_SECONDS ? GOLDEN_QUARKS_TIMER_CAP_SECONDS : advanced
+}

--- a/packages/logic/test/parity/globalMultipliers.parity.test.ts
+++ b/packages/logic/test/parity/globalMultipliers.parity.test.ts
@@ -1,0 +1,633 @@
+// Parity tests for computeGlobalMultipliers. Old body transcribed verbatim from
+// packages/web_ui/src/Synergism.ts (multipliers, ~line 2572 pre-migration).
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import { CalcECC } from '../../src/mechanics/challenges'
+import {
+  computeGlobalMultipliers as newComputeGlobalMultipliers,
+  type GlobalMultipliersInput,
+  type GlobalMultipliersResult
+} from '../../src/mechanics/globalMultipliers'
+
+const oldComputeGlobalMultipliers = (input: GlobalMultipliersInput): GlobalMultipliersResult => {
+  let s = new Decimal(1)
+  let c = new Decimal(1)
+
+  s = s.times(input.multiplierEffect)
+  s = s.times(input.acceleratorEffect)
+  s = s.times(input.crystalMult)
+  s = s.times(input.buildingPowerMult)
+  s = s.times(input.antMultiplier)
+
+  const first6CoinUp = new Decimal(input.totalCoinOwned + 1).times(
+    Decimal.min(1e30, Decimal.pow(1.008, input.totalCoinOwned))
+  )
+
+  if (input.highestSingularityCount > 0) {
+    s = s.times(
+      Math.pow(input.goldenQuarks + 1, 1.5)
+        * Math.pow(input.highestSingularityCount + 1, 2)
+    )
+  }
+  if (input.upgrade6 > 0.5) s = s.times(first6CoinUp)
+  if (input.upgrade12 > 0.5) s = s.times(Decimal.min(1e4, Decimal.pow(1.01, input.prestigeCount)))
+  if (input.upgrade20 > 0.5) s = s.times(Decimal.pow(input.totalCoinOwned / 4 + 1, 10))
+  if (input.upgrade41 > 0.5) {
+    s = s.times(Decimal.min(1e30, Decimal.pow(input.transcendPoints.add(4), 1 / 2)))
+  }
+  if (input.upgrade43 > 0.5) {
+    s = s.times(Decimal.min(1e30, Decimal.pow(1.01, input.transcendCount)))
+  }
+  if (input.upgrade48 > 0.5) {
+    s = s.times(Decimal.pow((input.totalMultiplier * input.totalAccelerator) / 1000 + 1, 8))
+  }
+  if (input.reincarnationChallenge === 6) s = s.dividedBy(1e250)
+  if (input.reincarnationChallenge === 7) s = s.dividedBy('1e1250')
+  if (input.reincarnationChallenge === 9) s = s.dividedBy('1e2000000')
+  c = Decimal.pow(s, 1 + 0.001 * input.research17)
+  let lol = Decimal.pow(c, 1 + 0.025 * input.upgrade123)
+  if (input.ascensionChallenge === 15 && input.platonicUpgrade5 > 0) {
+    lol = Decimal.pow(lol, 1.1)
+  }
+  if (input.ascensionChallenge === 15 && input.platonicUpgrade14 > 0) {
+    lol = Decimal.pow(
+      lol,
+      1
+        + ((1 / 20)
+            * input.recessionCorruptionLevel
+            * Decimal.log(input.coins.add(1), 10))
+          / (1e7 + Decimal.log(input.coins.add(1), 10))
+    )
+  }
+  if (input.ascensionChallenge === 15 && input.platonicUpgrade15 > 0) {
+    lol = Decimal.pow(lol, 1.1)
+  }
+  lol = Decimal.pow(lol, input.challenge15CoinExponent)
+  let globalCoinMultiplier = lol
+  globalCoinMultiplier = Decimal.pow(globalCoinMultiplier, input.recessionPower)
+
+  let coinOneMulti = new Decimal(1)
+  if (input.upgrade1 > 0.5) coinOneMulti = coinOneMulti.times(first6CoinUp)
+  if (input.upgrade10 > 0.5) {
+    coinOneMulti = coinOneMulti.times(Decimal.pow(2, Math.min(50, input.secondOwnedCoin / 15)))
+  }
+  if (input.upgrade56 > 0.5) coinOneMulti = coinOneMulti.times('1e5000')
+
+  let coinTwoMulti = new Decimal(1)
+  if (input.upgrade2 > 0.5) coinTwoMulti = coinTwoMulti.times(first6CoinUp)
+  if (input.upgrade13 > 0.5) {
+    coinTwoMulti = coinTwoMulti.times(
+      Decimal.min(
+        1e50,
+        Decimal.pow(input.firstGeneratedMythos.add(input.firstOwnedMythos).add(1), 4 / 3).times(1e22)
+      )
+    )
+  }
+  if (input.upgrade19 > 0.5) {
+    coinTwoMulti = coinTwoMulti.times(Decimal.min(1e200, input.transcendPoints.times(1e30).add(1)))
+  }
+  if (input.upgrade57 > 0.5) coinTwoMulti = coinTwoMulti.times('1e7500')
+
+  let coinThreeMulti = new Decimal(1)
+  if (input.upgrade3 > 0.5) coinThreeMulti = coinThreeMulti.times(first6CoinUp)
+  if (input.upgrade18 > 0.5) {
+    coinThreeMulti = coinThreeMulti.times(Decimal.min(1e125, input.transcendShards.add(1)))
+  }
+  if (input.upgrade58 > 0.5) coinThreeMulti = coinThreeMulti.times('1e15000')
+
+  let coinFourMulti = new Decimal(1)
+  if (input.upgrade4 > 0.5) coinFourMulti = coinFourMulti.times(first6CoinUp)
+  if (input.upgrade17 > 0.5) coinFourMulti = coinFourMulti.times(1e100)
+  if (input.upgrade59 > 0.5) coinFourMulti = coinFourMulti.times('1e25000')
+
+  let coinFiveMulti = new Decimal(1)
+  if (input.upgrade5 > 0.5) coinFiveMulti = coinFiveMulti.times(first6CoinUp)
+  if (input.upgrade60 > 0.5) coinFiveMulti = coinFiveMulti.times('1e35000')
+
+  let globalCrystalMultiplier = new Decimal(1)
+  globalCrystalMultiplier = globalCrystalMultiplier.times(input.crystalMultiplierAchievement)
+  globalCrystalMultiplier = globalCrystalMultiplier.times(Decimal.pow(10, input.prismProductionLog10))
+  if (input.upgrade36 > 0.5) {
+    globalCrystalMultiplier = globalCrystalMultiplier.times(
+      Decimal.min('1e5000', Decimal.pow(input.prestigePoints, 1 / 500))
+    )
+  }
+  if (input.upgrade63 > 0.5) {
+    globalCrystalMultiplier = globalCrystalMultiplier.times(
+      Decimal.min('1e6000', Decimal.pow(input.reincarnationPoints.add(1), 6))
+    )
+  }
+  if (input.research39 > 0.5) {
+    globalCrystalMultiplier = globalCrystalMultiplier.times(
+      Decimal.pow(input.buildingPowerMult, 1 / 50)
+    )
+  }
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(1 + 0.01 * input.crystalUpgrade0, input.achievementPoints)
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(
+      1 + input.crystalUpgrade1 * Decimal.log(input.coins.add(1), 10) / 100,
+      2 + Math.log2(input.crystalUpgrade1 + 1)
+    )
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(input.crystalUpgrade3Multiplier)
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(
+      1 + 0.05 * input.crystalUpgrade4,
+      input.c1Completions
+        + input.c2Completions
+        + input.c3Completions
+        + input.c4Completions
+        + input.c5Completions
+    )
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(10, CalcECC('transcend', input.c5Completions))
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(
+    Decimal.pow(
+      1e4,
+      input.research5 * (1 + (1 / 2) * CalcECC('ascension', input.c14Completions))
+    )
+  )
+  globalCrystalMultiplier = globalCrystalMultiplier.times(Decimal.pow(2.5, input.research26))
+  globalCrystalMultiplier = globalCrystalMultiplier.times(Decimal.pow(2.5, input.research27))
+
+  let globalMythosMultiplier = new Decimal(1)
+
+  if (input.upgrade37 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(Decimal.log(input.prestigePoints.add(10), 10), 2)
+    )
+  }
+  if (input.upgrade42 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.min(
+        1e50,
+        Decimal.pow(input.prestigePoints.add(1), 1 / 50).dividedBy(2.5).add(1)
+      )
+    )
+  }
+  if (input.upgrade47 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier
+      .times(Decimal.pow(1.01, input.achievementPoints))
+      .times(input.achievementPoints / 5 + 1)
+  }
+  if (input.upgrade51 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(Decimal.pow(input.totalAcceleratorBoost, 2))
+  }
+  if (input.upgrade52 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(Decimal.pow(globalMythosMultiplier, 0.025))
+  }
+  if (input.upgrade64 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(input.reincarnationPoints.add(1), 2)
+    )
+  }
+  if (input.research40 > 0.5) {
+    globalMythosMultiplier = globalMythosMultiplier.times(
+      Decimal.pow(input.buildingPowerMult, 1 / 250)
+    )
+  }
+
+  let grandmasterMultiplier = new Decimal(1)
+  const totalMythosOwned = input.firstOwnedMythos
+    + input.secondOwnedMythos
+    + input.thirdOwnedMythos
+    + input.fourthOwnedMythos
+    + input.fifthOwnedMythos
+
+  const mythosBuildingPower = 1 + CalcECC('transcend', input.c3Completions) / 200
+  const challengeThreeMultiplier = Decimal.pow(mythosBuildingPower, totalMythosOwned)
+
+  grandmasterMultiplier = grandmasterMultiplier.times(challengeThreeMultiplier)
+
+  let mythosupgrade13 = new Decimal(1)
+  let mythosupgrade14 = new Decimal(1)
+  let mythosupgrade15 = new Decimal(1)
+  if (input.upgrade53 === 1) {
+    mythosupgrade13 = mythosupgrade13.times(
+      Decimal.min('1e1250', Decimal.pow(input.acceleratorEffect, 1 / 125))
+    )
+  }
+  if (input.upgrade54 === 1) {
+    mythosupgrade14 = mythosupgrade14.times(
+      Decimal.min('1e2000', Decimal.pow(input.multiplierEffect, 1 / 180))
+    )
+  }
+  if (input.upgrade55 === 1) {
+    mythosupgrade15 = mythosupgrade15.times(
+      Decimal.pow('1e1000', Math.min(1000, input.buildingPower - 1))
+    )
+  }
+
+  let globalConstantMult = new Decimal('1')
+  globalConstantMult = globalConstantMult.times(
+    Decimal.pow(
+      1.05 + input.constUpgrade1BuffAchievement + 0.001 * input.platonicUpgrade18,
+      input.constantUpgrade1
+    )
+  )
+  globalConstantMult = globalConstantMult.times(
+    Decimal.pow(
+      1
+        + 0.001
+          * Math.min(
+            100
+              + 1000 * input.constUpgrade2BuffAchievement
+              + 10 * input.constantEXMaxPercentIncrease
+              + 1000 * (input.challenge15ExponentValue - 1)
+              + 3 * input.platonicUpgrade18,
+            input.constantUpgrade2
+          ),
+      input.ascendBuildingDRValue
+    )
+  )
+  globalConstantMult = globalConstantMult.times(1 + (2 / 100) * input.research139)
+  globalConstantMult = globalConstantMult.times(1 + (3 / 100) * input.research154)
+  globalConstantMult = globalConstantMult.times(1 + (5 / 100) * input.research184)
+  globalConstantMult = globalConstantMult.times(1 + (10 / 100) * input.research199)
+  globalConstantMult = globalConstantMult.times(input.challenge15ConstantBonus)
+  if (input.platonicUpgrade5 > 0) globalConstantMult = globalConstantMult.times(2)
+  if (input.platonicUpgrade10 > 0) globalConstantMult = globalConstantMult.times(10)
+  if (input.platonicUpgrade15 > 0) globalConstantMult = globalConstantMult.times(1e250)
+  globalConstantMult = globalConstantMult.times(
+    Decimal.pow(input.overfluxPowder + 1, 10 * input.platonicUpgrade16)
+  )
+
+  return {
+    globalCoinMultiplier,
+    coinOneMulti,
+    coinTwoMulti,
+    coinThreeMulti,
+    coinFourMulti,
+    coinFiveMulti,
+    globalCrystalMultiplier,
+    globalMythosMultiplier,
+    grandmasterMultiplier,
+    totalMythosOwned,
+    mythosBuildingPower,
+    challengeThreeMultiplier,
+    mythosupgrade13,
+    mythosupgrade14,
+    mythosupgrade15,
+    globalConstantMult,
+    antMultiplier: input.antMultiplier
+  }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+const baseInput: GlobalMultipliersInput = {
+  upgrade1: 0, upgrade2: 0, upgrade3: 0, upgrade4: 0, upgrade5: 0, upgrade6: 0,
+  upgrade10: 0, upgrade12: 0, upgrade13: 0, upgrade17: 0, upgrade18: 0,
+  upgrade19: 0, upgrade20: 0, upgrade41: 0, upgrade43: 0, upgrade48: 0,
+  upgrade56: 0, upgrade57: 0, upgrade58: 0, upgrade59: 0, upgrade60: 0,
+  upgrade36: 0, upgrade37: 0, upgrade42: 0, upgrade47: 0, upgrade51: 0,
+  upgrade52: 0, upgrade53: 0, upgrade54: 0, upgrade55: 0, upgrade63: 0,
+  upgrade64: 0, upgrade123: 0,
+  research5: 0, research17: 0, research26: 0, research27: 0, research39: 0,
+  research40: 0, research139: 0, research154: 0, research184: 0, research199: 0,
+  crystalUpgrade0: 0, crystalUpgrade1: 0, crystalUpgrade4: 0,
+  constantUpgrade1: 0, constantUpgrade2: 0,
+  platonicUpgrade5: 0, platonicUpgrade10: 0, platonicUpgrade14: 0,
+  platonicUpgrade15: 0, platonicUpgrade16: 0, platonicUpgrade18: 0,
+  coins: new Decimal(1e20),
+  prestigePoints: new Decimal(1e30),
+  transcendPoints: new Decimal(1e100),
+  reincarnationPoints: new Decimal(1e10),
+  transcendShards: new Decimal(1e300),
+  prestigeCount: 0,
+  transcendCount: 0,
+  highestSingularityCount: 0,
+  goldenQuarks: 0,
+  overfluxPowder: 0,
+  secondOwnedCoin: 0,
+  firstGeneratedMythos: new Decimal(0),
+  firstOwnedMythos: 0,
+  secondOwnedMythos: 0,
+  thirdOwnedMythos: 0,
+  fourthOwnedMythos: 0,
+  fifthOwnedMythos: 0,
+  c1Completions: 0,
+  c2Completions: 0,
+  c3Completions: 0,
+  c4Completions: 0,
+  c5Completions: 0,
+  c14Completions: 0,
+  reincarnationChallenge: 0,
+  ascensionChallenge: 0,
+  recessionCorruptionLevel: 0,
+  crystalMult: new Decimal(1),
+  buildingPower: 1,
+  buildingPowerMult: new Decimal(1),
+  totalCoinOwned: 0,
+  antMultiplier: new Decimal(1),
+  crystalUpgrade3Multiplier: new Decimal(1),
+  achievementPoints: 0,
+  crystalMultiplierAchievement: 1,
+  constUpgrade1BuffAchievement: 0,
+  constUpgrade2BuffAchievement: 0,
+  prismProductionLog10: 0,
+  constantEXMaxPercentIncrease: 0,
+  ascendBuildingDRValue: 1,
+  multiplierEffect: new Decimal(1),
+  acceleratorEffect: new Decimal(1),
+  totalMultiplier: 0,
+  totalAccelerator: 0,
+  totalAcceleratorBoost: 0,
+  challenge15CoinExponent: 1,
+  challenge15ExponentValue: 1,
+  challenge15ConstantBonus: 1,
+  recessionPower: 1
+}
+
+const cases: Array<{ name: string, input: GlobalMultipliersInput }> = [
+  { name: 'baseline (all neutral)', input: baseInput },
+
+  // ─── s multiplier branches ────────────────────────────────────────────
+  {
+    name: 'singularity s bonus (highestSingularityCount > 0)',
+    input: { ...baseInput, highestSingularityCount: 50, goldenQuarks: 1e6 }
+  },
+  {
+    name: 'upgrade 6 adds first6CoinUp',
+    input: { ...baseInput, upgrade6: 1, totalCoinOwned: 100 }
+  },
+  {
+    name: 'upgrade 12 with prestigeCount',
+    input: { ...baseInput, upgrade12: 1, prestigeCount: 50 }
+  },
+  {
+    name: 'upgrade 20 with totalCoinOwned',
+    input: { ...baseInput, upgrade20: 1, totalCoinOwned: 1000 }
+  },
+  {
+    name: 'upgrade 41/43 transcendPoints/Count',
+    input: { ...baseInput, upgrade41: 1, upgrade43: 1, transcendCount: 100 }
+  },
+  {
+    name: 'upgrade 48 with totalMultiplier × totalAccelerator',
+    input: { ...baseInput, upgrade48: 1, totalMultiplier: 1000, totalAccelerator: 500 }
+  },
+
+  // ─── Reincarnation challenge divisors ─────────────────────────────────
+  { name: 'r-chal 6 divides s by 1e250', input: { ...baseInput, reincarnationChallenge: 6 } },
+  { name: 'r-chal 7 divides s by 1e1250', input: { ...baseInput, reincarnationChallenge: 7 } },
+  { name: 'r-chal 9 divides s by 1e2000000', input: { ...baseInput, reincarnationChallenge: 9 } },
+
+  // ─── research17 / upgrade123 / a-chal 15 platonics ───────────────────
+  {
+    name: 'research 17 applies exponent on s',
+    input: { ...baseInput, research17: 50, upgrade6: 1, totalCoinOwned: 100 }
+  },
+  {
+    name: 'upgrade 123 applies exponent on c',
+    input: { ...baseInput, upgrade123: 10, upgrade6: 1, totalCoinOwned: 100 }
+  },
+  {
+    name: 'a-chal 15 + platonic 5 → ^1.1',
+    input: { ...baseInput, ascensionChallenge: 15, platonicUpgrade5: 1 }
+  },
+  {
+    name: 'a-chal 15 + platonic 14 with recession + log coins',
+    input: {
+      ...baseInput,
+      ascensionChallenge: 15,
+      platonicUpgrade14: 1,
+      recessionCorruptionLevel: 5,
+      coins: new Decimal(1e50)
+    }
+  },
+  {
+    name: 'a-chal 15 + platonic 15 → ^1.1',
+    input: { ...baseInput, ascensionChallenge: 15, platonicUpgrade15: 1 }
+  },
+  {
+    name: 'challenge15CoinExponent applies to lol',
+    input: { ...baseInput, challenge15CoinExponent: 1.05 }
+  },
+  {
+    name: 'recessionPower applies to globalCoinMultiplier',
+    input: { ...baseInput, recessionPower: 0.9 }
+  },
+
+  // ─── Coin tier multipliers (each gates) ───────────────────────────────
+  {
+    name: 'coinOneMulti: upgrades 1/10/56 all on',
+    input: { ...baseInput, upgrade1: 1, upgrade10: 1, upgrade56: 1, secondOwnedCoin: 200, totalCoinOwned: 100 }
+  },
+  {
+    name: 'coinTwoMulti: upgrades 2/13/19/57 all on',
+    input: {
+      ...baseInput,
+      upgrade2: 1, upgrade13: 1, upgrade19: 1, upgrade57: 1,
+      firstGeneratedMythos: new Decimal(1e5), firstOwnedMythos: 100, totalCoinOwned: 100
+    }
+  },
+  {
+    name: 'coinThreeMulti: upgrades 3/18/58 all on',
+    input: { ...baseInput, upgrade3: 1, upgrade18: 1, upgrade58: 1, totalCoinOwned: 100 }
+  },
+  {
+    name: 'coinFourMulti: upgrades 4/17/59 all on',
+    input: { ...baseInput, upgrade4: 1, upgrade17: 1, upgrade59: 1, totalCoinOwned: 100 }
+  },
+  {
+    name: 'coinFiveMulti: upgrades 5/60 all on',
+    input: { ...baseInput, upgrade5: 1, upgrade60: 1, totalCoinOwned: 100 }
+  },
+
+  // ─── globalCrystalMultiplier contributions ────────────────────────────
+  {
+    name: 'crystal: achievement + prism + upgrade36/63 + research39',
+    input: {
+      ...baseInput,
+      crystalMultiplierAchievement: 2.5,
+      prismProductionLog10: 5,
+      upgrade36: 1, upgrade63: 1, research39: 1,
+      buildingPowerMult: new Decimal(1e100)
+    }
+  },
+  {
+    name: 'crystal: crystalUpgrade 0/1/4 + c1-c5 completions',
+    input: {
+      ...baseInput,
+      crystalUpgrade0: 100, crystalUpgrade1: 50, crystalUpgrade4: 50,
+      c1Completions: 25, c2Completions: 25, c3Completions: 25, c4Completions: 25, c5Completions: 25,
+      achievementPoints: 100,
+      crystalUpgrade3Multiplier: new Decimal(1e10)
+    }
+  },
+  {
+    name: 'crystal: research5 with c14 ECC + research26/27',
+    input: { ...baseInput, research5: 10, c14Completions: 25, research26: 5, research27: 5 }
+  },
+
+  // ─── globalMythosMultiplier contributions ─────────────────────────────
+  {
+    name: 'mythos: upgrades 37/42/47/51/52/64 + research 40',
+    input: {
+      ...baseInput,
+      upgrade37: 1, upgrade42: 1, upgrade47: 1, upgrade51: 1, upgrade52: 1, upgrade64: 1, research40: 1,
+      achievementPoints: 100,
+      totalAcceleratorBoost: 50,
+      buildingPowerMult: new Decimal(1e50)
+    }
+  },
+
+  // ─── grandmaster + challengeThreeMultiplier ───────────────────────────
+  {
+    name: 'totalMythosOwned + c3 ECC scales challengeThreeMultiplier',
+    input: {
+      ...baseInput,
+      firstOwnedMythos: 50, secondOwnedMythos: 50, thirdOwnedMythos: 50,
+      fourthOwnedMythos: 50, fifthOwnedMythos: 50,
+      c3Completions: 25
+    }
+  },
+
+  // ─── mythosupgrade13/14/15 ────────────────────────────────────────────
+  {
+    name: 'mythosupgrade13/14/15 all active',
+    input: {
+      ...baseInput,
+      upgrade53: 1, upgrade54: 1, upgrade55: 1,
+      acceleratorEffect: new Decimal(1e100),
+      multiplierEffect: new Decimal(1e150),
+      buildingPower: 50
+    }
+  },
+
+  // ─── globalConstantMult contributions ─────────────────────────────────
+  {
+    name: 'constant: upgrade 1 base exponent with platonic18 + achievement',
+    input: {
+      ...baseInput,
+      constantUpgrade1: 100,
+      platonicUpgrade18: 10,
+      constUpgrade1BuffAchievement: 0.05
+    }
+  },
+  {
+    name: 'constant: upgrade 2 with bounded percent + ascendBuildingDR',
+    input: {
+      ...baseInput,
+      constantUpgrade2: 200,
+      constUpgrade2BuffAchievement: 0.05,
+      constantEXMaxPercentIncrease: 5,
+      challenge15ExponentValue: 1.05,
+      platonicUpgrade18: 5,
+      ascendBuildingDRValue: 0.5
+    }
+  },
+  {
+    name: 'constant: researches 139/154/184/199 + challenge15ConstantBonus',
+    input: {
+      ...baseInput,
+      research139: 10, research154: 10, research184: 10, research199: 10,
+      challenge15ConstantBonus: 1.5
+    }
+  },
+  {
+    name: 'constant: platonic 5/10/15 multiply by 2/10/1e250',
+    input: { ...baseInput, platonicUpgrade5: 1, platonicUpgrade10: 1, platonicUpgrade15: 1 }
+  },
+  {
+    name: 'constant: platonic16 with overfluxPowder',
+    input: { ...baseInput, platonicUpgrade16: 5, overfluxPowder: 100 }
+  },
+
+  // ─── antMultiplier passthrough ────────────────────────────────────────
+  {
+    name: 'antMultiplier passthrough surfaces unchanged',
+    input: { ...baseInput, antMultiplier: new Decimal(1e25) }
+  },
+
+  // ─── Big combined stack ───────────────────────────────────────────────
+  {
+    name: 'big stack: many flags + late-game state',
+    input: {
+      ...baseInput,
+      upgrade1: 1, upgrade2: 1, upgrade3: 1, upgrade4: 1, upgrade5: 1,
+      upgrade6: 1, upgrade10: 1, upgrade12: 1, upgrade13: 1, upgrade17: 1,
+      upgrade18: 1, upgrade19: 1, upgrade20: 1, upgrade41: 1, upgrade43: 1,
+      upgrade48: 1, upgrade36: 1, upgrade37: 1, upgrade42: 1, upgrade47: 1,
+      upgrade51: 1, upgrade53: 1, upgrade54: 1, upgrade55: 1, upgrade63: 1,
+      upgrade64: 1, upgrade123: 5,
+      research5: 5, research17: 25, research26: 3, research27: 3, research39: 1,
+      research40: 1, research139: 5, research154: 5, research184: 5, research199: 5,
+      crystalUpgrade0: 50, crystalUpgrade1: 25, crystalUpgrade4: 25,
+      constantUpgrade1: 50, constantUpgrade2: 100,
+      platonicUpgrade5: 1, platonicUpgrade14: 1, platonicUpgrade16: 3, platonicUpgrade18: 5,
+      coins: new Decimal('1e1000'),
+      prestigePoints: new Decimal('1e500'),
+      transcendPoints: new Decimal('1e1000'),
+      reincarnationPoints: new Decimal('1e500'),
+      transcendShards: new Decimal('1e1000'),
+      prestigeCount: 100,
+      transcendCount: 100,
+      highestSingularityCount: 100,
+      goldenQuarks: 1e10,
+      overfluxPowder: 1000,
+      secondOwnedCoin: 1000,
+      firstGeneratedMythos: new Decimal(1e10),
+      firstOwnedMythos: 500, secondOwnedMythos: 500, thirdOwnedMythos: 500,
+      fourthOwnedMythos: 500, fifthOwnedMythos: 500,
+      c1Completions: 25, c2Completions: 25, c3Completions: 25, c4Completions: 25, c5Completions: 25,
+      c14Completions: 25,
+      ascensionChallenge: 15,
+      recessionCorruptionLevel: 8,
+      crystalMult: new Decimal(1e50),
+      buildingPower: 100,
+      buildingPowerMult: new Decimal(1e80),
+      totalCoinOwned: 5000,
+      antMultiplier: new Decimal(1e30),
+      crystalUpgrade3Multiplier: new Decimal(1e20),
+      achievementPoints: 250,
+      crystalMultiplierAchievement: 4,
+      constUpgrade1BuffAchievement: 0.05,
+      constUpgrade2BuffAchievement: 0.02,
+      prismProductionLog10: 10,
+      constantEXMaxPercentIncrease: 5,
+      ascendBuildingDRValue: 0.7,
+      multiplierEffect: new Decimal(1e200),
+      acceleratorEffect: new Decimal(1e150),
+      totalMultiplier: 5000,
+      totalAccelerator: 10000,
+      totalAcceleratorBoost: 500,
+      challenge15CoinExponent: 1.1,
+      challenge15ExponentValue: 1.05,
+      challenge15ConstantBonus: 1.5,
+      recessionPower: 0.92
+    }
+  }
+]
+
+describe('parity: computeGlobalMultipliers', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      const newRes = newComputeGlobalMultipliers(c.input)
+      const oldRes = oldComputeGlobalMultipliers(c.input)
+      expect(decimalEq(newRes.globalCoinMultiplier, oldRes.globalCoinMultiplier)).toBe(true)
+      expect(decimalEq(newRes.coinOneMulti, oldRes.coinOneMulti)).toBe(true)
+      expect(decimalEq(newRes.coinTwoMulti, oldRes.coinTwoMulti)).toBe(true)
+      expect(decimalEq(newRes.coinThreeMulti, oldRes.coinThreeMulti)).toBe(true)
+      expect(decimalEq(newRes.coinFourMulti, oldRes.coinFourMulti)).toBe(true)
+      expect(decimalEq(newRes.coinFiveMulti, oldRes.coinFiveMulti)).toBe(true)
+      expect(decimalEq(newRes.globalCrystalMultiplier, oldRes.globalCrystalMultiplier)).toBe(true)
+      expect(decimalEq(newRes.globalMythosMultiplier, oldRes.globalMythosMultiplier)).toBe(true)
+      expect(decimalEq(newRes.grandmasterMultiplier, oldRes.grandmasterMultiplier)).toBe(true)
+      expect(newRes.totalMythosOwned).toBe(oldRes.totalMythosOwned)
+      expect(newRes.mythosBuildingPower).toBe(oldRes.mythosBuildingPower)
+      expect(decimalEq(newRes.challengeThreeMultiplier, oldRes.challengeThreeMultiplier)).toBe(true)
+      expect(decimalEq(newRes.mythosupgrade13, oldRes.mythosupgrade13)).toBe(true)
+      expect(decimalEq(newRes.mythosupgrade14, oldRes.mythosupgrade14)).toBe(true)
+      expect(decimalEq(newRes.mythosupgrade15, oldRes.mythosupgrade15)).toBe(true)
+      expect(decimalEq(newRes.globalConstantMult, oldRes.globalConstantMult)).toBe(true)
+      expect(decimalEq(newRes.antMultiplier, oldRes.antMultiplier)).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/resetCurrency.parity.test.ts
+++ b/packages/logic/test/parity/resetCurrency.parity.test.ts
@@ -1,0 +1,193 @@
+// Parity tests for resetCurrency. Old body transcribed verbatim from
+// packages/web_ui/src/Synergism.ts (resetCurrency, ~line 3466 pre-migration).
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import {
+  resetCurrency as newResetCurrency,
+  type ResetCurrencyInput
+} from '../../src/mechanics/resetCurrency'
+
+const oldResetCurrency = (input: ResetCurrencyInput) => {
+  let prestigePow = 0.5 + input.ecc5 / 100
+  let transcendPow = 0.03
+
+  if (input.transcensionChallenge === 5) {
+    prestigePow = 0.01
+  }
+  if (input.reincarnationChallenge === 10) {
+    prestigePow = 1e-4
+    transcendPow = 0.001
+  }
+  prestigePow *= input.deflationMultiplier
+
+  let prestigePointGain = Decimal.floor(
+    Decimal.pow(input.coinsThisPrestige.dividedBy(1e12), prestigePow)
+  )
+  if (
+    input.upgrade16 > 0.5
+    && input.transcensionChallenge !== 5
+    && input.reincarnationChallenge !== 10
+  ) {
+    prestigePointGain = prestigePointGain.times(
+      Decimal.min(
+        Decimal.pow(10, 1e33),
+        Decimal.pow(
+          input.acceleratorEffect,
+          (1 / 3) * input.deflationMultiplier
+        )
+      )
+    )
+  }
+
+  let transcendPointGain = Decimal.floor(
+    Decimal.pow(input.coinsThisTranscension.dividedBy(1e100), transcendPow)
+  )
+  if (
+    input.upgrade44 > 0.5
+    && input.transcensionChallenge !== 5
+    && input.reincarnationChallenge !== 10
+  ) {
+    transcendPointGain = transcendPointGain.times(
+      Decimal.min(1e6, Decimal.pow(1.01, input.transcendCount))
+    )
+  }
+
+  let reincarnationPointGain = Decimal.floor(
+    Decimal.pow(input.transcendShards.dividedBy(1e300), 0.01)
+  )
+  if (input.reincarnationChallenge !== 0) {
+    reincarnationPointGain = Decimal.pow(reincarnationPointGain, 0.01)
+  }
+  reincarnationPointGain = reincarnationPointGain.times(input.particleGainReward)
+  if (input.upgrade65 > 0.5) {
+    reincarnationPointGain = reincarnationPointGain.times(5)
+  }
+  if (input.ascensionChallenge === 12) {
+    reincarnationPointGain = new Decimal('0')
+  }
+
+  return { prestigePointGain, transcendPointGain, reincarnationPointGain }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+const baseInput: ResetCurrencyInput = {
+  ecc5: 0,
+  transcensionChallenge: 0,
+  reincarnationChallenge: 0,
+  ascensionChallenge: 0,
+  deflationMultiplier: 1,
+  coinsThisPrestige: new Decimal('1e20'),
+  coinsThisTranscension: new Decimal('1e120'),
+  transcendShards: new Decimal('1e320'),
+  upgrade16: 0,
+  upgrade44: 0,
+  upgrade65: 0,
+  transcendCount: 0,
+  acceleratorEffect: new Decimal(1),
+  particleGainReward: 1
+}
+
+const cases: Array<{ name: string, input: ResetCurrencyInput }> = [
+  { name: 'baseline (no upgrades, no challenges)', input: baseInput },
+
+  // ─── Challenge overrides ──────────────────────────────────────────────
+  {
+    name: 't-chal 5 forces prestigePow to 0.01 and disables upgrade-16 mult',
+    input: { ...baseInput, transcensionChallenge: 5, upgrade16: 1, acceleratorEffect: new Decimal('1e10') }
+  },
+  {
+    name: 'r-chal 10 forces prestigePow to 1e-4, transcendPow to 0.001, disables both upgrade mults',
+    input: { ...baseInput, reincarnationChallenge: 10, upgrade16: 1, upgrade44: 1, transcendCount: 100 }
+  },
+  {
+    name: 'r-chal non-zero (not 10) re-exponents reincarnationPointGain by 0.01',
+    input: { ...baseInput, reincarnationChallenge: 4 }
+  },
+  {
+    name: 'a-chal 12 zeroes reincarnationPointGain after all other math',
+    input: { ...baseInput, ascensionChallenge: 12, upgrade65: 1, particleGainReward: 5 }
+  },
+
+  // ─── Upgrade gates ────────────────────────────────────────────────────
+  {
+    name: 'upgrade 16 active multiplies prestigePointGain by acceleratorEffect-derived factor',
+    input: { ...baseInput, upgrade16: 1, acceleratorEffect: new Decimal('1e10') }
+  },
+  {
+    name: 'upgrade 16 saturates against 10^1e33 cap when acceleratorEffect is huge',
+    input: { ...baseInput, upgrade16: 1, acceleratorEffect: new Decimal('1e1000') }
+  },
+  {
+    name: 'upgrade 44 active multiplies transcendPointGain by 1.01^transcendCount',
+    input: { ...baseInput, upgrade44: 1, transcendCount: 200 }
+  },
+  {
+    name: 'upgrade 44 saturates at 1e6 when transcendCount is huge',
+    input: { ...baseInput, upgrade44: 1, transcendCount: 100000 }
+  },
+  {
+    name: 'upgrade 65 multiplies reincarnationPointGain by 5',
+    input: { ...baseInput, upgrade65: 1 }
+  },
+
+  // ─── Other inputs ─────────────────────────────────────────────────────
+  {
+    name: 'ecc5 raises prestigePow (0.5 + ecc5/100)',
+    input: { ...baseInput, ecc5: 25 }
+  },
+  {
+    name: 'deflationMultiplier 0.5 halves prestigePow',
+    input: { ...baseInput, deflationMultiplier: 0.5 }
+  },
+  {
+    name: 'deflationMultiplier 0.1 with upgrade 16 (both prestigePow and 16-mult exponent scaled)',
+    input: { ...baseInput, deflationMultiplier: 0.1, upgrade16: 1, acceleratorEffect: new Decimal('1e10') }
+  },
+  {
+    name: 'particleGainReward 5 multiplies reincarnationPointGain by 5',
+    input: { ...baseInput, particleGainReward: 5 }
+  },
+  {
+    name: 'particleGainReward 0 zeroes reincarnationPointGain',
+    input: { ...baseInput, particleGainReward: 0 }
+  },
+
+  // ─── Resource extremes ────────────────────────────────────────────────
+  {
+    name: 'coinsThisPrestige < 1e12 → fractional base (< 1) → prestigePointGain floors to 0',
+    input: { ...baseInput, coinsThisPrestige: new Decimal('1e10') }
+  },
+  {
+    name: 'transcendShards < 1e300 → reincarnationPointGain floors to 0',
+    input: { ...baseInput, transcendShards: new Decimal('1e200') }
+  },
+  {
+    name: 'all-on combo (ecc5+upgrades+nonzero r-chal+deflation)',
+    input: {
+      ...baseInput,
+      ecc5: 20,
+      deflationMultiplier: 0.7,
+      upgrade16: 1,
+      upgrade44: 1,
+      upgrade65: 1,
+      transcendCount: 50,
+      acceleratorEffect: new Decimal('1e8'),
+      particleGainReward: 3,
+      reincarnationChallenge: 5
+    }
+  }
+]
+
+describe('parity: resetCurrency', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      const newRes = newResetCurrency(c.input)
+      const oldRes = oldResetCurrency(c.input)
+      expect(decimalEq(newRes.prestigePointGain, oldRes.prestigePointGain)).toBe(true)
+      expect(decimalEq(newRes.transcendPointGain, oldRes.transcendPointGain)).toBe(true)
+      expect(decimalEq(newRes.reincarnationPointGain, oldRes.reincarnationPointGain)).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/resourceGain.parity.test.ts
+++ b/packages/logic/test/parity/resourceGain.parity.test.ts
@@ -1,0 +1,569 @@
+// Parity tests for resourceGain. Old body transcribed verbatim from
+// packages/web_ui/src/Synergism.ts (resourceGain, ~line 2709 pre-migration),
+// minus the terminal challenge resetCheck dispatch (which stays in web_ui).
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import type { CoreEvent } from '../../src/events/types'
+import {
+  resourceGain as newResourceGain,
+  type ResourceGainInput,
+  type ResourceGainResult
+} from '../../src/mechanics/resourceGain'
+
+const oldResourceGain = (input: ResourceGainInput): ResourceGainResult => {
+  const dt = input.dt
+  const events: CoreEvent[] = []
+
+  let coins = input.coins
+  let coinsThisPrestige = input.coinsThisPrestige
+  let coinsThisTranscension = input.coinsThisTranscension
+  let coinsThisReincarnation = input.coinsThisReincarnation
+  let coinsTotal = input.coinsTotal
+  if (input.produceTotal.gte(0.001)) {
+    const addcoin = Decimal.min(
+      input.produceTotal.dividedBy(input.taxdivisor),
+      Decimal.pow(10, input.maxexponent - Decimal.log(input.taxdivisorcheck, 10))
+    ).times(dt / 0.025)
+    coins = coins.add(addcoin)
+    coinsThisPrestige = coinsThisPrestige.add(addcoin)
+    coinsThisTranscension = coinsThisTranscension.add(addcoin)
+    coinsThisReincarnation = coinsThisReincarnation.add(addcoin)
+    coinsTotal = coinsTotal.add(addcoin)
+  }
+
+  let prestigePoints = input.prestigePoints
+  let transcendPoints = input.transcendPoints
+  let reincarnationPoints = input.reincarnationPoints
+  if (input.upgrade93 === 1 && coinsThisPrestige.gte(1e16)) {
+    prestigePoints = prestigePoints.add(
+      Decimal.floor(input.prestigePointGain.dividedBy(4000).times(dt / 0.025))
+    )
+  }
+  if (input.upgrade100 === 1 && coinsThisTranscension.gte(1e100)) {
+    transcendPoints = transcendPoints.add(
+      Decimal.floor(input.transcendPointGain.dividedBy(4000).times(dt / 0.025))
+    )
+  }
+  if (input.cubeUpgrade28 > 0 && input.transcendShards.gte(1e300)) {
+    reincarnationPoints = reincarnationPoints.add(
+      Decimal.floor(input.reincarnationPointGain.dividedBy(4000).times(dt / 0.025))
+    )
+  }
+
+  const produceFirstDiamonds = input.firstGeneratedDiamonds.add(input.firstOwnedDiamonds)
+    .times(input.firstProduceDiamonds).times(input.globalCrystalMultiplier)
+  const produceSecondDiamonds = input.secondGeneratedDiamonds.add(input.secondOwnedDiamonds)
+    .times(input.secondProduceDiamonds).times(input.globalCrystalMultiplier)
+  const produceThirdDiamonds = input.thirdGeneratedDiamonds.add(input.thirdOwnedDiamonds)
+    .times(input.thirdProduceDiamonds).times(input.globalCrystalMultiplier)
+  const produceFourthDiamonds = input.fourthGeneratedDiamonds.add(input.fourthOwnedDiamonds)
+    .times(input.fourthProduceDiamonds).times(input.globalCrystalMultiplier)
+  const produceFifthDiamonds = input.fifthGeneratedDiamonds.add(input.fifthOwnedDiamonds)
+    .times(input.fifthProduceDiamonds).times(input.globalCrystalMultiplier)
+
+  const fourthGeneratedDiamonds = input.fourthGeneratedDiamonds.add(produceFifthDiamonds.times(dt / 0.025))
+  const thirdGeneratedDiamonds = input.thirdGeneratedDiamonds.add(produceFourthDiamonds.times(dt / 0.025))
+  const secondGeneratedDiamonds = input.secondGeneratedDiamonds.add(produceThirdDiamonds.times(dt / 0.025))
+  const firstGeneratedDiamonds = input.firstGeneratedDiamonds.add(produceSecondDiamonds.times(dt / 0.025))
+  const produceDiamonds = produceFirstDiamonds
+
+  let prestigeShards = input.prestigeShards
+  if (input.transcensionChallenge !== 3 && input.reincarnationChallenge !== 10) {
+    prestigeShards = prestigeShards.add(produceDiamonds.times(dt / 0.025))
+  }
+
+  const produceFifthMythos = input.fifthGeneratedMythos.add(input.fifthOwnedMythos)
+    .times(input.fifthProduceMythos).times(input.globalMythosMultiplier)
+    .times(input.grandmasterMultiplier).times(input.mythosupgrade15)
+  const produceFourthMythos = input.fourthGeneratedMythos.add(input.fourthOwnedMythos)
+    .times(input.fourthProduceMythos).times(input.globalMythosMultiplier)
+  const produceThirdMythos = input.thirdGeneratedMythos.add(input.thirdOwnedMythos)
+    .times(input.thirdProduceMythos).times(input.globalMythosMultiplier).times(input.mythosupgrade14)
+  const produceSecondMythos = input.secondGeneratedMythos.add(input.secondOwnedMythos)
+    .times(input.secondProduceMythos).times(input.globalMythosMultiplier)
+  const produceFirstMythos = input.firstGeneratedMythos.add(input.firstOwnedMythos)
+    .times(input.firstProduceMythos).times(input.globalMythosMultiplier).times(input.mythosupgrade13)
+  const fourthGeneratedMythos = input.fourthGeneratedMythos.add(produceFifthMythos.times(dt / 0.025))
+  const thirdGeneratedMythos = input.thirdGeneratedMythos.add(produceFourthMythos.times(dt / 0.025))
+  const secondGeneratedMythos = input.secondGeneratedMythos.add(produceThirdMythos.times(dt / 0.025))
+  const firstGeneratedMythos = input.firstGeneratedMythos.add(produceSecondMythos.times(dt / 0.025))
+
+  const produceMythos = firstGeneratedMythos.add(input.firstOwnedMythos)
+    .times(input.firstProduceMythos).times(input.globalMythosMultiplier).times(input.mythosupgrade13)
+  const producePerSecondMythos = produceMythos.times(40)
+
+  let pm = new Decimal('1')
+  if (input.upgrade67 > 0.5) {
+    pm = pm.times(Decimal.pow(
+      1.03,
+      input.firstOwnedParticles + input.secondOwnedParticles
+        + input.thirdOwnedParticles + input.fourthOwnedParticles + input.fifthOwnedParticles
+    ))
+  }
+  const produceFifthParticles = input.fifthGeneratedParticles.add(input.fifthOwnedParticles).times(input.fifthProduceParticles)
+  const produceFourthParticles = input.fourthGeneratedParticles.add(input.fourthOwnedParticles).times(input.fourthProduceParticles)
+  const produceThirdParticles = input.thirdGeneratedParticles.add(input.thirdOwnedParticles).times(input.thirdProduceParticles)
+  const produceSecondParticles = input.secondGeneratedParticles.add(input.secondOwnedParticles).times(input.secondProduceParticles)
+  const produceFirstParticles = input.firstGeneratedParticles.add(input.firstOwnedParticles).times(input.firstProduceParticles).times(pm)
+  const fourthGeneratedParticles = input.fourthGeneratedParticles.add(produceFifthParticles.times(dt / 0.025))
+  const thirdGeneratedParticles = input.thirdGeneratedParticles.add(produceFourthParticles.times(dt / 0.025))
+  const secondGeneratedParticles = input.secondGeneratedParticles.add(produceThirdParticles.times(dt / 0.025))
+  const firstGeneratedParticles = input.firstGeneratedParticles.add(produceSecondParticles.times(dt / 0.025))
+
+  const produceParticles = firstGeneratedParticles.add(input.firstOwnedParticles).times(input.firstProduceParticles).times(pm)
+  const producePerSecondParticles = produceParticles.times(40)
+
+  let transcendShards = input.transcendShards
+  if (input.transcensionChallenge !== 3 && input.reincarnationChallenge !== 10) {
+    transcendShards = transcendShards.add(produceMythos.times(dt / 0.025))
+  }
+  const reincarnationShards = input.reincarnationShards.add(produceParticles.times(dt / 0.025))
+
+  const ascendOwned = [input.ascendBuilding1Owned, input.ascendBuilding2Owned, input.ascendBuilding3Owned, input.ascendBuilding4Owned, input.ascendBuilding5Owned]
+  const ascendGenerated = [input.ascendBuilding1Generated, input.ascendBuilding2Generated, input.ascendBuilding3Generated, input.ascendBuilding4Generated, input.ascendBuilding5Generated]
+  const ascendProd = [new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0), new Decimal(0)]
+  for (let j = 4; j >= 0; j--) {
+    ascendProd[j] = ascendGenerated[j].add(ascendOwned[j]).times(0.05).times(input.globalConstantMult)
+    if (j !== 0) {
+      ascendGenerated[j - 1] = ascendGenerated[j - 1].add(ascendProd[j].times(dt))
+    }
+  }
+  const ascendShards = input.ascendShards.add(ascendProd[0].times(dt))
+
+  if (input.ascensionCount > 0) {
+    events.push({ kind: 'achievement-group-awarded', group: 'constant' })
+  }
+
+  let c1Completions = input.c1Completions
+  let c2Completions = input.c2Completions
+  let c3Completions = input.c3Completions
+  let c4Completions = input.c4Completions
+  let c5Completions = input.c5Completions
+
+  if (
+    input.research71 > 0.5
+    && c1Completions < Math.min(input.highestC1, 25 + 5 * input.research66 + 925 * input.research105)
+    && coins.gte(Decimal.pow(10, 1.25 * input.challengeBaseRequirements[0] * Math.pow(1 + c1Completions, 2)))
+  ) {
+    c1Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 1, newCompletions: c1Completions })
+  }
+  if (
+    input.research72 > 0.5
+    && c2Completions < Math.min(input.highestC2, 25 + 5 * input.research67_ + 925 * input.research105)
+    && coins.gte(Decimal.pow(10, 1.6 * input.challengeBaseRequirements[1] * Math.pow(1 + c2Completions, 2)))
+  ) {
+    c2Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 2, newCompletions: c2Completions })
+  }
+  if (
+    input.research73 > 0.5
+    && c3Completions < Math.min(input.highestC3, 25 + 5 * input.research68 + 925 * input.research105)
+    && coins.gte(Decimal.pow(10, 1.7 * input.challengeBaseRequirements[2] * Math.pow(1 + c3Completions, 2)))
+  ) {
+    c3Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 3, newCompletions: c3Completions })
+  }
+  if (
+    input.research74 > 0.5
+    && c4Completions < Math.min(input.highestC4, 25 + 5 * input.research69 + 925 * input.research105)
+    && coins.gte(Decimal.pow(10, 1.45 * input.challengeBaseRequirements[3] * Math.pow(1 + c4Completions, 2)))
+  ) {
+    c4Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 4, newCompletions: c4Completions })
+  }
+  if (
+    input.research75 > 0.5
+    && c5Completions < Math.min(input.highestC5, 25 + 5 * input.research70 + 925 * input.research105)
+    && coins.gte(Decimal.pow(10, 2 * input.challengeBaseRequirements[4] * Math.pow(1 + c5Completions, 2)))
+  ) {
+    c5Completions += 1
+    events.push({ kind: 'challenge-auto-completed', challengeIndex: 5, newCompletions: c5Completions })
+  }
+
+  return {
+    coins,
+    coinsThisPrestige,
+    coinsThisTranscension,
+    coinsThisReincarnation,
+    coinsTotal,
+    prestigePoints,
+    transcendPoints,
+    reincarnationPoints,
+    prestigeShards,
+    transcendShards,
+    reincarnationShards,
+    ascendShards,
+    firstGeneratedDiamonds,
+    secondGeneratedDiamonds,
+    thirdGeneratedDiamonds,
+    fourthGeneratedDiamonds,
+    firstGeneratedMythos,
+    secondGeneratedMythos,
+    thirdGeneratedMythos,
+    fourthGeneratedMythos,
+    firstGeneratedParticles,
+    secondGeneratedParticles,
+    thirdGeneratedParticles,
+    fourthGeneratedParticles,
+    ascendBuilding1Generated: ascendGenerated[0],
+    ascendBuilding2Generated: ascendGenerated[1],
+    ascendBuilding3Generated: ascendGenerated[2],
+    ascendBuilding4Generated: ascendGenerated[3],
+    c1Completions,
+    c2Completions,
+    c3Completions,
+    c4Completions,
+    c5Completions,
+    produceFirstDiamonds,
+    produceSecondDiamonds,
+    produceThirdDiamonds,
+    produceFourthDiamonds,
+    produceFifthDiamonds,
+    produceDiamonds,
+    produceFirstMythos,
+    produceSecondMythos,
+    produceThirdMythos,
+    produceFourthMythos,
+    produceFifthMythos,
+    produceMythos,
+    producePerSecondMythos,
+    produceFirstParticles,
+    produceSecondParticles,
+    produceThirdParticles,
+    produceFourthParticles,
+    produceFifthParticles,
+    produceParticles,
+    producePerSecondParticles,
+    ascendBuildingProduction: { first: ascendProd[0], second: ascendProd[1], third: ascendProd[2], fourth: ascendProd[3], fifth: ascendProd[4] },
+    events
+  }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+const baseInput: ResourceGainInput = {
+  dt: 0.025,
+  produceTotal: new Decimal(0),
+  taxdivisor: new Decimal(1),
+  taxdivisorcheck: new Decimal(1),
+  maxexponent: 100,
+  coins: new Decimal(0),
+  coinsThisPrestige: new Decimal(0),
+  coinsThisTranscension: new Decimal(0),
+  coinsThisReincarnation: new Decimal(0),
+  coinsTotal: new Decimal(0),
+
+  upgrade93: 0, upgrade100: 0, cubeUpgrade28: 0,
+  prestigePoints: new Decimal(0), transcendPoints: new Decimal(0), reincarnationPoints: new Decimal(0),
+  prestigePointGain: new Decimal(0), transcendPointGain: new Decimal(0), reincarnationPointGain: new Decimal(0),
+
+  firstGeneratedDiamonds: new Decimal(0), secondGeneratedDiamonds: new Decimal(0),
+  thirdGeneratedDiamonds: new Decimal(0), fourthGeneratedDiamonds: new Decimal(0), fifthGeneratedDiamonds: new Decimal(0),
+  firstOwnedDiamonds: 0, secondOwnedDiamonds: 0, thirdOwnedDiamonds: 0, fourthOwnedDiamonds: 0, fifthOwnedDiamonds: 0,
+  firstProduceDiamonds: 0, secondProduceDiamonds: 0,
+  thirdProduceDiamonds: 0, fourthProduceDiamonds: 0, fifthProduceDiamonds: 0,
+  globalCrystalMultiplier: new Decimal(1),
+
+  firstGeneratedMythos: new Decimal(0), secondGeneratedMythos: new Decimal(0),
+  thirdGeneratedMythos: new Decimal(0), fourthGeneratedMythos: new Decimal(0), fifthGeneratedMythos: new Decimal(0),
+  firstOwnedMythos: 0, secondOwnedMythos: 0, thirdOwnedMythos: 0, fourthOwnedMythos: 0, fifthOwnedMythos: 0,
+  firstProduceMythos: 0, secondProduceMythos: 0,
+  thirdProduceMythos: 0, fourthProduceMythos: 0, fifthProduceMythos: 0,
+  globalMythosMultiplier: new Decimal(1), grandmasterMultiplier: new Decimal(1),
+  mythosupgrade13: new Decimal(1), mythosupgrade14: new Decimal(1), mythosupgrade15: new Decimal(1),
+
+  firstGeneratedParticles: new Decimal(0), secondGeneratedParticles: new Decimal(0),
+  thirdGeneratedParticles: new Decimal(0), fourthGeneratedParticles: new Decimal(0), fifthGeneratedParticles: new Decimal(0),
+  firstOwnedParticles: 0, secondOwnedParticles: 0, thirdOwnedParticles: 0, fourthOwnedParticles: 0, fifthOwnedParticles: 0,
+  firstProduceParticles: 0, secondProduceParticles: 0,
+  thirdProduceParticles: 0, fourthProduceParticles: 0, fifthProduceParticles: 0,
+  upgrade67: 0,
+
+  prestigeShards: new Decimal(0), transcendShards: new Decimal(0),
+  reincarnationShards: new Decimal(0), ascendShards: new Decimal(0),
+
+  ascendBuilding1Generated: new Decimal(0), ascendBuilding2Generated: new Decimal(0),
+  ascendBuilding3Generated: new Decimal(0), ascendBuilding4Generated: new Decimal(0), ascendBuilding5Generated: new Decimal(0),
+  ascendBuilding1Owned: 0, ascendBuilding2Owned: 0, ascendBuilding3Owned: 0, ascendBuilding4Owned: 0, ascendBuilding5Owned: 0,
+  globalConstantMult: new Decimal(1),
+
+  ascensionCount: 0,
+  transcensionChallenge: 0, reincarnationChallenge: 0,
+
+  research66: 0, research67_: 0, research68: 0, research69: 0, research70: 0,
+  research71: 0, research72: 0, research73: 0, research74: 0, research75: 0,
+  research105: 0,
+  c1Completions: 0, c2Completions: 0, c3Completions: 0, c4Completions: 0, c5Completions: 0,
+  highestC1: 0, highestC2: 0, highestC3: 0, highestC4: 0, highestC5: 0,
+  challengeBaseRequirements: [10, 30, 100, 300, 1000]
+}
+
+const cases: Array<{ name: string, input: ResourceGainInput }> = [
+  { name: 'baseline (nothing happens)', input: baseInput },
+
+  // ─── Coin gain ────────────────────────────────────────────────────────
+  {
+    name: 'coin gain when produceTotal ≥ 0.001',
+    input: { ...baseInput, produceTotal: new Decimal(1e10), taxdivisor: new Decimal(100), maxexponent: 30, taxdivisorcheck: new Decimal(100), coins: new Decimal(1e20), coinsThisPrestige: new Decimal(1e20), coinsThisTranscension: new Decimal(1e20), coinsThisReincarnation: new Decimal(1e20), coinsTotal: new Decimal(1e20) }
+  },
+  {
+    name: 'coin gain skipped when produceTotal < 0.001',
+    input: { ...baseInput, produceTotal: new Decimal(0.0001) }
+  },
+  {
+    name: 'coin gain maxexponent clamp',
+    input: { ...baseInput, produceTotal: new Decimal('1e1000'), taxdivisor: new Decimal(100), taxdivisorcheck: new Decimal(100), maxexponent: 10 }
+  },
+
+  // ─── Point gains ──────────────────────────────────────────────────────
+  {
+    name: 'upgrade 93 prestige point drip',
+    input: { ...baseInput, upgrade93: 1, coinsThisPrestige: new Decimal(1e20), prestigePointGain: new Decimal(8000) }
+  },
+  {
+    name: 'upgrade 93 no drip without coin threshold',
+    input: { ...baseInput, upgrade93: 1, coinsThisPrestige: new Decimal(1e10), prestigePointGain: new Decimal(8000) }
+  },
+  {
+    name: 'upgrade 100 transcend point drip',
+    input: { ...baseInput, upgrade100: 1, coinsThisTranscension: new Decimal('1e120'), transcendPointGain: new Decimal(8000) }
+  },
+  {
+    name: 'cubeUpgrade 28 reincarnation point drip',
+    input: { ...baseInput, cubeUpgrade28: 1, transcendShards: new Decimal('1e310'), reincarnationPointGain: new Decimal(8000) }
+  },
+
+  // ─── Diamond cascade ──────────────────────────────────────────────────
+  {
+    name: 'diamond cascade with all 5 tiers + crystal mult',
+    input: {
+      ...baseInput,
+      firstGeneratedDiamonds: new Decimal(10), secondGeneratedDiamonds: new Decimal(5),
+      thirdGeneratedDiamonds: new Decimal(2), fourthGeneratedDiamonds: new Decimal(1),
+      fifthGeneratedDiamonds: new Decimal(1),
+      firstOwnedDiamonds: 100, secondOwnedDiamonds: 50, thirdOwnedDiamonds: 25,
+      fourthOwnedDiamonds: 10, fifthOwnedDiamonds: 5,
+      firstProduceDiamonds: 1, secondProduceDiamonds: 1,
+      thirdProduceDiamonds: 1, fourthProduceDiamonds: 1,
+      fifthProduceDiamonds: 1,
+      globalCrystalMultiplier: new Decimal(1e5)
+    }
+  },
+  {
+    name: 'prestigeShards gated off in t-chal 3',
+    input: { ...baseInput, transcensionChallenge: 3, firstOwnedDiamonds: 100, firstProduceDiamonds: 1, globalCrystalMultiplier: new Decimal(1) }
+  },
+  {
+    name: 'prestigeShards gated off in r-chal 10',
+    input: { ...baseInput, reincarnationChallenge: 10, firstOwnedDiamonds: 100, firstProduceDiamonds: 1, globalCrystalMultiplier: new Decimal(1) }
+  },
+
+  // ─── Mythos cascade ───────────────────────────────────────────────────
+  {
+    name: 'mythos cascade with grandmaster + upgrades 13/14/15',
+    input: {
+      ...baseInput,
+      firstGeneratedMythos: new Decimal(10), secondGeneratedMythos: new Decimal(5),
+      thirdGeneratedMythos: new Decimal(2), fourthGeneratedMythos: new Decimal(1),
+      fifthGeneratedMythos: new Decimal(1),
+      firstOwnedMythos: 100, secondOwnedMythos: 50, thirdOwnedMythos: 25,
+      fourthOwnedMythos: 10, fifthOwnedMythos: 5,
+      firstProduceMythos: 1, secondProduceMythos: 1,
+      thirdProduceMythos: 1, fourthProduceMythos: 1,
+      fifthProduceMythos: 1,
+      globalMythosMultiplier: new Decimal(1e5),
+      grandmasterMultiplier: new Decimal(1.5),
+      mythosupgrade13: new Decimal(2), mythosupgrade14: new Decimal(2), mythosupgrade15: new Decimal(2)
+    }
+  },
+  {
+    name: 'transcendShards gated off in t-chal 3 / r-chal 10',
+    input: { ...baseInput, transcensionChallenge: 3, firstOwnedMythos: 100, firstProduceMythos: 1, globalMythosMultiplier: new Decimal(1) }
+  },
+
+  // ─── Particle cascade ─────────────────────────────────────────────────
+  {
+    name: 'particle cascade without upgrade 67',
+    input: {
+      ...baseInput,
+      firstGeneratedParticles: new Decimal(10), secondGeneratedParticles: new Decimal(5),
+      thirdGeneratedParticles: new Decimal(2), fourthGeneratedParticles: new Decimal(1),
+      fifthGeneratedParticles: new Decimal(1),
+      firstOwnedParticles: 100, secondOwnedParticles: 50, thirdOwnedParticles: 25,
+      fourthOwnedParticles: 10, fifthOwnedParticles: 5,
+      firstProduceParticles: 1, secondProduceParticles: 1,
+      thirdProduceParticles: 1, fourthProduceParticles: 1,
+      fifthProduceParticles: 1
+    }
+  },
+  {
+    name: 'particle cascade with upgrade 67 pm factor',
+    input: {
+      ...baseInput,
+      upgrade67: 1,
+      firstOwnedParticles: 50, secondOwnedParticles: 50, thirdOwnedParticles: 50,
+      fourthOwnedParticles: 50, fifthOwnedParticles: 50,
+      firstProduceParticles: 1
+    }
+  },
+
+  // ─── AscendBuildings cascade ──────────────────────────────────────────
+  {
+    name: 'ascendBuilding cascade with globalConstantMult',
+    input: {
+      ...baseInput,
+      ascendBuilding1Owned: 100, ascendBuilding2Owned: 50, ascendBuilding3Owned: 25,
+      ascendBuilding4Owned: 10, ascendBuilding5Owned: 5,
+      ascendBuilding1Generated: new Decimal(10), ascendBuilding2Generated: new Decimal(5),
+      ascendBuilding3Generated: new Decimal(2), ascendBuilding4Generated: new Decimal(1),
+      ascendBuilding5Generated: new Decimal(1),
+      globalConstantMult: new Decimal(10),
+      dt: 1
+    }
+  },
+
+  // ─── Achievement event ───────────────────────────────────────────────
+  {
+    name: 'awardAchievementGroup constant emitted when ascensionCount > 0',
+    input: { ...baseInput, ascensionCount: 5 }
+  },
+
+  // ─── Challenge auto-completion ────────────────────────────────────────
+  {
+    name: 'c1 auto-completes when research71 + coins + highestC1 satisfy',
+    input: { ...baseInput, research71: 1, highestC1: 25, coins: new Decimal('1e30'), challengeBaseRequirements: [10, 30, 100, 300, 1000] }
+  },
+  {
+    name: 'c1 does not auto-complete when at highest cap',
+    input: { ...baseInput, research71: 1, highestC1: 10, c1Completions: 10, coins: new Decimal('1e100') }
+  },
+  {
+    name: 'c2 auto-completes',
+    input: { ...baseInput, research72: 1, highestC2: 25, coins: new Decimal('1e50') }
+  },
+  {
+    name: 'c3 auto-completes',
+    input: { ...baseInput, research73: 1, highestC3: 25, coins: new Decimal('1e200') }
+  },
+  {
+    name: 'c4 auto-completes',
+    input: { ...baseInput, research74: 1, highestC4: 25, coins: new Decimal('1e500') }
+  },
+  {
+    name: 'c5 auto-completes',
+    input: { ...baseInput, research75: 1, highestC5: 25, coins: new Decimal('1e3000') }
+  },
+  {
+    name: 'all 5 challenges auto-complete in one tick',
+    input: {
+      ...baseInput,
+      research71: 1, research72: 1, research73: 1, research74: 1, research75: 1,
+      highestC1: 25, highestC2: 25, highestC3: 25, highestC4: 25, highestC5: 25,
+      coins: new Decimal('1e10000'),
+      ascensionCount: 1
+    }
+  },
+
+  // ─── Combined late-game tick ─────────────────────────────────────────
+  {
+    name: 'big late-game tick: cascades + points + achievement + challenges',
+    input: {
+      ...baseInput,
+      dt: 0.5,
+      produceTotal: new Decimal('1e100'),
+      taxdivisor: new Decimal(1000),
+      taxdivisorcheck: new Decimal(1000),
+      maxexponent: 300,
+      coins: new Decimal('1e300'),
+      coinsThisPrestige: new Decimal('1e300'),
+      coinsThisTranscension: new Decimal('1e300'),
+      coinsThisReincarnation: new Decimal('1e300'),
+      coinsTotal: new Decimal('1e300'),
+      upgrade93: 1, upgrade100: 1, cubeUpgrade28: 1,
+      prestigePointGain: new Decimal('1e50'),
+      transcendPointGain: new Decimal('1e30'),
+      reincarnationPointGain: new Decimal('1e20'),
+      transcendShards: new Decimal('1e310'),
+      firstOwnedDiamonds: 100, fifthOwnedDiamonds: 50, fifthProduceDiamonds: 10, firstProduceDiamonds: 5,
+      globalCrystalMultiplier: new Decimal(1e10),
+      firstOwnedMythos: 100, fifthOwnedMythos: 50, fifthProduceMythos: 10, firstProduceMythos: 5,
+      globalMythosMultiplier: new Decimal(1e10),
+      mythosupgrade13: new Decimal(5), mythosupgrade14: new Decimal(5), mythosupgrade15: new Decimal(5),
+      grandmasterMultiplier: new Decimal(2),
+      upgrade67: 1,
+      firstOwnedParticles: 100, fifthOwnedParticles: 50, fifthProduceParticles: 10, firstProduceParticles: 5,
+      secondOwnedParticles: 75, thirdOwnedParticles: 50, fourthOwnedParticles: 25,
+      ascendBuilding1Owned: 1000, ascendBuilding5Owned: 100,
+      globalConstantMult: new Decimal(100),
+      ascensionCount: 50,
+      research71: 1, research72: 1, research73: 1, research74: 1, research75: 1,
+      highestC1: 25, highestC2: 25, highestC3: 25, highestC4: 25, highestC5: 25,
+      c1Completions: 10, c2Completions: 5
+    }
+  }
+]
+
+const expectEventsEqual = (a: CoreEvent[], b: CoreEvent[]): void => {
+  expect(a.length).toBe(b.length)
+  for (let i = 0; i < a.length; i++) {
+    expect(a[i]).toEqual(b[i])
+  }
+}
+
+describe('parity: resourceGain', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      const newRes = newResourceGain(c.input)
+      const oldRes = oldResourceGain(c.input)
+      expect(decimalEq(newRes.coins, oldRes.coins)).toBe(true)
+      expect(decimalEq(newRes.coinsThisPrestige, oldRes.coinsThisPrestige)).toBe(true)
+      expect(decimalEq(newRes.coinsThisTranscension, oldRes.coinsThisTranscension)).toBe(true)
+      expect(decimalEq(newRes.coinsThisReincarnation, oldRes.coinsThisReincarnation)).toBe(true)
+      expect(decimalEq(newRes.coinsTotal, oldRes.coinsTotal)).toBe(true)
+      expect(decimalEq(newRes.prestigePoints, oldRes.prestigePoints)).toBe(true)
+      expect(decimalEq(newRes.transcendPoints, oldRes.transcendPoints)).toBe(true)
+      expect(decimalEq(newRes.reincarnationPoints, oldRes.reincarnationPoints)).toBe(true)
+      expect(decimalEq(newRes.prestigeShards, oldRes.prestigeShards)).toBe(true)
+      expect(decimalEq(newRes.transcendShards, oldRes.transcendShards)).toBe(true)
+      expect(decimalEq(newRes.reincarnationShards, oldRes.reincarnationShards)).toBe(true)
+      expect(decimalEq(newRes.ascendShards, oldRes.ascendShards)).toBe(true)
+      expect(decimalEq(newRes.firstGeneratedDiamonds, oldRes.firstGeneratedDiamonds)).toBe(true)
+      expect(decimalEq(newRes.secondGeneratedDiamonds, oldRes.secondGeneratedDiamonds)).toBe(true)
+      expect(decimalEq(newRes.thirdGeneratedDiamonds, oldRes.thirdGeneratedDiamonds)).toBe(true)
+      expect(decimalEq(newRes.fourthGeneratedDiamonds, oldRes.fourthGeneratedDiamonds)).toBe(true)
+      expect(decimalEq(newRes.firstGeneratedMythos, oldRes.firstGeneratedMythos)).toBe(true)
+      expect(decimalEq(newRes.secondGeneratedMythos, oldRes.secondGeneratedMythos)).toBe(true)
+      expect(decimalEq(newRes.thirdGeneratedMythos, oldRes.thirdGeneratedMythos)).toBe(true)
+      expect(decimalEq(newRes.fourthGeneratedMythos, oldRes.fourthGeneratedMythos)).toBe(true)
+      expect(decimalEq(newRes.firstGeneratedParticles, oldRes.firstGeneratedParticles)).toBe(true)
+      expect(decimalEq(newRes.secondGeneratedParticles, oldRes.secondGeneratedParticles)).toBe(true)
+      expect(decimalEq(newRes.thirdGeneratedParticles, oldRes.thirdGeneratedParticles)).toBe(true)
+      expect(decimalEq(newRes.fourthGeneratedParticles, oldRes.fourthGeneratedParticles)).toBe(true)
+      expect(decimalEq(newRes.ascendBuilding1Generated, oldRes.ascendBuilding1Generated)).toBe(true)
+      expect(decimalEq(newRes.ascendBuilding2Generated, oldRes.ascendBuilding2Generated)).toBe(true)
+      expect(decimalEq(newRes.ascendBuilding3Generated, oldRes.ascendBuilding3Generated)).toBe(true)
+      expect(decimalEq(newRes.ascendBuilding4Generated, oldRes.ascendBuilding4Generated)).toBe(true)
+      expect(newRes.c1Completions).toBe(oldRes.c1Completions)
+      expect(newRes.c2Completions).toBe(oldRes.c2Completions)
+      expect(newRes.c3Completions).toBe(oldRes.c3Completions)
+      expect(newRes.c4Completions).toBe(oldRes.c4Completions)
+      expect(newRes.c5Completions).toBe(oldRes.c5Completions)
+      expect(decimalEq(newRes.produceFirstDiamonds, oldRes.produceFirstDiamonds)).toBe(true)
+      expect(decimalEq(newRes.produceFifthDiamonds, oldRes.produceFifthDiamonds)).toBe(true)
+      expect(decimalEq(newRes.produceDiamonds, oldRes.produceDiamonds)).toBe(true)
+      expect(decimalEq(newRes.produceFirstMythos, oldRes.produceFirstMythos)).toBe(true)
+      expect(decimalEq(newRes.produceFifthMythos, oldRes.produceFifthMythos)).toBe(true)
+      expect(decimalEq(newRes.produceMythos, oldRes.produceMythos)).toBe(true)
+      expect(decimalEq(newRes.producePerSecondMythos, oldRes.producePerSecondMythos)).toBe(true)
+      expect(decimalEq(newRes.produceFirstParticles, oldRes.produceFirstParticles)).toBe(true)
+      expect(decimalEq(newRes.produceFifthParticles, oldRes.produceFifthParticles)).toBe(true)
+      expect(decimalEq(newRes.produceParticles, oldRes.produceParticles)).toBe(true)
+      expect(decimalEq(newRes.producePerSecondParticles, oldRes.producePerSecondParticles)).toBe(true)
+      expect(decimalEq(newRes.ascendBuildingProduction.first, oldRes.ascendBuildingProduction.first)).toBe(true)
+      expect(decimalEq(newRes.ascendBuildingProduction.fifth, oldRes.ascendBuildingProduction.fifth)).toBe(true)
+      expectEventsEqual(newRes.events, oldRes.events)
+    })
+  }
+})

--- a/packages/logic/test/parity/timers.parity.test.ts
+++ b/packages/logic/test/parity/timers.parity.test.ts
@@ -1,0 +1,240 @@
+// Parity tests for the 7 simple-counter cases of addTimers.
+// Old bodies transcribed verbatim from packages/web_ui/src/Helper.ts
+// (addTimers, prestige / transcension / reincarnation / ascension /
+// singularity / quarks / goldenQuarks cases pre-migration).
+
+import { describe, expect, it } from 'vitest'
+import {
+  advanceAscensionTimer as newAdvanceAscension,
+  type AdvanceAscensionTimerInput,
+  type AdvanceAscensionTimerResult,
+  advanceGoldenQuarksTimer as newAdvanceGoldenQuarks,
+  type AdvanceGoldenQuarksTimerInput,
+  advanceQuarksTimer as newAdvanceQuarks,
+  type AdvanceQuarksTimerInput,
+  advanceResetCounter as newAdvanceResetCounter,
+  advanceSingularityTimer as newAdvanceSingularity,
+  type AdvanceSingularityTimerInput,
+  type AdvanceSingularityTimerResult
+} from '../../src/tick/timers'
+
+// ─── advanceResetCounter ────────────────────────────────────────────────
+
+const oldAdvanceResetCounter = (counter: number, time: number, mult: number): number => {
+  return counter + time * mult
+}
+
+describe('parity: advanceResetCounter', () => {
+  const cases: Array<{ counter: number, time: number, mult: number }> = [
+    { counter: 0, time: 0, mult: 1 },
+    { counter: 100, time: 0.025, mult: 1 },
+    { counter: 500, time: 1, mult: 10 },
+    { counter: 1e6, time: 0.5, mult: 0.5 },
+    // halfMind gives mult=10
+    { counter: 50, time: 0.025, mult: 10 },
+    // Slow tick (mult < 1)
+    { counter: 50, time: 1, mult: 0.1 }
+  ]
+  for (const c of cases) {
+    it(`counter=${c.counter} time=${c.time} mult=${c.mult}`, () => {
+      expect(newAdvanceResetCounter(c.counter, c.time, c.mult))
+        .toBe(oldAdvanceResetCounter(c.counter, c.time, c.mult))
+    })
+  }
+})
+
+// ─── advanceAscensionTimer ─────────────────────────────────────────────
+
+const oldAdvanceAscension = (input: AdvanceAscensionTimerInput): AdvanceAscensionTimerResult => {
+  // Legacy: timeMultiplier = 1 for ascension case, so the multiplication
+  // collapses to `time * 1 * ascensionSpeedMulti`.
+  return {
+    ascensionCounter: input.ascensionCounter + input.time * input.ascensionSpeedMulti,
+    ascensionCounterReal: input.ascensionCounterReal + input.time
+  }
+}
+
+describe('parity: advanceAscensionTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceAscensionTimerInput }> = [
+    {
+      name: 'baseline (no ascensions, no speed)',
+      input: { time: 0.025, ascensionCounter: 0, ascensionCounterReal: 0, ascensionSpeedMulti: 1 }
+    },
+    {
+      name: 'oneMind active (speed=10)',
+      input: { time: 1, ascensionCounter: 500, ascensionCounterReal: 500, ascensionSpeedMulti: 10 }
+    },
+    {
+      name: 'fractional speed multiplier',
+      input: { time: 0.5, ascensionCounter: 100, ascensionCounterReal: 200, ascensionSpeedMulti: 2.5 }
+    },
+    {
+      name: 'real-time diverges from scaled-time',
+      input: { time: 0.025, ascensionCounter: 1000, ascensionCounterReal: 100, ascensionSpeedMulti: 50 }
+    }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAdvanceAscension(c.input)
+      const oldR = oldAdvanceAscension(c.input)
+      expect(newR.ascensionCounter).toBe(oldR.ascensionCounter)
+      expect(newR.ascensionCounterReal).toBe(oldR.ascensionCounterReal)
+    })
+  }
+})
+
+// ─── advanceSingularityTimer ───────────────────────────────────────────
+
+const oldAdvanceSingularity = (input: AdvanceSingularityTimerInput): AdvanceSingularityTimerResult => {
+  // Legacy: timeMultiplier = 1 for singularity case.
+  const ascensionCounterRealReal = input.ascensionCounterRealReal + input.time
+  const singularityCounter = input.singularityCounter + input.time * input.singularitySpeedMulti
+  let singChallengeTimer: number
+  if (input.insideSingularityChallenge) {
+    singChallengeTimer = input.singChallengeTimer + input.time * input.singularitySpeedMulti
+  } else {
+    singChallengeTimer = 0
+  }
+  return { ascensionCounterRealReal, singularityCounter, singChallengeTimer }
+}
+
+describe('parity: advanceSingularityTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceSingularityTimerInput }> = [
+    {
+      name: 'baseline (no singularities, not in challenge)',
+      input: {
+        time: 0.025,
+        ascensionCounterRealReal: 0,
+        singularityCounter: 0,
+        singChallengeTimer: 0,
+        insideSingularityChallenge: false,
+        singularitySpeedMulti: 1
+      }
+    },
+    {
+      name: 'inside challenge accumulates challenge timer',
+      input: {
+        time: 1,
+        ascensionCounterRealReal: 1000,
+        singularityCounter: 1000,
+        singChallengeTimer: 500,
+        insideSingularityChallenge: true,
+        singularitySpeedMulti: 1
+      }
+    },
+    {
+      name: 'leaving challenge resets challenge timer to 0',
+      input: {
+        time: 1,
+        ascensionCounterRealReal: 1000,
+        singularityCounter: 1000,
+        singChallengeTimer: 9999,
+        insideSingularityChallenge: false,
+        singularitySpeedMulti: 1
+      }
+    },
+    {
+      name: 'brick-of-lead speed multiplier',
+      input: {
+        time: 0.025,
+        ascensionCounterRealReal: 500,
+        singularityCounter: 500,
+        singChallengeTimer: 0,
+        insideSingularityChallenge: false,
+        singularitySpeedMulti: 2.5
+      }
+    },
+    {
+      name: 'realReal advances independently of speed multiplier',
+      input: {
+        time: 10,
+        ascensionCounterRealReal: 0,
+        singularityCounter: 0,
+        singChallengeTimer: 0,
+        insideSingularityChallenge: true,
+        singularitySpeedMulti: 100
+      }
+    }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAdvanceSingularity(c.input)
+      const oldR = oldAdvanceSingularity(c.input)
+      expect(newR.ascensionCounterRealReal).toBe(oldR.ascensionCounterRealReal)
+      expect(newR.singularityCounter).toBe(oldR.singularityCounter)
+      expect(newR.singChallengeTimer).toBe(oldR.singChallengeTimer)
+    })
+  }
+})
+
+// ─── advanceQuarksTimer ────────────────────────────────────────────────
+
+const oldAdvanceQuarks = (input: AdvanceQuarksTimerInput): number => {
+  // Legacy: timeMultiplier = 1 for quarks case.
+  let q = input.quarkstimer + input.time
+  q = q > input.maxQuarkTimer ? input.maxQuarkTimer : q
+  return q
+}
+
+describe('parity: advanceQuarksTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceQuarksTimerInput }> = [
+    {
+      name: 'baseline well under cap',
+      input: { time: 0.025, quarkstimer: 0, maxQuarkTimer: 90000 }
+    },
+    {
+      name: 'increment that crosses cap clamps to maxQuarkTimer',
+      input: { time: 1000, quarkstimer: 89500, maxQuarkTimer: 90000 }
+    },
+    {
+      name: 'already at cap stays at cap',
+      input: { time: 0.025, quarkstimer: 90000, maxQuarkTimer: 90000 }
+    },
+    {
+      name: 'extended cap from Research 8x20',
+      input: { time: 1, quarkstimer: 100000, maxQuarkTimer: 180000 }
+    }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(newAdvanceQuarks(c.input)).toBe(oldAdvanceQuarks(c.input))
+    })
+  }
+})
+
+// ─── advanceGoldenQuarksTimer ──────────────────────────────────────────
+
+const GOLDEN_QUARKS_CAP = 3600 * 168
+
+const oldAdvanceGoldenQuarks = (input: AdvanceGoldenQuarksTimerInput): number => {
+  if (input.exportGQPerHour === 0) return input.goldenQuarksTimer
+  let g = input.goldenQuarksTimer + input.time
+  g = g > GOLDEN_QUARKS_CAP ? GOLDEN_QUARKS_CAP : g
+  return g
+}
+
+describe('parity: advanceGoldenQuarksTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceGoldenQuarksTimerInput }> = [
+    {
+      name: 'exportGQPerHour=0 short-circuits (timer unchanged)',
+      input: { time: 100, goldenQuarksTimer: 500, exportGQPerHour: 0 }
+    },
+    {
+      name: 'baseline accumulation',
+      input: { time: 0.025, goldenQuarksTimer: 0, exportGQPerHour: 1 }
+    },
+    {
+      name: 'increment crosses 168-hour cap',
+      input: { time: 10000, goldenQuarksTimer: GOLDEN_QUARKS_CAP - 100, exportGQPerHour: 5 }
+    },
+    {
+      name: 'already at cap stays at cap',
+      input: { time: 1, goldenQuarksTimer: GOLDEN_QUARKS_CAP, exportGQPerHour: 5 }
+    }
+  ]
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(newAdvanceGoldenQuarks(c.input)).toBe(oldAdvanceGoldenQuarks(c.input))
+    })
+  }
+})

--- a/packages/logic/test/parity/updateAllMultiplier.parity.test.ts
+++ b/packages/logic/test/parity/updateAllMultiplier.parity.test.ts
@@ -1,0 +1,494 @@
+// Parity tests for updateAllMultiplier. Old body transcribed verbatim from
+// packages/web_ui/src/Synergism.ts (updateAllMultiplier, ~line 2435 pre-migration).
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import { CalcECC } from '../../src/mechanics/challenges'
+import {
+  updateAllMultiplier as newUpdateAllMultiplier,
+  type UpdateAllMultiplierInput,
+  type UpdateAllMultiplierResult
+} from '../../src/mechanics/updateAllMultiplier'
+
+const oldUpdateAllMultiplier = (
+  input: UpdateAllMultiplierInput
+): UpdateAllMultiplierResult => {
+  let a = 0
+
+  if (input.upgrade7 > 0) {
+    a += Math.min(4, 1 + Math.floor(Decimal.log(input.fifthOwnedCoin + 1, 10)))
+  }
+  if (input.upgrade9 > 0) {
+    a += Math.floor(input.acceleratorBought / 10)
+  }
+  if (input.upgrade21 > 0) a += 1
+  if (input.upgrade22 > 0) a += 1
+  if (input.upgrade23 > 0) a += 1
+  if (input.upgrade24 > 0) a += 1
+  if (input.upgrade25 > 0) a += 1
+  if (input.upgrade33 > 0) a += input.totalAcceleratorBoost
+  if (input.upgrade49 > 0) {
+    a += Math.min(50, Math.floor(Decimal.log(input.transcendPoints.add(1), 1e10)))
+  }
+  if (input.upgrade68 > 0) {
+    a += Math.min(2500, Math.floor((Decimal.log(input.taxdivisor, 10) * 1) / 1000))
+  }
+  if (input.c1Completions > 0) a += 1
+
+  a += input.multipliersAchievement
+  a += 20 * input.research94 * Math.floor(input.sumOfRuneLevels / 8)
+
+  const freeUpgradeMultiplier = Math.min(1e100, a)
+
+  const ecc14a = CalcECC('ascension', input.c14Completions)
+  const ecc1tr = CalcECC('transcend', input.c1Completions)
+  const ecc7r = CalcECC('reincarnation', input.c7Completions)
+
+  a *= Math.pow(
+    1.01,
+    input.upgrade21 + input.upgrade22 + input.upgrade23 + input.upgrade24 + input.upgrade25
+  )
+  a *= 1 + 0.03 * input.upgrade34 + 0.02 * input.upgrade35
+  a *= 1 + (1 / 5) * input.research2 * (1 + (1 / 2) * ecc14a)
+  a *= 1
+    + (1 / 20) * input.research11
+    + (1 / 25) * input.research12
+    + (1 / 40) * input.research13
+    + (3 / 200) * input.research14
+    + (1 / 200) * input.research15
+  a *= input.multiplicativeMultipliersRune
+  a *= 1 + (1 / 20) * input.research87
+  a *= 1 + (1 / 100) * input.research128
+  a *= 1 + (0.8 / 100) * input.research143
+  a *= 1 + (0.6 / 100) * input.research158
+  a *= 1 + (0.4 / 100) * input.research173
+  a *= 1 + (0.2 / 100) * input.research188
+  a *= 1 + (0.01 / 100) * input.research200
+  a *= 1 + (0.01 / 100) * input.cubeUpgrade50
+  a *= input.antMultiplierMult
+  a *= input.multiplierCubeBlessing
+
+  if (
+    (input.transcensionChallenge !== 0 || input.reincarnationChallenge !== 0)
+    && input.upgrade50 > 0.5
+  ) {
+    a *= 1.25
+  }
+  a = Math.pow(
+    a,
+    Math.min(1, (1 + input.platonicUpgrade6 / 30) * input.viscosityPower)
+  )
+  a += input.hepteractMultiplier
+  a *= input.challenge15RewardMultiplier
+  a *= input.hepteractMultiplierMult
+  a = Math.floor(Math.min(1e100, a))
+
+  if (input.viscosityCorruptionLevel >= 15) a = Math.pow(a, 0.2)
+  if (input.viscosityCorruptionLevel >= 16) a = 1
+
+  const freeMultiplier = a
+  const totalMultiplier = freeMultiplier + input.multiplierBought
+  const challengeOneLog = 3
+
+  let b = 0
+  b += Decimal.log(input.transcendShards.add(1), 3)
+  b += input.multiplierBoostsRune
+  b += 2 * ecc1tr
+  b *= 1 + (11 * input.research33) / 100
+  b *= 1 + (11 * input.research34) / 100
+  b *= 1 + (11 * input.research35) / 100
+  b *= 1 + input.research89 / 5
+  b *= input.multiplierBoostsRuneBlessing
+
+  const totalMultiplierBoost = Math.pow(Math.floor(b), 1 + ecc7r * 0.04)
+
+  const c7 = input.c7Completions > 0.5 ? 1.25 : 1
+
+  let multiplierPower = 2 + 0.02 * totalMultiplierBoost * c7
+
+  if (
+    input.reincarnationChallenge !== 7
+    && input.reincarnationChallenge !== 10
+  ) {
+    if (input.transcensionChallenge === 1) multiplierPower = 1
+    if (input.transcensionChallenge === 2) multiplierPower = 1.25 + 0.0012 * b * c7
+  }
+  multiplierPower = Math.min(1e300, multiplierPower)
+
+  if (input.reincarnationChallenge === 7) multiplierPower = 1
+  if (input.reincarnationChallenge === 10) multiplierPower = 1
+
+  const multiplierEffect = Decimal.pow(multiplierPower, totalMultiplier)
+
+  return {
+    freeUpgradeMultiplier,
+    freeMultiplier,
+    totalMultiplier,
+    challengeOneLog,
+    totalMultiplierBoost,
+    multiplierPower,
+    multiplierEffect
+  }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+const baseInput: UpdateAllMultiplierInput = {
+  upgrade7: 0,
+  upgrade9: 0,
+  upgrade21: 0,
+  upgrade22: 0,
+  upgrade23: 0,
+  upgrade24: 0,
+  upgrade25: 0,
+  upgrade33: 0,
+  upgrade34: 0,
+  upgrade35: 0,
+  upgrade49: 0,
+  upgrade50: 0,
+  upgrade68: 0,
+  acceleratorBought: 0,
+  multiplierBought: 0,
+  fifthOwnedCoin: 0,
+  c1Completions: 0,
+  c7Completions: 0,
+  c14Completions: 0,
+  transcendPoints: new Decimal(0),
+  transcendShards: new Decimal(0),
+  research2: 0,
+  research11: 0,
+  research12: 0,
+  research13: 0,
+  research14: 0,
+  research15: 0,
+  research33: 0,
+  research34: 0,
+  research35: 0,
+  research87: 0,
+  research89: 0,
+  research94: 0,
+  research128: 0,
+  research143: 0,
+  research158: 0,
+  research173: 0,
+  research188: 0,
+  research200: 0,
+  cubeUpgrade50: 0,
+  platonicUpgrade6: 0,
+  transcensionChallenge: 0,
+  reincarnationChallenge: 0,
+  viscosityCorruptionLevel: 0,
+
+  multipliersAchievement: 0,
+  sumOfRuneLevels: 0,
+  multiplicativeMultipliersRune: 1,
+  multiplierBoostsRune: 0,
+  multiplierBoostsRuneBlessing: 1,
+  antMultiplierMult: 1,
+  multiplierCubeBlessing: 1,
+  hepteractMultiplier: 0,
+  hepteractMultiplierMult: 1,
+
+  totalAcceleratorBoost: 0,
+  taxdivisor: new Decimal(1),
+  viscosityPower: 1,
+  challenge15RewardMultiplier: 1
+}
+
+interface Case {
+  name: string
+  input: UpdateAllMultiplierInput
+}
+
+const cases: Case[] = [
+  { name: 'baseline (all zero)', input: baseInput },
+
+  // ─── Upgrade additions ────────────────────────────────────────────────
+  {
+    name: 'upgrade 7 adds min(4, 1 + log10(fifthOwnedCoin+1))',
+    input: { ...baseInput, upgrade7: 1, fifthOwnedCoin: 100 }
+  },
+  {
+    name: 'upgrade 9 adds floor(acceleratorBought / 10)',
+    input: { ...baseInput, upgrade9: 1, acceleratorBought: 35 }
+  },
+  {
+    name: 'upgrades 21-25 each add +1 and feed 1.01^count',
+    input: { ...baseInput, upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1 }
+  },
+  {
+    name: 'upgrade 33 adds totalAcceleratorBoost',
+    input: { ...baseInput, upgrade33: 1, totalAcceleratorBoost: 50 }
+  },
+  {
+    name: 'upgrade 49 adds min(50, log1e10(transcendPoints+1))',
+    input: { ...baseInput, upgrade49: 1, transcendPoints: new Decimal('1e500') }
+  },
+  {
+    name: 'upgrade 68 adds min(2500, log10(taxdivisor)/1000)',
+    input: { ...baseInput, upgrade68: 1, taxdivisor: new Decimal('1e1000') }
+  },
+  {
+    name: 'c1 completions add +1',
+    input: { ...baseInput, c1Completions: 5, multipliersAchievement: 10 }
+  },
+
+  // ─── Research / cube / rune contributions ─────────────────────────────
+  {
+    name: 'research 94 with sumOfRuneLevels adds 20*94*floor(n/8)',
+    input: { ...baseInput, research94: 5, sumOfRuneLevels: 100 }
+  },
+  {
+    name: 'upgrade 34/35 add 0.03n + 0.02n multiplier',
+    input: { ...baseInput, multipliersAchievement: 50, upgrade34: 10, upgrade35: 10 }
+  },
+  {
+    name: 'research 2 with c14 ECC scales',
+    input: { ...baseInput, multipliersAchievement: 50, research2: 5, c14Completions: 25 }
+  },
+  {
+    name: 'researches 11-15 stack',
+    input: {
+      ...baseInput,
+      multipliersAchievement: 50,
+      research11: 10,
+      research12: 10,
+      research13: 10,
+      research14: 10,
+      research15: 10
+    }
+  },
+  {
+    name: 'multiplicativeMultipliersRune scales',
+    input: { ...baseInput, multipliersAchievement: 50, multiplicativeMultipliersRune: 2.5 }
+  },
+  {
+    name: 'researches 87/128/143/158/173/188/200 stack',
+    input: {
+      ...baseInput,
+      multipliersAchievement: 50,
+      research87: 10,
+      research128: 100,
+      research143: 100,
+      research158: 100,
+      research173: 100,
+      research188: 100,
+      research200: 100000
+    }
+  },
+  {
+    name: 'cubeUpgrade 50 multiplier',
+    input: { ...baseInput, multipliersAchievement: 50, cubeUpgrade50: 50000 }
+  },
+  {
+    name: 'antMultiplierMult and cube blessing scale',
+    input: {
+      ...baseInput,
+      multipliersAchievement: 50,
+      antMultiplierMult: 2,
+      multiplierCubeBlessing: 3
+    }
+  },
+  {
+    name: 'upgrade 50 in a challenge gives 1.25x',
+    input: {
+      ...baseInput,
+      multipliersAchievement: 50,
+      upgrade50: 1,
+      transcensionChallenge: 4
+    }
+  },
+  {
+    name: 'upgrade 50 outside a challenge does nothing',
+    input: { ...baseInput, multipliersAchievement: 50, upgrade50: 1 }
+  },
+
+  // ─── Viscosity exponent + corruption gates ────────────────────────────
+  {
+    name: 'platonic 6 + viscosity power exponent',
+    input: {
+      ...baseInput,
+      multipliersAchievement: 50,
+      platonicUpgrade6: 10,
+      viscosityPower: 0.9
+    }
+  },
+  {
+    name: 'viscosity corruption 15 applies ^0.2',
+    input: { ...baseInput, multipliersAchievement: 100, viscosityCorruptionLevel: 15 }
+  },
+  {
+    name: 'viscosity corruption 16 clamps to 1',
+    input: { ...baseInput, multipliersAchievement: 100, viscosityCorruptionLevel: 16 }
+  },
+
+  // ─── Hepteract + challenge15 ──────────────────────────────────────────
+  {
+    name: 'hepteract multiplier adds, mult scales, challenge15 reward scales',
+    input: {
+      ...baseInput,
+      multipliersAchievement: 50,
+      hepteractMultiplier: 25,
+      hepteractMultiplierMult: 1.5,
+      challenge15RewardMultiplier: 2
+    }
+  },
+
+  // ─── multiplierBought added to totalMultiplier ────────────────────────
+  {
+    name: 'multiplierBought added to totalMultiplier',
+    input: { ...baseInput, multipliersAchievement: 100, multiplierBought: 50 }
+  },
+
+  // ─── b / totalMultiplierBoost / multiplierPower ───────────────────────
+  {
+    name: 'b accumulates from transcendShards + rune + ecc',
+    input: {
+      ...baseInput,
+      transcendShards: new Decimal('1e20'),
+      multiplierBoostsRune: 10,
+      c1Completions: 25,
+      multipliersAchievement: 50
+    }
+  },
+  {
+    name: 'research 33/34/35/89 + rune blessing multiplies b',
+    input: {
+      ...baseInput,
+      transcendShards: new Decimal('1e20'),
+      research33: 5,
+      research34: 5,
+      research35: 5,
+      research89: 5,
+      multiplierBoostsRuneBlessing: 1.5,
+      multipliersAchievement: 50
+    }
+  },
+  {
+    name: 'c7 > 0 sets c7 multiplier to 1.25 in multiplierPower',
+    input: {
+      ...baseInput,
+      transcendShards: new Decimal('1e20'),
+      c7Completions: 25,
+      multipliersAchievement: 50
+    }
+  },
+
+  // ─── Transcension challenge overrides ─────────────────────────────────
+  {
+    name: 't-chal 1 forces multiplierPower = 1',
+    input: { ...baseInput, transcensionChallenge: 1, multipliersAchievement: 50 }
+  },
+  {
+    name: 't-chal 2 sets multiplierPower = 1.25 + 0.0012*b*c7',
+    input: {
+      ...baseInput,
+      transcensionChallenge: 2,
+      transcendShards: new Decimal('1e20'),
+      c7Completions: 25,
+      multipliersAchievement: 50
+    }
+  },
+
+  // ─── Reincarnation challenge overrides ────────────────────────────────
+  {
+    name: 'r-chal 7 forces multiplierPower = 1 even with stack',
+    input: {
+      ...baseInput,
+      reincarnationChallenge: 7,
+      transcendShards: new Decimal('1e20'),
+      c7Completions: 25,
+      multipliersAchievement: 50
+    }
+  },
+  {
+    name: 'r-chal 10 forces multiplierPower = 1 even with stack',
+    input: {
+      ...baseInput,
+      reincarnationChallenge: 10,
+      transcendShards: new Decimal('1e20'),
+      c7Completions: 25,
+      multipliersAchievement: 50
+    }
+  },
+
+  // ─── Combined scenarios ───────────────────────────────────────────────
+  {
+    name: 'big stack: upgrades + researches + hepteract + boosts + viscosity',
+    input: {
+      ...baseInput,
+      multiplierBought: 100,
+      upgrade7: 1,
+      fifthOwnedCoin: 1e8,
+      upgrade9: 1,
+      acceleratorBought: 200,
+      upgrade21: 1,
+      upgrade22: 1,
+      upgrade23: 1,
+      upgrade24: 1,
+      upgrade25: 1,
+      upgrade33: 1,
+      upgrade34: 5,
+      upgrade35: 5,
+      upgrade49: 1,
+      transcendPoints: new Decimal('1e500'),
+      upgrade50: 1,
+      upgrade68: 1,
+      research2: 5,
+      research11: 10,
+      research12: 10,
+      research13: 10,
+      research14: 10,
+      research15: 10,
+      research33: 5,
+      research34: 5,
+      research35: 5,
+      research87: 10,
+      research89: 5,
+      research94: 5,
+      research128: 100,
+      research143: 100,
+      research158: 100,
+      research173: 100,
+      research188: 100,
+      research200: 100000,
+      cubeUpgrade50: 50000,
+      platonicUpgrade6: 5,
+      transcensionChallenge: 3,
+      viscosityCorruptionLevel: 12,
+      sumOfRuneLevels: 200,
+      multipliersAchievement: 50,
+      multiplicativeMultipliersRune: 1.5,
+      multiplierBoostsRune: 10,
+      multiplierBoostsRuneBlessing: 1.3,
+      antMultiplierMult: 2,
+      multiplierCubeBlessing: 1.5,
+      hepteractMultiplier: 50,
+      hepteractMultiplierMult: 1.4,
+      totalAcceleratorBoost: 100,
+      taxdivisor: new Decimal('1e500'),
+      viscosityPower: 0.85,
+      challenge15RewardMultiplier: 1.6,
+      transcendShards: new Decimal('1e100'),
+      c1Completions: 25,
+      c7Completions: 25,
+      c14Completions: 25
+    }
+  }
+]
+
+describe('parity: updateAllMultiplier', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      const newRes = newUpdateAllMultiplier(c.input)
+      const oldRes = oldUpdateAllMultiplier(c.input)
+      expect(newRes.freeUpgradeMultiplier).toBe(oldRes.freeUpgradeMultiplier)
+      expect(newRes.freeMultiplier).toBe(oldRes.freeMultiplier)
+      expect(newRes.totalMultiplier).toBe(oldRes.totalMultiplier)
+      expect(newRes.challengeOneLog).toBe(oldRes.challengeOneLog)
+      expect(newRes.totalMultiplierBoost).toBe(oldRes.totalMultiplierBoost)
+      expect(newRes.multiplierPower).toBe(oldRes.multiplierPower)
+      expect(decimalEq(newRes.multiplierEffect, oldRes.multiplierEffect)).toBe(true)
+    })
+  }
+})

--- a/packages/logic/test/parity/updateAllTick.parity.test.ts
+++ b/packages/logic/test/parity/updateAllTick.parity.test.ts
@@ -1,0 +1,378 @@
+// Parity tests for updateAllTick. Old body transcribed verbatim from
+// packages/web_ui/src/Synergism.ts (updateAllTick, ~line 2372 pre-migration).
+// Same input/output shape as the new function so the comparison is direct.
+
+import Decimal from 'break_infinity.js'
+import { describe, expect, it } from 'vitest'
+import { CalcECC } from '../../src/mechanics/challenges'
+import {
+  updateAllTick as newUpdateAllTick,
+  type UpdateAllTickInput,
+  type UpdateAllTickResult
+} from '../../src/mechanics/updateAllTick'
+
+const oldUpdateAllTick = (
+  input: UpdateAllTickInput,
+  totalMultiplier: number
+): UpdateAllTickResult => {
+  let a = 0
+
+  const totalAcceleratorInit = input.acceleratorBought
+  const costDivisor = 1
+
+  if (input.upgrade8 !== 0) {
+    a += Math.floor(input.multiplierBought / 7)
+  }
+  if (input.upgrade21 !== 0) a += 5
+  if (input.upgrade22 !== 0) a += 4
+  if (input.upgrade23 !== 0) a += 3
+  if (input.upgrade24 !== 0) a += 2
+  if (input.upgrade25 !== 0) a += 1
+  if (input.upgrade32 !== 0) {
+    a += Math.min(500, Math.floor(Decimal.log(input.prestigePoints.add(1), 1e25)))
+  }
+  if (input.upgrade45 !== 0) {
+    a += Math.min(2500, Math.floor(Decimal.log(input.transcendShards.add(1), 10)))
+  }
+  a += input.acceleratorsAchievement
+
+  const ecc2tr = CalcECC('transcend', input.c2Completions)
+  const ecc7r = CalcECC('reincarnation', input.c7Completions)
+
+  a += 5 * ecc2tr
+  const freeUpgradeAccelerator = a
+
+  a += input.totalAcceleratorBoost
+    * (5
+      + 2 * input.research18
+      + 2 * input.research19
+      + 3 * input.research20
+      + input.acceleratorCubeBlessing)
+
+  if (input.prestigeUnlocked) {
+    a *= input.multiplicativeAcceleratorsRune
+  }
+
+  a *= input.acceleratorMultiplier
+  a = Math.pow(
+    a,
+    Math.min(1, (1 + input.platonicUpgrade6 / 30) * input.viscosityPower)
+  )
+  a += input.hepteractAccelerators
+  a *= input.challenge15RewardAccelerator
+  a *= input.hepteractAcceleratorMult
+  a = Math.floor(Math.min(1e100, a))
+
+  if (input.viscosityCorruptionLevel >= 15) a = Math.pow(a, 0.2)
+  if (input.viscosityCorruptionLevel >= 16) a = 1
+
+  const freeAccelerator = a
+  const totalAccelerator = totalAcceleratorInit + freeAccelerator
+
+  const tuSevenMulti = input.upgrade46 > 0.5 ? 1.05 : 1
+
+  let acceleratorPower = Math.pow(
+    1.1
+      + input.acceleratorPowerRune
+      + 1 / 400 * ecc2tr
+      + input.acceleratorPowerAchievement
+      + tuSevenMulti * (input.totalAcceleratorBoost / 100) * (1 + ecc2tr / 20),
+    1 + 0.04 * ecc7r
+  )
+
+  if (
+    input.reincarnationChallenge !== 7
+    && input.reincarnationChallenge !== 10
+  ) {
+    if (input.transcensionChallenge === 1) {
+      acceleratorPower *= 25 / (50 + input.c1Completions)
+      acceleratorPower += 0.55
+      acceleratorPower = Math.max(1, acceleratorPower)
+    }
+    if (input.transcensionChallenge === 2) acceleratorPower = 1
+    if (input.transcensionChallenge === 3) acceleratorPower = 1 + acceleratorPower / 2
+  }
+  acceleratorPower = Math.min(1e300, acceleratorPower)
+  if (input.reincarnationChallenge === 7) acceleratorPower = 1
+  if (input.reincarnationChallenge === 10) acceleratorPower = 1
+
+  let acceleratorEffect: Decimal
+  if (input.transcensionChallenge !== 1) {
+    acceleratorEffect = Decimal.pow(acceleratorPower, totalAccelerator)
+  } else {
+    acceleratorEffect = Decimal.pow(acceleratorPower, totalAccelerator + totalMultiplier)
+  }
+  const acceleratorEffectDisplay = new Decimal(acceleratorPower * 100 - 100)
+  if (input.reincarnationChallenge === 10) {
+    acceleratorEffect = new Decimal(1)
+  }
+
+  let generatorPower = new Decimal(1)
+  if (input.upgrade11 > 0.5 && input.reincarnationChallenge !== 7) {
+    generatorPower = Decimal.pow(1.02, totalAccelerator)
+  }
+
+  return {
+    totalAccelerator,
+    costDivisor,
+    freeUpgradeAccelerator,
+    freeAccelerator,
+    tuSevenMulti,
+    acceleratorPower,
+    acceleratorEffect,
+    acceleratorEffectDisplay,
+    generatorPower
+  }
+}
+
+const decimalEq = (a: Decimal, b: Decimal): boolean => a.eq(b)
+
+const baseInput: UpdateAllTickInput = {
+  acceleratorBought: 0,
+  multiplierBought: 0,
+  upgrade8: 0,
+  upgrade11: 0,
+  upgrade21: 0,
+  upgrade22: 0,
+  upgrade23: 0,
+  upgrade24: 0,
+  upgrade25: 0,
+  upgrade32: 0,
+  upgrade45: 0,
+  upgrade46: 0,
+  prestigePoints: new Decimal(0),
+  transcendShards: new Decimal(0),
+  c1Completions: 0,
+  c2Completions: 0,
+  c7Completions: 0,
+  transcensionChallenge: 0,
+  reincarnationChallenge: 0,
+  research18: 0,
+  research19: 0,
+  research20: 0,
+  platonicUpgrade6: 0,
+  prestigeUnlocked: false,
+  viscosityCorruptionLevel: 0,
+
+  acceleratorsAchievement: 0,
+  acceleratorPowerAchievement: 0,
+  multiplicativeAcceleratorsRune: 1,
+  acceleratorPowerRune: 0,
+  acceleratorCubeBlessing: 0,
+  hepteractAccelerators: 0,
+  hepteractAcceleratorMult: 1,
+
+  totalAcceleratorBoost: 0,
+  acceleratorMultiplier: 1,
+  viscosityPower: 1,
+  challenge15RewardAccelerator: 1
+}
+
+interface Case {
+  name: string
+  input: UpdateAllTickInput
+  totalMultiplier: number
+}
+
+const cases: Case[] = [
+  { name: 'baseline (all zero)', input: baseInput, totalMultiplier: 0 },
+
+  // ─── Upgrade additions ────────────────────────────────────────────────
+  {
+    name: 'upgrade 8 adds floor(multiplierBought / 7)',
+    input: { ...baseInput, upgrade8: 1, multiplierBought: 100 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrades 21-25 add 5/4/3/2/1',
+    input: { ...baseInput, upgrade21: 1, upgrade22: 1, upgrade23: 1, upgrade24: 1, upgrade25: 1 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrade 32 adds min(500, log1e25(prestigePoints+1))',
+    input: { ...baseInput, upgrade32: 1, prestigePoints: new Decimal('1e100') },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrade 32 saturates at 500 for huge prestigePoints',
+    input: { ...baseInput, upgrade32: 1, prestigePoints: new Decimal('1e20000') },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrade 45 adds min(2500, log10(transcendShards+1))',
+    input: { ...baseInput, upgrade45: 1, transcendShards: new Decimal('1e1000') },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrade 45 saturates at 2500 for huge transcendShards',
+    input: { ...baseInput, upgrade45: 1, transcendShards: new Decimal('1e3000') },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrade 46 sets tuSevenMulti to 1.05',
+    input: { ...baseInput, upgrade46: 1 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'upgrade 11 enables generatorPower formula',
+    input: { ...baseInput, upgrade11: 1, acceleratorBought: 50 },
+    totalMultiplier: 0
+  },
+
+  // ─── ECC contributions ────────────────────────────────────────────────
+  {
+    name: 'c2 completions raise freeUpgradeAccelerator via ECC + acceleratorPower',
+    input: { ...baseInput, c2Completions: 30, totalAcceleratorBoost: 100 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'c7 completions raise acceleratorPower exponent',
+    input: { ...baseInput, c7Completions: 25, totalAcceleratorBoost: 50 },
+    totalMultiplier: 0
+  },
+
+  // ─── Boost / multiplier path ──────────────────────────────────────────
+  {
+    name: 'totalAcceleratorBoost + research stack',
+    input: {
+      ...baseInput,
+      totalAcceleratorBoost: 100,
+      research18: 10,
+      research19: 10,
+      research20: 10,
+      acceleratorCubeBlessing: 5
+    },
+    totalMultiplier: 0
+  },
+  {
+    name: 'prestige unlocked applies multiplicative rune',
+    input: { ...baseInput, totalAcceleratorBoost: 100, prestigeUnlocked: true, multiplicativeAcceleratorsRune: 1.5 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'acceleratorMultiplier scales a',
+    input: { ...baseInput, totalAcceleratorBoost: 100, acceleratorMultiplier: 2.5 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'platonic 6 + viscosity power raise exponent',
+    input: {
+      ...baseInput,
+      totalAcceleratorBoost: 100,
+      platonicUpgrade6: 10,
+      viscosityPower: 0.9
+    },
+    totalMultiplier: 0
+  },
+
+  // ─── Hepteract + challenge15 ──────────────────────────────────────────
+  {
+    name: 'hepteract accelerators add + multiplier scales',
+    input: {
+      ...baseInput,
+      totalAcceleratorBoost: 100,
+      hepteractAccelerators: 50,
+      hepteractAcceleratorMult: 2,
+      challenge15RewardAccelerator: 1.5
+    },
+    totalMultiplier: 0
+  },
+
+  // ─── Corruption viscosity gates ───────────────────────────────────────
+  {
+    name: 'viscosity 15 applies ^0.2 to a',
+    input: { ...baseInput, totalAcceleratorBoost: 100, viscosityCorruptionLevel: 15 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'viscosity 16 clamps a to 1',
+    input: { ...baseInput, totalAcceleratorBoost: 100, viscosityCorruptionLevel: 16 },
+    totalMultiplier: 0
+  },
+
+  // ─── Transcension challenge overrides ─────────────────────────────────
+  {
+    name: 't-chal 1 overrides acceleratorPower (25/(50+c1))',
+    input: { ...baseInput, transcensionChallenge: 1, c1Completions: 25, totalAcceleratorBoost: 50 },
+    totalMultiplier: 100
+  },
+  {
+    name: 't-chal 2 forces acceleratorPower = 1',
+    input: { ...baseInput, transcensionChallenge: 2, totalAcceleratorBoost: 100 },
+    totalMultiplier: 0
+  },
+  {
+    name: 't-chal 3 halves acceleratorPower then adds 1',
+    input: { ...baseInput, transcensionChallenge: 3, totalAcceleratorBoost: 100 },
+    totalMultiplier: 0
+  },
+
+  // ─── Reincarnation challenge overrides ────────────────────────────────
+  {
+    name: 'r-chal 7 forces acceleratorPower = 1 and disables generatorPower',
+    input: { ...baseInput, reincarnationChallenge: 7, upgrade11: 1, totalAcceleratorBoost: 50, acceleratorBought: 50 },
+    totalMultiplier: 0
+  },
+  {
+    name: 'r-chal 10 forces acceleratorPower = 1 and acceleratorEffect = 1',
+    input: { ...baseInput, reincarnationChallenge: 10, totalAcceleratorBoost: 50, acceleratorBought: 50 },
+    totalMultiplier: 0
+  },
+
+  // ─── Combined scenarios ───────────────────────────────────────────────
+  {
+    name: 'big stack: upgrades + boost + cube + rune + viscosity',
+    input: {
+      ...baseInput,
+      acceleratorBought: 100,
+      upgrade8: 1,
+      multiplierBought: 35,
+      upgrade21: 1,
+      upgrade32: 1,
+      prestigePoints: new Decimal('1e150'),
+      upgrade45: 1,
+      transcendShards: new Decimal('1e500'),
+      upgrade46: 1,
+      upgrade11: 1,
+      research18: 5,
+      research19: 5,
+      research20: 3,
+      platonicUpgrade6: 5,
+      prestigeUnlocked: true,
+      viscosityCorruptionLevel: 12,
+      acceleratorsAchievement: 25,
+      acceleratorPowerAchievement: 0.1,
+      multiplicativeAcceleratorsRune: 1.3,
+      acceleratorPowerRune: 0.05,
+      acceleratorCubeBlessing: 3,
+      hepteractAccelerators: 100,
+      hepteractAcceleratorMult: 1.5,
+      totalAcceleratorBoost: 200,
+      acceleratorMultiplier: 2.2,
+      viscosityPower: 0.85,
+      challenge15RewardAccelerator: 1.4,
+      c1Completions: 25,
+      c2Completions: 25,
+      c7Completions: 20
+    },
+    totalMultiplier: 500
+  }
+]
+
+describe('parity: updateAllTick', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      const newRes = newUpdateAllTick(c.input, c.totalMultiplier)
+      const oldRes = oldUpdateAllTick(c.input, c.totalMultiplier)
+      expect(newRes.totalAccelerator).toBe(oldRes.totalAccelerator)
+      expect(newRes.costDivisor).toBe(oldRes.costDivisor)
+      expect(newRes.freeUpgradeAccelerator).toBe(oldRes.freeUpgradeAccelerator)
+      expect(newRes.freeAccelerator).toBe(oldRes.freeAccelerator)
+      expect(newRes.tuSevenMulti).toBe(oldRes.tuSevenMulti)
+      expect(newRes.acceleratorPower).toBe(oldRes.acceleratorPower)
+      expect(decimalEq(newRes.acceleratorEffect, oldRes.acceleratorEffect)).toBe(true)
+      expect(decimalEq(newRes.acceleratorEffectDisplay, oldRes.acceleratorEffectDisplay)).toBe(true)
+      expect(decimalEq(newRes.generatorPower, oldRes.generatorPower)).toBe(true)
+    })
+  }
+})

--- a/packages/web_ui/src/Helper.ts
+++ b/packages/web_ui/src/Helper.ts
@@ -1,3 +1,10 @@
+import {
+  advanceAscensionTimer as logicAdvanceAscensionTimer,
+  advanceGoldenQuarksTimer as logicAdvanceGoldenQuarksTimer,
+  advanceQuarksTimer as logicAdvanceQuarksTimer,
+  advanceResetCounter as logicAdvanceResetCounter,
+  advanceSingularityTimer as logicAdvanceSingularityTimer
+} from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import { getAmbrosiaUpgradeEffects } from './BlueberryUpgrades'
 import {
@@ -70,57 +77,60 @@ export const addTimers = (input: TimerInput, time = 0) => {
 
   switch (input) {
     case 'prestige': {
-      player.prestigecounter += time * timeMultiplier
+      player.prestigecounter = logicAdvanceResetCounter(player.prestigecounter, time, timeMultiplier)
       break
     }
     case 'transcension': {
-      player.transcendcounter += time * timeMultiplier
+      player.transcendcounter = logicAdvanceResetCounter(player.transcendcounter, time, timeMultiplier)
       break
     }
     case 'reincarnation': {
-      player.reincarnationcounter += time * timeMultiplier
+      player.reincarnationcounter = logicAdvanceResetCounter(player.reincarnationcounter, time, timeMultiplier)
       break
     }
     case 'ascension': {
-      // Anything in here is affected by add code
       const ascensionSpeedMulti = getGQUpgradeEffect('oneMind', 'unlocked')
         ? 10
         : calculateAscensionSpeedMult()
-      player.ascensionCounter += time * timeMultiplier * ascensionSpeedMulti
-      player.ascensionCounterReal += time * timeMultiplier
+      const r = logicAdvanceAscensionTimer({
+        time,
+        ascensionCounter: player.ascensionCounter,
+        ascensionCounterReal: player.ascensionCounterReal,
+        ascensionSpeedMulti
+      })
+      player.ascensionCounter = r.ascensionCounter
+      player.ascensionCounterReal = r.ascensionCounterReal
       break
     }
     case 'singularity': {
       const singularitySpeedMulti = getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'singularitySpeedMult')
-      player.ascensionCounterRealReal += time
-      player.singularityCounter += time * timeMultiplier * singularitySpeedMulti
-
-      if (player.insideSingularityChallenge) {
-        player.singChallengeTimer += time * timeMultiplier * singularitySpeedMulti
-      } else {
-        player.singChallengeTimer = 0
-      }
-
+      const r = logicAdvanceSingularityTimer({
+        time,
+        ascensionCounterRealReal: player.ascensionCounterRealReal,
+        singularityCounter: player.singularityCounter,
+        singChallengeTimer: player.singChallengeTimer,
+        insideSingularityChallenge: player.insideSingularityChallenge,
+        singularitySpeedMulti
+      })
+      player.ascensionCounterRealReal = r.ascensionCounterRealReal
+      player.singularityCounter = r.singularityCounter
+      player.singChallengeTimer = r.singChallengeTimer
       break
     }
     case 'quarks': {
-      // First get maximum Quark Clock (25h, up to +25 from Research 8x20)
-      const maxQuarkTimer = quarkHandler().maxTime
-      player.quarkstimer += time * timeMultiplier
-      // Checks if this new time is greater than maximum, in which it will default to that time.
-      // Otherwise returns itself.
-      player.quarkstimer = player.quarkstimer > maxQuarkTimer ? maxQuarkTimer : player.quarkstimer
+      player.quarkstimer = logicAdvanceQuarksTimer({
+        time,
+        quarkstimer: player.quarkstimer,
+        maxQuarkTimer: quarkHandler().maxTime
+      })
       break
     }
     case 'goldenQuarks': {
-      if (getGQUpgradeEffect('goldenQuarks3', 'exportGQPerHour') === 0) {
-        return
-      } else {
-        player.goldenQuarksTimer += time * timeMultiplier
-        player.goldenQuarksTimer = player.goldenQuarksTimer > 3600 * 168
-          ? 3600 * 168
-          : player.goldenQuarksTimer
-      }
+      player.goldenQuarksTimer = logicAdvanceGoldenQuarksTimer({
+        time,
+        goldenQuarksTimer: player.goldenQuarksTimer,
+        exportGQPerHour: getGQUpgradeEffect('goldenQuarks3', 'exportGQPerHour')
+      })
       break
     }
     case 'octeracts': {

--- a/packages/web_ui/src/Synergism.ts
+++ b/packages/web_ui/src/Synergism.ts
@@ -6,11 +6,13 @@ import {
   calculateCrystalCoinMultiplier as logicCalculateCrystalCoinMultiplier,
   calculateCrystalExponent as logicCalculateCrystalExponent,
   computeGlobalMultipliers as logicComputeGlobalMultipliers,
+  type CoreEvent,
   crystalUpgrade3Base as logicCrystalUpgrade3Base,
   crystalUpgrade3CrystalMultiplier as logicCrystalUpgrade3CrystalMultiplier,
   crystalUpgrade3MaxBase as logicCrystalUpgrade3MaxBase,
   crystalUpgrade4MaxExponent as logicCrystalUpgrade4MaxExponent,
   resetCurrency as logicResetCurrency,
+  resourceGain as logicResourceGain,
   updateAllMultiplier as logicUpdateAllMultiplier,
   updateAllTick as logicUpdateAllTick
 } from '@synergism/logic'
@@ -160,7 +162,6 @@ import type { Player, resetNames } from './types/Synergism'
 import {
   ascendBuildingKeys,
   buildingCostKeys,
-  buildingOrdinalNames,
   buildingOwnedKeys,
   buildingResources,
   digitToOneToFive,
@@ -2706,325 +2707,218 @@ export const multipliers = (): void => {
   G.antMultiplier = result.antMultiplier
 }
 
-export const resourceGain = (dt: number): void => {
-  calculateTotalAcceleratorBoost()
+// Dispatches CoreEvents returned by logic resourceGain back into web_ui side
+// effects. Kept inline rather than a separate module so the data flow is
+// obvious next to the shim that emits them.
+const dispatchResourceGainEvents = (events: readonly CoreEvent[]): void => {
+  for (const ev of events) {
+    if (ev.kind === 'achievement-group-awarded') {
+      awardAchievementGroup(ev.group as 'constant')
+    } else if (ev.kind === 'challenge-auto-completed') {
+      challengeAchievementCheck(ev.challengeIndex)
+      updateChallengeLevel(ev.challengeIndex)
+    }
+  }
+}
 
+export const resourceGain = (dt: number): void => {
+  // Pre-tick orchestration — populate G.* derived state that logic reads.
+  calculateTotalAcceleratorBoost()
   updateAllTick()
   updateAllMultiplier()
   multipliers()
   calculatetax()
-  if (G.produceTotal.gte(0.001)) {
-    const addcoin = Decimal.min(
-      G.produceTotal.dividedBy(G.taxdivisor),
-      Decimal.pow(10, G.maxexponent - Decimal.log(G.taxdivisorcheck, 10))
-    ).times(dt / 0.025)
-    player.coins = player.coins.add(addcoin)
-    player.coinsThisPrestige = player.coinsThisPrestige.add(addcoin)
-    player.coinsThisTranscension = player.coinsThisTranscension.add(addcoin)
-    player.coinsThisReincarnation = player.coinsThisReincarnation.add(addcoin)
-    player.coinsTotal = player.coinsTotal.add(addcoin)
-  }
-
   resetCurrency()
-  if (player.upgrades[93] === 1 && player.coinsThisPrestige.gte(1e16)) {
-    player.prestigePoints = player.prestigePoints.add(
-      Decimal.floor(G.prestigePointGain.dividedBy(4000).times(dt / 0.025))
-    )
-  }
-  if (player.upgrades[100] === 1 && player.coinsThisTranscension.gte(1e100)) {
-    player.transcendPoints = player.transcendPoints.add(
-      Decimal.floor(G.transcendPointGain.dividedBy(4000).times(dt / 0.025))
-    )
-  }
-  if (player.cubeUpgrades[28] > 0 && player.transcendShards.gte(1e300)) {
-    player.reincarnationPoints = player.reincarnationPoints.add(
-      Decimal.floor(G.reincarnationPointGain.dividedBy(4000).times(dt / 0.025))
-    )
-  }
-  G.produceFirstDiamonds = player.firstGeneratedDiamonds
-    .add(player.firstOwnedDiamonds)
-    .times(player.firstProduceDiamonds)
-    .times(G.globalCrystalMultiplier)
-  G.produceSecondDiamonds = player.secondGeneratedDiamonds
-    .add(player.secondOwnedDiamonds)
-    .times(player.secondProduceDiamonds)
-    .times(G.globalCrystalMultiplier)
-  G.produceThirdDiamonds = player.thirdGeneratedDiamonds
-    .add(player.thirdOwnedDiamonds)
-    .times(player.thirdProduceDiamonds)
-    .times(G.globalCrystalMultiplier)
-  G.produceFourthDiamonds = player.fourthGeneratedDiamonds
-    .add(player.fourthOwnedDiamonds)
-    .times(player.fourthProduceDiamonds)
-    .times(G.globalCrystalMultiplier)
-  G.produceFifthDiamonds = player.fifthGeneratedDiamonds
-    .add(player.fifthOwnedDiamonds)
-    .times(player.fifthProduceDiamonds)
-    .times(G.globalCrystalMultiplier)
 
-  player.fourthGeneratedDiamonds = player.fourthGeneratedDiamonds.add(
-    G.produceFifthDiamonds.times(dt / 0.025)
-  )
-  player.thirdGeneratedDiamonds = player.thirdGeneratedDiamonds.add(
-    G.produceFourthDiamonds.times(dt / 0.025)
-  )
-  player.secondGeneratedDiamonds = player.secondGeneratedDiamonds.add(
-    G.produceThirdDiamonds.times(dt / 0.025)
-  )
-  player.firstGeneratedDiamonds = player.firstGeneratedDiamonds.add(
-    G.produceSecondDiamonds.times(dt / 0.025)
-  )
-  G.produceDiamonds = G.produceFirstDiamonds
+  const result = logicResourceGain({
+    dt,
+    produceTotal: G.produceTotal,
+    taxdivisor: G.taxdivisor,
+    taxdivisorcheck: G.taxdivisorcheck,
+    maxexponent: G.maxexponent,
+    coins: player.coins,
+    coinsThisPrestige: player.coinsThisPrestige,
+    coinsThisTranscension: player.coinsThisTranscension,
+    coinsThisReincarnation: player.coinsThisReincarnation,
+    coinsTotal: player.coinsTotal,
 
-  if (
-    player.currentChallenge.transcension !== 3
-    && player.currentChallenge.reincarnation !== 10
-  ) {
-    player.prestigeShards = player.prestigeShards.add(
-      G.produceDiamonds.times(dt / 0.025)
-    )
-  }
+    upgrade93: player.upgrades[93],
+    upgrade100: player.upgrades[100],
+    cubeUpgrade28: player.cubeUpgrades[28],
+    prestigePoints: player.prestigePoints,
+    transcendPoints: player.transcendPoints,
+    reincarnationPoints: player.reincarnationPoints,
+    prestigePointGain: G.prestigePointGain,
+    transcendPointGain: G.transcendPointGain,
+    reincarnationPointGain: G.reincarnationPointGain,
 
-  G.produceFifthMythos = player.fifthGeneratedMythos
-    .add(player.fifthOwnedMythos)
-    .times(player.fifthProduceMythos)
-    .times(G.globalMythosMultiplier)
-    .times(G.grandmasterMultiplier)
-    .times(G.mythosupgrade15)
-  G.produceFourthMythos = player.fourthGeneratedMythos
-    .add(player.fourthOwnedMythos)
-    .times(player.fourthProduceMythos)
-    .times(G.globalMythosMultiplier)
-  G.produceThirdMythos = player.thirdGeneratedMythos
-    .add(player.thirdOwnedMythos)
-    .times(player.thirdProduceMythos)
-    .times(G.globalMythosMultiplier)
-    .times(G.mythosupgrade14)
-  G.produceSecondMythos = player.secondGeneratedMythos
-    .add(player.secondOwnedMythos)
-    .times(player.secondProduceMythos)
-    .times(G.globalMythosMultiplier)
-  G.produceFirstMythos = player.firstGeneratedMythos
-    .add(player.firstOwnedMythos)
-    .times(player.firstProduceMythos)
-    .times(G.globalMythosMultiplier)
-    .times(G.mythosupgrade13)
-  player.fourthGeneratedMythos = player.fourthGeneratedMythos.add(
-    G.produceFifthMythos.times(dt / 0.025)
-  )
-  player.thirdGeneratedMythos = player.thirdGeneratedMythos.add(
-    G.produceFourthMythos.times(dt / 0.025)
-  )
-  player.secondGeneratedMythos = player.secondGeneratedMythos.add(
-    G.produceThirdMythos.times(dt / 0.025)
-  )
-  player.firstGeneratedMythos = player.firstGeneratedMythos.add(
-    G.produceSecondMythos.times(dt / 0.025)
-  )
+    firstGeneratedDiamonds: player.firstGeneratedDiamonds,
+    secondGeneratedDiamonds: player.secondGeneratedDiamonds,
+    thirdGeneratedDiamonds: player.thirdGeneratedDiamonds,
+    fourthGeneratedDiamonds: player.fourthGeneratedDiamonds,
+    fifthGeneratedDiamonds: player.fifthGeneratedDiamonds,
+    firstOwnedDiamonds: player.firstOwnedDiamonds,
+    secondOwnedDiamonds: player.secondOwnedDiamonds,
+    thirdOwnedDiamonds: player.thirdOwnedDiamonds,
+    fourthOwnedDiamonds: player.fourthOwnedDiamonds,
+    fifthOwnedDiamonds: player.fifthOwnedDiamonds,
+    firstProduceDiamonds: player.firstProduceDiamonds,
+    secondProduceDiamonds: player.secondProduceDiamonds,
+    thirdProduceDiamonds: player.thirdProduceDiamonds,
+    fourthProduceDiamonds: player.fourthProduceDiamonds,
+    fifthProduceDiamonds: player.fifthProduceDiamonds,
+    globalCrystalMultiplier: G.globalCrystalMultiplier,
 
-  G.produceMythos = new Decimal('0')
-  G.produceMythos = player.firstGeneratedMythos
-    .add(player.firstOwnedMythos)
-    .times(player.firstProduceMythos)
-    .times(G.globalMythosMultiplier)
-    .times(G.mythosupgrade13)
-  G.producePerSecondMythos = G.produceMythos.times(40)
+    firstGeneratedMythos: player.firstGeneratedMythos,
+    secondGeneratedMythos: player.secondGeneratedMythos,
+    thirdGeneratedMythos: player.thirdGeneratedMythos,
+    fourthGeneratedMythos: player.fourthGeneratedMythos,
+    fifthGeneratedMythos: player.fifthGeneratedMythos,
+    firstOwnedMythos: player.firstOwnedMythos,
+    secondOwnedMythos: player.secondOwnedMythos,
+    thirdOwnedMythos: player.thirdOwnedMythos,
+    fourthOwnedMythos: player.fourthOwnedMythos,
+    fifthOwnedMythos: player.fifthOwnedMythos,
+    firstProduceMythos: player.firstProduceMythos,
+    secondProduceMythos: player.secondProduceMythos,
+    thirdProduceMythos: player.thirdProduceMythos,
+    fourthProduceMythos: player.fourthProduceMythos,
+    fifthProduceMythos: player.fifthProduceMythos,
+    globalMythosMultiplier: G.globalMythosMultiplier,
+    grandmasterMultiplier: G.grandmasterMultiplier,
+    mythosupgrade13: G.mythosupgrade13,
+    mythosupgrade14: G.mythosupgrade14,
+    mythosupgrade15: G.mythosupgrade15,
 
-  let pm = new Decimal('1')
-  if (player.upgrades[67] > 0.5) {
-    pm = pm.times(
-      Decimal.pow(
-        1.03,
-        player.firstOwnedParticles
-          + player.secondOwnedParticles
-          + player.thirdOwnedParticles
-          + player.fourthOwnedParticles
-          + player.fifthOwnedParticles
-      )
-    )
-  }
-  G.produceFifthParticles = player.fifthGeneratedParticles
-    .add(player.fifthOwnedParticles)
-    .times(player.fifthProduceParticles)
-  G.produceFourthParticles = player.fourthGeneratedParticles
-    .add(player.fourthOwnedParticles)
-    .times(player.fourthProduceParticles)
-  G.produceThirdParticles = player.thirdGeneratedParticles
-    .add(player.thirdOwnedParticles)
-    .times(player.thirdProduceParticles)
-  G.produceSecondParticles = player.secondGeneratedParticles
-    .add(player.secondOwnedParticles)
-    .times(player.secondProduceParticles)
-  G.produceFirstParticles = player.firstGeneratedParticles
-    .add(player.firstOwnedParticles)
-    .times(player.firstProduceParticles)
-    .times(pm)
-  player.fourthGeneratedParticles = player.fourthGeneratedParticles.add(
-    G.produceFifthParticles.times(dt / 0.025)
-  )
-  player.thirdGeneratedParticles = player.thirdGeneratedParticles.add(
-    G.produceFourthParticles.times(dt / 0.025)
-  )
-  player.secondGeneratedParticles = player.secondGeneratedParticles.add(
-    G.produceThirdParticles.times(dt / 0.025)
-  )
-  player.firstGeneratedParticles = player.firstGeneratedParticles.add(
-    G.produceSecondParticles.times(dt / 0.025)
-  )
+    firstGeneratedParticles: player.firstGeneratedParticles,
+    secondGeneratedParticles: player.secondGeneratedParticles,
+    thirdGeneratedParticles: player.thirdGeneratedParticles,
+    fourthGeneratedParticles: player.fourthGeneratedParticles,
+    fifthGeneratedParticles: player.fifthGeneratedParticles,
+    firstOwnedParticles: player.firstOwnedParticles,
+    secondOwnedParticles: player.secondOwnedParticles,
+    thirdOwnedParticles: player.thirdOwnedParticles,
+    fourthOwnedParticles: player.fourthOwnedParticles,
+    fifthOwnedParticles: player.fifthOwnedParticles,
+    firstProduceParticles: player.firstProduceParticles,
+    secondProduceParticles: player.secondProduceParticles,
+    thirdProduceParticles: player.thirdProduceParticles,
+    fourthProduceParticles: player.fourthProduceParticles,
+    fifthProduceParticles: player.fifthProduceParticles,
+    upgrade67: player.upgrades[67],
 
-  G.produceParticles = new Decimal('0')
-  G.produceParticles = player.firstGeneratedParticles
-    .add(player.firstOwnedParticles)
-    .times(player.firstProduceParticles)
-    .times(pm)
-  G.producePerSecondParticles = G.produceParticles.times(40)
+    prestigeShards: player.prestigeShards,
+    transcendShards: player.transcendShards,
+    reincarnationShards: player.reincarnationShards,
+    ascendShards: player.ascendShards,
 
-  if (
-    player.currentChallenge.transcension !== 3
-    && player.currentChallenge.reincarnation !== 10
-  ) {
-    player.transcendShards = player.transcendShards.add(
-      G.produceMythos.times(dt / 0.025)
-    )
-  }
+    ascendBuilding1Generated: player.ascendBuilding1.generated,
+    ascendBuilding2Generated: player.ascendBuilding2.generated,
+    ascendBuilding3Generated: player.ascendBuilding3.generated,
+    ascendBuilding4Generated: player.ascendBuilding4.generated,
+    ascendBuilding5Generated: player.ascendBuilding5.generated,
+    ascendBuilding1Owned: player.ascendBuilding1.owned,
+    ascendBuilding2Owned: player.ascendBuilding2.owned,
+    ascendBuilding3Owned: player.ascendBuilding3.owned,
+    ascendBuilding4Owned: player.ascendBuilding4.owned,
+    ascendBuilding5Owned: player.ascendBuilding5.owned,
+    globalConstantMult: G.globalConstantMult,
 
-  player.reincarnationShards = player.reincarnationShards.add(
-    G.produceParticles.times(dt / 0.025)
-  )
+    ascensionCount: player.ascensionCount,
+    transcensionChallenge: player.currentChallenge.transcension,
+    reincarnationChallenge: player.currentChallenge.reincarnation,
 
-  /*if (player.currentChallenge.reincarnation !== 10) {
-    player.reincarnationShards = player.reincarnationShards.add(
-      G.produceParticles.times(dt / 0.025)
-    )
-  }*/
+    research66: player.researches[66],
+    research67_: player.researches[67],
+    research68: player.researches[68],
+    research69: player.researches[69],
+    research70: player.researches[70],
+    research71: player.researches[71],
+    research72: player.researches[72],
+    research73: player.researches[73],
+    research74: player.researches[74],
+    research75: player.researches[75],
+    research105: player.researches[105],
+    c1Completions: player.challengecompletions[1],
+    c2Completions: player.challengecompletions[2],
+    c3Completions: player.challengecompletions[3],
+    c4Completions: player.challengecompletions[4],
+    c5Completions: player.challengecompletions[5],
+    highestC1: player.highestchallengecompletions[1],
+    highestC2: player.highestchallengecompletions[2],
+    highestC3: player.highestchallengecompletions[3],
+    highestC4: player.highestchallengecompletions[4],
+    highestC5: player.highestchallengecompletions[5],
+    challengeBaseRequirements: G.challengeBaseRequirements
+  })
 
-  for (let j = 4; j >= 0; j--) {
-    const buildingKey = ascendBuildingKeys[j]
-    const ordinalName = buildingOrdinalNames[j]
-    G.ascendBuildingProduction[ordinalName] = player[buildingKey].generated
-      .add(player[buildingKey].owned)
-      // 4.1.0: Removing this from player, also because I want to make the multiplier 0.05 instead of 0.01 anyway
-      // .times(player[buildingKey].multiplier)
-      .times(0.05)
-      .times(G.globalConstantMult)
+  // Apply player updates
+  player.coins = result.coins
+  player.coinsThisPrestige = result.coinsThisPrestige
+  player.coinsThisTranscension = result.coinsThisTranscension
+  player.coinsThisReincarnation = result.coinsThisReincarnation
+  player.coinsTotal = result.coinsTotal
+  player.prestigePoints = result.prestigePoints
+  player.transcendPoints = result.transcendPoints
+  player.reincarnationPoints = result.reincarnationPoints
+  player.prestigeShards = result.prestigeShards
+  player.transcendShards = result.transcendShards
+  player.reincarnationShards = result.reincarnationShards
+  player.ascendShards = result.ascendShards
+  player.firstGeneratedDiamonds = result.firstGeneratedDiamonds
+  player.secondGeneratedDiamonds = result.secondGeneratedDiamonds
+  player.thirdGeneratedDiamonds = result.thirdGeneratedDiamonds
+  player.fourthGeneratedDiamonds = result.fourthGeneratedDiamonds
+  player.firstGeneratedMythos = result.firstGeneratedMythos
+  player.secondGeneratedMythos = result.secondGeneratedMythos
+  player.thirdGeneratedMythos = result.thirdGeneratedMythos
+  player.fourthGeneratedMythos = result.fourthGeneratedMythos
+  player.firstGeneratedParticles = result.firstGeneratedParticles
+  player.secondGeneratedParticles = result.secondGeneratedParticles
+  player.thirdGeneratedParticles = result.thirdGeneratedParticles
+  player.fourthGeneratedParticles = result.fourthGeneratedParticles
+  player.ascendBuilding1.generated = result.ascendBuilding1Generated
+  player.ascendBuilding2.generated = result.ascendBuilding2Generated
+  player.ascendBuilding3.generated = result.ascendBuilding3Generated
+  player.ascendBuilding4.generated = result.ascendBuilding4Generated
+  player.challengecompletions[1] = result.c1Completions
+  player.challengecompletions[2] = result.c2Completions
+  player.challengecompletions[3] = result.c3Completions
+  player.challengecompletions[4] = result.c4Completions
+  player.challengecompletions[5] = result.c5Completions
 
-    if (j !== 0) {
-      const prevKey = ascendBuildingKeys[j - 1]
-      player[prevKey].generated = player[prevKey].generated.add(
-        G.ascendBuildingProduction[ordinalName].times(dt)
-      )
-    }
-  }
+  // Apply G cache updates
+  G.produceFirstDiamonds = result.produceFirstDiamonds
+  G.produceSecondDiamonds = result.produceSecondDiamonds
+  G.produceThirdDiamonds = result.produceThirdDiamonds
+  G.produceFourthDiamonds = result.produceFourthDiamonds
+  G.produceFifthDiamonds = result.produceFifthDiamonds
+  G.produceDiamonds = result.produceDiamonds
+  G.produceFirstMythos = result.produceFirstMythos
+  G.produceSecondMythos = result.produceSecondMythos
+  G.produceThirdMythos = result.produceThirdMythos
+  G.produceFourthMythos = result.produceFourthMythos
+  G.produceFifthMythos = result.produceFifthMythos
+  G.produceMythos = result.produceMythos
+  G.producePerSecondMythos = result.producePerSecondMythos
+  G.produceFirstParticles = result.produceFirstParticles
+  G.produceSecondParticles = result.produceSecondParticles
+  G.produceThirdParticles = result.produceThirdParticles
+  G.produceFourthParticles = result.produceFourthParticles
+  G.produceFifthParticles = result.produceFifthParticles
+  G.produceParticles = result.produceParticles
+  G.producePerSecondParticles = result.producePerSecondParticles
+  G.ascendBuildingProduction.first = result.ascendBuildingProduction.first
+  G.ascendBuildingProduction.second = result.ascendBuildingProduction.second
+  G.ascendBuildingProduction.third = result.ascendBuildingProduction.third
+  G.ascendBuildingProduction.fourth = result.ascendBuildingProduction.fourth
+  G.ascendBuildingProduction.fifth = result.ascendBuildingProduction.fifth
 
-  player.ascendShards = player.ascendShards.add(
-    G.ascendBuildingProduction.first.times(dt)
-  )
+  dispatchResourceGainEvents(result.events)
 
-  if (player.ascensionCount > 0) {
-    awardAchievementGroup('constant')
-  }
-
-  if (
-    player.researches[71] > 0.5
-    && player.challengecompletions[1]
-      < Math.min(
-        player.highestchallengecompletions[1],
-        25 + 5 * player.researches[66] + 925 * player.researches[105]
-      )
-    && player.coins.gte(
-      Decimal.pow(
-        10,
-        1.25
-          * G.challengeBaseRequirements[0]
-          * Math.pow(1 + player.challengecompletions[1], 2)
-      )
-    )
-  ) {
-    player.challengecompletions[1] += 1
-    challengeAchievementCheck(1)
-    updateChallengeLevel(1)
-  }
-  if (
-    player.researches[72] > 0.5
-    && player.challengecompletions[2]
-      < Math.min(
-        player.highestchallengecompletions[2],
-        25 + 5 * player.researches[67] + 925 * player.researches[105]
-      )
-    && player.coins.gte(
-      Decimal.pow(
-        10,
-        1.6
-          * G.challengeBaseRequirements[1]
-          * Math.pow(1 + player.challengecompletions[2], 2)
-      )
-    )
-  ) {
-    player.challengecompletions[2] += 1
-    challengeAchievementCheck(2)
-    updateChallengeLevel(2)
-  }
-  if (
-    player.researches[73] > 0.5
-    && player.challengecompletions[3]
-      < Math.min(
-        player.highestchallengecompletions[3],
-        25 + 5 * player.researches[68] + 925 * player.researches[105]
-      )
-    && player.coins.gte(
-      Decimal.pow(
-        10,
-        1.7
-          * G.challengeBaseRequirements[2]
-          * Math.pow(1 + player.challengecompletions[3], 2)
-      )
-    )
-  ) {
-    player.challengecompletions[3] += 1
-    challengeAchievementCheck(3)
-    updateChallengeLevel(3)
-  }
-  if (
-    player.researches[74] > 0.5
-    && player.challengecompletions[4]
-      < Math.min(
-        player.highestchallengecompletions[4],
-        25 + 5 * player.researches[69] + 925 * player.researches[105]
-      )
-    && player.coins.gte(
-      Decimal.pow(
-        10,
-        1.45
-          * G.challengeBaseRequirements[3]
-          * Math.pow(1 + player.challengecompletions[4], 2)
-      )
-    )
-  ) {
-    player.challengecompletions[4] += 1
-    challengeAchievementCheck(4)
-    updateChallengeLevel(4)
-  }
-  if (
-    player.researches[75] > 0.5
-    && player.challengecompletions[5]
-      < Math.min(
-        player.highestchallengecompletions[5],
-        25 + 5 * player.researches[70] + 925 * player.researches[105]
-      )
-    && player.coins.gte(
-      Decimal.pow(
-        10,
-        2
-          * G.challengeBaseRequirements[4]
-          * Math.pow(1 + player.challengecompletions[5], 2)
-      )
-    )
-  ) {
-    player.challengecompletions[5] += 1
-    challengeAchievementCheck(5)
-    updateChallengeLevel(5)
-  }
-
+  // Terminal challenge resetCheck dispatch — async + modal-aware, stays in
+  // web_ui. Reads the post-tick player state so threshold checks see the
+  // resources we just generated.
   const chal = player.currentChallenge.transcension
   const reinchal = player.currentChallenge.reincarnation
   const ascendchal = player.currentChallenge.ascension
@@ -3041,11 +2935,7 @@ export const resourceGain = (dt: number): void => {
   if (reinchal < 9 && reinchal !== 0) {
     if (
       player.transcendShards.gte(
-        challengeRequirement(
-          reinchal,
-          player.challengecompletions[reinchal],
-          reinchal
-        )
+        challengeRequirement(reinchal, player.challengecompletions[reinchal], reinchal)
       )
     ) {
       void resetCheck('reincarnationChallenge', false)
@@ -3055,11 +2945,7 @@ export const resourceGain = (dt: number): void => {
   if (reinchal >= 9) {
     if (
       player.coins.gte(
-        challengeRequirement(
-          reinchal,
-          player.challengecompletions[reinchal],
-          reinchal
-        )
+        challengeRequirement(reinchal, player.challengecompletions[reinchal], reinchal)
       )
     ) {
       void resetCheck('reincarnationChallenge', false)
@@ -3069,11 +2955,7 @@ export const resourceGain = (dt: number): void => {
   if (ascendchal !== 0 && ascendchal < 15) {
     if (
       player.challengecompletions[10]
-        >= (challengeRequirement(
-          ascendchal,
-          player.challengecompletions[ascendchal],
-          ascendchal
-        ) as number)
+        >= (challengeRequirement(ascendchal, player.challengecompletions[ascendchal], ascendchal) as number)
     ) {
       void resetCheck('ascensionChallenge', false)
       challengeAchievementCheck(ascendchal)

--- a/packages/web_ui/src/Synergism.ts
+++ b/packages/web_ui/src/Synergism.ts
@@ -5,10 +5,14 @@ import {
   calculateBuildingPowerCoinMultiplier as logicCalculateBuildingPowerCoinMultiplier,
   calculateCrystalCoinMultiplier as logicCalculateCrystalCoinMultiplier,
   calculateCrystalExponent as logicCalculateCrystalExponent,
+  computeGlobalMultipliers as logicComputeGlobalMultipliers,
   crystalUpgrade3Base as logicCrystalUpgrade3Base,
   crystalUpgrade3CrystalMultiplier as logicCrystalUpgrade3CrystalMultiplier,
   crystalUpgrade3MaxBase as logicCrystalUpgrade3MaxBase,
-  crystalUpgrade4MaxExponent as logicCrystalUpgrade4MaxExponent
+  crystalUpgrade4MaxExponent as logicCrystalUpgrade4MaxExponent,
+  resetCurrency as logicResetCurrency,
+  updateAllMultiplier as logicUpdateAllMultiplier,
+  updateAllTick as logicUpdateAllTick
 } from '@synergism/logic'
 import Decimal, { type DecimalSource } from 'break_infinity.js'
 import LZString from 'lz-string'
@@ -2369,303 +2373,139 @@ export const formatDecimalAsPercentIncrease = (n: Decimal, accuracy = 2) => {
 }
 
 export const updateAllTick = (): void => {
-  let a = 0
-
-  G.totalAccelerator = player.acceleratorBought
-  G.costDivisor = 1
-
-  if (player.upgrades[8] !== 0) {
-    a += Math.floor(player.multiplierBought / 7)
-  }
-  if (player.upgrades[21] !== 0) {
-    a += 5
-  }
-  if (player.upgrades[22] !== 0) {
-    a += 4
-  }
-  if (player.upgrades[23] !== 0) {
-    a += 3
-  }
-  if (player.upgrades[24] !== 0) {
-    a += 2
-  }
-  if (player.upgrades[25] !== 0) {
-    a += 1
-  }
-  if (player.upgrades[32] !== 0) {
-    a += Math.min(
-      500,
-      Math.floor(Decimal.log(player.prestigePoints.add(1), 1e25))
-    )
-  }
-  if (player.upgrades[45] !== 0) {
-    a += Math.min(
-      2500,
-      Math.floor(Decimal.log(player.transcendShards.add(1), 10))
-    )
-  }
-  a += +getAchievementReward('accelerators')
-
-  a += 5 * CalcECC('transcend', player.challengecompletions[2])
-  G.freeUpgradeAccelerator = a
-  a += G.totalAcceleratorBoost
-    * (5
-      + 2 * player.researches[18]
-      + 2 * player.researches[19]
-      + 3 * player.researches[20]
-      + calculateAcceleratorCubeBlessing())
-
-  if (player.unlocks.prestige) {
-    a *= getRuneEffects('speed', 'multiplicativeAccelerators')
-  }
-
+  // calculateAcceleratorMultiplier mutates G.acceleratorMultiplier; logic
+  // expects it as input so we refresh it here before pre-extracting.
   calculateAcceleratorMultiplier()
-  a *= G.acceleratorMultiplier
-  a = Math.pow(
-    a,
-    Math.min(
-      1,
-      (1 + player.platonicUpgrades[6] / 30)
-        * G.viscosityPower[player.corruptions.used.viscosity]
-    )
+
+  const hepteractAccelerator = getHepteractEffects('accelerator')
+
+  const result = logicUpdateAllTick(
+    {
+      acceleratorBought: player.acceleratorBought,
+      multiplierBought: player.multiplierBought,
+      upgrade8: player.upgrades[8],
+      upgrade11: player.upgrades[11],
+      upgrade21: player.upgrades[21],
+      upgrade22: player.upgrades[22],
+      upgrade23: player.upgrades[23],
+      upgrade24: player.upgrades[24],
+      upgrade25: player.upgrades[25],
+      upgrade32: player.upgrades[32],
+      upgrade45: player.upgrades[45],
+      upgrade46: player.upgrades[46],
+      prestigePoints: player.prestigePoints,
+      transcendShards: player.transcendShards,
+      c1Completions: player.challengecompletions[1],
+      c2Completions: player.challengecompletions[2],
+      c7Completions: player.challengecompletions[7],
+      transcensionChallenge: player.currentChallenge.transcension,
+      reincarnationChallenge: player.currentChallenge.reincarnation,
+      research18: player.researches[18],
+      research19: player.researches[19],
+      research20: player.researches[20],
+      platonicUpgrade6: player.platonicUpgrades[6],
+      prestigeUnlocked: player.unlocks.prestige,
+      viscosityCorruptionLevel: player.corruptions.used.viscosity,
+
+      acceleratorsAchievement: +getAchievementReward('accelerators'),
+      acceleratorPowerAchievement: +getAchievementReward('acceleratorPower'),
+      multiplicativeAcceleratorsRune: getRuneEffects('speed', 'multiplicativeAccelerators'),
+      acceleratorPowerRune: getRuneEffects('speed', 'acceleratorPower'),
+      acceleratorCubeBlessing: calculateAcceleratorCubeBlessing(),
+      hepteractAccelerators: hepteractAccelerator.accelerators,
+      hepteractAcceleratorMult: hepteractAccelerator.acceleratorMultiplier,
+
+      totalAcceleratorBoost: G.totalAcceleratorBoost,
+      acceleratorMultiplier: G.acceleratorMultiplier,
+      viscosityPower: G.viscosityPower[player.corruptions.used.viscosity],
+      challenge15RewardAccelerator: G.challenge15Rewards.accelerator.value
+    },
+    G.totalMultiplier
   )
-  a += getHepteractEffects('accelerator').accelerators
-  a *= G.challenge15Rewards.accelerator.value
-  a *= getHepteractEffects('accelerator').acceleratorMultiplier
-  a = Math.floor(Math.min(1e100, a))
 
-  if (player.corruptions.used.viscosity >= 15) {
-    a = Math.pow(a, 0.2)
-  }
-  if (player.corruptions.used.viscosity >= 16) {
-    a = 1
-  }
-
-  G.freeAccelerator = a
-  G.totalAccelerator += G.freeAccelerator
-
-  G.tuSevenMulti = 1
-
-  if (player.upgrades[46] > 0.5) {
-    G.tuSevenMulti = 1.05
-  }
-
-  const achievementBonus = +getAchievementReward('acceleratorPower')
-
-  G.acceleratorPower = Math.pow(
-    1.1
-      + getRuneEffects('speed', 'acceleratorPower')
-      + 1 / 400 * CalcECC('transcend', player.challengecompletions[2])
-      + achievementBonus
-      + G.tuSevenMulti
-        * (G.totalAcceleratorBoost / 100)
-        * (1 + CalcECC('transcend', player.challengecompletions[2]) / 20),
-    1 + 0.04 * CalcECC('reincarnation', player.challengecompletions[7])
-  )
-
-  // No MA and Sadistic will always overwrite Transcend challenges starting in v2.0.0
-  if (
-    player.currentChallenge.reincarnation !== 7
-    && player.currentChallenge.reincarnation !== 10
-  ) {
-    if (player.currentChallenge.transcension === 1) {
-      G.acceleratorPower *= 25 / (50 + player.challengecompletions[1])
-      G.acceleratorPower += 0.55
-      G.acceleratorPower = Math.max(1, G.acceleratorPower)
-    }
-    if (player.currentChallenge.transcension === 2) {
-      G.acceleratorPower = 1
-    }
-    if (player.currentChallenge.transcension === 3) {
-      G.acceleratorPower = 1 + G.acceleratorPower / 2
-    }
-  }
-  G.acceleratorPower = Math.min(1e300, G.acceleratorPower)
-  if (player.currentChallenge.reincarnation === 7) {
-    G.acceleratorPower = 1
-  }
-  if (player.currentChallenge.reincarnation === 10) {
-    G.acceleratorPower = 1
-  }
-
-  if (player.currentChallenge.transcension !== 1) {
-    G.acceleratorEffect = Decimal.pow(G.acceleratorPower, G.totalAccelerator)
-  }
-
-  if (player.currentChallenge.transcension === 1) {
-    G.acceleratorEffect = Decimal.pow(
-      G.acceleratorPower,
-      G.totalAccelerator + G.totalMultiplier
-    )
-  }
-  G.acceleratorEffectDisplay = new Decimal(G.acceleratorPower * 100 - 100)
-  if (player.currentChallenge.reincarnation === 10) {
-    G.acceleratorEffect = new Decimal(1)
-  }
-  G.generatorPower = new Decimal(1)
-  if (
-    player.upgrades[11] > 0.5
-    && player.currentChallenge.reincarnation !== 7
-  ) {
-    G.generatorPower = Decimal.pow(1.02, G.totalAccelerator)
-  }
+  G.totalAccelerator = result.totalAccelerator
+  G.costDivisor = result.costDivisor
+  G.freeUpgradeAccelerator = result.freeUpgradeAccelerator
+  G.freeAccelerator = result.freeAccelerator
+  G.tuSevenMulti = result.tuSevenMulti
+  G.acceleratorPower = result.acceleratorPower
+  G.acceleratorEffect = result.acceleratorEffect
+  G.acceleratorEffectDisplay = result.acceleratorEffectDisplay
+  G.generatorPower = result.generatorPower
 }
 
 export const updateAllMultiplier = (): void => {
-  let a = 0
+  const hepteractMultiplier = getHepteractEffects('multiplier')
 
-  if (player.upgrades[7] > 0) {
-    a += Math.min(
-      4,
-      1 + Math.floor(Decimal.log(player.fifthOwnedCoin + 1, 10))
-    )
-  }
-  if (player.upgrades[9] > 0) {
-    a += Math.floor(player.acceleratorBought / 10)
-  }
-  if (player.upgrades[21] > 0) {
-    a += 1
-  }
-  if (player.upgrades[22] > 0) {
-    a += 1
-  }
-  if (player.upgrades[23] > 0) {
-    a += 1
-  }
-  if (player.upgrades[24] > 0) {
-    a += 1
-  }
-  if (player.upgrades[25] > 0) {
-    a += 1
-  }
-  if (player.upgrades[33] > 0) {
-    a += G.totalAcceleratorBoost
-  }
-  if (player.upgrades[49] > 0) {
-    a += Math.min(
-      50,
-      Math.floor(Decimal.log(player.transcendPoints.add(1), 1e10))
-    )
-  }
-  if (player.upgrades[68] > 0) {
-    a += Math.min(2500, Math.floor((Decimal.log(G.taxdivisor, 10) * 1) / 1000))
-  }
-  if (player.challengecompletions[1] > 0) {
-    a += 1
-  }
+  const result = logicUpdateAllMultiplier({
+    upgrade7: player.upgrades[7],
+    upgrade9: player.upgrades[9],
+    upgrade21: player.upgrades[21],
+    upgrade22: player.upgrades[22],
+    upgrade23: player.upgrades[23],
+    upgrade24: player.upgrades[24],
+    upgrade25: player.upgrades[25],
+    upgrade33: player.upgrades[33],
+    upgrade34: player.upgrades[34],
+    upgrade35: player.upgrades[35],
+    upgrade49: player.upgrades[49],
+    upgrade50: player.upgrades[50],
+    upgrade68: player.upgrades[68],
+    acceleratorBought: player.acceleratorBought,
+    multiplierBought: player.multiplierBought,
+    fifthOwnedCoin: player.fifthOwnedCoin,
+    c1Completions: player.challengecompletions[1],
+    c7Completions: player.challengecompletions[7],
+    c14Completions: player.challengecompletions[14],
+    transcendPoints: player.transcendPoints,
+    transcendShards: player.transcendShards,
+    research2: player.researches[2],
+    research11: player.researches[11],
+    research12: player.researches[12],
+    research13: player.researches[13],
+    research14: player.researches[14],
+    research15: player.researches[15],
+    research33: player.researches[33],
+    research34: player.researches[34],
+    research35: player.researches[35],
+    research87: player.researches[87],
+    research89: player.researches[89],
+    research94: player.researches[94],
+    research128: player.researches[128],
+    research143: player.researches[143],
+    research158: player.researches[158],
+    research173: player.researches[173],
+    research188: player.researches[188],
+    research200: player.researches[200],
+    cubeUpgrade50: player.cubeUpgrades[50],
+    platonicUpgrade6: player.platonicUpgrades[6],
+    transcensionChallenge: player.currentChallenge.transcension,
+    reincarnationChallenge: player.currentChallenge.reincarnation,
+    viscosityCorruptionLevel: player.corruptions.used.viscosity,
 
-  a += +getAchievementReward('multipliers')
-  a += 20
-    * player.researches[94]
-    * Math.floor(sumOfRuneLevels() / 8)
+    multipliersAchievement: +getAchievementReward('multipliers'),
+    sumOfRuneLevels: sumOfRuneLevels(),
+    multiplicativeMultipliersRune: getRuneEffects('duplication', 'multiplicativeMultipliers'),
+    multiplierBoostsRune: getRuneEffects('duplication', 'multiplierBoosts'),
+    multiplierBoostsRuneBlessing: getRuneBlessingEffect('duplication').multiplierBoosts,
+    antMultiplierMult: getAntUpgradeEffect(AntUpgrades.Multipliers).multiplierMult,
+    multiplierCubeBlessing: calculateMultiplierCubeBlessing(),
+    hepteractMultiplier: hepteractMultiplier.multiplier,
+    hepteractMultiplierMult: hepteractMultiplier.multiplierMultiplier,
 
-  G.freeUpgradeMultiplier = Math.min(1e100, a)
-  a *= Math.pow(
-    1.01,
-    player.upgrades[21]
-      + player.upgrades[22]
-      + player.upgrades[23]
-      + player.upgrades[24]
-      + player.upgrades[25]
-  )
-  a *= 1 + 0.03 * player.upgrades[34] + 0.02 * player.upgrades[35]
-  a *= 1
-    + (1 / 5)
-      * player.researches[2]
-      * (1 + (1 / 2) * CalcECC('ascension', player.challengecompletions[14]))
-  a *= 1
-    + (1 / 20) * player.researches[11]
-    + (1 / 25) * player.researches[12]
-    + (1 / 40) * player.researches[13]
-    + (3 / 200) * player.researches[14]
-    + (1 / 200) * player.researches[15]
-  a *= getRuneEffects('duplication', 'multiplicativeMultipliers')
-  a *= 1 + (1 / 20) * player.researches[87]
-  a *= 1 + (1 / 100) * player.researches[128]
-  a *= 1 + (0.8 / 100) * player.researches[143]
-  a *= 1 + (0.6 / 100) * player.researches[158]
-  a *= 1 + (0.4 / 100) * player.researches[173]
-  a *= 1 + (0.2 / 100) * player.researches[188]
-  a *= 1 + (0.01 / 100) * player.researches[200]
-  a *= 1 + (0.01 / 100) * player.cubeUpgrades[50]
-  a *= getAntUpgradeEffect(AntUpgrades.Multipliers).multiplierMult
-  a *= calculateMultiplierCubeBlessing()
-  if (
-    (player.currentChallenge.transcension !== 0
-      || player.currentChallenge.reincarnation !== 0)
-    && player.upgrades[50] > 0.5
-  ) {
-    a *= 1.25
-  }
-  a = Math.pow(
-    a,
-    Math.min(
-      1,
-      (1 + player.platonicUpgrades[6] / 30)
-        * G.viscosityPower[player.corruptions.used.viscosity]
-    )
-  )
-  a += getHepteractEffects('multiplier').multiplier
-  a *= G.challenge15Rewards.multiplier.value
-  a *= getHepteractEffects('multiplier').multiplierMultiplier
-  a = Math.floor(Math.min(1e100, a))
+    totalAcceleratorBoost: G.totalAcceleratorBoost,
+    taxdivisor: G.taxdivisor,
+    viscosityPower: G.viscosityPower[player.corruptions.used.viscosity],
+    challenge15RewardMultiplier: G.challenge15Rewards.multiplier.value
+  })
 
-  if (player.corruptions.used.viscosity >= 15) {
-    a = Math.pow(a, 0.2)
-  }
-  if (player.corruptions.used.viscosity >= 16) {
-    a = 1
-  }
-
-  G.freeMultiplier = a
-  G.totalMultiplier = G.freeMultiplier + player.multiplierBought
-
-  G.challengeOneLog = 3
-
-  let b = 0
-  b += Decimal.log(player.transcendShards.add(1), 3)
-  b += getRuneEffects('duplication', 'multiplierBoosts')
-  b += 2 * CalcECC('transcend', player.challengecompletions[1])
-  b *= 1 + (11 * player.researches[33]) / 100
-  b *= 1 + (11 * player.researches[34]) / 100
-  b *= 1 + (11 * player.researches[35]) / 100
-  b *= 1 + player.researches[89] / 5
-  b *= getRuneBlessingEffect('duplication').multiplierBoosts
-
-  G.totalMultiplierBoost = Math.pow(
-    Math.floor(b),
-    1 + CalcECC('reincarnation', player.challengecompletions[7]) * 0.04
-  )
-
-  let c7 = 1
-  if (player.challengecompletions[7] > 0.5) {
-    c7 = 1.25
-  }
-
-  G.multiplierPower = 2 + 0.02 * G.totalMultiplierBoost * c7
-
-  // No MA and Sadistic will always override Transcend Challenges starting in v2.0.0
-  if (
-    player.currentChallenge.reincarnation !== 7
-    && player.currentChallenge.reincarnation !== 10
-  ) {
-    if (player.currentChallenge.transcension === 1) {
-      G.multiplierPower = 1
-    }
-    if (player.currentChallenge.transcension === 2) {
-      G.multiplierPower = 1.25 + 0.0012 * b * c7
-    }
-  }
-  G.multiplierPower = Math.min(1e300, G.multiplierPower)
-
-  if (player.currentChallenge.reincarnation === 7) {
-    G.multiplierPower = 1
-  }
-  if (player.currentChallenge.reincarnation === 10) {
-    G.multiplierPower = 1
-  }
-
-  G.multiplierEffect = Decimal.pow(G.multiplierPower, G.totalMultiplier)
+  G.freeUpgradeMultiplier = result.freeUpgradeMultiplier
+  G.freeMultiplier = result.freeMultiplier
+  G.totalMultiplier = result.totalMultiplier
+  G.challengeOneLog = result.challengeOneLog
+  G.totalMultiplierBoost = result.totalMultiplierBoost
+  G.multiplierPower = result.multiplierPower
+  G.multiplierEffect = result.multiplierEffect
 }
 
 export const calculateBuildingPower = (): number =>
@@ -2731,361 +2571,139 @@ export const crystalUpgrade3CrystalMultiplier = (base?: number): Decimal =>
   })
 
 export const multipliers = (): void => {
-  let s = new Decimal(1)
-  let c = new Decimal(1)
-
-  const crystalMult = calculateCrystalCoinMultiplier()
-
   const buildingPower = calculateBuildingPower()
   const buildingPowerMult = calculateBuildingPowerCoinMultiplier(buildingPower)
+  const antMultiplier = getAntUpgradeEffect(AntUpgrades.Coins).coinMultiplier
 
-  G.antMultiplier = getAntUpgradeEffect(AntUpgrades.Coins).coinMultiplier
+  const result = logicComputeGlobalMultipliers({
+    upgrade1: player.upgrades[1],
+    upgrade2: player.upgrades[2],
+    upgrade3: player.upgrades[3],
+    upgrade4: player.upgrades[4],
+    upgrade5: player.upgrades[5],
+    upgrade6: player.upgrades[6],
+    upgrade10: player.upgrades[10],
+    upgrade12: player.upgrades[12],
+    upgrade13: player.upgrades[13],
+    upgrade17: player.upgrades[17],
+    upgrade18: player.upgrades[18],
+    upgrade19: player.upgrades[19],
+    upgrade20: player.upgrades[20],
+    upgrade41: player.upgrades[41],
+    upgrade43: player.upgrades[43],
+    upgrade48: player.upgrades[48],
+    upgrade56: player.upgrades[56],
+    upgrade57: player.upgrades[57],
+    upgrade58: player.upgrades[58],
+    upgrade59: player.upgrades[59],
+    upgrade60: player.upgrades[60],
+    upgrade36: player.upgrades[36],
+    upgrade37: player.upgrades[37],
+    upgrade42: player.upgrades[42],
+    upgrade47: player.upgrades[47],
+    upgrade51: player.upgrades[51],
+    upgrade52: player.upgrades[52],
+    upgrade53: player.upgrades[53],
+    upgrade54: player.upgrades[54],
+    upgrade55: player.upgrades[55],
+    upgrade63: player.upgrades[63],
+    upgrade64: player.upgrades[64],
+    upgrade123: player.upgrades[123],
 
-  s = s.times(G.multiplierEffect)
-  s = s.times(G.acceleratorEffect)
-  s = s.times(crystalMult)
-  s = s.times(buildingPowerMult)
-  s = s.times(G.antMultiplier)
+    research5: player.researches[5],
+    research17: player.researches[17],
+    research26: player.researches[26],
+    research27: player.researches[27],
+    research39: player.researches[39],
+    research40: player.researches[40],
+    research139: player.researches[139],
+    research154: player.researches[154],
+    research184: player.researches[184],
+    research199: player.researches[199],
 
-  const totalCoinOwned = calculateTotalCoinOwned()
-  const first6CoinUp = new Decimal(totalCoinOwned + 1).times(
-    Decimal.min(1e30, Decimal.pow(1.008, totalCoinOwned))
-  )
+    crystalUpgrade0: player.crystalUpgrades[0],
+    crystalUpgrade1: player.crystalUpgrades[1],
+    crystalUpgrade4: player.crystalUpgrades[4],
+    constantUpgrade1: player.constantUpgrades[1],
+    constantUpgrade2: player.constantUpgrades[2],
+    platonicUpgrade5: player.platonicUpgrades[5],
+    platonicUpgrade10: player.platonicUpgrades[10],
+    platonicUpgrade14: player.platonicUpgrades[14],
+    platonicUpgrade15: player.platonicUpgrades[15],
+    platonicUpgrade16: player.platonicUpgrades[16],
+    platonicUpgrade18: player.platonicUpgrades[18],
 
-  if (player.highestSingularityCount > 0) {
-    s = s.times(
-      Math.pow(player.goldenQuarks + 1, 1.5)
-        * Math.pow(player.highestSingularityCount + 1, 2)
-    )
-  }
-  if (player.upgrades[6] > 0.5) {
-    s = s.times(first6CoinUp)
-  }
-  if (player.upgrades[12] > 0.5) {
-    s = s.times(Decimal.min(1e4, Decimal.pow(1.01, player.prestigeCount)))
-  }
-  if (player.upgrades[20] > 0.5) {
-    // PLAT - check
-    s = s.times(Decimal.pow(totalCoinOwned / 4 + 1, 10))
-  }
-  if (player.upgrades[41] > 0.5) {
-    s = s.times(
-      Decimal.min(1e30, Decimal.pow(player.transcendPoints.add(4), 1 / 2))
-    )
-  }
-  if (player.upgrades[43] > 0.5) {
-    s = s.times(Decimal.min(1e30, Decimal.pow(1.01, player.transcendCount)))
-  }
-  if (player.upgrades[48] > 0.5) {
-    s = s.times(
-      Decimal.pow((G.totalMultiplier * G.totalAccelerator) / 1000 + 1, 8)
-    )
-  }
-  if (player.currentChallenge.reincarnation === 6) {
-    s = s.dividedBy(1e250)
-  }
-  if (player.currentChallenge.reincarnation === 7) {
-    s = s.dividedBy('1e1250')
-  }
-  if (player.currentChallenge.reincarnation === 9) {
-    s = s.dividedBy('1e2000000')
-  }
-  c = Decimal.pow(s, 1 + 0.001 * player.researches[17])
-  let lol = Decimal.pow(c, 1 + 0.025 * player.upgrades[123])
-  if (
-    player.currentChallenge.ascension === 15
-    && player.platonicUpgrades[5] > 0
-  ) {
-    lol = Decimal.pow(lol, 1.1)
-  }
-  if (
-    player.currentChallenge.ascension === 15
-    && player.platonicUpgrades[14] > 0
-  ) {
-    lol = Decimal.pow(
-      lol,
-      1
-        + ((1 / 20)
-            * player.corruptions.used.recession
-            * Decimal.log(player.coins.add(1), 10))
-          / (1e7 + Decimal.log(player.coins.add(1), 10))
-    )
-  }
-  if (
-    player.currentChallenge.ascension === 15
-    && player.platonicUpgrades[15] > 0
-  ) {
-    lol = Decimal.pow(lol, 1.1)
-  }
-  lol = Decimal.pow(lol, G.challenge15Rewards.coinExponent.value)
-  G.globalCoinMultiplier = lol
-  G.globalCoinMultiplier = Decimal.pow(
-    G.globalCoinMultiplier,
-    G.recessionPower[player.corruptions.used.recession]
-  )
+    coins: player.coins,
+    prestigePoints: player.prestigePoints,
+    transcendPoints: player.transcendPoints,
+    reincarnationPoints: player.reincarnationPoints,
+    transcendShards: player.transcendShards,
+    prestigeCount: player.prestigeCount,
+    transcendCount: player.transcendCount,
+    highestSingularityCount: player.highestSingularityCount,
+    goldenQuarks: player.goldenQuarks,
+    overfluxPowder: player.overfluxPowder,
 
-  G.coinOneMulti = new Decimal(1)
-  if (player.upgrades[1] > 0.5) {
-    G.coinOneMulti = G.coinOneMulti.times(first6CoinUp)
-  }
-  if (player.upgrades[10] > 0.5) {
-    G.coinOneMulti = G.coinOneMulti.times(
-      Decimal.pow(2, Math.min(50, player.secondOwnedCoin / 15))
-    )
-  }
-  if (player.upgrades[56] > 0.5) {
-    G.coinOneMulti = G.coinOneMulti.times('1e5000')
-  }
+    secondOwnedCoin: player.secondOwnedCoin,
+    firstGeneratedMythos: player.firstGeneratedMythos,
+    firstOwnedMythos: player.firstOwnedMythos,
+    secondOwnedMythos: player.secondOwnedMythos,
+    thirdOwnedMythos: player.thirdOwnedMythos,
+    fourthOwnedMythos: player.fourthOwnedMythos,
+    fifthOwnedMythos: player.fifthOwnedMythos,
 
-  G.coinTwoMulti = new Decimal(1)
-  if (player.upgrades[2] > 0.5) {
-    G.coinTwoMulti = G.coinTwoMulti.times(first6CoinUp)
-  }
-  if (player.upgrades[13] > 0.5) {
-    G.coinTwoMulti = G.coinTwoMulti.times(
-      Decimal.min(
-        1e50,
-        Decimal.pow(
-          player.firstGeneratedMythos.add(player.firstOwnedMythos).add(1),
-          4 / 3
-        ).times(1e22)
-      )
-    )
-  }
-  if (player.upgrades[19] > 0.5) {
-    G.coinTwoMulti = G.coinTwoMulti.times(
-      Decimal.min(1e200, player.transcendPoints.times(1e30).add(1))
-    )
-  }
-  if (player.upgrades[57] > 0.5) {
-    G.coinTwoMulti = G.coinTwoMulti.times('1e7500')
-  }
+    c1Completions: player.challengecompletions[1],
+    c2Completions: player.challengecompletions[2],
+    c3Completions: player.challengecompletions[3],
+    c4Completions: player.challengecompletions[4],
+    c5Completions: player.challengecompletions[5],
+    c14Completions: player.challengecompletions[14],
+    reincarnationChallenge: player.currentChallenge.reincarnation,
+    ascensionChallenge: player.currentChallenge.ascension,
+    recessionCorruptionLevel: player.corruptions.used.recession,
 
-  G.coinThreeMulti = new Decimal(1)
-  if (player.upgrades[3] > 0.5) {
-    G.coinThreeMulti = G.coinThreeMulti.times(first6CoinUp)
-  }
-  if (player.upgrades[18] > 0.5) {
-    G.coinThreeMulti = G.coinThreeMulti.times(
-      Decimal.min(1e125, player.transcendShards.add(1))
-    )
-  }
-  if (player.upgrades[58] > 0.5) {
-    G.coinThreeMulti = G.coinThreeMulti.times('1e15000')
-  }
+    crystalMult: calculateCrystalCoinMultiplier(),
+    buildingPower,
+    buildingPowerMult,
+    totalCoinOwned: calculateTotalCoinOwned(),
+    antMultiplier,
+    crystalUpgrade3Multiplier: crystalUpgrade3CrystalMultiplier(),
+    achievementPoints,
+    crystalMultiplierAchievement: +getAchievementReward('crystalMultiplier'),
+    constUpgrade1BuffAchievement: +getAchievementReward('constUpgrade1Buff'),
+    constUpgrade2BuffAchievement: +getAchievementReward('constUpgrade2Buff'),
+    prismProductionLog10: getRuneEffects('prism', 'productionLog10'),
+    constantEXMaxPercentIncrease: getShopUpgradeEffects('constantEX', 'maxPercentIncrease'),
+    ascendBuildingDRValue: ascendBuildingDR(),
 
-  G.coinFourMulti = new Decimal(1)
-  if (player.upgrades[4] > 0.5) {
-    G.coinFourMulti = G.coinFourMulti.times(first6CoinUp)
-  }
-  if (player.upgrades[17] > 0.5) {
-    G.coinFourMulti = G.coinFourMulti.times(1e100)
-  }
-  if (player.upgrades[59] > 0.5) {
-    G.coinFourMulti = G.coinFourMulti.times('1e25000')
-  }
+    multiplierEffect: G.multiplierEffect,
+    acceleratorEffect: G.acceleratorEffect,
+    totalMultiplier: G.totalMultiplier,
+    totalAccelerator: G.totalAccelerator,
+    totalAcceleratorBoost: G.totalAcceleratorBoost,
+    challenge15CoinExponent: G.challenge15Rewards.coinExponent.value,
+    challenge15ExponentValue: G.challenge15Rewards.exponent.value,
+    challenge15ConstantBonus: G.challenge15Rewards.constantBonus.value,
+    recessionPower: G.recessionPower[player.corruptions.used.recession]
+  })
 
-  G.coinFiveMulti = new Decimal(1)
-  if (player.upgrades[5] > 0.5) {
-    G.coinFiveMulti = G.coinFiveMulti.times(first6CoinUp)
-  }
-  if (player.upgrades[60] > 0.5) {
-    G.coinFiveMulti = G.coinFiveMulti.times('1e35000')
-  }
-
-  const upgrade3Multiplier = crystalUpgrade3CrystalMultiplier()
-
-  G.globalCrystalMultiplier = new Decimal(1)
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    +getAchievementReward('crystalMultiplier')
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(10, getRuneEffects('prism', 'productionLog10'))
-  )
-  if (player.upgrades[36] > 0.5) {
-    G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-      Decimal.min('1e5000', Decimal.pow(player.prestigePoints, 1 / 500))
-    )
-  }
-  if (player.upgrades[63] > 0.5) {
-    G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-      Decimal.min('1e6000', Decimal.pow(player.reincarnationPoints.add(1), 6))
-    )
-  }
-  if (player.researches[39] > 0.5) {
-    G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-      Decimal.pow(buildingPowerMult, 1 / 50)
-    )
-  }
-
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(1 + 0.01 * player.crystalUpgrades[0], achievementPoints)
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(
-      1 + player.crystalUpgrades[1] * Decimal.log(player.coins.add(1), 10) / 100,
-      2 + Math.log2(player.crystalUpgrades[1] + 1)
-    )
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    upgrade3Multiplier
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(
-      1 + 0.05 * player.crystalUpgrades[4],
-      player.challengecompletions[1]
-        + player.challengecompletions[2]
-        + player.challengecompletions[3]
-        + player.challengecompletions[4]
-        + player.challengecompletions[5]
-    )
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(10, CalcECC('transcend', player.challengecompletions[5]))
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(
-      1e4,
-      player.researches[5]
-        * (1 + (1 / 2) * CalcECC('ascension', player.challengecompletions[14]))
-    )
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(2.5, player.researches[26])
-  )
-  G.globalCrystalMultiplier = G.globalCrystalMultiplier.times(
-    Decimal.pow(2.5, player.researches[27])
-  )
-
-  G.globalMythosMultiplier = new Decimal(1)
-
-  if (player.upgrades[37] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier.times(
-      Decimal.pow(Decimal.log(player.prestigePoints.add(10), 10), 2)
-    )
-  }
-  if (player.upgrades[42] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier.times(
-      Decimal.min(
-        1e50,
-        Decimal.pow(player.prestigePoints.add(1), 1 / 50)
-          .dividedBy(2.5)
-          .add(1)
-      )
-    )
-  }
-  if (player.upgrades[47] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier
-      .times(Decimal.pow(1.01, achievementPoints))
-      .times(achievementPoints / 5 + 1)
-  }
-  if (player.upgrades[51] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier.times(
-      Decimal.pow(G.totalAcceleratorBoost, 2)
-    )
-  }
-  if (player.upgrades[52] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier.times(
-      Decimal.pow(G.globalMythosMultiplier, 0.025)
-    )
-  }
-  if (player.upgrades[64] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier.times(
-      Decimal.pow(player.reincarnationPoints.add(1), 2)
-    )
-  }
-  if (player.researches[40] > 0.5) {
-    G.globalMythosMultiplier = G.globalMythosMultiplier.times(
-      Decimal.pow(buildingPowerMult, 1 / 250)
-    )
-  }
-  G.grandmasterMultiplier = new Decimal(1)
-  G.totalMythosOwned = player.firstOwnedMythos
-    + player.secondOwnedMythos
-    + player.thirdOwnedMythos
-    + player.fourthOwnedMythos
-    + player.fifthOwnedMythos
-
-  G.mythosBuildingPower = 1 + CalcECC('transcend', player.challengecompletions[3]) / 200
-  G.challengeThreeMultiplier = Decimal.pow(
-    G.mythosBuildingPower,
-    G.totalMythosOwned
-  )
-
-  G.grandmasterMultiplier = G.grandmasterMultiplier.times(
-    G.challengeThreeMultiplier
-  )
-
-  G.mythosupgrade13 = new Decimal(1)
-  G.mythosupgrade14 = new Decimal(1)
-  G.mythosupgrade15 = new Decimal(1)
-  if (player.upgrades[53] === 1) {
-    G.mythosupgrade13 = G.mythosupgrade13.times(
-      Decimal.min('1e1250', Decimal.pow(G.acceleratorEffect, 1 / 125))
-    )
-  }
-  if (player.upgrades[54] === 1) {
-    G.mythosupgrade14 = G.mythosupgrade14.times(
-      Decimal.min('1e2000', Decimal.pow(G.multiplierEffect, 1 / 180))
-    )
-  }
-  if (player.upgrades[55] === 1) {
-    G.mythosupgrade15 = G.mythosupgrade15.times(
-      Decimal.pow('1e1000', Math.min(1000, buildingPower - 1))
-    )
-  }
-
-  G.globalConstantMult = new Decimal('1')
-  G.globalConstantMult = G.globalConstantMult.times(
-    Decimal.pow(
-      1.05
-        + +getAchievementReward('constUpgrade1Buff')
-        + 0.001 * player.platonicUpgrades[18],
-      player.constantUpgrades[1]
-    )
-  )
-  G.globalConstantMult = G.globalConstantMult.times(
-    Decimal.pow(
-      1
-        + 0.001
-          * Math.min(
-            100
-              + 1000 * +getAchievementReward('constUpgrade2Buff')
-              + 10 * getShopUpgradeEffects('constantEX', 'maxPercentIncrease')
-              + 1000 * (G.challenge15Rewards.exponent.value - 1)
-              + 3 * player.platonicUpgrades[18],
-            player.constantUpgrades[2]
-          ),
-      ascendBuildingDR()
-    )
-  )
-  G.globalConstantMult = G.globalConstantMult.times(
-    1 + (2 / 100) * player.researches[139]
-  )
-  G.globalConstantMult = G.globalConstantMult.times(
-    1 + (3 / 100) * player.researches[154]
-  )
-  G.globalConstantMult = G.globalConstantMult.times(
-    1 + (5 / 100) * player.researches[184]
-  )
-  G.globalConstantMult = G.globalConstantMult.times(
-    1 + (10 / 100) * player.researches[199]
-  )
-  G.globalConstantMult = G.globalConstantMult.times(
-    G.challenge15Rewards.constantBonus.value
-  )
-  if (player.platonicUpgrades[5] > 0) {
-    G.globalConstantMult = G.globalConstantMult.times(2)
-  }
-  if (player.platonicUpgrades[10] > 0) {
-    G.globalConstantMult = G.globalConstantMult.times(10)
-  }
-  if (player.platonicUpgrades[15] > 0) {
-    G.globalConstantMult = G.globalConstantMult.times(1e250)
-  }
-  G.globalConstantMult = G.globalConstantMult.times(
-    Decimal.pow(player.overfluxPowder + 1, 10 * player.platonicUpgrades[16])
-  )
+  G.globalCoinMultiplier = result.globalCoinMultiplier
+  G.coinOneMulti = result.coinOneMulti
+  G.coinTwoMulti = result.coinTwoMulti
+  G.coinThreeMulti = result.coinThreeMulti
+  G.coinFourMulti = result.coinFourMulti
+  G.coinFiveMulti = result.coinFiveMulti
+  G.globalCrystalMultiplier = result.globalCrystalMultiplier
+  G.globalMythosMultiplier = result.globalMythosMultiplier
+  G.grandmasterMultiplier = result.grandmasterMultiplier
+  G.totalMythosOwned = result.totalMythosOwned
+  G.mythosBuildingPower = result.mythosBuildingPower
+  G.challengeThreeMultiplier = result.challengeThreeMultiplier
+  G.mythosupgrade13 = result.mythosupgrade13
+  G.mythosupgrade14 = result.mythosupgrade14
+  G.mythosupgrade15 = result.mythosupgrade15
+  G.globalConstantMult = result.globalConstantMult
+  G.antMultiplier = result.antMultiplier
 }
 
 export const resourceGain = (dt: number): void => {
@@ -3464,68 +3082,25 @@ export const resourceGain = (dt: number): void => {
 }
 
 export const resetCurrency = (): void => {
-  let prestigePow = 0.5 + CalcECC('transcend', player.challengecompletions[5]) / 100
-  let transcendPow = 0.03
-
-  // Calculates the conversion exponent for resets (Challenges 5 and 10 reduce the exponent accordingly).
-  if (player.currentChallenge.transcension === 5) {
-    prestigePow = 0.01
-  }
-  if (player.currentChallenge.reincarnation === 10) {
-    prestigePow = 1e-4
-    transcendPow = 0.001
-  }
-  prestigePow *= G.deflationMultiplier[player.corruptions.used.deflation]
-  // Prestige Point Formulae
-  G.prestigePointGain = Decimal.floor(
-    Decimal.pow(player.coinsThisPrestige.dividedBy(1e12), prestigePow)
-  )
-  if (
-    player.upgrades[16] > 0.5
-    && player.currentChallenge.transcension !== 5
-    && player.currentChallenge.reincarnation !== 10
-  ) {
-    G.prestigePointGain = G.prestigePointGain.times(
-      Decimal.min(
-        Decimal.pow(10, 1e33),
-        Decimal.pow(
-          G.acceleratorEffect,
-          (1 / 3) * G.deflationMultiplier[player.corruptions.used.deflation]
-        )
-      )
-    )
-  }
-
-  // Transcend Point Formulae
-  G.transcendPointGain = Decimal.floor(
-    Decimal.pow(player.coinsThisTranscension.dividedBy(1e100), transcendPow)
-  )
-  if (
-    player.upgrades[44] > 0.5
-    && player.currentChallenge.transcension !== 5
-    && player.currentChallenge.reincarnation !== 10
-  ) {
-    G.transcendPointGain = G.transcendPointGain.times(
-      Decimal.min(1e6, Decimal.pow(1.01, player.transcendCount))
-    )
-  }
-
-  // Reincarnation Point Formulae
-  G.reincarnationPointGain = Decimal.floor(
-    Decimal.pow(player.transcendShards.dividedBy(1e300), 0.01)
-  )
-  if (player.currentChallenge.reincarnation !== 0) {
-    G.reincarnationPointGain = Decimal.pow(G.reincarnationPointGain, 0.01)
-  }
-  G.reincarnationPointGain = G.reincarnationPointGain.times(
-    +getAchievementReward('particleGain')
-  )
-  if (player.upgrades[65] > 0.5) {
-    G.reincarnationPointGain = G.reincarnationPointGain.times(5)
-  }
-  if (player.currentChallenge.ascension === 12) {
-    G.reincarnationPointGain = new Decimal('0')
-  }
+  const result = logicResetCurrency({
+    ecc5: CalcECC('transcend', player.challengecompletions[5]),
+    transcensionChallenge: player.currentChallenge.transcension,
+    reincarnationChallenge: player.currentChallenge.reincarnation,
+    ascensionChallenge: player.currentChallenge.ascension,
+    deflationMultiplier: G.deflationMultiplier[player.corruptions.used.deflation],
+    coinsThisPrestige: player.coinsThisPrestige,
+    coinsThisTranscension: player.coinsThisTranscension,
+    transcendShards: player.transcendShards,
+    upgrade16: player.upgrades[16],
+    upgrade44: player.upgrades[44],
+    upgrade65: player.upgrades[65],
+    transcendCount: player.transcendCount,
+    acceleratorEffect: G.acceleratorEffect,
+    particleGainReward: +getAchievementReward('particleGain')
+  })
+  G.prestigePointGain = result.prestigePointGain
+  G.transcendPointGain = result.transcendPointGain
+  G.reincarnationPointGain = result.reincarnationPointGain
 }
 
 export const resetCheck = async (


### PR DESCRIPTION
## Summary

Three commits migrating the tick body's pure-math leaves and orchestration foundation from `packages/web_ui/src/Synergism.ts` into `@synergism/logic`. Sets up the structural pieces needed for the eventual Rust port of the game loop.

- **Phase 1 + 2** (`e67951a7`): Adds 7 new tick-related `CoreEvent` variants (resources-gained, auto-reset-triggered, achievement-group-awarded, auto-tool-fired, challenge-sweep-transitioned, reveal-needed, challenge-auto-completed). Migrates 4 pure-math leaves: `resetCurrency` (63 lines), `updateAllTick` (142), `updateAllMultiplier` (157), `multipliers` (358). Web_ui versions become thin shims that pre-extract player.* / G.* and call the logic functions.
- **Phase 3a** (`a92cd305`): Migrates `resourceGain` (~370 lines) — the first event-emitting tick function. Coin gain, point gains, 4 producer cascades (Diamonds/Mythos/Particles/AscendBuildings), challenge auto-completion. Side effects (`awardAchievementGroup`, `challengeAchievementCheck` + `updateChallengeLevel`) surface as `CoreEvent`s the web_ui shim dispatches.
- **Phase 3b** (`5b1f39f8`): Migrates 7 of 11 `addTimers` cases — the simple counter timers (prestige/transcension/reincarnation/ascension/singularity/quarks/goldenQuarks). The 4 complex cases (octeracts/autoPotion/ambrosia/redAmbrosia) stay in web_ui pending `seededRandom` migration and consumable-orchestration scaffolding.

## Stats
- `packages/web_ui/src/Synergism.ts` lost ~1030 lines of inline state mutation to thin shims (~900 lines of replacement).
- **New logic files**: 6 mechanic files + 1 tick file + 7 new `CoreEvent` variants.
- **New parity tests**: 5 files, 156 test cases.
- **Test totals**: 32,427 → 32,583 tests (+156). All green.
- Workspace `tsc` clean across logic + web_ui + desktop_ui at every commit.

## Test plan

- [ ] `npm run check:tsc` passes
- [ ] `npm test -w @synergism/logic` shows 32,583+ tests passing
- [ ] In-browser smoke: idle production, manual prestige/transcend/reincarnation reset, auto-prestige trigger, golden-quark timer ticking, ascension timer scaling with oneMind, quark timer hitting cap
- [ ] Diff review focuses on the 6 web_ui shim rewrites — every legacy `player.* = ...` and `G.* = ...` should have a matching writeback from the logic result
- [ ] Confirm the 4 unmigrated `addTimers` cases (octeracts/autoPotion/ambrosia/redAmbrosia) still behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)