### PR TITLE
refactor: migrate per-tick subsystems (Phase 3c-3e + 3.5 + 4 + 5 partial + octeracts + ant gen) into @synergism/logic

### DIFF
--- a/packages/logic/src/events/types.ts
+++ b/packages/logic/src/events/types.ts
@@ -1,4 +1,5 @@
 import type { Decimal } from '../math/bignum'
+import type { SweepStates } from '../tick/challengeSweep'
 
 // Discriminated union of events the logic core emits for the UI tier to
 // react to. UI subscribers translate these into user-facing effects
@@ -106,10 +107,14 @@ export type CoreEvent =
     }
   | {
       kind: 'challenge-sweep-transitioned'
-      /** SweepState kind transitioned out of. */
-      from: string
-      /** SweepState kind transitioned into. */
-      to: string
+      /** Full SweepState transitioned out of — handler routes
+       * resetCheck('transcensionChallenge' | 'reincarnationChallenge')
+       * by `from.index` when from.kind === 'active'. */
+      from: SweepStates
+      /** Full SweepState transitioned into — handler picks
+       * toggleAutoChallengeModeText by `to.kind`, and additionally calls
+       * toggleChallenges(to.index, true) when to.kind === 'active'. */
+      to: SweepStates
     }
   | {
       kind: 'reveal-needed'

--- a/packages/logic/src/events/types.ts
+++ b/packages/logic/src/events/types.ts
@@ -138,3 +138,10 @@ export type CoreEvent =
       /** Total red ambrosia gained this tick. */
       amount: number
     }
+  | {
+      kind: 'octeract-tick-fired'
+      /** Number of integer 1-second giveaway buckets that crossed this tick.
+       * Always ≥ 1 when emitted (the event only fires when at least one
+       * giveaway-second elapsed; otherwise no refresh is needed). */
+      amountOfGiveaways: number
+    }

--- a/packages/logic/src/events/types.ts
+++ b/packages/logic/src/events/types.ts
@@ -128,3 +128,13 @@ export type CoreEvent =
       /** New completion count after increment. */
       newCompletions: number
     }
+  | {
+      kind: 'ambrosia-gained'
+      /** Total ambrosia gained this tick (sum across all loop iterations). */
+      amount: number
+    }
+  | {
+      kind: 'red-ambrosia-gained'
+      /** Total red ambrosia gained this tick. */
+      amount: number
+    }

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -911,17 +911,23 @@ export type {
 } from './mechanics/resourceGain'
 export { resourceGain } from './mechanics/resourceGain'
 export type {
+  AdvanceAmbrosiaTimerInput,
+  AdvanceAmbrosiaTimerResult,
   AdvanceAscensionTimerInput,
   AdvanceAscensionTimerResult,
   AdvanceGoldenQuarksTimerInput,
   AdvanceQuarksTimerInput,
+  AdvanceRedAmbrosiaTimerInput,
+  AdvanceRedAmbrosiaTimerResult,
   AdvanceSingularityTimerInput,
   AdvanceSingularityTimerResult
 } from './tick/timers'
 export {
+  advanceAmbrosiaTimer,
   advanceAscensionTimer,
   advanceGoldenQuarksTimer,
   advanceQuarksTimer,
+  advanceRedAmbrosiaTimer,
   advanceResetCounter,
   advanceSingularityTimer
 } from './tick/timers'
@@ -946,6 +952,12 @@ export type {
   TickChallengeSweepResult
 } from './tick/challengeSweep'
 export { tickChallengeSweep } from './tick/challengeSweep'
+export type {
+  SeededBetweenResult,
+  SeededRandomResult,
+  SeedValues
+} from './math/rng'
+export { Seed, seededBetween, seededRandom } from './math/rng'
 export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -958,6 +958,8 @@ export type {
   SeedValues
 } from './math/rng'
 export { Seed, seededBetween, seededRandom } from './math/rng'
+export type { TackTailInput, TackTailResult } from './tick/tackTail'
+export { tackTail } from './tick/tackTail'
 export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -965,6 +965,12 @@ export { Seed, seededBetween, seededRandom } from './math/rng'
 export type { TackTailInput, TackTailResult } from './tick/tackTail'
 export { tackTail } from './tick/tackTail'
 export type {
+  GenerateAntsAndCrumbsInput,
+  GenerateAntsAndCrumbsProducerInput,
+  GenerateAntsAndCrumbsResult
+} from './tick/antGeneration'
+export { generateAntsAndCrumbs as logicGenerateAntsAndCrumbs } from './tick/antGeneration'
+export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,
   SpeedRuneBlessingEffects,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -916,6 +916,8 @@ export type {
   AdvanceAscensionTimerInput,
   AdvanceAscensionTimerResult,
   AdvanceGoldenQuarksTimerInput,
+  AdvanceOcteractTimerInput,
+  AdvanceOcteractTimerResult,
   AdvanceQuarksTimerInput,
   AdvanceRedAmbrosiaTimerInput,
   AdvanceRedAmbrosiaTimerResult,
@@ -926,10 +928,12 @@ export {
   advanceAmbrosiaTimer,
   advanceAscensionTimer,
   advanceGoldenQuarksTimer,
+  advanceOcteractTimer,
   advanceQuarksTimer,
   advanceRedAmbrosiaTimer,
   advanceResetCounter,
-  advanceSingularityTimer
+  advanceSingularityTimer,
+  OCTERACT_GIVEAWAY_LEVELS
 } from './tick/timers'
 export type {
   AddObtainiumInput,

--- a/packages/logic/src/index.ts
+++ b/packages/logic/src/index.ts
@@ -926,6 +926,27 @@ export {
   advanceSingularityTimer
 } from './tick/timers'
 export type {
+  AddObtainiumInput,
+  AddObtainiumResult,
+  AddOfferingsInput,
+  AddOfferingsResult
+} from './tick/automaticTools'
+export {
+  addObtainium,
+  addOfferings
+} from './tick/automaticTools'
+export type {
+  ApplyAutoResetsInput,
+  ApplyAutoResetsResult
+} from './tick/autoReset'
+export { applyAutoResets } from './tick/autoReset'
+export type {
+  SweepStates,
+  TickChallengeSweepInput,
+  TickChallengeSweepResult
+} from './tick/challengeSweep'
+export { tickChallengeSweep } from './tick/challengeSweep'
+export type {
   DuplicationRuneBlessingEffects,
   PrismRuneBlessingEffects,
   SpeedRuneBlessingEffects,

--- a/packages/logic/src/math/rng.ts
+++ b/packages/logic/src/math/rng.ts
@@ -1,0 +1,57 @@
+// Pure seeded RNG. Lifted from packages/web_ui/src/RNG.ts.
+//
+// Legacy web_ui exposes `seededRandom(index)` that reads + post-increments
+// `player.seed[index]` and uses `MersenneTwister(seed).random()`. Logic
+// can't touch player state, so the migrated function is pure: takes the
+// current seed, returns both the random value AND the next seed value.
+// The web_ui shim does the read/write against player.seed.
+//
+// The Seed enum is the index into player.seed[]. It lives here because
+// the pure RNG functions consume it and because future Rust state code
+// will declare the same indices — keeping it co-located with the RNG
+// helpers makes the contract one-stop.
+
+import { MersenneTwister } from 'fast-mersenne-twister'
+
+export const Seed = {
+  PromoCodes: 0,
+  Ambrosia: 1,
+  RedAmbrosia: 2
+} as const
+
+export type SeedValues = typeof Seed[keyof typeof Seed]
+
+export interface SeededRandomResult {
+  /** Random value in [0, 1) from `MersenneTwister(seed).random()`. */
+  value: number
+  /** `seed + 1`. Caller writes back to its mutable seed store. */
+  newSeed: number
+}
+
+/**
+ * Single Mersenne Twister roll. Constructs a fresh MT seeded with the
+ * input and returns `.random()`. Each call advances the seed by 1.
+ * Pure: caller manages the seed lifecycle.
+ */
+export const seededRandom = (seed: number): SeededRandomResult => ({
+  value: MersenneTwister(seed).random(),
+  newSeed: seed + 1
+})
+
+export interface SeededBetweenResult {
+  /** Inclusive integer in [min, max]. */
+  value: number
+  newSeed: number
+}
+
+/**
+ * Inclusive integer roll in [min, max]. Same seed-advance semantics
+ * as `seededRandom`.
+ */
+export const seededBetween = (seed: number, min: number, max: number): SeededBetweenResult => {
+  const { value, newSeed } = seededRandom(seed)
+  return {
+    value: Math.floor(value * (max - min + 1) + min),
+    newSeed
+  }
+}

--- a/packages/logic/src/tick/antGeneration.ts
+++ b/packages/logic/src/tick/antGeneration.ts
@@ -1,0 +1,122 @@
+// Per-tick ant production. Lifted from
+// packages/web_ui/src/Features/Ants/AntProducers/lib/generate-ant-producers.ts
+// (the `generateAntsAndCrumbs` function, producer loop + crumb math).
+//
+// Web_ui's pre-migration shape:
+//   - Loop from HolySpirit (8) down to Breeders (1): each tier reads its
+//     own producers state + writes to (tier-1).generated, using
+//     calculateBaseAntsToBeGenerated × dt.
+//   - After the loop, Workers (0) computes crumbsToGenerate from its own
+//     (now-updated) generated count and adds to the three crumb fields.
+//   - Finally calls activateELO(dt) — stays in web_ui (depends on
+//     Date.now, getLotusTimeExpiresAt, updateAntLeaderboards DOM,
+//     player.worlds.add quark crediting).
+//
+// The producer loop has a real iteration dependency: iter for antType=N
+// writes to (N-1).generated, and iter for antType=N-1 (next iteration,
+// since the loop decrements) reads (N-1).generated for its own base
+// computation. We preserve this by mutating a local `updatedGenerated`
+// array in place across iterations.
+
+import { Decimal } from '../math/bignum'
+import { antMasteryData, calculateSelfSpeedFromMastery } from '../mechanics/antMasteries'
+import { antProducerData, calculateBaseAntsToBeGenerated } from '../mechanics/antProducers'
+
+/** AntProducers.HolySpirit (top of producer chain). Web_ui's enum mirrors
+ * this — Workers=0, Breeders=1, ..., HolySpirit=8. We use bare numbers
+ * here to avoid coupling logic to the web_ui enum. */
+const LAST_ANT_PRODUCER = 8
+
+export interface GenerateAntsAndCrumbsProducerInput {
+  /** player.ants.producers[i].generated — current generated count (Decimal). */
+  generated: Decimal
+  /** player.ants.producers[i].purchased — manually purchased count (number). */
+  purchased: number
+  /** player.ants.masteries[i].mastery — current mastery level (0..12). */
+  masteryLevel: number
+}
+
+export interface GenerateAntsAndCrumbsInput {
+  /** Tick delta in seconds. */
+  dt: number
+  /** Pre-evaluated `calculateActualAntSpeedMult()` — outer speed multiplier
+   * applied to every producer's base generation. */
+  antSpeedMult: Decimal
+  /** 9-entry array indexed 0..8 (Workers..HolySpirit). */
+  producers: readonly GenerateAntsAndCrumbsProducerInput[]
+  /** player.ants.crumbs — running total for sacrifice consumption. */
+  crumbs: Decimal
+  /** player.ants.crumbsThisSacrifice — resets on ant sacrifice. */
+  crumbsThisSacrifice: Decimal
+  /** player.ants.crumbsEverMade — lifetime accumulator (never resets). */
+  crumbsEverMade: Decimal
+}
+
+export interface GenerateAntsAndCrumbsResult {
+  /** Updated `generated` values for each tier, indexed 0..8. */
+  producersGenerated: readonly Decimal[]
+  crumbs: Decimal
+  crumbsThisSacrifice: Decimal
+  crumbsEverMade: Decimal
+}
+
+/**
+ * Per-tick ant production. The producer loop iterates from
+ * LAST_ANT_PRODUCER (HolySpirit) down to 1 (Breeders), each iteration
+ * crediting the tier below via `baseGeneration × dt`. After the loop,
+ * Workers (tier 0) produces crumbs that fan out into three accumulators.
+ *
+ * Loop iteration N reads `updatedGenerated[N]` (which may have been
+ * updated by a higher-tier iteration earlier) and writes
+ * `updatedGenerated[antProducerData[N].produces]`.
+ */
+export function generateAntsAndCrumbs (input: GenerateAntsAndCrumbsInput): GenerateAntsAndCrumbsResult {
+  // Local mutable copy of the generated values — the loop writes here.
+  const updatedGenerated: Decimal[] = input.producers.map((p) => p.generated)
+
+  // Producer loop: each higher-tier produces the tier directly below.
+  for (let antType = LAST_ANT_PRODUCER; antType > 0; antType--) {
+    const selfSpeedMult = calculateSelfSpeedFromMastery({
+      antData: antMasteryData[antType],
+      masteryLevel: input.producers[antType].masteryLevel,
+      purchased: input.producers[antType].purchased
+    })
+    const baseGeneration = calculateBaseAntsToBeGenerated({
+      generated: updatedGenerated[antType],
+      purchased: input.producers[antType].purchased,
+      baseProduction: antProducerData[antType].baseProduction,
+      selfSpeedMult,
+      antSpeedMult: input.antSpeedMult
+    })
+    const producedAnt = antProducerData[antType].produces
+    if (producedAnt === undefined) {
+      // Shouldn't happen for antType > 0, but guard for type safety.
+      continue
+    }
+    updatedGenerated[producedAnt] = updatedGenerated[producedAnt].add(
+      baseGeneration.times(input.dt)
+    )
+  }
+
+  // Workers (tier 0) produces crumbs separately. Uses the
+  // already-updated Workers.generated from the loop above.
+  const workersSelfSpeed = calculateSelfSpeedFromMastery({
+    antData: antMasteryData[0],
+    masteryLevel: input.producers[0].masteryLevel,
+    purchased: input.producers[0].purchased
+  })
+  const crumbsToGenerate = calculateBaseAntsToBeGenerated({
+    generated: updatedGenerated[0],
+    purchased: input.producers[0].purchased,
+    baseProduction: antProducerData[0].baseProduction,
+    selfSpeedMult: workersSelfSpeed,
+    antSpeedMult: input.antSpeedMult
+  }).times(input.dt)
+
+  return {
+    producersGenerated: updatedGenerated,
+    crumbs: Decimal.add(input.crumbs, crumbsToGenerate),
+    crumbsThisSacrifice: Decimal.add(input.crumbsThisSacrifice, crumbsToGenerate),
+    crumbsEverMade: Decimal.add(input.crumbsEverMade, crumbsToGenerate)
+  }
+}

--- a/packages/logic/src/tick/autoReset.ts
+++ b/packages/logic/src/tick/autoReset.ts
@@ -1,0 +1,239 @@
+// Per-tick auto-reset state machine. Lifted from packages/web_ui/src/Synergism.ts
+// (`tack`, the three auto-reset blocks at lines ~4135-4226 pre-migration).
+//
+// Decides whether prestige / transcend / reincarnation auto-resets should
+// fire this tick, accumulates time-mode counters, and emits
+// `auto-reset-triggered` events for the UI tier to dispatch. The actual
+// `reset(tier, true)` call and `resetAchievementCheck(...)` award stay
+// in web_ui — `reset()` is its own migration with deep player mutation,
+// achievement awards funnel through web_ui's `awardAchievementGroup`.
+//
+// Bug-for-bug parity note: the legacy prestige *time-mode* branch awards
+// the **transcension** achievement check (line 4159 in the original) —
+// almost certainly a copy-paste typo, but it ships in production so the
+// migration preserves it. The logic-tier emits a clean
+// `{ tier: 'prestige', mode: 'time' }` event; the UI dispatcher
+// hard-codes the typo so the side-effect is identical.
+
+import type { CoreEvent } from '../events/types'
+import { Decimal } from '../math/bignum'
+
+export interface ApplyAutoResetsInput {
+  /** Tick delta in seconds (already scaled by globalSpeedMult by the caller — same `dt` fed to resourceGain etc.). */
+  dt: number
+
+  // ─── Prestige tier inputs ────────────────────────────────────────────
+
+  /** player.resetToggleModes.prestige — `amount` checks point-gain
+   * threshold, `time` accumulates `autoResetTimerPrestige` and fires on
+   * threshold. */
+  prestigeMode: 'amount' | 'time'
+  /** player.toggles[15] — prestige autobuyer master switch. */
+  toggle15: boolean
+  /** getLevelMilestone('autoPrestige') — strictly === 1 to unlock the
+   * prestige autobuyer; legacy uses === 1 not >= 1. */
+  autoPrestigeMilestone: number
+  /** player.prestigePoints — currently-held prestige points.
+   * Amount-mode threshold is `prestigePoints * 10^prestigeamount`. */
+  prestigePoints: Decimal
+  /** G.prestigePointGain — per-tick prestige-point gain candidate
+   * (from logic `resetCurrency`). */
+  prestigePointGain: Decimal
+  /** player.prestigeamount — exponent for amount-mode threshold;
+   * also the time-mode threshold (in seconds, with `max(0.01, x)` floor). */
+  prestigeamount: number
+  /** player.coinsThisPrestige — must be ≥ 1e16 for either mode to fire. */
+  coinsThisPrestige: Decimal
+  /** G.autoResetTimers.prestige — wall-clock since last prestige (time mode). */
+  autoResetTimerPrestige: number
+
+  // ─── Transcend tier inputs ───────────────────────────────────────────
+
+  /** player.resetToggleModes.transcend — same shape as prestige. */
+  transcendMode: 'amount' | 'time'
+  /** player.toggles[21] — transcend autobuyer master switch. */
+  toggle21: boolean
+  /** player.upgrades[89] — strictly === 1 to unlock the transcend autobuyer. */
+  upgrade89: number
+  /** player.transcendPoints — current transcend points balance. */
+  transcendPoints: Decimal
+  /** G.transcendPointGain — per-tick transcend-point gain candidate. */
+  transcendPointGain: Decimal
+  /** player.transcendamount — exponent + time threshold (same dual use as prestigeamount). */
+  transcendamount: number
+  /** player.coinsThisTranscension — must be ≥ 1e100 to fire. */
+  coinsThisTranscension: Decimal
+  /** G.autoResetTimers.transcension — time-mode counter. */
+  autoResetTimerTranscension: number
+
+  // ─── Reincarnation tier inputs ───────────────────────────────────────
+
+  /** player.resetToggleModes.reincarnation — same shape. */
+  reincarnationMode: 'amount' | 'time'
+  /** player.toggles[27] — reincarnation autobuyer master switch. */
+  toggle27: boolean
+  /** player.researches[46] — must be > 0.5 (i.e. ≥ 1) to unlock. */
+  research46: number
+  /** player.reincarnationPoints — current reincarnation points; note the
+   * amount-mode threshold adds 1 first (`(rPoints + 1) * 10^amount`),
+   * unlike prestige/transcend which use the raw points. */
+  reincarnationPoints: Decimal
+  /** G.reincarnationPointGain — per-tick reincarnation-point gain candidate. */
+  reincarnationPointGain: Decimal
+  /** player.reincarnationamount — exponent + time threshold. */
+  reincarnationamount: number
+  /** player.transcendShards — must be ≥ 1e300 for either reincarnation mode. */
+  transcendShards: Decimal
+  /** G.autoResetTimers.reincarnation — wall-clock; legacy accumulates this
+   * regardless of mode (any mode, every tick when ascensionChallenge !== 12). */
+  autoResetTimerReincarnation: number
+
+  // ─── Shared challenge gates ──────────────────────────────────────────
+
+  /** player.currentChallenge.ascension — when === 12, the entire
+   * reincarnation block (timer accumulation + both mode checks) is
+   * short-circuited. Doesn't affect prestige/transcend. */
+  ascensionChallenge: number
+  /** player.currentChallenge.transcension — must === 0 for transcend or
+   * reincarnation to fire (either mode). */
+  transcensionChallenge: number
+  /** player.currentChallenge.reincarnation — must === 0 for reincarnation
+   * to fire. */
+  reincarnationChallenge: number
+}
+
+export interface ApplyAutoResetsResult {
+  /** Updated G.autoResetTimers.prestige (only time mode mutates it). */
+  autoResetTimerPrestige: number
+  /** Updated G.autoResetTimers.transcension (only time mode mutates it). */
+  autoResetTimerTranscension: number
+  /** Updated G.autoResetTimers.reincarnation (accumulates regardless of
+   * mode when ascensionChallenge !== 12; untouched otherwise). */
+  autoResetTimerReincarnation: number
+  /** `auto-reset-triggered` events — zero or more per tick. The UI
+   * dispatcher translates each into the corresponding
+   * `resetAchievementCheck(...)` + `reset(tier, true)` pair. */
+  events: CoreEvent[]
+}
+
+/**
+ * Check all three reset tiers for auto-fire conditions. Pure — given the
+ * full input bundle, returns the post-tick timer values and the event
+ * list. Mirrors the legacy three `if`-block sequence exactly: prestige
+ * amount/time → transcend amount/time → reincarnation (gated by
+ * ascensionChallenge !== 12) time/amount.
+ */
+export function applyAutoResets (input: ApplyAutoResetsInput): ApplyAutoResetsResult {
+  const events: CoreEvent[] = []
+  let autoResetTimerPrestige = input.autoResetTimerPrestige
+  let autoResetTimerTranscension = input.autoResetTimerTranscension
+  let autoResetTimerReincarnation = input.autoResetTimerReincarnation
+
+  // ─── Prestige amount mode ──────────────────────────────────────────
+  if (input.prestigeMode === 'amount') {
+    if (
+      input.toggle15
+      && input.autoPrestigeMilestone === 1
+      && input.prestigePointGain.gte(
+        input.prestigePoints.times(Decimal.pow(10, input.prestigeamount))
+      )
+      && input.coinsThisPrestige.gte(1e16)
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'prestige', mode: 'amount' })
+    }
+  }
+
+  // ─── Prestige time mode ────────────────────────────────────────────
+  if (input.prestigeMode === 'time') {
+    autoResetTimerPrestige += input.dt
+    const time = Math.max(0.01, input.prestigeamount)
+    if (
+      input.toggle15
+      && input.autoPrestigeMilestone === 1
+      && autoResetTimerPrestige >= time
+      && input.coinsThisPrestige.gte(1e16)
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'prestige', mode: 'time' })
+    }
+  }
+
+  // ─── Transcend amount mode ─────────────────────────────────────────
+  if (input.transcendMode === 'amount') {
+    if (
+      input.toggle21
+      && input.upgrade89 === 1
+      && input.transcendPointGain.gte(
+        input.transcendPoints.times(Decimal.pow(10, input.transcendamount))
+      )
+      && input.coinsThisTranscension.gte(1e100)
+      && input.transcensionChallenge === 0
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'transcension', mode: 'amount' })
+    }
+  }
+
+  // ─── Transcend time mode ───────────────────────────────────────────
+  if (input.transcendMode === 'time') {
+    autoResetTimerTranscension += input.dt
+    const time = Math.max(0.01, input.transcendamount)
+    if (
+      input.toggle21
+      && input.upgrade89 === 1
+      && autoResetTimerTranscension >= time
+      && input.coinsThisTranscension.gte(1e100)
+      && input.transcensionChallenge === 0
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'transcension', mode: 'time' })
+    }
+  }
+
+  // ─── Reincarnation block (gated by ascensionChallenge !== 12) ──────
+  if (input.ascensionChallenge !== 12) {
+    // Timer accumulates UNCONDITIONALLY here — both modes share the same
+    // counter. (Legacy quirk: it ticks even in amount mode where it's
+    // never read; preserved for bug-for-bug parity.)
+    autoResetTimerReincarnation += input.dt
+
+    // Reincarnation time mode
+    if (input.reincarnationMode === 'time') {
+      const time = Math.max(0.01, input.reincarnationamount)
+      if (
+        input.toggle27
+        && input.research46 > 0.5
+        && input.transcendShards.gte('1e300')
+        && autoResetTimerReincarnation >= time
+        && input.transcensionChallenge === 0
+        && input.reincarnationChallenge === 0
+      ) {
+        events.push({ kind: 'auto-reset-triggered', tier: 'reincarnation', mode: 'time' })
+      }
+    }
+
+    // Reincarnation amount mode — note the `+1` shift before exponentiation
+    // (unique to this tier; prestige and transcend don't add 1 to their
+    // current-point value).
+    if (input.reincarnationMode === 'amount') {
+      if (
+        input.toggle27
+        && input.research46 > 0.5
+        && input.reincarnationPointGain.gte(
+          input.reincarnationPoints
+            .add(1)
+            .times(Decimal.pow(10, input.reincarnationamount))
+        )
+        && input.transcendShards.gte(1e300)
+        && input.transcensionChallenge === 0
+        && input.reincarnationChallenge === 0
+      ) {
+        events.push({ kind: 'auto-reset-triggered', tier: 'reincarnation', mode: 'amount' })
+      }
+    }
+  }
+
+  return {
+    autoResetTimerPrestige,
+    autoResetTimerTranscension,
+    autoResetTimerReincarnation,
+    events
+  }
+}

--- a/packages/logic/src/tick/automaticTools.ts
+++ b/packages/logic/src/tick/automaticTools.ts
@@ -1,0 +1,100 @@
+// Per-tick auto-tool branches. Lifted from packages/web_ui/src/Helper.ts
+// (automaticTools, addObtainium + addOfferings cases).
+//
+// Covers the two simple cases of automaticTools — counter math with at most
+// one UI-tier visual refresh:
+//   addObtainium  — clamps + adds research-automatic obtainium, gated by c14
+//                   abort and taxmanLastStand singularity-challenge cap.
+//   addOfferings  — fractional auto-offering counter; floor of accumulated
+//                   counter is moved into player.offerings each tick.
+//
+// The two complex cases (runeSacrifice, antSacrifice) stay in web_ui — they
+// fan out into multiple un-migrated subsystems (RuneBlessings, RuneSpirits,
+// Talismans, sacrificeOfferings on the rune side; sacrificeAnts on the ant
+// side). They'll migrate once those subsystems land in logic.
+//
+// Caller pre-evaluates the obtainium gain by calling the existing
+// `calculateResearchAutomaticObtainium(time)` shim (itself already a logic
+// call) and passes the result in — that keeps automaticTools.ts decoupled
+// from the giant tax/ant/research input bundle.
+
+import type { CoreEvent } from '../events/types'
+import { Decimal } from '../math/bignum'
+
+export interface AddObtainiumInput {
+  /** player.obtainium — current obtainium balance to credit the gain against. */
+  obtainium: Decimal
+  /** Pre-evaluated `calculateResearchAutomaticObtainium(time)` — the per-tick
+   * obtainium gain before the taxmanLastStand clamp is applied. */
+  obtainiumGain: Decimal
+  /** player.currentChallenge.ascension — when === 14, the entire branch
+   * short-circuits and obtainium is unchanged (no event emitted). */
+  ascensionChallenge: number
+  /** player.singularityChallenges.taxmanLastStand.enabled — combined with the
+   * completions check below, gates a runaway-prevention clamp on the gain. */
+  taxmanLastStandEnabled: boolean
+  /** player.singularityChallenges.taxmanLastStand.completions — when ≥ 2,
+   * clamps obtainiumGain to `min(obtainiumGain, obtainium * 100 + 1)`. */
+  taxmanLastStandCompletions: number
+}
+
+export interface AddObtainiumResult {
+  obtainium: Decimal
+  /** `auto-tool-fired` event when the branch did real work (not c14-aborted),
+   * empty otherwise. The UI handler reacts by refreshing the Research tab
+   * visual when that tab is open. */
+  events: CoreEvent[]
+}
+
+/**
+ * Apply the per-tick automatic obtainium gain with the c14 abort + the
+ * taxmanLastStand singularity-challenge clamp. Mirrors the legacy
+ * `addObtainium` case of `automaticTools` 1:1.
+ */
+export function addObtainium (input: AddObtainiumInput): AddObtainiumResult {
+  if (input.ascensionChallenge === 14) {
+    return { obtainium: input.obtainium, events: [] }
+  }
+
+  let gain = input.obtainiumGain
+  if (input.taxmanLastStandEnabled && input.taxmanLastStandCompletions >= 2) {
+    gain = Decimal.min(gain, input.obtainium.times(100).plus(1))
+  }
+
+  return {
+    obtainium: input.obtainium.add(gain),
+    events: [{ kind: 'auto-tool-fired', tool: 'addObtainium' }]
+  }
+}
+
+export interface AddOfferingsInput {
+  /** Tick delta (seconds). Added to autoOfferingCounter raw. */
+  time: number
+  /** G.autoOfferingCounter — fractional carry between ticks. Reduced mod 1
+   * after each tick so only the integer overflow is moved into offerings. */
+  autoOfferingCounter: number
+  /** player.offerings — receives `floor(autoOfferingCounter + time)`
+   * additional offerings each tick. */
+  offerings: Decimal
+}
+
+export interface AddOfferingsResult {
+  autoOfferingCounter: number
+  offerings: Decimal
+}
+
+/**
+ * Fractional auto-offering counter: any whole-number portion of the
+ * accumulated counter is moved into `offerings`, and the fractional
+ * remainder stays for next tick. Mirrors the legacy `addOfferings` case
+ * of `automaticTools` 1:1. No event is emitted — the legacy branch has
+ * no UI-tier side effect, so the per-tick offering credit is observed
+ * via the resources display's normal refresh cycle.
+ */
+export function addOfferings (input: AddOfferingsInput): AddOfferingsResult {
+  const advanced = input.autoOfferingCounter + input.time
+  return {
+    autoOfferingCounter: advanced % 1,
+    offerings: input.offerings.add(Math.floor(advanced))
+  }
+}

--- a/packages/logic/src/tick/challengeSweep.ts
+++ b/packages/logic/src/tick/challengeSweep.ts
@@ -1,0 +1,251 @@
+// Per-tick challenge-sweep state machine. Lifted from
+// packages/web_ui/src/Challenges.ts (`tickChallengeSweep`,
+// `sweepTransitionFunc`, `SweepStates`, ~lines 395-575 pre-migration).
+//
+// The state machine cycles the player through Transcension + Reincarnation
+// challenges automatically when the autoChallenge feature is enabled. It
+// holds two pieces of mutable state — the current SweepState (one of six
+// variants) and the wall-clock since the last state change — both of which
+// live in module-locals in web_ui pre-migration. The migrated version
+// takes both as input and returns them as output; web_ui keeps the
+// module-locals and threads them through.
+//
+// Side effects (DOM toggleAutoChallengeModeText, async resetCheck on
+// challenge exit, toggleChallenges to enter a new challenge) become
+// `challenge-sweep-transitioned` events that the UI dispatcher
+// translates back into the corresponding calls. The event carries the
+// full SweepStates `from` and `to` so the dispatcher can route
+// resetCheck by oldState.index (when active) and toggleChallenges by
+// newState.index.
+//
+// External lookups that the transition function needs are pre-evaluated
+// by the caller and passed in:
+//   - `nextRegularChallengeFromInitial` / `nextRegularChallengeFromActive`
+//     wrap the (already-migrated) `getNextRegularChallenge` for the two
+//     transitions that consume it.
+//   - `challenge15AutoExponentCheck` is the pre-evaluated guard for the
+//     active → c15_wait branch.
+//   - `isFinishedStillValid` covers the `finished` revalidation check
+//     (both c1 and c6 still at max completions).
+
+import type { CoreEvent } from '../events/types'
+
+// ─── State variants ─────────────────────────────────────────────────────
+
+export type SweepStates =
+  | { kind: 'idle' }
+  | { kind: 'initial_wait' }
+  // `enter_wait` and `active` carry the `explored` set so a single cycle
+  // doesn't repeat challenges. `c10_detour` (legacy comment in
+  // getNextRegularChallenge) uses the explored set to avoid retrying.
+  | { kind: 'enter_wait', toIndex: number, explored: Set<number> }
+  | { kind: 'active', index: number, explored: Set<number> }
+  // `c15_wait` is the 5-second pause when the player can auto-gain
+  // challenge-15 exponent (autoAscend + cubeUpgrade 10 + realAscensionTime
+  // mode), letting the c15 exponent climb between sweeps.
+  | { kind: 'c15_wait' }
+  // `finished` parks the machine once every regular challenge (1-10) is
+  // maxed; re-enters `initial_wait` if a max-completions cap changes.
+  | { kind: 'finished' }
+
+// ─── tickChallengeSweep ─────────────────────────────────────────────────
+
+export interface TickChallengeSweepInput {
+  /** Tick delta in seconds (same `dt` passed to other tick subsystems). */
+  dt: number
+
+  // ─── Current state (mutable bookkeeping fed back in each tick) ──────
+
+  /** Reference to the current SweepState. The transition function compares
+   * with `===` to detect a real transition (some branches return the
+   * same reference to mean "no change"). */
+  state: SweepStates
+  /** Wall-clock seconds since the last state change. Compared against
+   * timerStart/timerExit/timerEnter (and a hardcoded 5 for c15_wait). */
+  timeSinceLastStateChange: number
+
+  // ─── Enable gate (pre-eval'd `shouldRunSweep()`) ────────────────────
+
+  /** Pre-evaluated `player.researches[150] > 0 && player.autoChallengeRunning`.
+   * When this flips false while sweep is running, the machine resets to
+   * idle. When it flips true while idle, the machine boots to
+   * initial_wait. */
+  shouldRunSweep: boolean
+
+  // ─── Timer thresholds (player.autoChallengeTimer) ───────────────────
+
+  /** initial_wait → active threshold. */
+  timerStart: number
+  /** active → next-stage threshold (enter_wait or initial_wait or c15_wait). */
+  timerExit: number
+  /** enter_wait → active threshold. */
+  timerEnter: number
+
+  // ─── Pre-eval'd transition lookups ──────────────────────────────────
+
+  /** Initial index for the first sweep of a cycle: 1 by default, 10 when
+   * highestSingularityCount ≥ 2 AND currentChallenge.ascension !== 0.
+   * The caller pre-computes this and the corresponding
+   * `getNextRegularChallenge(initialIndex, new Set())` result. Only
+   * consulted in the `initial_wait` branch. */
+  initialIndex: number
+  /** `getNextRegularChallenge(initialIndex, new Set())` — -1 means every
+   * regular challenge is already maxed, in which case the machine
+   * transitions to `finished`. Only consulted in `initial_wait`. */
+  nextRegularChallengeFromInitial: number
+
+  /** `getNextRegularChallenge(state.index, state.explored)` for the
+   * `active` branch — -1 means the cycle is exhausted and the next
+   * transition is either `c15_wait` (if challenge15AutoExponentCheck
+   * passes) or `initial_wait`. */
+  nextRegularChallengeFromActive: number
+
+  /** Pre-evaluated `challenge15AutoExponentCheck()` — gates the
+   * `active` exhausted → `c15_wait` branch vs. plain restart. */
+  challenge15AutoExponentCheck: boolean
+
+  /** Pre-evaluated guard for the `finished` revalidation: true when
+   * `highestchallengecompletions[1] === getMaxChallenges(1)` AND the
+   * same for index 6. When false, the machine restarts the sweep. */
+  isFinishedStillValid: boolean
+}
+
+export interface TickChallengeSweepResult {
+  state: SweepStates
+  timeSinceLastStateChange: number
+  /** `challenge-sweep-transitioned` events (0 or 1 per tick) carrying the
+   * full from/to states so the UI dispatcher can fire the right
+   * resetCheck (based on from.index when from.kind === 'active') and
+   * toggleChallenges call (based on to.index when to.kind === 'active'). */
+  events: CoreEvent[]
+}
+
+/**
+ * Pure transition function. Given the current state, the wall-clock
+ * elapsed since the last transition, and the pre-eval'd lookups,
+ * returns either the same state reference (no transition) or a new
+ * state object (transition). Caller compares with `===` to detect
+ * a real change.
+ */
+function sweepTransition (state: SweepStates, elapsed: number, input: TickChallengeSweepInput): SweepStates {
+  switch (state.kind) {
+    case 'idle':
+      // Externally toggled in/out — no time-based transition.
+      return state
+
+    case 'initial_wait':
+      if (elapsed >= input.timerStart) {
+        if (input.nextRegularChallengeFromInitial === -1) {
+          // Every regular challenge maxed → park in `finished`.
+          return { kind: 'finished' }
+        }
+        return {
+          kind: 'active',
+          index: input.nextRegularChallengeFromInitial,
+          explored: new Set([input.nextRegularChallengeFromInitial])
+        }
+      }
+      return state
+
+    case 'active':
+      if (elapsed >= input.timerExit) {
+        if (input.nextRegularChallengeFromActive === -1) {
+          // Cycle exhausted.
+          if (input.challenge15AutoExponentCheck) {
+            return { kind: 'c15_wait' }
+          }
+          return { kind: 'initial_wait' }
+        }
+        return {
+          kind: 'enter_wait',
+          toIndex: input.nextRegularChallengeFromActive,
+          explored: state.explored
+        }
+      }
+      return state
+
+    case 'enter_wait':
+      if (elapsed >= input.timerEnter) {
+        return {
+          kind: 'active',
+          index: state.toIndex,
+          explored: new Set([...state.explored, state.toIndex])
+        }
+      }
+      return state
+
+    case 'c15_wait':
+      if (elapsed >= 5) {
+        return { kind: 'initial_wait' }
+      }
+      return state
+
+    case 'finished':
+      // Revalidate against current caps — restart sweep if a max changed.
+      if (input.isFinishedStillValid) {
+        return state
+      }
+      return { kind: 'initial_wait' }
+
+    default: {
+      throw new Error(`Unhandled SweepState kind: ${(state as { kind: string }).kind}`)
+    }
+  }
+}
+
+/**
+ * Per-tick driver. Handles the four cases from the legacy body:
+ *   1. Idle + shouldRunSweep → boot to initial_wait.
+ *   2. Running + !shouldRunSweep → tear down to idle.
+ *   3. !shouldRunSweep + already idle → no-op.
+ *   4. Running → accumulate timer + sweepTransition + emit event on change.
+ */
+export function tickChallengeSweep (input: TickChallengeSweepInput): TickChallengeSweepResult {
+  const wasEnabled = input.state.kind !== 'idle'
+  const isEnabled = input.shouldRunSweep
+
+  if (!wasEnabled && isEnabled) {
+    const from: SweepStates = { kind: 'idle' }
+    const to: SweepStates = { kind: 'initial_wait' }
+    return {
+      state: to,
+      timeSinceLastStateChange: 0,
+      events: [{ kind: 'challenge-sweep-transitioned', from, to }]
+    }
+  }
+
+  if (wasEnabled && !isEnabled) {
+    const from = input.state
+    const to: SweepStates = { kind: 'idle' }
+    return {
+      state: to,
+      timeSinceLastStateChange: 0,
+      events: [{ kind: 'challenge-sweep-transitioned', from, to }]
+    }
+  }
+
+  if (!isEnabled) {
+    return {
+      state: input.state,
+      timeSinceLastStateChange: input.timeSinceLastStateChange,
+      events: []
+    }
+  }
+
+  const elapsed = input.timeSinceLastStateChange + input.dt
+  const newState = sweepTransition(input.state, elapsed, input)
+
+  if (newState !== input.state) {
+    return {
+      state: newState,
+      timeSinceLastStateChange: 0,
+      events: [{ kind: 'challenge-sweep-transitioned', from: input.state, to: newState }]
+    }
+  }
+
+  return {
+    state: input.state,
+    timeSinceLastStateChange: elapsed,
+    events: []
+  }
+}

--- a/packages/logic/src/tick/tackTail.ts
+++ b/packages/logic/src/tick/tackTail.ts
@@ -1,0 +1,175 @@
+// Bundled "tail" of the per-tick body. Composes the three migrated
+// subsystems that run AFTER the !timeWarp block in the legacy tack
+// (Synergism.ts), in their fixed sequential order:
+//
+//   1. automaticTools('addOfferings', dt/2)  — gated by highestchallengecompletions[3] > 0
+//   2. tickChallengeSweep(dt)
+//   3. applyAutoResets(dt)  — emits auto-reset-triggered events
+//
+// Each sub-call is itself already in logic; this orchestrator just
+// threads the inputs through and collects all CoreEvents into a single
+// array. The web_ui adapter passes player + G + pre-eval'd lookups as
+// one flat input bundle and writes the result back. Events flow through
+// the central dispatcher in packages/web_ui/src/tickEventHandlers.ts.
+//
+// Hole context: `calculateOfferings()` runs in legacy tack AFTER this
+// tail, but it's a vestigial no-op (computes a value and discards it),
+// so the tail boundary stops at applyAutoResets.
+
+import type { CoreEvent } from '../events/types'
+import type { Decimal } from '../math/bignum'
+import { applyAutoResets } from './autoReset'
+import { addOfferings } from './automaticTools'
+import { type SweepStates, tickChallengeSweep } from './challengeSweep'
+
+export interface TackTailInput {
+  /** Tick delta (seconds). addOfferings gets `dt/2`; sweep + resets get `dt`. */
+  dt: number
+
+  // ─── addOfferings inputs ────────────────────────────────────────────
+  /** player.highestchallengecompletions[3] — gate (> 0 to run addOfferings).
+   * When the gate fails, autoOfferingCounter/offerings pass through unchanged. */
+  highestchallengecompletions3: number
+  /** G.autoOfferingCounter. */
+  autoOfferingCounter: number
+  /** player.offerings. */
+  offerings: Decimal
+
+  // ─── tickChallengeSweep inputs (mirrors TickChallengeSweepInput minus dt) ─
+  sweepState: SweepStates
+  timeSinceLastStateChange: number
+  shouldRunSweep: boolean
+  timerStart: number
+  timerExit: number
+  timerEnter: number
+  initialIndex: number
+  nextRegularChallengeFromInitial: number
+  nextRegularChallengeFromActive: number
+  challenge15AutoExponentCheck: boolean
+  isFinishedStillValid: boolean
+
+  // ─── applyAutoResets inputs (mirrors ApplyAutoResetsInput minus dt) ─
+  prestigeMode: 'amount' | 'time'
+  toggle15: boolean
+  autoPrestigeMilestone: number
+  prestigePoints: Decimal
+  prestigePointGain: Decimal
+  prestigeamount: number
+  coinsThisPrestige: Decimal
+  autoResetTimerPrestige: number
+  transcendMode: 'amount' | 'time'
+  toggle21: boolean
+  upgrade89: number
+  transcendPoints: Decimal
+  transcendPointGain: Decimal
+  transcendamount: number
+  coinsThisTranscension: Decimal
+  autoResetTimerTranscension: number
+  reincarnationMode: 'amount' | 'time'
+  toggle27: boolean
+  research46: number
+  reincarnationPoints: Decimal
+  reincarnationPointGain: Decimal
+  reincarnationamount: number
+  transcendShards: Decimal
+  autoResetTimerReincarnation: number
+  ascensionChallenge: number
+  transcensionChallenge: number
+  reincarnationChallenge: number
+}
+
+export interface TackTailResult {
+  autoOfferingCounter: number
+  offerings: Decimal
+  sweepState: SweepStates
+  timeSinceLastStateChange: number
+  autoResetTimerPrestige: number
+  autoResetTimerTranscension: number
+  autoResetTimerReincarnation: number
+  /** Composed event list — sweep transitions then auto-reset triggers,
+   * in legacy order. (addOfferings emits nothing — no UI side effect.) */
+  events: CoreEvent[]
+}
+
+/**
+ * Pure composition of the per-tick tail. Mirrors lines ~4128-4192 of the
+ * legacy tack body 1:1, just bundled so the web_ui adapter makes one
+ * call instead of three (plus inline dispatchers).
+ */
+export function tackTail (input: TackTailInput): TackTailResult {
+  const events: CoreEvent[] = []
+
+  // ─── addOfferings (dt/2, gated) ─────────────────────────────────────
+  let autoOfferingCounter = input.autoOfferingCounter
+  let offerings = input.offerings
+  if (input.highestchallengecompletions3 > 0) {
+    const r = addOfferings({
+      time: input.dt / 2,
+      autoOfferingCounter,
+      offerings
+    })
+    autoOfferingCounter = r.autoOfferingCounter
+    offerings = r.offerings
+  }
+
+  // ─── tickChallengeSweep ─────────────────────────────────────────────
+  const sweep = tickChallengeSweep({
+    dt: input.dt,
+    state: input.sweepState,
+    timeSinceLastStateChange: input.timeSinceLastStateChange,
+    shouldRunSweep: input.shouldRunSweep,
+    timerStart: input.timerStart,
+    timerExit: input.timerExit,
+    timerEnter: input.timerEnter,
+    initialIndex: input.initialIndex,
+    nextRegularChallengeFromInitial: input.nextRegularChallengeFromInitial,
+    nextRegularChallengeFromActive: input.nextRegularChallengeFromActive,
+    challenge15AutoExponentCheck: input.challenge15AutoExponentCheck,
+    isFinishedStillValid: input.isFinishedStillValid
+  })
+  for (const e of sweep.events) events.push(e)
+
+  // ─── applyAutoResets ────────────────────────────────────────────────
+  const resets = applyAutoResets({
+    dt: input.dt,
+    prestigeMode: input.prestigeMode,
+    toggle15: input.toggle15,
+    autoPrestigeMilestone: input.autoPrestigeMilestone,
+    prestigePoints: input.prestigePoints,
+    prestigePointGain: input.prestigePointGain,
+    prestigeamount: input.prestigeamount,
+    coinsThisPrestige: input.coinsThisPrestige,
+    autoResetTimerPrestige: input.autoResetTimerPrestige,
+    transcendMode: input.transcendMode,
+    toggle21: input.toggle21,
+    upgrade89: input.upgrade89,
+    transcendPoints: input.transcendPoints,
+    transcendPointGain: input.transcendPointGain,
+    transcendamount: input.transcendamount,
+    coinsThisTranscension: input.coinsThisTranscension,
+    autoResetTimerTranscension: input.autoResetTimerTranscension,
+    reincarnationMode: input.reincarnationMode,
+    toggle27: input.toggle27,
+    research46: input.research46,
+    reincarnationPoints: input.reincarnationPoints,
+    reincarnationPointGain: input.reincarnationPointGain,
+    reincarnationamount: input.reincarnationamount,
+    transcendShards: input.transcendShards,
+    autoResetTimerReincarnation: input.autoResetTimerReincarnation,
+    ascensionChallenge: input.ascensionChallenge,
+    transcensionChallenge: input.transcensionChallenge,
+    reincarnationChallenge: input.reincarnationChallenge
+  })
+  for (const e of resets.events) events.push(e)
+
+  return {
+    autoOfferingCounter,
+    offerings,
+    sweepState: sweep.state,
+    timeSinceLastStateChange: sweep.timeSinceLastStateChange,
+    autoResetTimerPrestige: resets.autoResetTimerPrestige,
+    autoResetTimerTranscension: resets.autoResetTimerTranscension,
+    autoResetTimerReincarnation: resets.autoResetTimerReincarnation,
+    events
+  }
+}

--- a/packages/logic/src/tick/timers.ts
+++ b/packages/logic/src/tick/timers.ts
@@ -1,7 +1,7 @@
 // Per-tick reset/quark/singularity counter advancement. Lifted from
 // packages/web_ui/src/Helper.ts (addTimers, simple counter cases).
 //
-// Covers 9 of the 11 addTimers cases:
+// Covers 10 of the 11 addTimers cases:
 //   prestige, transcension, reincarnation (shared shape: counter += time × mult)
 //   ascension (dual counter + ascensionSpeedMulti)
 //   singularity (triple counter + singularitySpeedMulti + challenge timer)
@@ -9,12 +9,9 @@
 //   goldenQuarks (capped at 168 hours, gated by exportGQPerHour > 0)
 //   ambrosia (chunked + seeded-random luck roll + recursive bar grant)
 //   redAmbrosia (chunked + seeded-random luck roll + bonus blueberry time)
+//   octeracts (chunked + per-giveaway-second GQ loop with qts decay)
 //
-// The remaining two cases stay in web_ui:
-//   octeracts — calculateGoldenQuarks called inside the giveaway loop
-//     reads `player.quarksThisSingularity` that the loop mutates each
-//     iteration; migrating cleanly requires inlining the goldenQuarks
-//     stat dependency or restructuring the loop semantics.
+// The remaining case stays in web_ui:
 //   autoPotion — fires `useConsumable(...)` which mutates player and
 //     enqueues DOM/modal side effects; needs the consumable subsystem
 //     migrated first.
@@ -150,6 +147,7 @@ export function advanceGoldenQuarksTimer (input: AdvanceGoldenQuarksTimerInput):
 
 import type { CoreEvent } from '../events/types'
 import { calculateRequiredBlueberryTime, calculateRequiredRedAmbrosiaTime } from '../mechanics/ambrosia'
+import { calculateBaseGoldenQuarks } from '../mechanics/singularityMilestones'
 import { seededRandom } from '../math/rng'
 
 export interface AdvanceAmbrosiaTimerInput {
@@ -437,5 +435,164 @@ export function advanceRedAmbrosiaTimer (input: AdvanceRedAmbrosiaTimerInput): A
     seed,
     bonusAmbrosiaTime,
     events: [{ kind: 'red-ambrosia-gained', amount: totalGained }]
+  }
+}
+
+// ─── Octeracts ────────────────────────────────────────────────────────────
+
+/** Singularity-count thresholds for the GQ-giveaway scaling bonus. Each
+ * crossed threshold adds 1 to `actualLevel`, which scales the quark
+ * fraction siphoned per giveaway-second. Lifted verbatim from
+ * `packages/web_ui/src/Helper.ts` (the `octeractGiveawayLevels` module
+ * constant). */
+export const OCTERACT_GIVEAWAY_LEVELS: readonly number[] = [
+  160,
+  173,
+  185,
+  194,
+  204,
+  210,
+  219,
+  229,
+  240,
+  249
+]
+
+export interface AdvanceOcteractTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** Pre-evaluated per-tick globalTimeMultiplier. */
+  timeMultiplier: number
+
+  // ─── Gate ──────────────────────────────────────────────────────────
+  /** Pre-evaluated `getGQUpgradeEffect('octeractUnlock', 'unlocked')`. */
+  octeractUnlocked: boolean
+
+  // ─── State accumulators ───────────────────────────────────────────
+  /** player.octeractTimer — fractional accumulator (whole seconds get
+   * spent on giveaways, fractional remainder carries to next tick). */
+  octeractTimer: number
+  /** player.wowOcteracts — receives `amountOfGiveaways * perSecond`. */
+  wowOcteracts: number
+  /** player.totalWowOcteracts — same delta as wowOcteracts. */
+  totalWowOcteracts: number
+  /** player.goldenQuarks — credited per loop iteration when the GQ-bonus
+   * gate (highestSingularityCount ≥ 160) passes. */
+  goldenQuarks: number
+  /** player.quarksThisSingularity — geometrically decayed per iteration
+   * inside the GQ loop. Feeds back into `calculateBaseGoldenQuarks` each
+   * iteration. */
+  quarksThisSingularity: number
+
+  // ─── Award per giveaway-second ────────────────────────────────────
+  /** Pre-evaluated `calculateOcteractMultiplier()` — per-second octeract
+   * reward. */
+  perSecond: number
+
+  // ─── GQ-giveaway scaling inputs ───────────────────────────────────
+  /** player.highestSingularityCount — gates the GQ giveaway block (≥ 160)
+   * and feeds into `calculateBaseGoldenQuarks`. Also drives `actualLevel`
+   * via OCTERACT_GIVEAWAY_LEVELS. */
+  highestSingularityCount: number
+  /** player.singularityCount — current singularity (not historical max).
+   * Drives `calculateBaseGoldenQuarks`'s 100 × 1.04^singularity term. */
+  singularityCount: number
+  /** Pre-evaluated product of all `allGoldenQuarkMultiplierStats` EXCEPT
+   * the qts-dependent base (stat 0). Caller computes by mapping the
+   * stats array, dropping index 0, and reducing with multiplication.
+   * Stable across the inner loop since none of the remaining stats
+   * read qts. */
+  goldenQuarksMultiplierExcludingBase: number
+}
+
+export interface AdvanceOcteractTimerResult {
+  octeractTimer: number
+  wowOcteracts: number
+  totalWowOcteracts: number
+  goldenQuarks: number
+  quarksThisSingularity: number
+  /** `octeract-tick-fired` event when at least one giveaway-second
+   * elapsed (i.e. the timer crossed 1.0). UI handler refreshes the
+   * octeract display. Empty otherwise. */
+  events: CoreEvent[]
+}
+
+/**
+ * Octeracts case of addTimers. Accumulates a 1-second-chunked timer;
+ * each elapsed whole second credits `perSecond` octeracts. Above
+ * singularity 160, also siphons a geometric fraction of
+ * `quarksThisSingularity` into `goldenQuarks` per giveaway-second,
+ * with `calculateBaseGoldenQuarks` recomputed each iteration (qts
+ * mutates inside the loop).
+ *
+ * Gate behavior matches legacy `addTimers('octeracts', ...)`:
+ *   - `!octeractUnlocked` → return state unchanged, no event.
+ *   - timer + dt*mult < 1 → accumulate timer, no other state change.
+ *   - timer >= 1 → spend the whole-second portion, emit event.
+ */
+export function advanceOcteractTimer (input: AdvanceOcteractTimerInput): AdvanceOcteractTimerResult {
+  if (!input.octeractUnlocked) {
+    return {
+      octeractTimer: input.octeractTimer,
+      wowOcteracts: input.wowOcteracts,
+      totalWowOcteracts: input.totalWowOcteracts,
+      goldenQuarks: input.goldenQuarks,
+      quarksThisSingularity: input.quarksThisSingularity,
+      events: []
+    }
+  }
+
+  let octeractTimer = input.octeractTimer + input.time * input.timeMultiplier
+  if (octeractTimer < 1) {
+    return {
+      octeractTimer,
+      wowOcteracts: input.wowOcteracts,
+      totalWowOcteracts: input.totalWowOcteracts,
+      goldenQuarks: input.goldenQuarks,
+      quarksThisSingularity: input.quarksThisSingularity,
+      events: []
+    }
+  }
+
+  const amountOfGiveaways = octeractTimer - (octeractTimer % 1)
+  octeractTimer %= 1
+
+  const wowOcteracts = input.wowOcteracts + amountOfGiveaways * input.perSecond
+  const totalWowOcteracts = input.totalWowOcteracts + amountOfGiveaways * input.perSecond
+
+  let goldenQuarks = input.goldenQuarks
+  let qts = input.quarksThisSingularity
+
+  if (input.highestSingularityCount >= 160) {
+    const frac = 1e-6
+    let actualLevel = 0
+    for (const level of OCTERACT_GIVEAWAY_LEVELS) {
+      if (input.highestSingularityCount >= level) {
+        actualLevel += 1
+      }
+    }
+
+    const quarkFraction = frac * actualLevel
+    for (let i = 0; i < amountOfGiveaways; i++) {
+      // calculateGoldenQuarks(stats) === product(stats); we precomputed
+      // the product of stats 1..12 in goldenQuarksMultiplierExcludingBase
+      // and recompute the qts-dependent base here.
+      const base = calculateBaseGoldenQuarks({
+        singularity: input.singularityCount,
+        quarksThisSingularity: qts,
+        highestSingularityCount: input.highestSingularityCount
+      })
+      goldenQuarks += quarkFraction * base * input.goldenQuarksMultiplierExcludingBase
+      qts *= 1 - quarkFraction
+    }
+  }
+
+  return {
+    octeractTimer,
+    wowOcteracts,
+    totalWowOcteracts,
+    goldenQuarks,
+    quarksThisSingularity: qts,
+    events: [{ kind: 'octeract-tick-fired', amountOfGiveaways }]
   }
 }

--- a/packages/logic/src/tick/timers.ts
+++ b/packages/logic/src/tick/timers.ts
@@ -1,17 +1,23 @@
 // Per-tick reset/quark/singularity counter advancement. Lifted from
 // packages/web_ui/src/Helper.ts (addTimers, simple counter cases).
 //
-// Covers the 7 cases of addTimers that are pure counter math with no
-// side effects, no RNG, and no consumable orchestration:
+// Covers 9 of the 11 addTimers cases:
 //   prestige, transcension, reincarnation (shared shape: counter += time × mult)
 //   ascension (dual counter + ascensionSpeedMulti)
 //   singularity (triple counter + singularitySpeedMulti + challenge timer)
 //   quarks (capped at maxQuarkTimer)
 //   goldenQuarks (capped at 168 hours, gated by exportGQPerHour > 0)
+//   ambrosia (chunked + seeded-random luck roll + recursive bar grant)
+//   redAmbrosia (chunked + seeded-random luck roll + bonus blueberry time)
 //
-// The four complex cases (octeracts, autoPotion, ambrosia, redAmbrosia)
-// stay in web_ui for now — each involves modal/consumable side effects or
-// the seededRandom RNG, which need their own migration scaffolding.
+// The remaining two cases stay in web_ui:
+//   octeracts — calculateGoldenQuarks called inside the giveaway loop
+//     reads `player.quarksThisSingularity` that the loop mutates each
+//     iteration; migrating cleanly requires inlining the goldenQuarks
+//     stat dependency or restructuring the loop semantics.
+//   autoPotion — fires `useConsumable(...)` which mutates player and
+//     enqueues DOM/modal side effects; needs the consumable subsystem
+//     migrated first.
 //
 // Caller pre-evaluates the per-tick globalTimeMultiplier
 // (`getGQUpgradeEffect('halfMind', 'unlocked') ? 10 : calculateGlobalSpeedMult()`)
@@ -138,4 +144,298 @@ export function advanceGoldenQuarksTimer (input: AdvanceGoldenQuarksTimerInput):
   }
   const advanced = input.goldenQuarksTimer + input.time
   return advanced > GOLDEN_QUARKS_TIMER_CAP_SECONDS ? GOLDEN_QUARKS_TIMER_CAP_SECONDS : advanced
+}
+
+// ─── Ambrosia ──────────────────────────────────────────────────────────────
+
+import type { CoreEvent } from '../events/types'
+import { calculateRequiredBlueberryTime, calculateRequiredRedAmbrosiaTime } from '../mechanics/ambrosia'
+import { seededRandom } from '../math/rng'
+
+export interface AdvanceAmbrosiaTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** Pre-evaluated per-tick globalTimeMultiplier (halfMind or globalSpeedMult). */
+  timeMultiplier: number
+
+  // ─── Gates ─────────────────────────────────────────────────────────
+  /** player.singularityChallenges.noSingularityUpgrades.completions — the whole
+   * branch is gated on `> 0`. */
+  noSingularityUpgradesCompletions: number
+  /** Pre-evaluated `calculateAmbrosiaGenerationSpeed()` — when 0, the branch
+   * short-circuits before touching ambrosiaTimerG. (Legacy calls this twice
+   * with `compute === 0` check then re-reads as `baseBlueberryTime`; the
+   * function is pure for the tick so passing one value is fine.) */
+  ambrosiaGenerationSpeed: number
+
+  // ─── State accumulators ───────────────────────────────────────────
+  /** G.ambrosiaTimer — fractional accumulator; processes at 1/8s
+   * granularity (anything below 0.125 short-circuits). */
+  ambrosiaTimerG: number
+  /** player.blueberryTime — accumulates `floor(8 * ambrosiaTimerG)/8 *
+   * baseBlueberryTime` per tick; loop consumes it via timeToAmbrosia. */
+  blueberryTime: number
+  /** player.ambrosia — credited by each loop iteration. */
+  ambrosia: number
+  /** player.lifetimeAmbrosia — same delta as ambrosia; feeds back into
+   * `calculateRequiredBlueberryTime` for the next iteration's threshold. */
+  lifetimeAmbrosia: number
+  /** player.seed[Seed.Ambrosia] — RNG state advanced once per loop iteration. */
+  seed: number
+
+  // ─── Pre-evaluated per-tick lookups (stable across iterations) ────
+  /** Pre-evaluated `calculateAmbrosiaLuck()` — drives ambrosiaMult + luckMult. */
+  ambrosiaLuck: number
+  /** Pre-evaluated `getSingularityChallengeEffect('noAmbrosiaUpgrades', 'bonusAmbrosia')`. */
+  bonusAmbrosia: number
+
+  // ─── Inputs for inner calculateRequiredBlueberryTime calls ─────────
+  /** G.TIME_PER_AMBROSIA — constant base. */
+  timePerAmbrosia: number
+  /** getShopUpgradeEffects('shopAmbrosiaAccelerator', 'ambrosiaPointRequirementMult'). */
+  acceleratorMult: number
+  /** getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'barRequirementMult'). */
+  brickOfLeadMult: number
+}
+
+export interface AdvanceAmbrosiaTimerResult {
+  ambrosiaTimerG: number
+  blueberryTime: number
+  ambrosia: number
+  lifetimeAmbrosia: number
+  seed: number
+  /** `ambrosia-gained` event with the total delta when any iteration ran;
+   * empty otherwise. UI handler refreshes the ambrosia display. */
+  events: CoreEvent[]
+}
+
+/**
+ * Ambrosia case of addTimers. Accumulates G.ambrosiaTimer in 1/8s ticks,
+ * adds blueberryTime, then loops crediting ambrosia bars when
+ * blueberryTime meets the (mutating) `calculateRequiredBlueberryTime`
+ * threshold. Each iteration rolls one seededRandom value for luck.
+ *
+ * Pre-tick gates that short-circuit (returning unchanged state, no event):
+ *   - noSingularityUpgradesCompletions === 0 — feature locked.
+ *   - ambrosiaGenerationSpeed === 0 — disabled (most paths).
+ *   - ambrosiaTimerG + dt*mult < 0.125 — sub-tick threshold not met.
+ */
+export function advanceAmbrosiaTimer (input: AdvanceAmbrosiaTimerInput): AdvanceAmbrosiaTimerResult {
+  if (input.noSingularityUpgradesCompletions <= 0) {
+    return {
+      ambrosiaTimerG: input.ambrosiaTimerG,
+      blueberryTime: input.blueberryTime,
+      ambrosia: input.ambrosia,
+      lifetimeAmbrosia: input.lifetimeAmbrosia,
+      seed: input.seed,
+      events: []
+    }
+  }
+  if (input.ambrosiaGenerationSpeed === 0) {
+    return {
+      ambrosiaTimerG: input.ambrosiaTimerG,
+      blueberryTime: input.blueberryTime,
+      ambrosia: input.ambrosia,
+      lifetimeAmbrosia: input.lifetimeAmbrosia,
+      seed: input.seed,
+      events: []
+    }
+  }
+
+  let ambrosiaTimerG = input.ambrosiaTimerG + input.time * input.timeMultiplier
+  if (ambrosiaTimerG < 0.125) {
+    return {
+      ambrosiaTimerG,
+      blueberryTime: input.blueberryTime,
+      ambrosia: input.ambrosia,
+      lifetimeAmbrosia: input.lifetimeAmbrosia,
+      seed: input.seed,
+      events: []
+    }
+  }
+
+  let blueberryTime = input.blueberryTime + Math.floor(8 * ambrosiaTimerG) / 8 * input.ambrosiaGenerationSpeed
+  ambrosiaTimerG %= 0.125
+
+  let ambrosia = input.ambrosia
+  let lifetimeAmbrosia = input.lifetimeAmbrosia
+  let seed = input.seed
+  let totalGained = 0
+
+  let timeToAmbrosia = calculateRequiredBlueberryTime({
+    timePerAmbrosia: input.timePerAmbrosia,
+    lifetimeAmbrosia,
+    acceleratorMult: input.acceleratorMult,
+    brickOfLeadMult: input.brickOfLeadMult
+  })
+
+  while (blueberryTime >= timeToAmbrosia) {
+    const rng = seededRandom(seed)
+    seed = rng.newSeed
+    const ambrosiaMult = Math.floor(input.ambrosiaLuck / 100)
+    const luckMult = rng.value < input.ambrosiaLuck / 100 - Math.floor(input.ambrosiaLuck / 100) ? 1 : 0
+    const ambrosiaToGain = (ambrosiaMult + luckMult) + input.bonusAmbrosia
+
+    ambrosia += ambrosiaToGain
+    lifetimeAmbrosia += ambrosiaToGain
+    totalGained += ambrosiaToGain
+    blueberryTime -= timeToAmbrosia
+
+    timeToAmbrosia = calculateRequiredBlueberryTime({
+      timePerAmbrosia: input.timePerAmbrosia,
+      lifetimeAmbrosia,
+      acceleratorMult: input.acceleratorMult,
+      brickOfLeadMult: input.brickOfLeadMult
+    })
+  }
+
+  return {
+    ambrosiaTimerG,
+    blueberryTime,
+    ambrosia,
+    lifetimeAmbrosia,
+    seed,
+    events: [{ kind: 'ambrosia-gained', amount: totalGained }]
+  }
+}
+
+// ─── Red Ambrosia ─────────────────────────────────────────────────────────
+
+export interface AdvanceRedAmbrosiaTimerInput {
+  /** Tick delta (seconds). */
+  time: number
+  /** Pre-evaluated per-tick globalTimeMultiplier. */
+  timeMultiplier: number
+
+  // ─── Gates ─────────────────────────────────────────────────────────
+  /** player.singularityChallenges.noAmbrosiaUpgrades.completions — branch
+   * gated on `> 0`. */
+  noAmbrosiaUpgradesCompletions: number
+  /** Pre-evaluated `calculateRedAmbrosiaGenerationSpeed()`. */
+  redAmbrosiaGenerationSpeed: number
+
+  // ─── State accumulators ───────────────────────────────────────────
+  /** G.redAmbrosiaTimer — fractional accumulator; same 1/8s chunking as
+   * ambrosia. */
+  redAmbrosiaTimerG: number
+  /** player.redAmbrosiaTime — receives `floor(8 * timerG)/8 * speed`. */
+  redAmbrosiaTime: number
+  /** player.redAmbrosia — credited per loop iteration. */
+  redAmbrosia: number
+  /** player.lifetimeRedAmbrosia — same delta as redAmbrosia; feeds back
+   * into `calculateRequiredRedAmbrosiaTime` for the next iteration. */
+  lifetimeRedAmbrosia: number
+  /** player.seed[Seed.RedAmbrosia] — advanced once per iteration. */
+  seed: number
+
+  // ─── Pre-evaluated per-tick lookups (stable across iterations) ────
+  /** Pre-evaluated `calculateRedAmbrosiaLuck()` — drives the luck rolls.
+   * Legacy calls this inside the loop, but it depends only on tick-stable
+   * player state, so a single pre-eval is bug-for-bug equivalent. */
+  redAmbrosiaLuck: number
+  /** Pre-evaluated `getRedAmbrosiaUpgradeEffects('redAmbrosiaAccelerator',
+   * 'ambrosiaTimePerRedAmbrosia')` — bonus blueberry time per red ambrosia. */
+  ambrosiaTimePerRedAmbrosia: number
+
+  // ─── Inputs for inner calculateRequiredRedAmbrosiaTime calls ───────
+  /** G.TIME_PER_RED_AMBROSIA — constant base. */
+  timePerRedAmbrosia: number
+  /** Pre-evaluated `getSingularityChallengeEffect('limitedTime',
+   * 'barRequirementMultiplier')`. */
+  barRequirementMultiplier: number
+}
+
+export interface AdvanceRedAmbrosiaTimerResult {
+  redAmbrosiaTimerG: number
+  redAmbrosiaTime: number
+  redAmbrosia: number
+  lifetimeRedAmbrosia: number
+  seed: number
+  /** Bonus blueberry time accumulated this tick — caller must feed into
+   * the ambrosia branch (`addTimers('ambrosia', bonusAmbrosiaTime)` in the
+   * legacy shim). 0 when no iteration ran or the upgrade is inactive. */
+  bonusAmbrosiaTime: number
+  /** `red-ambrosia-gained` event when any iteration ran; empty otherwise. */
+  events: CoreEvent[]
+}
+
+/**
+ * Red Ambrosia case of addTimers. Same shape as the ambrosia case:
+ * 1/8s chunked timer accumulation → blueberry-time-equivalent credit →
+ * inner loop that mints red ambrosia when redAmbrosiaTime meets the
+ * (mutating) `calculateRequiredRedAmbrosiaTime` threshold. Additionally
+ * accumulates `bonusAmbrosiaTime` (`redAmbrosiaToGain * timeCoeff`) that
+ * the caller feeds into the ambrosia timer afterward.
+ */
+export function advanceRedAmbrosiaTimer (input: AdvanceRedAmbrosiaTimerInput): AdvanceRedAmbrosiaTimerResult {
+  if (input.noAmbrosiaUpgradesCompletions <= 0) {
+    return {
+      redAmbrosiaTimerG: input.redAmbrosiaTimerG,
+      redAmbrosiaTime: input.redAmbrosiaTime,
+      redAmbrosia: input.redAmbrosia,
+      lifetimeRedAmbrosia: input.lifetimeRedAmbrosia,
+      seed: input.seed,
+      bonusAmbrosiaTime: 0,
+      events: []
+    }
+  }
+
+  let redAmbrosiaTimerG = input.redAmbrosiaTimerG + input.time * input.timeMultiplier
+  if (redAmbrosiaTimerG < 0.125) {
+    return {
+      redAmbrosiaTimerG,
+      redAmbrosiaTime: input.redAmbrosiaTime,
+      redAmbrosia: input.redAmbrosia,
+      lifetimeRedAmbrosia: input.lifetimeRedAmbrosia,
+      seed: input.seed,
+      bonusAmbrosiaTime: 0,
+      events: []
+    }
+  }
+
+  let redAmbrosiaTime = input.redAmbrosiaTime
+    + Math.floor(8 * redAmbrosiaTimerG) / 8 * input.redAmbrosiaGenerationSpeed
+  redAmbrosiaTimerG %= 0.125
+
+  let redAmbrosia = input.redAmbrosia
+  let lifetimeRedAmbrosia = input.lifetimeRedAmbrosia
+  let seed = input.seed
+  let totalGained = 0
+  let bonusAmbrosiaTime = 0
+
+  let timeToRedAmbrosia = calculateRequiredRedAmbrosiaTime({
+    timePerRedAmbrosia: input.timePerRedAmbrosia,
+    lifetimeRedAmbrosia,
+    barRequirementMultiplier: input.barRequirementMultiplier
+  })
+
+  while (redAmbrosiaTime >= timeToRedAmbrosia) {
+    const rng = seededRandom(seed)
+    seed = rng.newSeed
+    const redAmbrosiaMult = Math.floor(input.redAmbrosiaLuck / 100)
+    const luckMult = rng.value < input.redAmbrosiaLuck / 100 - Math.floor(input.redAmbrosiaLuck / 100) ? 1 : 0
+    const redAmbrosiaToGain = redAmbrosiaMult + luckMult
+
+    redAmbrosia += redAmbrosiaToGain
+    lifetimeRedAmbrosia += redAmbrosiaToGain
+    totalGained += redAmbrosiaToGain
+    bonusAmbrosiaTime += redAmbrosiaToGain * input.ambrosiaTimePerRedAmbrosia
+    redAmbrosiaTime -= timeToRedAmbrosia
+
+    timeToRedAmbrosia = calculateRequiredRedAmbrosiaTime({
+      timePerRedAmbrosia: input.timePerRedAmbrosia,
+      lifetimeRedAmbrosia,
+      barRequirementMultiplier: input.barRequirementMultiplier
+    })
+  }
+
+  return {
+    redAmbrosiaTimerG,
+    redAmbrosiaTime,
+    redAmbrosia,
+    lifetimeRedAmbrosia,
+    seed,
+    bonusAmbrosiaTime,
+    events: [{ kind: 'red-ambrosia-gained', amount: totalGained }]
+  }
 }

--- a/packages/logic/src/types/fast-mersenne-twister.d.ts
+++ b/packages/logic/src/types/fast-mersenne-twister.d.ts
@@ -1,0 +1,28 @@
+// Type declarations for fast-mersenne-twister. Mirrors the same .d.ts
+// file in packages/web_ui/src/types — logic can't import from web_ui, so
+// the declaration is duplicated here.
+
+declare module 'fast-mersenne-twister' {
+  interface MersenneTwisterApi {
+    genrand_int32: () => number
+    // [0,0x7fffffff]
+    genrand_int31: () => number
+    // [0,1]
+    genrand_real1: () => number
+    // [0,1)
+    genrand_real2: () => number
+    // (0,1)
+    genrand_real3: () => number
+    // [0,1), 53-bit resolution
+    genrand_res53: () => number
+
+    randomNumber: () => number
+    random31Bit: () => number
+    randomInclusive: () => number
+    random: () => number // returns values just like Math.random
+    randomExclusive: () => number
+    random53Bit: () => number
+  }
+
+  export function MersenneTwister (seed?: number): MersenneTwisterApi
+}

--- a/packages/logic/test/parity/ambrosiaTimers.parity.test.ts
+++ b/packages/logic/test/parity/ambrosiaTimers.parity.test.ts
@@ -1,0 +1,475 @@
+// Parity tests for the ambrosia + redAmbrosia addTimers cases and the
+// underlying seededRandom helper.
+//
+// Old bodies transcribed verbatim from packages/web_ui/src/Helper.ts
+// (addTimers, ambrosia + redAmbrosia switch cases pre-migration) and
+// packages/web_ui/src/RNG.ts (seededRandom). The legacy code reads/writes
+// player.seed[index] directly; the parity harness threads the seed
+// through a local variable instead.
+
+import { MersenneTwister } from 'fast-mersenne-twister'
+import { describe, expect, it } from 'vitest'
+import { calculateRequiredBlueberryTime, calculateRequiredRedAmbrosiaTime } from '../../src/mechanics/ambrosia'
+import {
+  seededRandom as newSeededRandom,
+  type SeededRandomResult
+} from '../../src/math/rng'
+import {
+  advanceAmbrosiaTimer as newAdvanceAmbrosia,
+  type AdvanceAmbrosiaTimerInput,
+  type AdvanceAmbrosiaTimerResult,
+  advanceRedAmbrosiaTimer as newAdvanceRedAmbrosia,
+  type AdvanceRedAmbrosiaTimerInput,
+  type AdvanceRedAmbrosiaTimerResult
+} from '../../src/tick/timers'
+
+// ─── seededRandom ──────────────────────────────────────────────────────
+
+const oldSeededRandom = (seed: number): SeededRandomResult => ({
+  value: MersenneTwister(seed).random(),
+  newSeed: seed + 1
+})
+
+describe('parity: seededRandom', () => {
+  const seeds = [0, 1, 42, 1024, 99999, 2147483647, 1735689600]
+  for (const seed of seeds) {
+    it(`seed=${seed}`, () => {
+      const a = newSeededRandom(seed)
+      const b = oldSeededRandom(seed)
+      expect(a.value).toBe(b.value)
+      expect(a.newSeed).toBe(b.newSeed)
+    })
+  }
+})
+
+// ─── advanceAmbrosiaTimer ──────────────────────────────────────────────
+
+const oldAdvanceAmbrosia = (input: AdvanceAmbrosiaTimerInput): AdvanceAmbrosiaTimerResult => {
+  if (input.noSingularityUpgradesCompletions <= 0) {
+    return {
+      ambrosiaTimerG: input.ambrosiaTimerG,
+      blueberryTime: input.blueberryTime,
+      ambrosia: input.ambrosia,
+      lifetimeAmbrosia: input.lifetimeAmbrosia,
+      seed: input.seed,
+      events: []
+    }
+  }
+  if (input.ambrosiaGenerationSpeed === 0) {
+    return {
+      ambrosiaTimerG: input.ambrosiaTimerG,
+      blueberryTime: input.blueberryTime,
+      ambrosia: input.ambrosia,
+      lifetimeAmbrosia: input.lifetimeAmbrosia,
+      seed: input.seed,
+      events: []
+    }
+  }
+
+  let ambrosiaTimerG = input.ambrosiaTimerG + input.time * input.timeMultiplier
+  if (ambrosiaTimerG < 0.125) {
+    return {
+      ambrosiaTimerG,
+      blueberryTime: input.blueberryTime,
+      ambrosia: input.ambrosia,
+      lifetimeAmbrosia: input.lifetimeAmbrosia,
+      seed: input.seed,
+      events: []
+    }
+  }
+
+  let blueberryTime = input.blueberryTime + Math.floor(8 * ambrosiaTimerG) / 8 * input.ambrosiaGenerationSpeed
+  ambrosiaTimerG %= 0.125
+
+  let ambrosia = input.ambrosia
+  let lifetimeAmbrosia = input.lifetimeAmbrosia
+  let seed = input.seed
+  let totalGained = 0
+
+  let timeToAmbrosia = calculateRequiredBlueberryTime({
+    timePerAmbrosia: input.timePerAmbrosia,
+    lifetimeAmbrosia,
+    acceleratorMult: input.acceleratorMult,
+    brickOfLeadMult: input.brickOfLeadMult
+  })
+
+  while (blueberryTime >= timeToAmbrosia) {
+    const rng = newSeededRandom(seed)
+    seed = rng.newSeed
+    const ambrosiaMult = Math.floor(input.ambrosiaLuck / 100)
+    const luckMult = rng.value < input.ambrosiaLuck / 100 - Math.floor(input.ambrosiaLuck / 100) ? 1 : 0
+    const ambrosiaToGain = (ambrosiaMult + luckMult) + input.bonusAmbrosia
+
+    ambrosia += ambrosiaToGain
+    lifetimeAmbrosia += ambrosiaToGain
+    totalGained += ambrosiaToGain
+    blueberryTime -= timeToAmbrosia
+
+    timeToAmbrosia = calculateRequiredBlueberryTime({
+      timePerAmbrosia: input.timePerAmbrosia,
+      lifetimeAmbrosia,
+      acceleratorMult: input.acceleratorMult,
+      brickOfLeadMult: input.brickOfLeadMult
+    })
+  }
+
+  return {
+    ambrosiaTimerG,
+    blueberryTime,
+    ambrosia,
+    lifetimeAmbrosia,
+    seed,
+    events: [{ kind: 'ambrosia-gained', amount: totalGained }]
+  }
+}
+
+const defaultAmbrosia = (overrides: Partial<AdvanceAmbrosiaTimerInput> = {}): AdvanceAmbrosiaTimerInput => ({
+  time: 0.025,
+  timeMultiplier: 1,
+  noSingularityUpgradesCompletions: 1,
+  ambrosiaGenerationSpeed: 1,
+  ambrosiaTimerG: 0,
+  blueberryTime: 0,
+  ambrosia: 0,
+  lifetimeAmbrosia: 0,
+  seed: 42,
+  ambrosiaLuck: 100,
+  bonusAmbrosia: 0,
+  timePerAmbrosia: 45,
+  acceleratorMult: 1,
+  brickOfLeadMult: 1,
+  ...overrides
+})
+
+describe('parity: advanceAmbrosiaTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceAmbrosiaTimerInput }> = [
+    {
+      name: 'gate — completions=0 (feature locked)',
+      input: defaultAmbrosia({ noSingularityUpgradesCompletions: 0, ambrosiaTimerG: 0.5 })
+    },
+    {
+      name: 'gate — ambrosiaGenerationSpeed=0',
+      input: defaultAmbrosia({ ambrosiaGenerationSpeed: 0, ambrosiaTimerG: 0.5 })
+    },
+    {
+      name: 'sub-1/8s timer accumulates but no work',
+      input: defaultAmbrosia({ time: 0.05, ambrosiaTimerG: 0.05, blueberryTime: 0 })
+    },
+    {
+      name: 'fractional timer rounds to nearest 1/8',
+      input: defaultAmbrosia({
+        time: 0.025,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 8,
+        blueberryTime: 0
+      })
+    },
+    {
+      name: 'gains 1 ambrosia (single bar)',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 1000, // jump blueberryTime past 45
+        blueberryTime: 0,
+        ambrosiaLuck: 100,
+        bonusAmbrosia: 0,
+        lifetimeAmbrosia: 0
+      })
+    },
+    {
+      name: 'gains multiple ambrosia bars in one tick',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.625, // 5*0.125 = 5 ticks worth
+        ambrosiaGenerationSpeed: 100,
+        blueberryTime: 0,
+        ambrosiaLuck: 100,
+        lifetimeAmbrosia: 0
+      })
+    },
+    {
+      name: 'ambrosiaLuck >= 200 (ambrosiaMult=2, luckMult always 0 from floor)',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 1000,
+        ambrosiaLuck: 200,
+        lifetimeAmbrosia: 0,
+        seed: 1
+      })
+    },
+    {
+      name: 'fractional ambrosiaLuck (150) — luckMult depends on RNG roll',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 1000,
+        ambrosiaLuck: 150,
+        lifetimeAmbrosia: 0,
+        seed: 7
+      })
+    },
+    {
+      name: 'bonusAmbrosia adds to each iteration',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.25,
+        ambrosiaGenerationSpeed: 100,
+        bonusAmbrosia: 5,
+        lifetimeAmbrosia: 0
+      })
+    },
+    {
+      name: 'lifetimeAmbrosia >= 10000 (power-scaling kicks in)',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 1e6,
+        lifetimeAmbrosia: 50000,
+        ambrosiaLuck: 100
+      })
+    },
+    {
+      name: 'acceleratorMult inflates threshold (fewer gains)',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 200,
+        acceleratorMult: 3,
+        lifetimeAmbrosia: 0
+      })
+    },
+    {
+      name: 'brickOfLeadMult inflates threshold',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 0.125,
+        ambrosiaGenerationSpeed: 200,
+        brickOfLeadMult: 2,
+        lifetimeAmbrosia: 0
+      })
+    },
+    {
+      name: 'big multi-bar tick — threshold ramps with lifetimeAmbrosia',
+      input: defaultAmbrosia({
+        time: 0,
+        ambrosiaTimerG: 1.0, // 8 chunks
+        ambrosiaGenerationSpeed: 100,
+        ambrosiaLuck: 250, // mult=2, luckMult depends on RNG
+        bonusAmbrosia: 1,
+        lifetimeAmbrosia: 500,
+        seed: 1000
+      })
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAdvanceAmbrosia(c.input)
+      const oldR = oldAdvanceAmbrosia(c.input)
+      expect(newR.ambrosiaTimerG).toBeCloseTo(oldR.ambrosiaTimerG, 10)
+      expect(newR.blueberryTime).toBeCloseTo(oldR.blueberryTime, 10)
+      expect(newR.ambrosia).toBe(oldR.ambrosia)
+      expect(newR.lifetimeAmbrosia).toBe(oldR.lifetimeAmbrosia)
+      expect(newR.seed).toBe(oldR.seed)
+      expect(newR.events).toEqual(oldR.events)
+    })
+  }
+})
+
+// ─── advanceRedAmbrosiaTimer ───────────────────────────────────────────
+
+const oldAdvanceRedAmbrosia = (input: AdvanceRedAmbrosiaTimerInput): AdvanceRedAmbrosiaTimerResult => {
+  if (input.noAmbrosiaUpgradesCompletions <= 0) {
+    return {
+      redAmbrosiaTimerG: input.redAmbrosiaTimerG,
+      redAmbrosiaTime: input.redAmbrosiaTime,
+      redAmbrosia: input.redAmbrosia,
+      lifetimeRedAmbrosia: input.lifetimeRedAmbrosia,
+      seed: input.seed,
+      bonusAmbrosiaTime: 0,
+      events: []
+    }
+  }
+
+  let redAmbrosiaTimerG = input.redAmbrosiaTimerG + input.time * input.timeMultiplier
+  if (redAmbrosiaTimerG < 0.125) {
+    return {
+      redAmbrosiaTimerG,
+      redAmbrosiaTime: input.redAmbrosiaTime,
+      redAmbrosia: input.redAmbrosia,
+      lifetimeRedAmbrosia: input.lifetimeRedAmbrosia,
+      seed: input.seed,
+      bonusAmbrosiaTime: 0,
+      events: []
+    }
+  }
+
+  let redAmbrosiaTime = input.redAmbrosiaTime
+    + Math.floor(8 * redAmbrosiaTimerG) / 8 * input.redAmbrosiaGenerationSpeed
+  redAmbrosiaTimerG %= 0.125
+
+  let redAmbrosia = input.redAmbrosia
+  let lifetimeRedAmbrosia = input.lifetimeRedAmbrosia
+  let seed = input.seed
+  let totalGained = 0
+  let bonusAmbrosiaTime = 0
+
+  let timeToRedAmbrosia = calculateRequiredRedAmbrosiaTime({
+    timePerRedAmbrosia: input.timePerRedAmbrosia,
+    lifetimeRedAmbrosia,
+    barRequirementMultiplier: input.barRequirementMultiplier
+  })
+
+  while (redAmbrosiaTime >= timeToRedAmbrosia) {
+    const rng = newSeededRandom(seed)
+    seed = rng.newSeed
+    const redAmbrosiaMult = Math.floor(input.redAmbrosiaLuck / 100)
+    const luckMult = rng.value < input.redAmbrosiaLuck / 100 - Math.floor(input.redAmbrosiaLuck / 100) ? 1 : 0
+    const redAmbrosiaToGain = redAmbrosiaMult + luckMult
+
+    redAmbrosia += redAmbrosiaToGain
+    lifetimeRedAmbrosia += redAmbrosiaToGain
+    totalGained += redAmbrosiaToGain
+    bonusAmbrosiaTime += redAmbrosiaToGain * input.ambrosiaTimePerRedAmbrosia
+    redAmbrosiaTime -= timeToRedAmbrosia
+
+    timeToRedAmbrosia = calculateRequiredRedAmbrosiaTime({
+      timePerRedAmbrosia: input.timePerRedAmbrosia,
+      lifetimeRedAmbrosia,
+      barRequirementMultiplier: input.barRequirementMultiplier
+    })
+  }
+
+  return {
+    redAmbrosiaTimerG,
+    redAmbrosiaTime,
+    redAmbrosia,
+    lifetimeRedAmbrosia,
+    seed,
+    bonusAmbrosiaTime,
+    events: [{ kind: 'red-ambrosia-gained', amount: totalGained }]
+  }
+}
+
+const defaultRedAmbrosia = (overrides: Partial<AdvanceRedAmbrosiaTimerInput> = {}): AdvanceRedAmbrosiaTimerInput => ({
+  time: 0.025,
+  timeMultiplier: 1,
+  noAmbrosiaUpgradesCompletions: 1,
+  redAmbrosiaGenerationSpeed: 1,
+  redAmbrosiaTimerG: 0,
+  redAmbrosiaTime: 0,
+  redAmbrosia: 0,
+  lifetimeRedAmbrosia: 0,
+  seed: 100,
+  redAmbrosiaLuck: 100,
+  ambrosiaTimePerRedAmbrosia: 0,
+  timePerRedAmbrosia: 100000,
+  barRequirementMultiplier: 1,
+  ...overrides
+})
+
+describe('parity: advanceRedAmbrosiaTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceRedAmbrosiaTimerInput }> = [
+    {
+      name: 'gate — completions=0 (feature locked)',
+      input: defaultRedAmbrosia({ noAmbrosiaUpgradesCompletions: 0, redAmbrosiaTimerG: 0.5 })
+    },
+    {
+      name: 'sub-1/8s timer accumulates',
+      input: defaultRedAmbrosia({ time: 0.05, redAmbrosiaTimerG: 0.05 })
+    },
+    {
+      name: 'gains 1 red ambrosia + bonus blueberry time',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.125,
+        redAmbrosiaGenerationSpeed: 1e7,
+        redAmbrosiaTime: 0,
+        ambrosiaTimePerRedAmbrosia: 30,
+        redAmbrosiaLuck: 100
+      })
+    },
+    {
+      name: 'gains 1 red ambrosia with 0 ambrosiaTimePerRedAmbrosia (no bonus)',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.125,
+        redAmbrosiaGenerationSpeed: 1e7,
+        redAmbrosiaTime: 0,
+        ambrosiaTimePerRedAmbrosia: 0,
+        redAmbrosiaLuck: 100
+      })
+    },
+    {
+      name: 'redAmbrosiaLuck = 175 (mult=1, fractional luck from RNG)',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.125,
+        redAmbrosiaGenerationSpeed: 1e7,
+        redAmbrosiaLuck: 175,
+        seed: 7,
+        ambrosiaTimePerRedAmbrosia: 30
+      })
+    },
+    {
+      name: 'redAmbrosiaLuck = 300 (mult=3)',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.125,
+        redAmbrosiaGenerationSpeed: 1e7,
+        redAmbrosiaLuck: 300,
+        seed: 7,
+        ambrosiaTimePerRedAmbrosia: 30
+      })
+    },
+    {
+      name: 'multi-bar tick — threshold ramps with lifetimeRedAmbrosia (linear ramp +200/each)',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.5,
+        redAmbrosiaGenerationSpeed: 1e7,
+        redAmbrosiaTime: 0,
+        ambrosiaTimePerRedAmbrosia: 60,
+        redAmbrosiaLuck: 100,
+        seed: 99,
+        lifetimeRedAmbrosia: 0
+      })
+    },
+    {
+      name: 'barRequirementMultiplier inflates threshold',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.125,
+        redAmbrosiaGenerationSpeed: 5e5,
+        barRequirementMultiplier: 2,
+        redAmbrosiaLuck: 100
+      })
+    },
+    {
+      name: 'barRequirementMultiplier caps val to max',
+      input: defaultRedAmbrosia({
+        time: 0,
+        redAmbrosiaTimerG: 0.125,
+        redAmbrosiaGenerationSpeed: 1e10,
+        lifetimeRedAmbrosia: 1e7, // would push val past cap
+        barRequirementMultiplier: 1,
+        redAmbrosiaLuck: 100
+      })
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAdvanceRedAmbrosia(c.input)
+      const oldR = oldAdvanceRedAmbrosia(c.input)
+      expect(newR.redAmbrosiaTimerG).toBeCloseTo(oldR.redAmbrosiaTimerG, 10)
+      expect(newR.redAmbrosiaTime).toBeCloseTo(oldR.redAmbrosiaTime, 10)
+      expect(newR.redAmbrosia).toBe(oldR.redAmbrosia)
+      expect(newR.lifetimeRedAmbrosia).toBe(oldR.lifetimeRedAmbrosia)
+      expect(newR.seed).toBe(oldR.seed)
+      expect(newR.bonusAmbrosiaTime).toBeCloseTo(oldR.bonusAmbrosiaTime, 10)
+      expect(newR.events).toEqual(oldR.events)
+    })
+  }
+})

--- a/packages/logic/test/parity/antGeneration.parity.test.ts
+++ b/packages/logic/test/parity/antGeneration.parity.test.ts
@@ -1,0 +1,208 @@
+// Parity tests for generateAntsAndCrumbs.
+// Old body transcribed verbatim from
+// packages/web_ui/src/Features/Ants/AntProducers/lib/generate-ant-producers.ts
+// (pre-migration), minus the `activateELO(dt)` tail call which stays
+// in web_ui (depends on Date.now / DOM / quark-credit side effects).
+
+import { describe, expect, it } from 'vitest'
+import { Decimal } from '../../src/math/bignum'
+import { antMasteryData, calculateSelfSpeedFromMastery } from '../../src/mechanics/antMasteries'
+import { antProducerData, calculateBaseAntsToBeGenerated } from '../../src/mechanics/antProducers'
+import {
+  generateAntsAndCrumbs as newGenerate,
+  type GenerateAntsAndCrumbsInput,
+  type GenerateAntsAndCrumbsResult
+} from '../../src/tick/antGeneration'
+
+const LAST_ANT_PRODUCER = 8
+
+// Verbatim transcription mirroring the legacy producer loop + crumb math.
+const oldGenerate = (input: GenerateAntsAndCrumbsInput): GenerateAntsAndCrumbsResult => {
+  const updatedGenerated: Decimal[] = input.producers.map((p) => p.generated)
+
+  for (let antType = LAST_ANT_PRODUCER; antType > 0; antType--) {
+    const selfSpeedMult = calculateSelfSpeedFromMastery({
+      antData: antMasteryData[antType],
+      masteryLevel: input.producers[antType].masteryLevel,
+      purchased: input.producers[antType].purchased
+    })
+    const baseGeneration = calculateBaseAntsToBeGenerated({
+      generated: updatedGenerated[antType],
+      purchased: input.producers[antType].purchased,
+      baseProduction: antProducerData[antType].baseProduction,
+      selfSpeedMult,
+      antSpeedMult: input.antSpeedMult
+    })
+    const producedAnt = antProducerData[antType].produces!
+    updatedGenerated[producedAnt] = updatedGenerated[producedAnt].add(baseGeneration.times(input.dt))
+  }
+
+  const workersSelfSpeed = calculateSelfSpeedFromMastery({
+    antData: antMasteryData[0],
+    masteryLevel: input.producers[0].masteryLevel,
+    purchased: input.producers[0].purchased
+  })
+  const crumbsToGenerate = calculateBaseAntsToBeGenerated({
+    generated: updatedGenerated[0],
+    purchased: input.producers[0].purchased,
+    baseProduction: antProducerData[0].baseProduction,
+    selfSpeedMult: workersSelfSpeed,
+    antSpeedMult: input.antSpeedMult
+  }).times(input.dt)
+
+  return {
+    producersGenerated: updatedGenerated,
+    crumbs: Decimal.add(input.crumbs, crumbsToGenerate),
+    crumbsThisSacrifice: Decimal.add(input.crumbsThisSacrifice, crumbsToGenerate),
+    crumbsEverMade: Decimal.add(input.crumbsEverMade, crumbsToGenerate)
+  }
+}
+
+const blankProducers = () => {
+  const arr = []
+  for (let i = 0; i <= LAST_ANT_PRODUCER; i++) {
+    arr.push({
+      generated: new Decimal(0),
+      purchased: 0,
+      masteryLevel: 0
+    })
+  }
+  return arr
+}
+
+const defaultInput = (overrides: Partial<GenerateAntsAndCrumbsInput> = {}): GenerateAntsAndCrumbsInput => ({
+  dt: 0.025,
+  antSpeedMult: new Decimal(1),
+  producers: blankProducers(),
+  crumbs: new Decimal(0),
+  crumbsThisSacrifice: new Decimal(0),
+  crumbsEverMade: new Decimal(0),
+  ...overrides
+})
+
+describe('parity: generateAntsAndCrumbs', () => {
+  const cases: Array<{ name: string, input: GenerateAntsAndCrumbsInput }> = [
+    {
+      name: 'cold start — no producers, no mastery (zero work)',
+      input: defaultInput()
+    },
+    {
+      name: 'Workers only (purchased 1, others empty) — produces only crumbs',
+      input: (() => {
+        const producers = blankProducers()
+        producers[0] = { generated: new Decimal(0), purchased: 1, masteryLevel: 0 }
+        return defaultInput({ producers })
+      })()
+    },
+    {
+      name: 'Breeders 1 + Workers 1 — Breeders produce Workers, Workers produce crumbs',
+      input: (() => {
+        const producers = blankProducers()
+        producers[0] = { generated: new Decimal(0), purchased: 1, masteryLevel: 0 }
+        producers[1] = { generated: new Decimal(0), purchased: 1, masteryLevel: 0 }
+        return defaultInput({ producers })
+      })()
+    },
+    {
+      name: 'mid-game — first 5 tiers populated',
+      input: (() => {
+        const producers = blankProducers()
+        producers[0] = { generated: new Decimal('1e6'), purchased: 100, masteryLevel: 5 }
+        producers[1] = { generated: new Decimal('1e4'), purchased: 50, masteryLevel: 4 }
+        producers[2] = { generated: new Decimal('1e2'), purchased: 25, masteryLevel: 3 }
+        producers[3] = { generated: new Decimal(10), purchased: 10, masteryLevel: 2 }
+        producers[4] = { generated: new Decimal(5), purchased: 5, masteryLevel: 1 }
+        return defaultInput({
+          producers,
+          dt: 0.1,
+          antSpeedMult: new Decimal(10),
+          crumbs: new Decimal('1e10'),
+          crumbsThisSacrifice: new Decimal('1e8'),
+          crumbsEverMade: new Decimal('1e12')
+        })
+      })()
+    },
+    {
+      name: 'late-game — all 9 tiers populated, max mastery',
+      input: (() => {
+        const producers = blankProducers()
+        for (let i = 0; i <= LAST_ANT_PRODUCER; i++) {
+          producers[i] = {
+            generated: new Decimal(Math.pow(10, 20 - i * 2)),
+            purchased: 200 - i * 10,
+            masteryLevel: 12
+          }
+        }
+        return defaultInput({
+          producers,
+          dt: 0.025,
+          antSpeedMult: new Decimal(1000),
+          crumbs: new Decimal('1e50'),
+          crumbsThisSacrifice: new Decimal('1e40'),
+          crumbsEverMade: new Decimal('1e100')
+        })
+      })()
+    },
+    {
+      name: 'producer-loop cascade — HolySpirit only, watch propagation',
+      input: (() => {
+        const producers = blankProducers()
+        producers[8] = { generated: new Decimal(1), purchased: 1, masteryLevel: 5 }
+        return defaultInput({ producers, dt: 1 })
+      })()
+    },
+    {
+      name: 'large dt (offline catch-up)',
+      input: (() => {
+        const producers = blankProducers()
+        producers[0] = { generated: new Decimal('1e10'), purchased: 1000, masteryLevel: 8 }
+        producers[1] = { generated: new Decimal('1e8'), purchased: 500, masteryLevel: 7 }
+        return defaultInput({ producers, dt: 3600 })
+      })()
+    },
+    {
+      name: 'high antSpeedMult (galaxy speed)',
+      input: (() => {
+        const producers = blankProducers()
+        producers[0] = { generated: new Decimal('1e8'), purchased: 100, masteryLevel: 6 }
+        producers[1] = { generated: new Decimal('1e6'), purchased: 80, masteryLevel: 6 }
+        producers[2] = { generated: new Decimal('1e4'), purchased: 60, masteryLevel: 6 }
+        return defaultInput({
+          producers,
+          antSpeedMult: new Decimal('1e30'),
+          dt: 0.025
+        })
+      })()
+    },
+    {
+      name: 'high mastery only on lower tiers (mid-progression)',
+      input: (() => {
+        const producers = blankProducers()
+        producers[0] = { generated: new Decimal('1e15'), purchased: 100, masteryLevel: 12 }
+        producers[1] = { generated: new Decimal('1e10'), purchased: 80, masteryLevel: 12 }
+        producers[2] = { generated: new Decimal('1e5'), purchased: 60, masteryLevel: 10 }
+        producers[3] = { generated: new Decimal(100), purchased: 40, masteryLevel: 0 }
+        return defaultInput({
+          producers,
+          antSpeedMult: new Decimal(50),
+          dt: 0.5
+        })
+      })()
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newGenerate(c.input)
+      const oldR = oldGenerate(c.input)
+      // Per-tier generated values match
+      for (let i = 0; i <= LAST_ANT_PRODUCER; i++) {
+        expect(newR.producersGenerated[i].toString())
+          .toBe(oldR.producersGenerated[i].toString())
+      }
+      expect(newR.crumbs.toString()).toBe(oldR.crumbs.toString())
+      expect(newR.crumbsThisSacrifice.toString()).toBe(oldR.crumbsThisSacrifice.toString())
+      expect(newR.crumbsEverMade.toString()).toBe(oldR.crumbsEverMade.toString())
+    })
+  }
+})

--- a/packages/logic/test/parity/autoReset.parity.test.ts
+++ b/packages/logic/test/parity/autoReset.parity.test.ts
@@ -1,0 +1,582 @@
+// Parity tests for the auto-reset state machine.
+// Old body transcribed verbatim from packages/web_ui/src/Synergism.ts
+// (tack, the three auto-reset blocks at ~lines 4135-4226 pre-migration),
+// minus the side-effects (resetAchievementCheck / reset) which stay in
+// web_ui — those are translated from the event list by the UI dispatcher.
+
+import { describe, expect, it } from 'vitest'
+import { Decimal } from '../../src/math/bignum'
+import {
+  applyAutoResets as newApplyAutoResets,
+  type ApplyAutoResetsInput,
+  type ApplyAutoResetsResult
+} from '../../src/tick/autoReset'
+
+// Verbatim transcription of legacy logic without the side-effect calls.
+// `events` mirrors the order of the legacy if-block sequence:
+//   prestige amount → prestige time → transcend amount → transcend time
+//   → (reincarnation timer accumulation) → reincarnation time → reincarnation amount
+const oldApplyAutoResets = (input: ApplyAutoResetsInput): ApplyAutoResetsResult => {
+  const events: ApplyAutoResetsResult['events'] = []
+  let autoResetTimerPrestige = input.autoResetTimerPrestige
+  let autoResetTimerTranscension = input.autoResetTimerTranscension
+  let autoResetTimerReincarnation = input.autoResetTimerReincarnation
+
+  if (input.prestigeMode === 'amount') {
+    if (
+      input.toggle15
+      && input.autoPrestigeMilestone === 1
+      && input.prestigePointGain.gte(
+        input.prestigePoints.times(Decimal.pow(10, input.prestigeamount))
+      )
+      && input.coinsThisPrestige.gte(1e16)
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'prestige', mode: 'amount' })
+    }
+  }
+  if (input.prestigeMode === 'time') {
+    autoResetTimerPrestige += input.dt
+    const time = Math.max(0.01, input.prestigeamount)
+    if (
+      input.toggle15
+      && input.autoPrestigeMilestone === 1
+      && autoResetTimerPrestige >= time
+      && input.coinsThisPrestige.gte(1e16)
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'prestige', mode: 'time' })
+    }
+  }
+
+  if (input.transcendMode === 'amount') {
+    if (
+      input.toggle21
+      && input.upgrade89 === 1
+      && input.transcendPointGain.gte(
+        input.transcendPoints.times(Decimal.pow(10, input.transcendamount))
+      )
+      && input.coinsThisTranscension.gte(1e100)
+      && input.transcensionChallenge === 0
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'transcension', mode: 'amount' })
+    }
+  }
+  if (input.transcendMode === 'time') {
+    autoResetTimerTranscension += input.dt
+    const time = Math.max(0.01, input.transcendamount)
+    if (
+      input.toggle21
+      && input.upgrade89 === 1
+      && autoResetTimerTranscension >= time
+      && input.coinsThisTranscension.gte(1e100)
+      && input.transcensionChallenge === 0
+    ) {
+      events.push({ kind: 'auto-reset-triggered', tier: 'transcension', mode: 'time' })
+    }
+  }
+
+  if (input.ascensionChallenge !== 12) {
+    autoResetTimerReincarnation += input.dt
+    if (input.reincarnationMode === 'time') {
+      const time = Math.max(0.01, input.reincarnationamount)
+      if (
+        input.toggle27
+        && input.research46 > 0.5
+        && input.transcendShards.gte('1e300')
+        && autoResetTimerReincarnation >= time
+        && input.transcensionChallenge === 0
+        && input.reincarnationChallenge === 0
+      ) {
+        events.push({ kind: 'auto-reset-triggered', tier: 'reincarnation', mode: 'time' })
+      }
+    }
+    if (input.reincarnationMode === 'amount') {
+      if (
+        input.toggle27
+        && input.research46 > 0.5
+        && input.reincarnationPointGain.gte(
+          input.reincarnationPoints
+            .add(1)
+            .times(Decimal.pow(10, input.reincarnationamount))
+        )
+        && input.transcendShards.gte(1e300)
+        && input.transcensionChallenge === 0
+        && input.reincarnationChallenge === 0
+      ) {
+        events.push({ kind: 'auto-reset-triggered', tier: 'reincarnation', mode: 'amount' })
+      }
+    }
+  }
+
+  return {
+    autoResetTimerPrestige,
+    autoResetTimerTranscension,
+    autoResetTimerReincarnation,
+    events
+  }
+}
+
+// Default input — every gate blocks. Override in each case to test one
+// condition at a time. dt=0.025 mirrors the typical 25ms tick.
+const defaultInput = (): ApplyAutoResetsInput => ({
+  dt: 0.025,
+  prestigeMode: 'amount',
+  toggle15: false,
+  autoPrestigeMilestone: 0,
+  prestigePoints: new Decimal(0),
+  prestigePointGain: new Decimal(0),
+  prestigeamount: 1,
+  coinsThisPrestige: new Decimal(0),
+  autoResetTimerPrestige: 0,
+  transcendMode: 'amount',
+  toggle21: false,
+  upgrade89: 0,
+  transcendPoints: new Decimal(0),
+  transcendPointGain: new Decimal(0),
+  transcendamount: 1,
+  coinsThisTranscension: new Decimal(0),
+  autoResetTimerTranscension: 0,
+  reincarnationMode: 'amount',
+  toggle27: false,
+  research46: 0,
+  reincarnationPoints: new Decimal(0),
+  reincarnationPointGain: new Decimal(0),
+  reincarnationamount: 1,
+  transcendShards: new Decimal(0),
+  autoResetTimerReincarnation: 0,
+  ascensionChallenge: 0,
+  transcensionChallenge: 0,
+  reincarnationChallenge: 0
+})
+
+describe('parity: applyAutoResets', () => {
+  const cases: Array<{ name: string, input: ApplyAutoResetsInput }> = [
+    // ─── Baseline: nothing fires ──────────────────────────────────────
+    { name: 'baseline — all gates blocking', input: defaultInput() },
+
+    // ─── Prestige amount mode ─────────────────────────────────────────
+    {
+      name: 'prestige amount — all conditions met (fires)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2, // 100 * 10^2 = 10000, gain 1e6 > 10000
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige amount — toggle15 off (blocked)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        toggle15: false,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige amount — autoPrestigeMilestone is 2 (blocked: strict === 1)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 2, // not strictly === 1
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige amount — gain below threshold (blocked)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(9999), // < 100 * 10^2 = 10000
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige amount — coinsThisPrestige just under 1e16 (blocked)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal('9.99e15')
+      }
+    },
+    {
+      name: 'prestige amount — gain exactly at threshold (fires)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(1),
+        prestigePointGain: new Decimal(10), // 1 * 10^1 = 10
+        prestigeamount: 1,
+        coinsThisPrestige: new Decimal(1e16)
+      }
+    },
+
+    // ─── Prestige time mode ───────────────────────────────────────────
+    {
+      name: 'prestige time — fires once timer reaches threshold',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'time',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigeamount: 5,
+        autoResetTimerPrestige: 4.99, // + dt=0.025 → 5.015 ≥ 5
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige time — timer not yet at threshold (timer accumulates, no event)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'time',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigeamount: 60,
+        autoResetTimerPrestige: 1.5,
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige time — prestigeamount = 0 (floor at 0.01)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'time',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigeamount: 0, // max(0.01, 0) = 0.01
+        autoResetTimerPrestige: 0,
+        dt: 0.025, // → 0.025 ≥ 0.01
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige time — prestigeamount = -5 (floor at 0.01)',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'time',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigeamount: -5,
+        autoResetTimerPrestige: 0,
+        dt: 0.025,
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    },
+    {
+      name: 'prestige time — mode is amount, prestige timer NOT incremented',
+      input: {
+        ...defaultInput(),
+        prestigeMode: 'amount',
+        autoResetTimerPrestige: 10
+      }
+    },
+
+    // ─── Transcend amount mode ────────────────────────────────────────
+    {
+      name: 'transcend amount — all conditions met (fires)',
+      input: {
+        ...defaultInput(),
+        transcendMode: 'amount',
+        toggle21: true,
+        upgrade89: 1,
+        transcendPoints: new Decimal(100),
+        transcendPointGain: new Decimal(1e6),
+        transcendamount: 2,
+        coinsThisTranscension: new Decimal(1e101),
+        transcensionChallenge: 0
+      }
+    },
+    {
+      name: 'transcend amount — upgrade89 = 2 (blocked: strict === 1)',
+      input: {
+        ...defaultInput(),
+        transcendMode: 'amount',
+        toggle21: true,
+        upgrade89: 2,
+        transcendPoints: new Decimal(100),
+        transcendPointGain: new Decimal(1e6),
+        transcendamount: 2,
+        coinsThisTranscension: new Decimal(1e101),
+        transcensionChallenge: 0
+      }
+    },
+    {
+      name: 'transcend amount — transcensionChallenge !== 0 (blocked)',
+      input: {
+        ...defaultInput(),
+        transcendMode: 'amount',
+        toggle21: true,
+        upgrade89: 1,
+        transcendPoints: new Decimal(100),
+        transcendPointGain: new Decimal(1e6),
+        transcendamount: 2,
+        coinsThisTranscension: new Decimal(1e101),
+        transcensionChallenge: 3
+      }
+    },
+    {
+      name: 'transcend amount — coinsThisTranscension just under 1e100 (blocked)',
+      input: {
+        ...defaultInput(),
+        transcendMode: 'amount',
+        toggle21: true,
+        upgrade89: 1,
+        transcendPoints: new Decimal(100),
+        transcendPointGain: new Decimal(1e6),
+        transcendamount: 2,
+        coinsThisTranscension: new Decimal('9.99e99')
+      }
+    },
+
+    // ─── Transcend time mode ──────────────────────────────────────────
+    {
+      name: 'transcend time — fires once timer reaches threshold',
+      input: {
+        ...defaultInput(),
+        transcendMode: 'time',
+        toggle21: true,
+        upgrade89: 1,
+        transcendamount: 60,
+        autoResetTimerTranscension: 59.99,
+        dt: 0.025,
+        coinsThisTranscension: new Decimal(1e101)
+      }
+    },
+    {
+      name: 'transcend time — transcensionChallenge gate blocks',
+      input: {
+        ...defaultInput(),
+        transcendMode: 'time',
+        toggle21: true,
+        upgrade89: 1,
+        transcendamount: 1,
+        autoResetTimerTranscension: 100,
+        coinsThisTranscension: new Decimal(1e101),
+        transcensionChallenge: 1
+      }
+    },
+
+    // ─── Reincarnation block (ascensionChallenge === 12 gate) ─────────
+    {
+      name: 'reincarnation block — ascensionChallenge=12 (timer not accumulated, no fires)',
+      input: {
+        ...defaultInput(),
+        ascensionChallenge: 12,
+        reincarnationMode: 'time',
+        toggle27: true,
+        research46: 1,
+        reincarnationamount: 0,
+        transcendShards: new Decimal('1e301'),
+        autoResetTimerReincarnation: 100
+      }
+    },
+    {
+      name: 'reincarnation block — ascensionChallenge=0, amount mode unsatisfied (timer still accumulates)',
+      input: {
+        ...defaultInput(),
+        ascensionChallenge: 0,
+        reincarnationMode: 'amount',
+        toggle27: false, // blocked
+        autoResetTimerReincarnation: 5
+      }
+    },
+
+    // ─── Reincarnation time mode ──────────────────────────────────────
+    {
+      name: 'reincarnation time — all conditions met (fires)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'time',
+        toggle27: true,
+        research46: 1,
+        reincarnationamount: 10,
+        autoResetTimerReincarnation: 9.99,
+        dt: 0.025,
+        transcendShards: new Decimal('1e301')
+      }
+    },
+    {
+      name: 'reincarnation time — research46 = 0.5 exactly (blocked: > 0.5)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'time',
+        toggle27: true,
+        research46: 0.5, // not > 0.5
+        reincarnationamount: 0,
+        autoResetTimerReincarnation: 100,
+        transcendShards: new Decimal('1e301')
+      }
+    },
+    {
+      name: 'reincarnation time — transcendShards just under 1e300 (blocked)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'time',
+        toggle27: true,
+        research46: 1,
+        reincarnationamount: 0,
+        autoResetTimerReincarnation: 100,
+        transcendShards: new Decimal('9.99e299')
+      }
+    },
+    {
+      name: 'reincarnation time — transcensionChallenge !== 0 (blocked)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'time',
+        toggle27: true,
+        research46: 1,
+        reincarnationamount: 0,
+        autoResetTimerReincarnation: 100,
+        transcendShards: new Decimal('1e301'),
+        transcensionChallenge: 1
+      }
+    },
+    {
+      name: 'reincarnation time — reincarnationChallenge !== 0 (blocked)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'time',
+        toggle27: true,
+        research46: 1,
+        reincarnationamount: 0,
+        autoResetTimerReincarnation: 100,
+        transcendShards: new Decimal('1e301'),
+        reincarnationChallenge: 5
+      }
+    },
+
+    // ─── Reincarnation amount mode ────────────────────────────────────
+    {
+      name: 'reincarnation amount — (rPoints+1) * 10^amount threshold (fires)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'amount',
+        toggle27: true,
+        research46: 1,
+        reincarnationPoints: new Decimal(9), // (9+1)*10^2 = 1000
+        reincarnationPointGain: new Decimal(2000),
+        reincarnationamount: 2,
+        transcendShards: new Decimal('1e301')
+      }
+    },
+    {
+      name: 'reincarnation amount — rPoints=0, threshold = 1 * 10^amount (the +1 matters at 0)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'amount',
+        toggle27: true,
+        research46: 1,
+        reincarnationPoints: new Decimal(0), // (0+1)*10^1 = 10
+        reincarnationPointGain: new Decimal(10), // exactly at threshold
+        reincarnationamount: 1,
+        transcendShards: new Decimal('1e301')
+      }
+    },
+    {
+      name: 'reincarnation amount — gain just below (+1 boundary blocks)',
+      input: {
+        ...defaultInput(),
+        reincarnationMode: 'amount',
+        toggle27: true,
+        research46: 1,
+        reincarnationPoints: new Decimal(0),
+        reincarnationPointGain: new Decimal(9.99), // < 10
+        reincarnationamount: 1,
+        transcendShards: new Decimal('1e301')
+      }
+    },
+
+    // ─── Multi-tier simultaneous trigger ──────────────────────────────
+    {
+      name: 'all three tiers fire in the same tick',
+      input: {
+        dt: 0.025,
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal(1e17),
+        autoResetTimerPrestige: 0,
+        transcendMode: 'amount',
+        toggle21: true,
+        upgrade89: 1,
+        transcendPoints: new Decimal(100),
+        transcendPointGain: new Decimal(1e6),
+        transcendamount: 2,
+        coinsThisTranscension: new Decimal(1e101),
+        autoResetTimerTranscension: 0,
+        reincarnationMode: 'amount',
+        toggle27: true,
+        research46: 1,
+        reincarnationPoints: new Decimal(9),
+        reincarnationPointGain: new Decimal(2000),
+        reincarnationamount: 2,
+        transcendShards: new Decimal('1e301'),
+        autoResetTimerReincarnation: 0,
+        ascensionChallenge: 0,
+        transcensionChallenge: 0,
+        reincarnationChallenge: 0
+      }
+    },
+
+    // ─── dt edge cases ────────────────────────────────────────────────
+    {
+      name: 'dt = 0 — timers untouched, no fires',
+      input: {
+        ...defaultInput(),
+        dt: 0,
+        prestigeMode: 'time',
+        autoResetTimerPrestige: 5
+      }
+    },
+    {
+      name: 'large dt overshoots threshold in one tick',
+      input: {
+        ...defaultInput(),
+        dt: 100,
+        prestigeMode: 'time',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigeamount: 5,
+        autoResetTimerPrestige: 0,
+        coinsThisPrestige: new Decimal(1e17)
+      }
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newApplyAutoResets(c.input)
+      const oldR = oldApplyAutoResets(c.input)
+      expect(newR.autoResetTimerPrestige).toBe(oldR.autoResetTimerPrestige)
+      expect(newR.autoResetTimerTranscension).toBe(oldR.autoResetTimerTranscension)
+      expect(newR.autoResetTimerReincarnation).toBe(oldR.autoResetTimerReincarnation)
+      expect(newR.events).toEqual(oldR.events)
+    })
+  }
+})

--- a/packages/logic/test/parity/automaticTools.parity.test.ts
+++ b/packages/logic/test/parity/automaticTools.parity.test.ts
@@ -1,0 +1,218 @@
+// Parity tests for the 2 simple cases of automaticTools.
+// Old bodies transcribed verbatim from packages/web_ui/src/Helper.ts
+// (automaticTools, addObtainium + addOfferings cases pre-migration).
+
+import { describe, expect, it } from 'vitest'
+import { Decimal } from '../../src/math/bignum'
+import {
+  type AddObtainiumInput,
+  type AddObtainiumResult,
+  addObtainium as newAddObtainium,
+  type AddOfferingsInput,
+  type AddOfferingsResult,
+  addOfferings as newAddOfferings
+} from '../../src/tick/automaticTools'
+
+// ─── addObtainium ───────────────────────────────────────────────────────
+
+const oldAddObtainium = (input: AddObtainiumInput): AddObtainiumResult => {
+  // Legacy body: aborts in c14, else conditionally clamps gain, then adds.
+  // UI side effect (visualUpdateResearch) is gated by Tabs.Research in the
+  // caller; the logic-tier translation surfaces it as an auto-tool-fired
+  // event whenever the branch wasn't aborted.
+  if (input.ascensionChallenge === 14) {
+    return { obtainium: input.obtainium, events: [] }
+  }
+  let gain = input.obtainiumGain
+  if (input.taxmanLastStandEnabled && input.taxmanLastStandCompletions >= 2) {
+    gain = Decimal.min(gain, input.obtainium.times(100).plus(1))
+  }
+  return {
+    obtainium: input.obtainium.add(gain),
+    events: [{ kind: 'auto-tool-fired', tool: 'addObtainium' }]
+  }
+}
+
+describe('parity: addObtainium', () => {
+  const cases: Array<{ name: string, input: AddObtainiumInput }> = [
+    {
+      name: 'baseline — no challenge, no taxman, normal gain',
+      input: {
+        obtainium: new Decimal(1e6),
+        obtainiumGain: new Decimal(100),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 0
+      }
+    },
+    {
+      name: 'c14 abort — returns unchanged, no event',
+      input: {
+        obtainium: new Decimal(1e6),
+        obtainiumGain: new Decimal(500),
+        ascensionChallenge: 14,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 0
+      }
+    },
+    {
+      name: 'taxman enabled, completions < 2 (no clamp)',
+      input: {
+        obtainium: new Decimal(1),
+        obtainiumGain: new Decimal(1e30),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: true,
+        taxmanLastStandCompletions: 1
+      }
+    },
+    {
+      name: 'taxman enabled, completions = 2 (clamp engaged, gain capped)',
+      input: {
+        obtainium: new Decimal(10),
+        // Without clamp, gain is huge; with clamp, ceiling is 10*100+1 = 1001
+        obtainiumGain: new Decimal(1e30),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: true,
+        taxmanLastStandCompletions: 2
+      }
+    },
+    {
+      name: 'taxman enabled, completions = 3 (clamp still engaged)',
+      input: {
+        obtainium: new Decimal(0),
+        // obtainium=0 makes ceiling = 0*100 + 1 = 1
+        obtainiumGain: new Decimal(1e6),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: true,
+        taxmanLastStandCompletions: 3
+      }
+    },
+    {
+      name: 'taxman clamp inactive when gain already < ceiling',
+      input: {
+        obtainium: new Decimal(1e6),
+        // Ceiling = 1e8 + 1, gain = 500, so clamp is a no-op
+        obtainiumGain: new Decimal(500),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: true,
+        taxmanLastStandCompletions: 5
+      }
+    },
+    {
+      name: 'taxman disabled, completions = 5 (no clamp)',
+      input: {
+        obtainium: new Decimal(10),
+        obtainiumGain: new Decimal(1e30),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 5
+      }
+    },
+    {
+      name: 'fractional obtainium balance, normal gain',
+      input: {
+        obtainium: new Decimal('123.456e9'),
+        obtainiumGain: new Decimal('7.89e5'),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 0
+      }
+    },
+    {
+      name: 'zero gain (no-op add, event still fires)',
+      input: {
+        obtainium: new Decimal(1e9),
+        obtainiumGain: new Decimal(0),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: false,
+        taxmanLastStandCompletions: 0
+      }
+    },
+    {
+      name: 'c14 abort overrides taxman state',
+      input: {
+        obtainium: new Decimal(1e6),
+        obtainiumGain: new Decimal(1e30),
+        ascensionChallenge: 14,
+        taxmanLastStandEnabled: true,
+        taxmanLastStandCompletions: 5
+      }
+    },
+    {
+      name: 'tiny obtainium balance, taxman engaged (ceiling near 1)',
+      input: {
+        obtainium: new Decimal('1e-6'),
+        obtainiumGain: new Decimal(1e10),
+        ascensionChallenge: 0,
+        taxmanLastStandEnabled: true,
+        taxmanLastStandCompletions: 2
+      }
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAddObtainium(c.input)
+      const oldR = oldAddObtainium(c.input)
+      expect(newR.obtainium.toString()).toBe(oldR.obtainium.toString())
+      expect(newR.events).toEqual(oldR.events)
+    })
+  }
+})
+
+// ─── addOfferings ───────────────────────────────────────────────────────
+
+const oldAddOfferings = (input: AddOfferingsInput): AddOfferingsResult => {
+  // Legacy body in Helper.ts: G.autoOfferingCounter += time; offerings +=
+  // floor(counter); counter %= 1.
+  let counter = input.autoOfferingCounter + input.time
+  const offerings = input.offerings.add(Math.floor(counter))
+  counter = counter % 1
+  return { autoOfferingCounter: counter, offerings }
+}
+
+describe('parity: addOfferings', () => {
+  const cases: Array<{ name: string, input: AddOfferingsInput }> = [
+    {
+      name: 'tiny tick, no overflow',
+      input: { time: 0.025, autoOfferingCounter: 0, offerings: new Decimal(0) }
+    },
+    {
+      name: 'tick fills the bucket exactly',
+      input: { time: 0.5, autoOfferingCounter: 0.5, offerings: new Decimal(1e6) }
+    },
+    {
+      name: 'tick overflows by integer + remainder',
+      input: { time: 3.75, autoOfferingCounter: 0.5, offerings: new Decimal(1e6) }
+    },
+    {
+      name: 'time=0 (counter stays put, no offerings gained)',
+      input: { time: 0, autoOfferingCounter: 0.5, offerings: new Decimal(100) }
+    },
+    {
+      name: 'large multi-second tick (challenge 3 + cube 1x2 boost)',
+      input: { time: 25.4, autoOfferingCounter: 0.9, offerings: new Decimal(1e9) }
+    },
+    {
+      name: 'counter already > 1 (legacy never reduces incoming counter pre-add)',
+      input: { time: 0.025, autoOfferingCounter: 1.4, offerings: new Decimal(50) }
+    },
+    {
+      name: 'fractional carry — counter stays as fractional remainder',
+      input: { time: 0.125, autoOfferingCounter: 0.875, offerings: new Decimal(0) }
+    },
+    {
+      name: 'huge offerings balance, single offering gained',
+      input: { time: 1, autoOfferingCounter: 0.5, offerings: new Decimal('1.5e30') }
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAddOfferings(c.input)
+      const oldR = oldAddOfferings(c.input)
+      expect(newR.autoOfferingCounter).toBe(oldR.autoOfferingCounter)
+      expect(newR.offerings.toString()).toBe(oldR.offerings.toString())
+    })
+  }
+})

--- a/packages/logic/test/parity/challengeSweep.parity.test.ts
+++ b/packages/logic/test/parity/challengeSweep.parity.test.ts
@@ -1,0 +1,396 @@
+// Parity tests for the challenge-sweep state machine.
+// Old bodies transcribed verbatim from packages/web_ui/src/Challenges.ts
+// (`tickChallengeSweep` + `sweepTransitionFunc`, ~lines 407-575
+// pre-migration), minus the side effects (resetCheck,
+// toggleAutoChallengeModeText, toggleChallenges) which stay in web_ui as
+// CoreEvent handlers.
+
+import { describe, expect, it } from 'vitest'
+import {
+  type SweepStates,
+  tickChallengeSweep as newTickChallengeSweep,
+  type TickChallengeSweepInput,
+  type TickChallengeSweepResult
+} from '../../src/tick/challengeSweep'
+
+// Verbatim transcription. Mirrors the legacy code shape:
+//   - the four early-return paths (enable, disable, idle no-op)
+//   - timer accumulation
+//   - sweepTransition + reference-equality change detection
+const oldTickChallengeSweep = (input: TickChallengeSweepInput): TickChallengeSweepResult => {
+  const wasEnabled = input.state.kind !== 'idle'
+  const isEnabled = input.shouldRunSweep
+
+  if (!wasEnabled && isEnabled) {
+    const from: SweepStates = { kind: 'idle' }
+    const to: SweepStates = { kind: 'initial_wait' }
+    return {
+      state: to,
+      timeSinceLastStateChange: 0,
+      events: [{ kind: 'challenge-sweep-transitioned', from, to }]
+    }
+  }
+
+  if (wasEnabled && !isEnabled) {
+    const from = input.state
+    const to: SweepStates = { kind: 'idle' }
+    return {
+      state: to,
+      timeSinceLastStateChange: 0,
+      events: [{ kind: 'challenge-sweep-transitioned', from, to }]
+    }
+  }
+
+  if (!isEnabled) {
+    return {
+      state: input.state,
+      timeSinceLastStateChange: input.timeSinceLastStateChange,
+      events: []
+    }
+  }
+
+  const elapsed = input.timeSinceLastStateChange + input.dt
+  const newState = sweepTransition(input.state, elapsed, input)
+
+  if (newState !== input.state) {
+    return {
+      state: newState,
+      timeSinceLastStateChange: 0,
+      events: [{ kind: 'challenge-sweep-transitioned', from: input.state, to: newState }]
+    }
+  }
+
+  return {
+    state: input.state,
+    timeSinceLastStateChange: elapsed,
+    events: []
+  }
+}
+
+const sweepTransition = (state: SweepStates, elapsed: number, input: TickChallengeSweepInput): SweepStates => {
+  switch (state.kind) {
+    case 'idle':
+      return state
+    case 'initial_wait':
+      if (elapsed >= input.timerStart) {
+        if (input.nextRegularChallengeFromInitial === -1) {
+          return { kind: 'finished' }
+        }
+        return {
+          kind: 'active',
+          index: input.nextRegularChallengeFromInitial,
+          explored: new Set([input.nextRegularChallengeFromInitial])
+        }
+      }
+      return state
+    case 'active':
+      if (elapsed >= input.timerExit) {
+        if (input.nextRegularChallengeFromActive === -1) {
+          if (input.challenge15AutoExponentCheck) {
+            return { kind: 'c15_wait' }
+          }
+          return { kind: 'initial_wait' }
+        }
+        return { kind: 'enter_wait', toIndex: input.nextRegularChallengeFromActive, explored: state.explored }
+      }
+      return state
+    case 'enter_wait':
+      if (elapsed >= input.timerEnter) {
+        return {
+          kind: 'active',
+          index: state.toIndex,
+          explored: new Set([...state.explored, state.toIndex])
+        }
+      }
+      return state
+    case 'c15_wait':
+      if (elapsed >= 5) {
+        return { kind: 'initial_wait' }
+      }
+      return state
+    case 'finished':
+      if (input.isFinishedStillValid) {
+        return state
+      }
+      return { kind: 'initial_wait' }
+    default:
+      throw new Error(`Unhandled SweepState kind: ${(state as { kind: string }).kind}`)
+  }
+}
+
+const defaultInput = (overrides: Partial<TickChallengeSweepInput> = {}): TickChallengeSweepInput => ({
+  dt: 0.025,
+  state: { kind: 'idle' },
+  timeSinceLastStateChange: 0,
+  shouldRunSweep: false,
+  timerStart: 5,
+  timerExit: 30,
+  timerEnter: 2,
+  initialIndex: 1,
+  nextRegularChallengeFromInitial: -1,
+  nextRegularChallengeFromActive: -1,
+  challenge15AutoExponentCheck: false,
+  isFinishedStillValid: false,
+  ...overrides
+})
+
+describe('parity: tickChallengeSweep', () => {
+  const cases: Array<{ name: string, input: TickChallengeSweepInput }> = [
+    // ─── shouldRunSweep gates ──────────────────────────────────────────
+    {
+      name: 'idle + !shouldRunSweep — stays idle, no event',
+      input: defaultInput()
+    },
+    {
+      name: 'idle + shouldRunSweep — boots to initial_wait (event)',
+      input: defaultInput({ shouldRunSweep: true })
+    },
+    {
+      name: 'initial_wait + !shouldRunSweep — tears down to idle (event)',
+      input: defaultInput({
+        state: { kind: 'initial_wait' },
+        timeSinceLastStateChange: 3,
+        shouldRunSweep: false
+      })
+    },
+    {
+      name: 'active + !shouldRunSweep — fires resetCheck via event with from.index',
+      input: defaultInput({
+        state: { kind: 'active', index: 3, explored: new Set([1, 2, 3]) },
+        timeSinceLastStateChange: 10,
+        shouldRunSweep: false
+      })
+    },
+    {
+      name: 'active(reincarnation idx 8) + !shouldRunSweep — from.index preserved',
+      input: defaultInput({
+        state: { kind: 'active', index: 8, explored: new Set([6, 7, 8]) },
+        timeSinceLastStateChange: 10,
+        shouldRunSweep: false
+      })
+    },
+
+    // ─── initial_wait transitions ──────────────────────────────────────
+    {
+      name: 'initial_wait + elapsed < timerStart — stays (timer accumulates)',
+      input: defaultInput({
+        state: { kind: 'initial_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 4.9,
+        dt: 0.025,
+        timerStart: 5
+      })
+    },
+    {
+      name: 'initial_wait + elapsed >= timerStart + nextChallenge !== -1 → active',
+      input: defaultInput({
+        state: { kind: 'initial_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 4.99,
+        dt: 0.025,
+        timerStart: 5,
+        nextRegularChallengeFromInitial: 1
+      })
+    },
+    {
+      name: 'initial_wait + elapsed >= timerStart + nextChallenge === -1 → finished',
+      input: defaultInput({
+        state: { kind: 'initial_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 4.99,
+        dt: 0.025,
+        timerStart: 5,
+        nextRegularChallengeFromInitial: -1
+      })
+    },
+
+    // ─── active transitions ────────────────────────────────────────────
+    {
+      name: 'active + elapsed < timerExit — stays',
+      input: defaultInput({
+        state: { kind: 'active', index: 1, explored: new Set([1]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 25,
+        dt: 0.025,
+        timerExit: 30
+      })
+    },
+    {
+      name: 'active + elapsed >= timerExit + nextChallenge=2 → enter_wait(toIndex=2)',
+      input: defaultInput({
+        state: { kind: 'active', index: 1, explored: new Set([1]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 29.99,
+        dt: 0.025,
+        timerExit: 30,
+        nextRegularChallengeFromActive: 2
+      })
+    },
+    {
+      name: 'active + elapsed >= timerExit + nextChallenge=-1 + chal15Check → c15_wait',
+      input: defaultInput({
+        state: { kind: 'active', index: 10, explored: new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 29.99,
+        dt: 0.025,
+        timerExit: 30,
+        nextRegularChallengeFromActive: -1,
+        challenge15AutoExponentCheck: true
+      })
+    },
+    {
+      name: 'active + elapsed >= timerExit + nextChallenge=-1 + !chal15Check → initial_wait',
+      input: defaultInput({
+        state: { kind: 'active', index: 10, explored: new Set([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 29.99,
+        dt: 0.025,
+        timerExit: 30,
+        nextRegularChallengeFromActive: -1,
+        challenge15AutoExponentCheck: false
+      })
+    },
+
+    // ─── enter_wait transitions ────────────────────────────────────────
+    {
+      name: 'enter_wait + elapsed < timerEnter — stays',
+      input: defaultInput({
+        state: { kind: 'enter_wait', toIndex: 2, explored: new Set([1]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 1.9,
+        dt: 0.025,
+        timerEnter: 2
+      })
+    },
+    {
+      name: 'enter_wait + elapsed >= timerEnter → active (explored ∪ toIndex)',
+      input: defaultInput({
+        state: { kind: 'enter_wait', toIndex: 2, explored: new Set([1]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 1.99,
+        dt: 0.025,
+        timerEnter: 2
+      })
+    },
+    {
+      name: 'enter_wait — explored set carries forward and adds toIndex',
+      input: defaultInput({
+        state: { kind: 'enter_wait', toIndex: 7, explored: new Set([1, 2, 3, 4, 5, 6]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 1.99,
+        dt: 0.025,
+        timerEnter: 2
+      })
+    },
+
+    // ─── c15_wait transitions ──────────────────────────────────────────
+    {
+      name: 'c15_wait + elapsed < 5 — stays',
+      input: defaultInput({
+        state: { kind: 'c15_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 4.9,
+        dt: 0.025
+      })
+    },
+    {
+      name: 'c15_wait + elapsed >= 5 → initial_wait',
+      input: defaultInput({
+        state: { kind: 'c15_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 4.99,
+        dt: 0.025
+      })
+    },
+
+    // ─── finished transitions ──────────────────────────────────────────
+    {
+      name: 'finished + isFinishedStillValid — stays',
+      input: defaultInput({
+        state: { kind: 'finished' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 100,
+        dt: 0.025,
+        isFinishedStillValid: true
+      })
+    },
+    {
+      name: 'finished + !isFinishedStillValid → initial_wait',
+      input: defaultInput({
+        state: { kind: 'finished' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 100,
+        dt: 0.025,
+        isFinishedStillValid: false
+      })
+    },
+
+    // ─── Edge cases ────────────────────────────────────────────────────
+    {
+      name: 'dt = 0 — no timer change, no transition',
+      input: defaultInput({
+        state: { kind: 'initial_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 3,
+        dt: 0
+      })
+    },
+    {
+      name: 'large dt vaults past threshold in one tick',
+      input: defaultInput({
+        state: { kind: 'initial_wait' },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 0,
+        dt: 100,
+        timerStart: 5,
+        nextRegularChallengeFromInitial: 1
+      })
+    },
+    {
+      name: 'enter_wait toIndex=6 (reincarnation crosses transcension boundary)',
+      input: defaultInput({
+        state: { kind: 'enter_wait', toIndex: 6, explored: new Set([1, 2, 3, 4, 5]) },
+        shouldRunSweep: true,
+        timeSinceLastStateChange: 5,
+        dt: 0,
+        timerEnter: 2
+      })
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newTickChallengeSweep(c.input)
+      const oldR = oldTickChallengeSweep(c.input)
+      // State equality — kinds match
+      expect(newR.state.kind).toBe(oldR.state.kind)
+      // Discriminated fields by kind
+      if (newR.state.kind === 'active' && oldR.state.kind === 'active') {
+        expect(newR.state.index).toBe(oldR.state.index)
+        expect([...newR.state.explored].sort((a, b) => a - b)).toEqual([...oldR.state.explored].sort((a, b) => a - b))
+      }
+      if (newR.state.kind === 'enter_wait' && oldR.state.kind === 'enter_wait') {
+        expect(newR.state.toIndex).toBe(oldR.state.toIndex)
+        expect([...newR.state.explored].sort((a, b) => a - b)).toEqual([...oldR.state.explored].sort((a, b) => a - b))
+      }
+      expect(newR.timeSinceLastStateChange).toBe(oldR.timeSinceLastStateChange)
+      expect(newR.events.length).toBe(oldR.events.length)
+      // Per-event field equality (kinds, from/to kinds, indexes where applicable)
+      for (let i = 0; i < newR.events.length; i++) {
+        const ne = newR.events[i]
+        const oe = oldR.events[i]
+        expect(ne.kind).toBe(oe.kind)
+        if (ne.kind === 'challenge-sweep-transitioned' && oe.kind === 'challenge-sweep-transitioned') {
+          expect(ne.from.kind).toBe(oe.from.kind)
+          expect(ne.to.kind).toBe(oe.to.kind)
+          if (ne.from.kind === 'active' && oe.from.kind === 'active') {
+            expect(ne.from.index).toBe(oe.from.index)
+          }
+          if (ne.to.kind === 'active' && oe.to.kind === 'active') {
+            expect(ne.to.index).toBe(oe.to.index)
+          }
+        }
+      }
+    })
+  }
+})

--- a/packages/logic/test/parity/octeractTimer.parity.test.ts
+++ b/packages/logic/test/parity/octeractTimer.parity.test.ts
@@ -1,0 +1,244 @@
+// Parity tests for the octeracts addTimers case.
+// Old body transcribed verbatim from packages/web_ui/src/Helper.ts
+// (addTimers, `octeracts` switch case pre-migration). The legacy code
+// reads `calculateGoldenQuarks()` inside the giveaway loop, which is
+// equivalent to `calculateBaseGoldenQuarks(qts) * product(stats[1..])`;
+// the parity oracle here computes that the same way the migrated logic
+// does, since the equivalence is provable from the stat list (only
+// stat 0 / `calculateBaseGoldenQuarks` depends on quarksThisSingularity,
+// which is the only loop-mutated input).
+
+import { describe, expect, it } from 'vitest'
+import { calculateBaseGoldenQuarks } from '../../src/mechanics/singularityMilestones'
+import {
+  advanceOcteractTimer as newAdvanceOcteract,
+  type AdvanceOcteractTimerInput,
+  type AdvanceOcteractTimerResult,
+  OCTERACT_GIVEAWAY_LEVELS
+} from '../../src/tick/timers'
+
+// Verbatim transcription mirroring the legacy switch case body.
+const oldAdvanceOcteract = (input: AdvanceOcteractTimerInput): AdvanceOcteractTimerResult => {
+  if (!input.octeractUnlocked) {
+    return {
+      octeractTimer: input.octeractTimer,
+      wowOcteracts: input.wowOcteracts,
+      totalWowOcteracts: input.totalWowOcteracts,
+      goldenQuarks: input.goldenQuarks,
+      quarksThisSingularity: input.quarksThisSingularity,
+      events: []
+    }
+  }
+  let octeractTimer = input.octeractTimer + input.time * input.timeMultiplier
+  if (octeractTimer < 1) {
+    return {
+      octeractTimer,
+      wowOcteracts: input.wowOcteracts,
+      totalWowOcteracts: input.totalWowOcteracts,
+      goldenQuarks: input.goldenQuarks,
+      quarksThisSingularity: input.quarksThisSingularity,
+      events: []
+    }
+  }
+  const amountOfGiveaways = octeractTimer - (octeractTimer % 1)
+  octeractTimer %= 1
+
+  const wowOcteracts = input.wowOcteracts + amountOfGiveaways * input.perSecond
+  const totalWowOcteracts = input.totalWowOcteracts + amountOfGiveaways * input.perSecond
+
+  let goldenQuarks = input.goldenQuarks
+  let qts = input.quarksThisSingularity
+  if (input.highestSingularityCount >= 160) {
+    const frac = 1e-6
+    let actualLevel = 0
+    for (const level of OCTERACT_GIVEAWAY_LEVELS) {
+      if (input.highestSingularityCount >= level) actualLevel += 1
+    }
+    const quarkFraction = frac * actualLevel
+    for (let i = 0; i < amountOfGiveaways; i++) {
+      const base = calculateBaseGoldenQuarks({
+        singularity: input.singularityCount,
+        quarksThisSingularity: qts,
+        highestSingularityCount: input.highestSingularityCount
+      })
+      goldenQuarks += quarkFraction * base * input.goldenQuarksMultiplierExcludingBase
+      qts *= 1 - quarkFraction
+    }
+  }
+  return {
+    octeractTimer,
+    wowOcteracts,
+    totalWowOcteracts,
+    goldenQuarks,
+    quarksThisSingularity: qts,
+    events: [{ kind: 'octeract-tick-fired', amountOfGiveaways }]
+  }
+}
+
+const defaultInput = (overrides: Partial<AdvanceOcteractTimerInput> = {}): AdvanceOcteractTimerInput => ({
+  time: 0.025,
+  timeMultiplier: 1,
+  octeractUnlocked: true,
+  octeractTimer: 0,
+  wowOcteracts: 0,
+  totalWowOcteracts: 0,
+  goldenQuarks: 0,
+  quarksThisSingularity: 0,
+  perSecond: 1,
+  highestSingularityCount: 0,
+  singularityCount: 0,
+  goldenQuarksMultiplierExcludingBase: 1,
+  ...overrides
+})
+
+describe('parity: advanceOcteractTimer', () => {
+  const cases: Array<{ name: string, input: AdvanceOcteractTimerInput }> = [
+    {
+      name: 'gate — octeractUnlocked=false (no state change, no event)',
+      input: defaultInput({ octeractUnlocked: false, octeractTimer: 0.5, time: 0.5 })
+    },
+    {
+      name: 'sub-second timer accumulates only',
+      input: defaultInput({ octeractTimer: 0.1, time: 0.5 })
+    },
+    {
+      name: 'crosses 1s — 1 giveaway, no GQ block (highestSing < 160)',
+      input: defaultInput({
+        octeractTimer: 0.9,
+        time: 0.2,
+        perSecond: 50,
+        highestSingularityCount: 100
+      })
+    },
+    {
+      name: 'crosses multiple seconds at once (large dt)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 5.7,
+        timeMultiplier: 1,
+        perSecond: 10,
+        highestSingularityCount: 50
+      })
+    },
+    {
+      name: 'fractional remainder carries to next tick',
+      input: defaultInput({
+        octeractTimer: 0.75,
+        time: 1.5,
+        perSecond: 100
+      })
+    },
+    {
+      name: 'GQ block — sing=160 (actualLevel=1, single iteration)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 1.5, // → 1 giveaway
+        perSecond: 100,
+        highestSingularityCount: 160,
+        singularityCount: 160,
+        quarksThisSingularity: 1e8,
+        goldenQuarks: 1000,
+        goldenQuarksMultiplierExcludingBase: 5
+      })
+    },
+    {
+      name: 'GQ block — sing=210 (actualLevel=6, larger quarkFraction)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 1.1,
+        perSecond: 1000,
+        highestSingularityCount: 210,
+        singularityCount: 210,
+        quarksThisSingularity: 1e10,
+        goldenQuarks: 10000,
+        goldenQuarksMultiplierExcludingBase: 50
+      })
+    },
+    {
+      name: 'GQ block — sing=249 (actualLevel=10, max scaling)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 1.1,
+        perSecond: 1e6,
+        highestSingularityCount: 249,
+        singularityCount: 249,
+        quarksThisSingularity: 1e12,
+        goldenQuarks: 1e6,
+        goldenQuarksMultiplierExcludingBase: 100
+      })
+    },
+    {
+      name: 'GQ block — multi-iteration loop (qts decays geometrically)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 5.5, // → 5 giveaways
+        perSecond: 100,
+        highestSingularityCount: 200,
+        singularityCount: 200,
+        quarksThisSingularity: 1e9,
+        goldenQuarks: 5000,
+        goldenQuarksMultiplierExcludingBase: 20
+      })
+    },
+    {
+      name: 'GQ block — sing=159 (no GQ block, just octeracts)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 1.1,
+        perSecond: 100,
+        highestSingularityCount: 159, // strictly less than 160
+        singularityCount: 159,
+        quarksThisSingularity: 1e8
+      })
+    },
+    {
+      name: 'GQ block — sing=160 exactly (boundary)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 1.1,
+        perSecond: 100,
+        highestSingularityCount: 160,
+        singularityCount: 160,
+        quarksThisSingularity: 1e8,
+        goldenQuarksMultiplierExcludingBase: 10
+      })
+    },
+    {
+      name: 'large multi-iter (10 giveaways) — qts decay accumulates',
+      input: defaultInput({
+        octeractTimer: 0.5,
+        time: 10,
+        perSecond: 5,
+        highestSingularityCount: 230,
+        singularityCount: 230,
+        quarksThisSingularity: 1e10,
+        goldenQuarksMultiplierExcludingBase: 30
+      })
+    },
+    {
+      name: 'qts=0 (degenerate but valid — base formula still produces a value)',
+      input: defaultInput({
+        octeractTimer: 0,
+        time: 1.1,
+        perSecond: 50,
+        highestSingularityCount: 200,
+        singularityCount: 200,
+        quarksThisSingularity: 0,
+        goldenQuarksMultiplierExcludingBase: 10
+      })
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newAdvanceOcteract(c.input)
+      const oldR = oldAdvanceOcteract(c.input)
+      expect(newR.octeractTimer).toBeCloseTo(oldR.octeractTimer, 10)
+      expect(newR.wowOcteracts).toBe(oldR.wowOcteracts)
+      expect(newR.totalWowOcteracts).toBe(oldR.totalWowOcteracts)
+      expect(newR.goldenQuarks).toBeCloseTo(oldR.goldenQuarks, 6)
+      expect(newR.quarksThisSingularity).toBeCloseTo(oldR.quarksThisSingularity, 6)
+      expect(newR.events).toEqual(oldR.events)
+    })
+  }
+})

--- a/packages/logic/test/parity/tackTail.parity.test.ts
+++ b/packages/logic/test/parity/tackTail.parity.test.ts
@@ -1,0 +1,270 @@
+// Parity tests for the tackTail composition.
+//
+// tackTail bundles 3 already-tested logic functions (addOfferings,
+// tickChallengeSweep, applyAutoResets) in their fixed sequential order.
+// The unit-level parity is already covered by the individual subsystem
+// tests; these cases check that the composition preserves order, threads
+// state correctly, and merges events in legacy sequence.
+
+import { describe, expect, it } from 'vitest'
+import { Decimal } from '../../src/math/bignum'
+import { addOfferings } from '../../src/tick/automaticTools'
+import { applyAutoResets } from '../../src/tick/autoReset'
+import { type SweepStates, tickChallengeSweep } from '../../src/tick/challengeSweep'
+import { tackTail as newTackTail, type TackTailInput, type TackTailResult } from '../../src/tick/tackTail'
+
+// Verbatim reference — runs the three subsystems in sequence and merges events.
+const oldTackTail = (input: TackTailInput): TackTailResult => {
+  const events: TackTailResult['events'] = []
+
+  let autoOfferingCounter = input.autoOfferingCounter
+  let offerings = input.offerings
+  if (input.highestchallengecompletions3 > 0) {
+    const r = addOfferings({
+      time: input.dt / 2,
+      autoOfferingCounter,
+      offerings
+    })
+    autoOfferingCounter = r.autoOfferingCounter
+    offerings = r.offerings
+  }
+
+  const sweep = tickChallengeSweep({
+    dt: input.dt,
+    state: input.sweepState,
+    timeSinceLastStateChange: input.timeSinceLastStateChange,
+    shouldRunSweep: input.shouldRunSweep,
+    timerStart: input.timerStart,
+    timerExit: input.timerExit,
+    timerEnter: input.timerEnter,
+    initialIndex: input.initialIndex,
+    nextRegularChallengeFromInitial: input.nextRegularChallengeFromInitial,
+    nextRegularChallengeFromActive: input.nextRegularChallengeFromActive,
+    challenge15AutoExponentCheck: input.challenge15AutoExponentCheck,
+    isFinishedStillValid: input.isFinishedStillValid
+  })
+  for (const e of sweep.events) events.push(e)
+
+  const resets = applyAutoResets({
+    dt: input.dt,
+    prestigeMode: input.prestigeMode,
+    toggle15: input.toggle15,
+    autoPrestigeMilestone: input.autoPrestigeMilestone,
+    prestigePoints: input.prestigePoints,
+    prestigePointGain: input.prestigePointGain,
+    prestigeamount: input.prestigeamount,
+    coinsThisPrestige: input.coinsThisPrestige,
+    autoResetTimerPrestige: input.autoResetTimerPrestige,
+    transcendMode: input.transcendMode,
+    toggle21: input.toggle21,
+    upgrade89: input.upgrade89,
+    transcendPoints: input.transcendPoints,
+    transcendPointGain: input.transcendPointGain,
+    transcendamount: input.transcendamount,
+    coinsThisTranscension: input.coinsThisTranscension,
+    autoResetTimerTranscension: input.autoResetTimerTranscension,
+    reincarnationMode: input.reincarnationMode,
+    toggle27: input.toggle27,
+    research46: input.research46,
+    reincarnationPoints: input.reincarnationPoints,
+    reincarnationPointGain: input.reincarnationPointGain,
+    reincarnationamount: input.reincarnationamount,
+    transcendShards: input.transcendShards,
+    autoResetTimerReincarnation: input.autoResetTimerReincarnation,
+    ascensionChallenge: input.ascensionChallenge,
+    transcensionChallenge: input.transcensionChallenge,
+    reincarnationChallenge: input.reincarnationChallenge
+  })
+  for (const e of resets.events) events.push(e)
+
+  return {
+    autoOfferingCounter,
+    offerings,
+    sweepState: sweep.state,
+    timeSinceLastStateChange: sweep.timeSinceLastStateChange,
+    autoResetTimerPrestige: resets.autoResetTimerPrestige,
+    autoResetTimerTranscension: resets.autoResetTimerTranscension,
+    autoResetTimerReincarnation: resets.autoResetTimerReincarnation,
+    events
+  }
+}
+
+const defaultInput = (overrides: Partial<TackTailInput> = {}): TackTailInput => ({
+  dt: 0.025,
+  highestchallengecompletions3: 0,
+  autoOfferingCounter: 0,
+  offerings: new Decimal(1000),
+  sweepState: { kind: 'idle' } as SweepStates,
+  timeSinceLastStateChange: 0,
+  shouldRunSweep: false,
+  timerStart: 5,
+  timerExit: 30,
+  timerEnter: 2,
+  initialIndex: 1,
+  nextRegularChallengeFromInitial: -1,
+  nextRegularChallengeFromActive: -1,
+  challenge15AutoExponentCheck: false,
+  isFinishedStillValid: false,
+  prestigeMode: 'amount',
+  toggle15: false,
+  autoPrestigeMilestone: 0,
+  prestigePoints: new Decimal(0),
+  prestigePointGain: new Decimal(0),
+  prestigeamount: 1,
+  coinsThisPrestige: new Decimal(0),
+  autoResetTimerPrestige: 0,
+  transcendMode: 'amount',
+  toggle21: false,
+  upgrade89: 0,
+  transcendPoints: new Decimal(0),
+  transcendPointGain: new Decimal(0),
+  transcendamount: 1,
+  coinsThisTranscension: new Decimal(0),
+  autoResetTimerTranscension: 0,
+  reincarnationMode: 'amount',
+  toggle27: false,
+  research46: 0,
+  reincarnationPoints: new Decimal(0),
+  reincarnationPointGain: new Decimal(0),
+  reincarnationamount: 1,
+  transcendShards: new Decimal(0),
+  autoResetTimerReincarnation: 0,
+  ascensionChallenge: 0,
+  transcensionChallenge: 0,
+  reincarnationChallenge: 0,
+  ...overrides
+})
+
+describe('parity: tackTail', () => {
+  const cases: Array<{ name: string, input: TackTailInput }> = [
+    {
+      name: 'quiet tick — all gates blocking',
+      input: defaultInput()
+    },
+    {
+      name: 'addOfferings runs (c3 unlocked, fractional carry)',
+      input: defaultInput({
+        highestchallengecompletions3: 1,
+        autoOfferingCounter: 0.9,
+        offerings: new Decimal(100),
+        dt: 0.5
+      })
+    },
+    {
+      name: 'sweep boots from idle when shouldRunSweep flips on',
+      input: defaultInput({
+        sweepState: { kind: 'idle' },
+        shouldRunSweep: true
+      })
+    },
+    {
+      name: 'sweep transitions active → enter_wait + emits event',
+      input: defaultInput({
+        sweepState: { kind: 'active', index: 1, explored: new Set([1]) },
+        timeSinceLastStateChange: 29.99,
+        dt: 0.025,
+        timerExit: 30,
+        shouldRunSweep: true,
+        nextRegularChallengeFromActive: 2
+      })
+    },
+    {
+      name: 'auto-prestige amount-mode fires + emits event',
+      input: defaultInput({
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal(1e17)
+      })
+    },
+    {
+      name: 'all three subsystems fire — sweep transition + auto-transcend',
+      input: defaultInput({
+        highestchallengecompletions3: 1,
+        autoOfferingCounter: 0.5,
+        offerings: new Decimal(500),
+        dt: 0.025,
+        sweepState: { kind: 'c15_wait' },
+        timeSinceLastStateChange: 4.99,
+        shouldRunSweep: true,
+        transcendMode: 'amount',
+        toggle21: true,
+        upgrade89: 1,
+        transcendPoints: new Decimal(100),
+        transcendPointGain: new Decimal(1e6),
+        transcendamount: 2,
+        coinsThisTranscension: new Decimal(1e101)
+      })
+    },
+    {
+      name: 'auto-reincarnation amount-mode fires (+1 boundary at 0 points)',
+      input: defaultInput({
+        reincarnationMode: 'amount',
+        toggle27: true,
+        research46: 1,
+        reincarnationPoints: new Decimal(0),
+        reincarnationPointGain: new Decimal(10),
+        reincarnationamount: 1,
+        transcendShards: new Decimal('1e301')
+      })
+    },
+    {
+      name: 'sweep tears down when shouldRunSweep flips off mid-active (emits event with from.index)',
+      input: defaultInput({
+        sweepState: { kind: 'active', index: 7, explored: new Set([6, 7]) },
+        shouldRunSweep: false
+      })
+    },
+    {
+      name: 'event order: sweep then resets',
+      input: defaultInput({
+        // Sweep idle → initial_wait (emits sweep event)
+        sweepState: { kind: 'idle' },
+        shouldRunSweep: true,
+        // Auto-prestige fires (emits auto-reset event)
+        prestigeMode: 'amount',
+        toggle15: true,
+        autoPrestigeMilestone: 1,
+        prestigePoints: new Decimal(100),
+        prestigePointGain: new Decimal(1e6),
+        prestigeamount: 2,
+        coinsThisPrestige: new Decimal(1e17)
+      })
+    },
+    {
+      name: 'big dt (offline catch-up scenario)',
+      input: defaultInput({
+        dt: 100,
+        highestchallengecompletions3: 1,
+        autoOfferingCounter: 0,
+        offerings: new Decimal(100),
+        sweepState: { kind: 'initial_wait' },
+        shouldRunSweep: true,
+        timerStart: 5,
+        nextRegularChallengeFromInitial: 1
+      })
+    }
+  ]
+
+  for (const c of cases) {
+    it(c.name, () => {
+      const newR = newTackTail(c.input)
+      const oldR = oldTackTail(c.input)
+      expect(newR.autoOfferingCounter).toBeCloseTo(oldR.autoOfferingCounter, 10)
+      expect(newR.offerings.toString()).toBe(oldR.offerings.toString())
+      expect(newR.sweepState.kind).toBe(oldR.sweepState.kind)
+      expect(newR.timeSinceLastStateChange).toBe(oldR.timeSinceLastStateChange)
+      expect(newR.autoResetTimerPrestige).toBe(oldR.autoResetTimerPrestige)
+      expect(newR.autoResetTimerTranscension).toBe(oldR.autoResetTimerTranscension)
+      expect(newR.autoResetTimerReincarnation).toBe(oldR.autoResetTimerReincarnation)
+      // Event sequence matches (kinds + key fields)
+      expect(newR.events.length).toBe(oldR.events.length)
+      for (let i = 0; i < newR.events.length; i++) {
+        expect(newR.events[i].kind).toBe(oldR.events[i].kind)
+      }
+    })
+  }
+})

--- a/packages/logic/test/parity/tickHarness.parity.test.ts
+++ b/packages/logic/test/parity/tickHarness.parity.test.ts
@@ -1,0 +1,345 @@
+// Multi-tick parity harness for the tackTail composition.
+//
+// Per-leaf and per-case parity tests cover individual function correctness;
+// this harness exercises tackTail across N=1000 ticks against a small set
+// of fixtures, catching composition-level drift the per-case tests can't:
+//   - Sweep state machine cycling correctly over many ticks.
+//   - Timer accumulators (autoResetTimers, sweep elapsed) staying in sync.
+//   - Event counts and ordering invariants across long runs.
+//   - Floating-point drift between the migrated `tackTail` and the
+//     verbatim three-subsystem oracle.
+//
+// Scope caveat: this harness covers the migrated tail only. The full
+// pre-migration tack body (resourceGain through Roomba) still has holes
+// for un-migrated subsystems (generateAntsAndCrumbs, octeracts /
+// autoPotion timers, rune/ant sacrifice, auto-research / Roomba), so a
+// complete legacy-vs-new tack comparison would require reconstructing
+// the legacy body — out of scope here. As those subsystems migrate,
+// this harness can be extended to cover them.
+
+import { describe, expect, it } from 'vitest'
+import { Decimal } from '../../src/math/bignum'
+import { addOfferings } from '../../src/tick/automaticTools'
+import { applyAutoResets } from '../../src/tick/autoReset'
+import { type SweepStates, tickChallengeSweep } from '../../src/tick/challengeSweep'
+import { tackTail, type TackTailInput, type TackTailResult } from '../../src/tick/tackTail'
+
+// Verbatim three-subsystem oracle — same body as the tackTail
+// implementation, used as the comparison target.
+const oracleTackTail = (input: TackTailInput): TackTailResult => {
+  const events: TackTailResult['events'] = []
+
+  let autoOfferingCounter = input.autoOfferingCounter
+  let offerings = input.offerings
+  if (input.highestchallengecompletions3 > 0) {
+    const r = addOfferings({
+      time: input.dt / 2,
+      autoOfferingCounter,
+      offerings
+    })
+    autoOfferingCounter = r.autoOfferingCounter
+    offerings = r.offerings
+  }
+
+  const sweep = tickChallengeSweep({
+    dt: input.dt,
+    state: input.sweepState,
+    timeSinceLastStateChange: input.timeSinceLastStateChange,
+    shouldRunSweep: input.shouldRunSweep,
+    timerStart: input.timerStart,
+    timerExit: input.timerExit,
+    timerEnter: input.timerEnter,
+    initialIndex: input.initialIndex,
+    nextRegularChallengeFromInitial: input.nextRegularChallengeFromInitial,
+    nextRegularChallengeFromActive: input.nextRegularChallengeFromActive,
+    challenge15AutoExponentCheck: input.challenge15AutoExponentCheck,
+    isFinishedStillValid: input.isFinishedStillValid
+  })
+  for (const e of sweep.events) events.push(e)
+
+  const resets = applyAutoResets({
+    dt: input.dt,
+    prestigeMode: input.prestigeMode,
+    toggle15: input.toggle15,
+    autoPrestigeMilestone: input.autoPrestigeMilestone,
+    prestigePoints: input.prestigePoints,
+    prestigePointGain: input.prestigePointGain,
+    prestigeamount: input.prestigeamount,
+    coinsThisPrestige: input.coinsThisPrestige,
+    autoResetTimerPrestige: input.autoResetTimerPrestige,
+    transcendMode: input.transcendMode,
+    toggle21: input.toggle21,
+    upgrade89: input.upgrade89,
+    transcendPoints: input.transcendPoints,
+    transcendPointGain: input.transcendPointGain,
+    transcendamount: input.transcendamount,
+    coinsThisTranscension: input.coinsThisTranscension,
+    autoResetTimerTranscension: input.autoResetTimerTranscension,
+    reincarnationMode: input.reincarnationMode,
+    toggle27: input.toggle27,
+    research46: input.research46,
+    reincarnationPoints: input.reincarnationPoints,
+    reincarnationPointGain: input.reincarnationPointGain,
+    reincarnationamount: input.reincarnationamount,
+    transcendShards: input.transcendShards,
+    autoResetTimerReincarnation: input.autoResetTimerReincarnation,
+    ascensionChallenge: input.ascensionChallenge,
+    transcensionChallenge: input.transcensionChallenge,
+    reincarnationChallenge: input.reincarnationChallenge
+  })
+  for (const e of resets.events) events.push(e)
+
+  return {
+    autoOfferingCounter,
+    offerings,
+    sweepState: sweep.state,
+    timeSinceLastStateChange: sweep.timeSinceLastStateChange,
+    autoResetTimerPrestige: resets.autoResetTimerPrestige,
+    autoResetTimerTranscension: resets.autoResetTimerTranscension,
+    autoResetTimerReincarnation: resets.autoResetTimerReincarnation,
+    events
+  }
+}
+
+// ─── Fixture state — only the fields tackTail reads/writes ─────────────
+//
+// `input.*` fields that are stable across the tick (gates, lookups, timers)
+// are reset each iteration; the mutable accumulators (autoOfferingCounter,
+// offerings, sweepState, timeSinceLastStateChange, autoResetTimer*) thread
+// through tick-to-tick.
+
+interface FixtureState {
+  autoOfferingCounter: number
+  offerings: Decimal
+  sweepState: SweepStates
+  timeSinceLastStateChange: number
+  autoResetTimerPrestige: number
+  autoResetTimerTranscension: number
+  autoResetTimerReincarnation: number
+}
+
+// Snapshot two states for equality assertion at end-of-tick.
+const stateSnapshot = (s: FixtureState) => ({
+  autoOfferingCounter: s.autoOfferingCounter,
+  offerings: s.offerings.toString(),
+  sweepKind: s.sweepState.kind,
+  sweepIndex: s.sweepState.kind === 'active' ? s.sweepState.index : undefined,
+  sweepToIndex: s.sweepState.kind === 'enter_wait' ? s.sweepState.toIndex : undefined,
+  sweepExplored: ('explored' in s.sweepState)
+    ? [...s.sweepState.explored].sort((a, b) => a - b)
+    : undefined,
+  timeSinceLastStateChange: s.timeSinceLastStateChange,
+  autoResetTimerPrestige: s.autoResetTimerPrestige,
+  autoResetTimerTranscension: s.autoResetTimerTranscension,
+  autoResetTimerReincarnation: s.autoResetTimerReincarnation
+})
+
+// Build a TackTailInput from the per-fixture constants + the threaded state.
+type StaticInputs = Omit<TackTailInput,
+  | 'dt'
+  | 'autoOfferingCounter'
+  | 'offerings'
+  | 'sweepState'
+  | 'timeSinceLastStateChange'
+  | 'autoResetTimerPrestige'
+  | 'autoResetTimerTranscension'
+  | 'autoResetTimerReincarnation'
+>
+
+const buildInput = (statics: StaticInputs, state: FixtureState, dt: number): TackTailInput => ({
+  dt,
+  ...statics,
+  autoOfferingCounter: state.autoOfferingCounter,
+  offerings: state.offerings,
+  sweepState: state.sweepState,
+  timeSinceLastStateChange: state.timeSinceLastStateChange,
+  autoResetTimerPrestige: state.autoResetTimerPrestige,
+  autoResetTimerTranscension: state.autoResetTimerTranscension,
+  autoResetTimerReincarnation: state.autoResetTimerReincarnation
+})
+
+// Pull the mutable state out of a result back into a FixtureState.
+const stateFromResult = (r: TackTailResult): FixtureState => ({
+  autoOfferingCounter: r.autoOfferingCounter,
+  offerings: r.offerings,
+  sweepState: r.sweepState,
+  timeSinceLastStateChange: r.timeSinceLastStateChange,
+  autoResetTimerPrestige: r.autoResetTimerPrestige,
+  autoResetTimerTranscension: r.autoResetTimerTranscension,
+  autoResetTimerReincarnation: r.autoResetTimerReincarnation
+})
+
+// ─── Fixtures ──────────────────────────────────────────────────────────
+
+// Fixture A — quiet idle tick. Sweep off, all auto-reset gates blocking.
+// addOfferings active (c3 ≥ 1), so the only state change per tick is the
+// fractional offering counter accumulating ~0.0125 per 25ms tick.
+const FIXTURE_A_STATICS: StaticInputs = {
+  highestchallengecompletions3: 1,
+  shouldRunSweep: false,
+  timerStart: 5,
+  timerExit: 30,
+  timerEnter: 2,
+  initialIndex: 1,
+  nextRegularChallengeFromInitial: -1,
+  nextRegularChallengeFromActive: -1,
+  challenge15AutoExponentCheck: false,
+  isFinishedStillValid: false,
+  prestigeMode: 'amount',
+  toggle15: false,
+  autoPrestigeMilestone: 0,
+  prestigePoints: new Decimal(0),
+  prestigePointGain: new Decimal(0),
+  prestigeamount: 1,
+  coinsThisPrestige: new Decimal(0),
+  transcendMode: 'amount',
+  toggle21: false,
+  upgrade89: 0,
+  transcendPoints: new Decimal(0),
+  transcendPointGain: new Decimal(0),
+  transcendamount: 1,
+  coinsThisTranscension: new Decimal(0),
+  reincarnationMode: 'amount',
+  toggle27: false,
+  research46: 0,
+  reincarnationPoints: new Decimal(0),
+  reincarnationPointGain: new Decimal(0),
+  reincarnationamount: 1,
+  transcendShards: new Decimal(0),
+  ascensionChallenge: 0,
+  transcensionChallenge: 0,
+  reincarnationChallenge: 0
+}
+
+const FIXTURE_A_INITIAL: FixtureState = {
+  autoOfferingCounter: 0,
+  offerings: new Decimal(100),
+  sweepState: { kind: 'idle' },
+  timeSinceLastStateChange: 0,
+  autoResetTimerPrestige: 0,
+  autoResetTimerTranscension: 0,
+  autoResetTimerReincarnation: 0
+}
+
+// Fixture B — sweep running through challenges 1-5, no resets firing.
+// Loops the active → enter_wait → active cycle. nextRegularChallengeFromActive
+// is hardcoded so all six challenges feel "next"; the explored set guards
+// against repeats, so the cycle terminates naturally.
+const FIXTURE_B_STATICS: StaticInputs = {
+  ...FIXTURE_A_STATICS,
+  highestchallengecompletions3: 0,
+  shouldRunSweep: true,
+  timerStart: 0.5, // fast cycles for the harness
+  timerExit: 0.5,
+  timerEnter: 0.2,
+  initialIndex: 1,
+  // Return 2,3,4,5 in turn — driven by `explored` set tracking inside
+  // the state machine. We pin it to 2 here; the real game's lookup
+  // changes per state, but for the harness this exercises one
+  // active→enter_wait→active hop repeatedly.
+  nextRegularChallengeFromInitial: 1,
+  nextRegularChallengeFromActive: 2,
+  challenge15AutoExponentCheck: false,
+  isFinishedStillValid: false
+}
+
+const FIXTURE_B_INITIAL: FixtureState = {
+  autoOfferingCounter: 0,
+  offerings: new Decimal(1000),
+  sweepState: { kind: 'idle' },
+  timeSinceLastStateChange: 0,
+  autoResetTimerPrestige: 0,
+  autoResetTimerTranscension: 0,
+  autoResetTimerReincarnation: 0
+}
+
+// Fixture C — auto-prestige time mode actively firing.
+// Each ~1.5s the timer crosses prestigeamount=1.5 threshold and an
+// auto-reset-triggered event fires. (The harness doesn't actually
+// reset state since reset() is web_ui-only; the test verifies the
+// event/timer pattern stays in sync across the two implementations.)
+const FIXTURE_C_STATICS: StaticInputs = {
+  ...FIXTURE_A_STATICS,
+  highestchallengecompletions3: 1,
+  prestigeMode: 'time',
+  toggle15: true,
+  autoPrestigeMilestone: 1,
+  prestigeamount: 1.5,
+  coinsThisPrestige: new Decimal(1e17)
+}
+
+const FIXTURE_C_INITIAL: FixtureState = {
+  autoOfferingCounter: 0,
+  offerings: new Decimal(500),
+  sweepState: { kind: 'idle' },
+  timeSinceLastStateChange: 0,
+  autoResetTimerPrestige: 0,
+  autoResetTimerTranscension: 0,
+  autoResetTimerReincarnation: 0
+}
+
+// ─── Harness driver ────────────────────────────────────────────────────
+
+interface RunResult {
+  finalState: FixtureState
+  totalEventCount: number
+}
+
+const runTicks = (
+  statics: StaticInputs,
+  initial: FixtureState,
+  dt: number,
+  ticks: number,
+  fn: (input: TackTailInput) => TackTailResult
+): RunResult => {
+  let state = initial
+  let totalEventCount = 0
+  for (let i = 0; i < ticks; i++) {
+    const input = buildInput(statics, state, dt)
+    const result = fn(input)
+    state = stateFromResult(result)
+    totalEventCount += result.events.length
+  }
+  return { finalState: state, totalEventCount }
+}
+
+describe('parity harness: tackTail over N=1000 ticks', () => {
+  const fixtures: Array<{
+    name: string
+    statics: StaticInputs
+    initial: FixtureState
+    dt: number
+    ticks: number
+  }> = [
+    {
+      name: 'A — idle, only addOfferings active',
+      statics: FIXTURE_A_STATICS,
+      initial: FIXTURE_A_INITIAL,
+      dt: 0.025,
+      ticks: 1000
+    },
+    {
+      name: 'B — sweep cycling through active/enter_wait',
+      statics: FIXTURE_B_STATICS,
+      initial: FIXTURE_B_INITIAL,
+      dt: 0.025,
+      ticks: 1000
+    },
+    {
+      name: 'C — auto-prestige time mode firing repeatedly',
+      statics: FIXTURE_C_STATICS,
+      initial: FIXTURE_C_INITIAL,
+      dt: 0.025,
+      ticks: 1000
+    }
+  ]
+
+  for (const f of fixtures) {
+    it(`${f.name} — migrated matches oracle`, () => {
+      const migrated = runTicks(f.statics, f.initial, f.dt, f.ticks, tackTail)
+      const oracle = runTicks(f.statics, f.initial, f.dt, f.ticks, oracleTackTail)
+      expect(stateSnapshot(migrated.finalState)).toEqual(stateSnapshot(oracle.finalState))
+      expect(migrated.totalEventCount).toBe(oracle.totalEventCount)
+    })
+  }
+})

--- a/packages/web_ui/src/Challenges.ts
+++ b/packages/web_ui/src/Challenges.ts
@@ -4,7 +4,6 @@ import {
   challenge15ScoreMultiplier as logicChallenge15ScoreMultiplier,
   challengeRequirement as logicChallengeRequirement,
   challengeScoreDisplay as logicChallengeScoreDisplay,
-  type CoreEvent,
   getMaxChallenges as logicGetMaxChallenges,
   getNextAscensionChallenge as logicGetNextAscChallenge,
   getNextRegularChallenge as logicGetNextRegularChallenge,
@@ -19,6 +18,7 @@ import { getShopUpgradeEffects } from './Shop'
 import { getGQUpgradeEffect } from './singularity'
 import { getSingularityChallengeEffect } from './SingularityChallenges'
 import { format, player, resetCheck } from './Synergism'
+import { dispatchTickEvent } from './tickEventHandlers'
 import { AutoAscensionResetModes, toggleAutoChallengeModeText, toggleChallenges } from './Toggles'
 import { Globals as G } from './Variables'
 
@@ -403,7 +403,7 @@ export const challengeRequirement = (challenge: number, completion: number, spec
 
 let currentSweepState: SweepStates = { kind: 'idle' }
 
-function dispatchSweepTransition (from: SweepStates, to: SweepStates): void {
+export function dispatchSweepTransition (from: SweepStates, to: SweepStates): void {
   // Exiting an active challenge — fire the corresponding async reset check.
   if (from.kind === 'active') {
     if (from.index <= 5) {
@@ -457,10 +457,27 @@ export function resetChallengeSweep (): void {
   }
 }
 
-export function tickChallengeSweep (dt: number): void {
-  // Pre-evaluate the transition-lookup inputs that the logic state
-  // machine needs, scoped to the current state's possible transitions
-  // (skipping work that wouldn't be consulted this tick).
+export interface SweepInputForTackTail {
+  sweepState: SweepStates
+  timeSinceLastStateChange: number
+  shouldRunSweep: boolean
+  timerStart: number
+  timerExit: number
+  timerEnter: number
+  initialIndex: number
+  nextRegularChallengeFromInitial: number
+  nextRegularChallengeFromActive: number
+  challenge15AutoExponentCheck: boolean
+  isFinishedStillValid: boolean
+}
+
+/**
+ * Pre-evaluate the transition-lookup inputs for logicTickChallengeSweep,
+ * scoped to the current state's possible transitions (skipping work that
+ * wouldn't be consulted this tick). Used both by the standalone
+ * tickChallengeSweep wrapper and by the per-tick tackTail composition.
+ */
+export function prepareSweepInputForTackTail (): SweepInputForTackTail {
   let initialIndex = 1
   let nextRegularChallengeFromInitial = -1
   if (currentSweepState.kind === 'initial_wait') {
@@ -483,9 +500,8 @@ export function tickChallengeSweep (dt: number): void {
       && player.highestchallengecompletions[6] === getMaxChallenges(6)
   }
 
-  const result = logicTickChallengeSweep({
-    dt,
-    state: currentSweepState,
+  return {
+    sweepState: currentSweepState,
     timeSinceLastStateChange,
     shouldRunSweep: shouldRunSweep(),
     timerStart: player.autoChallengeTimer.start,
@@ -496,19 +512,38 @@ export function tickChallengeSweep (dt: number): void {
     nextRegularChallengeFromActive,
     challenge15AutoExponentCheck: chal15Check,
     isFinishedStillValid
-  })
-
-  currentSweepState = result.state
-  timeSinceLastStateChange = result.timeSinceLastStateChange
-
-  for (const event of result.events) {
-    dispatchSweepEvent(event)
   }
 }
 
-function dispatchSweepEvent (event: CoreEvent): void {
-  if (event.kind !== 'challenge-sweep-transitioned') return
-  dispatchSweepTransition(event.from, event.to)
+/**
+ * Write the sweep state back to the module-locals after a logic tick.
+ * Used both by the standalone tickChallengeSweep wrapper and by tack().
+ */
+export function applySweepResult (state: SweepStates, time: number): void {
+  currentSweepState = state
+  timeSinceLastStateChange = time
+}
+
+export function tickChallengeSweep (dt: number): void {
+  const input = prepareSweepInputForTackTail()
+  const result = logicTickChallengeSweep({
+    dt,
+    state: input.sweepState,
+    timeSinceLastStateChange: input.timeSinceLastStateChange,
+    shouldRunSweep: input.shouldRunSweep,
+    timerStart: input.timerStart,
+    timerExit: input.timerExit,
+    timerEnter: input.timerEnter,
+    initialIndex: input.initialIndex,
+    nextRegularChallengeFromInitial: input.nextRegularChallengeFromInitial,
+    nextRegularChallengeFromActive: input.nextRegularChallengeFromActive,
+    challenge15AutoExponentCheck: input.challenge15AutoExponentCheck,
+    isFinishedStillValid: input.isFinishedStillValid
+  })
+  applySweepResult(result.state, result.timeSinceLastStateChange)
+  for (const event of result.events) {
+    dispatchTickEvent(event)
+  }
 }
 
 export const autoAscensionChallengeSweepUnlock = () =>

--- a/packages/web_ui/src/Challenges.ts
+++ b/packages/web_ui/src/Challenges.ts
@@ -4,9 +4,12 @@ import {
   challenge15ScoreMultiplier as logicChallenge15ScoreMultiplier,
   challengeRequirement as logicChallengeRequirement,
   challengeScoreDisplay as logicChallengeScoreDisplay,
+  type CoreEvent,
   getMaxChallenges as logicGetMaxChallenges,
   getNextAscensionChallenge as logicGetNextAscChallenge,
-  getNextRegularChallenge as logicGetNextRegularChallenge
+  getNextRegularChallenge as logicGetNextRegularChallenge,
+  type SweepStates,
+  tickChallengeSweep as logicTickChallengeSweep
 } from '@synergism/logic'
 import Decimal from 'break_infinity.js'
 import i18next from 'i18next'
@@ -392,126 +395,41 @@ export const challengeRequirement = (challenge: number, completion: number, spec
   })
 }
 
-// Challenge State Machine
-type SweepStates =
-  | { kind: 'idle' }
-  | { kind: 'initial_wait' }
-  // Keep explored set in case we have to use c10_detour (don't run it twice)
-  | { kind: 'enter_wait'; toIndex: number; explored: Set<number> }
-  | { kind: 'active'; index: number; explored: Set<number> }
-  | { kind: 'c15_wait' } // Happens when you can autoGain c15 Exponent
-  | { kind: 'finished' } // Challenges 1-10 are all completely maxed
+// Challenge State Machine — pure logic lives in @synergism/logic
+// (packages/logic/src/tick/challengeSweep.ts). This module keeps the two
+// pieces of mutable bookkeeping (currentSweepState + timeSinceLastStateChange)
+// in module-locals and threads them through each tick; side effects fire
+// from the dispatcher below in response to challenge-sweep-transitioned events.
 
 let currentSweepState: SweepStates = { kind: 'idle' }
 
-function sweepTransitionFunc (
-  state: SweepStates,
-  elapsedTime: number,
-  timers = player.autoChallengeTimer
-): SweepStates {
-  switch (state.kind) {
-    case 'idle':
-      // Will be transitioned externally when sweep is enabled
-      return state
-
-    case 'initial_wait':
-      if (elapsedTime >= timers.start) {
-        let initialIndex = 1
-        if (player.highestSingularityCount >= 2 && player.currentChallenge.ascension !== 0) {
-          initialIndex = 10
-        }
-        // Find first valid challenge, which skips the enter time.
-        const firstChallenge = getNextRegularChallenge(initialIndex, new Set())
-        if (firstChallenge === -1) {
-          // If we max all the challenges, just don't change the state!
-          return { kind: 'finished' }
-        }
-        return { kind: 'active', index: firstChallenge, explored: new Set([firstChallenge]) }
-      }
-      return state
-
-    case 'active':
-      if (elapsedTime >= timers.exit) {
-        // Find next challenge
-        const nextChallenge = getNextRegularChallenge(state.index, state.explored)
-
-        // Check if we've wrapped around or exhausted all challenges
-        if (nextChallenge === -1) {
-          // Completed a full cycle, check if we need C15 wait
-          if (challenge15AutoExponentCheck()) {
-            return { kind: 'c15_wait' }
-          }
-          // Restart the sweep (wait 'start' seconds before first challenge)
-          return { kind: 'initial_wait' }
-        }
-
-        // Go to enter_wait before next challenge
-        return { kind: 'enter_wait', toIndex: nextChallenge, explored: state.explored }
-      }
-      return state
-
-    case 'enter_wait':
-      if (elapsedTime >= timers.enter) {
-        return { kind: 'active', index: state.toIndex, explored: new Set([...state.explored, state.toIndex]) }
-      }
-      return state
-
-    case 'c15_wait':
-      if (elapsedTime >= 5) {
-        // After 5 seconds, restart the sweep
-        return { kind: 'initial_wait' }
-      }
-      return state
-
-    case 'finished':
-      // Check to ensure that the max challenges did not change since we entered this state
-      // We check challenge 1 and 6 to represent Transcension and Reincarnation challenges respectively
-      if (
-        player.highestchallengecompletions[1] === getMaxChallenges(1)
-        && player.highestchallengecompletions[6] === getMaxChallenges(6)
-      ) {
-        return state
-      } else {
-        return { kind: 'initial_wait' }
-      }
-    default: {
-      throw new Error(`Unhandled SweepState kind: ${(state as { kind: string }).kind}`)
-    }
-  }
-}
-
-function handleStateTransition (oldState: SweepStates, newState: SweepStates): void {
-  if (oldState.kind === 'active') {
-    const challengeIndex = oldState.index
-    if (challengeIndex <= 5) {
+function dispatchSweepTransition (from: SweepStates, to: SweepStates): void {
+  // Exiting an active challenge — fire the corresponding async reset check.
+  if (from.kind === 'active') {
+    if (from.index <= 5) {
       void resetCheck('transcensionChallenge', undefined, true)
     } else {
       void resetCheck('reincarnationChallenge', undefined, true)
     }
   }
 
-  switch (newState.kind) {
+  switch (to.kind) {
     case 'idle':
       toggleAutoChallengeModeText('OFF')
       break
-
     case 'initial_wait':
       toggleAutoChallengeModeText('START')
       break
-
     case 'enter_wait':
       toggleAutoChallengeModeText('ENTER')
       break
-
     case 'active':
-      toggleChallenges(newState.index, true)
+      toggleChallenges(to.index, true)
       toggleAutoChallengeModeText('CHALLENGE')
       break
-
     case 'c15_wait':
       toggleAutoChallengeModeText('WAIT')
       break
-
     case 'finished':
       toggleAutoChallengeModeText('COMPLETE')
       break
@@ -540,38 +458,57 @@ export function resetChallengeSweep (): void {
 }
 
 export function tickChallengeSweep (dt: number): void {
-  const wasEnabled = currentSweepState.kind !== 'idle'
-  const isEnabled = shouldRunSweep()
-
-  if (!wasEnabled && isEnabled) {
-    currentSweepState = { kind: 'initial_wait' }
-    timeSinceLastStateChange = 0
-    handleStateTransition({ kind: 'idle' }, currentSweepState)
-    return
+  // Pre-evaluate the transition-lookup inputs that the logic state
+  // machine needs, scoped to the current state's possible transitions
+  // (skipping work that wouldn't be consulted this tick).
+  let initialIndex = 1
+  let nextRegularChallengeFromInitial = -1
+  if (currentSweepState.kind === 'initial_wait') {
+    if (player.highestSingularityCount >= 2 && player.currentChallenge.ascension !== 0) {
+      initialIndex = 10
+    }
+    nextRegularChallengeFromInitial = getNextRegularChallenge(initialIndex, new Set())
   }
 
-  if (wasEnabled && !isEnabled) {
-    const oldState = currentSweepState
-    currentSweepState = { kind: 'idle' }
-    timeSinceLastStateChange = 0
-    handleStateTransition(oldState, currentSweepState)
-    return
+  let nextRegularChallengeFromActive = -1
+  let chal15Check = false
+  if (currentSweepState.kind === 'active') {
+    nextRegularChallengeFromActive = getNextRegularChallenge(currentSweepState.index, currentSweepState.explored)
+    chal15Check = challenge15AutoExponentCheck()
   }
 
-  if (!isEnabled) {
-    return
+  let isFinishedStillValid = false
+  if (currentSweepState.kind === 'finished') {
+    isFinishedStillValid = player.highestchallengecompletions[1] === getMaxChallenges(1)
+      && player.highestchallengecompletions[6] === getMaxChallenges(6)
   }
 
-  timeSinceLastStateChange += dt
-  const newState = sweepTransitionFunc(currentSweepState, timeSinceLastStateChange)
+  const result = logicTickChallengeSweep({
+    dt,
+    state: currentSweepState,
+    timeSinceLastStateChange,
+    shouldRunSweep: shouldRunSweep(),
+    timerStart: player.autoChallengeTimer.start,
+    timerExit: player.autoChallengeTimer.exit,
+    timerEnter: player.autoChallengeTimer.enter,
+    initialIndex,
+    nextRegularChallengeFromInitial,
+    nextRegularChallengeFromActive,
+    challenge15AutoExponentCheck: chal15Check,
+    isFinishedStillValid
+  })
 
-  if (newState !== currentSweepState) {
-    // State changed, reset timer and handle side effects
-    const oldState = currentSweepState
-    currentSweepState = newState
-    timeSinceLastStateChange = 0
-    handleStateTransition(oldState, newState)
+  currentSweepState = result.state
+  timeSinceLastStateChange = result.timeSinceLastStateChange
+
+  for (const event of result.events) {
+    dispatchSweepEvent(event)
   }
+}
+
+function dispatchSweepEvent (event: CoreEvent): void {
+  if (event.kind !== 'challenge-sweep-transitioned') return
+  dispatchSweepTransition(event.from, event.to)
 }
 
 export const autoAscensionChallengeSweepUnlock = () =>

--- a/packages/web_ui/src/Features/Ants/AntProducers/lib/generate-ant-producers.ts
+++ b/packages/web_ui/src/Features/Ants/AntProducers/lib/generate-ant-producers.ts
@@ -1,10 +1,8 @@
-import Decimal from 'break_infinity.js'
+import { logicGenerateAntsAndCrumbs } from '@synergism/logic'
 import { calculateActualAntSpeedMult } from '../../../../Calculate'
 import { player } from '../../../../Synergism'
 import { activateELO } from '../../AntSacrifice/Rewards/ELO/RebornELO/lib/create-reborn'
 import { AntProducers, LAST_ANT_PRODUCER } from '../../structs/structs'
-import { antProducerData } from '../data/data'
-import { calculateBaseAntsToBeGenerated } from './calculate-production'
 
 export const canGenerateAntCrumbs = (): boolean => {
   // Cube 5x8 is "Wow! I want to ALWAYS generate Galactic Crumbs."
@@ -12,24 +10,37 @@ export const canGenerateAntCrumbs = (): boolean => {
 }
 
 export const generateAntsAndCrumbs = (dt: number): void => {
-  // TODO: Place somewhere in Ants.
   const antSpeedMult = calculateActualAntSpeedMult()
 
-  for (let antType = LAST_ANT_PRODUCER; antType > AntProducers.Workers; antType--) {
-    const baseGeneration = calculateBaseAntsToBeGenerated(antType, antSpeedMult)
-    const producedAnt = antProducerData[antType].produces!
-    player.ants.producers[producedAnt].generated = player.ants.producers[producedAnt].generated.add(
-      baseGeneration
-        .times(dt)
-    )
+  // Pack the per-tier state (0..LAST_ANT_PRODUCER) into the logic input.
+  const producersInput = []
+  for (let i = 0; i <= LAST_ANT_PRODUCER; i++) {
+    const ant = i as AntProducers
+    producersInput.push({
+      generated: player.ants.producers[ant].generated,
+      purchased: player.ants.producers[ant].purchased,
+      masteryLevel: player.ants.masteries[ant].mastery
+    })
   }
 
-  const crumbsToGenerate = calculateBaseAntsToBeGenerated(AntProducers.Workers, antSpeedMult).times(dt)
-  // Separately handle Crumbs in the same way
-  player.ants.crumbs = Decimal.add(player.ants.crumbs, crumbsToGenerate)
-  player.ants.crumbsThisSacrifice = Decimal.add(player.ants.crumbsThisSacrifice, crumbsToGenerate)
-  player.ants.crumbsEverMade = Decimal.add(player.ants.crumbsEverMade, crumbsToGenerate)
+  const result = logicGenerateAntsAndCrumbs({
+    dt,
+    antSpeedMult,
+    producers: producersInput,
+    crumbs: player.ants.crumbs,
+    crumbsThisSacrifice: player.ants.crumbsThisSacrifice,
+    crumbsEverMade: player.ants.crumbsEverMade
+  })
 
-  // Activate ELO if appropriate
+  // Write back generated values per tier.
+  for (let i = 0; i <= LAST_ANT_PRODUCER; i++) {
+    player.ants.producers[i as AntProducers].generated = result.producersGenerated[i]
+  }
+  player.ants.crumbs = result.crumbs
+  player.ants.crumbsThisSacrifice = result.crumbsThisSacrifice
+  player.ants.crumbsEverMade = result.crumbsEverMade
+
+  // ELO activation has wall-clock + DOM + quark-adding side effects;
+  // stays in web_ui for now. Runs in the same order as legacy.
   activateELO(dt)
 }

--- a/packages/web_ui/src/Helper.ts
+++ b/packages/web_ui/src/Helper.ts
@@ -29,6 +29,7 @@ import { getOcteractUpgradeEffect } from './Octeracts'
 import { quarkHandler } from './Quark'
 import { getRedAmbrosiaUpgradeEffects } from './RedAmbrosiaUpgrades'
 import { Seed } from './RNG'
+import { dispatchTickEvent } from './tickEventHandlers'
 import { buyAllBlessingLevels } from './RuneBlessings'
 import { getNumberUnlockedRunes, indexToRune, type RuneKeys, runes, sacrificeOfferings } from './Runes'
 import { buyAllSpiritLevels } from './RuneSpirits'
@@ -36,9 +37,8 @@ import { getShopUpgradeEffects, useConsumable } from './Shop'
 import { getGQUpgradeEffect } from './singularity'
 import { getSingularityChallengeEffect } from './SingularityChallenges'
 import { player } from './Synergism'
-import { Tabs } from './Tabs'
 import { buyAllTalismanResources } from './Talismans'
-import { visualUpdateAmbrosia, visualUpdateOcteracts, visualUpdateResearch } from './UpdateVisuals'
+import { visualUpdateOcteracts } from './UpdateVisuals'
 import { Globals as G } from './Variables'
 
 type TimerInput =
@@ -247,9 +247,7 @@ export const addTimers = (input: TimerInput, time = 0) => {
       player.lifetimeAmbrosia = ambrosiaResult.lifetimeAmbrosia
       player.seed[Seed.Ambrosia] = ambrosiaResult.seed
       for (const event of ambrosiaResult.events) {
-        if (event.kind === 'ambrosia-gained') {
-          visualUpdateAmbrosia()
-        }
+        dispatchTickEvent(event)
       }
       break
     }
@@ -281,9 +279,7 @@ export const addTimers = (input: TimerInput, time = 0) => {
         addTimers('ambrosia', redAmbrosiaResult.bonusAmbrosiaTime)
       }
       for (const event of redAmbrosiaResult.events) {
-        if (event.kind === 'red-ambrosia-gained') {
-          visualUpdateAmbrosia()
-        }
+        dispatchTickEvent(event)
       }
       break
     }
@@ -324,11 +320,7 @@ export const automaticTools = (input: AutoToolInput, time: number) => {
       })
       player.obtainium = obtainiumResult.obtainium
       for (const event of obtainiumResult.events) {
-        if (event.kind === 'auto-tool-fired' && event.tool === 'addObtainium') {
-          if (G.currentTab === Tabs.Research) {
-            visualUpdateResearch()
-          }
-        }
+        dispatchTickEvent(event)
       }
       break
     }

--- a/packages/web_ui/src/Helper.ts
+++ b/packages/web_ui/src/Helper.ts
@@ -4,6 +4,7 @@ import {
   advanceAmbrosiaTimer as logicAdvanceAmbrosiaTimer,
   advanceAscensionTimer as logicAdvanceAscensionTimer,
   advanceGoldenQuarksTimer as logicAdvanceGoldenQuarksTimer,
+  advanceOcteractTimer as logicAdvanceOcteractTimer,
   advanceQuarksTimer as logicAdvanceQuarksTimer,
   advanceRedAmbrosiaTimer as logicAdvanceRedAmbrosiaTimer,
   advanceResetCounter as logicAdvanceResetCounter,
@@ -16,7 +17,6 @@ import {
   calculateAmbrosiaLuck,
   calculateAscensionSpeedMult,
   calculateGlobalSpeedMult,
-  calculateGoldenQuarks,
   calculateOcteractMultiplier,
   calculateRedAmbrosiaGenerationSpeed,
   calculateRedAmbrosiaLuck,
@@ -34,11 +34,11 @@ import { buyAllBlessingLevels } from './RuneBlessings'
 import { getNumberUnlockedRunes, indexToRune, type RuneKeys, runes, sacrificeOfferings } from './Runes'
 import { buyAllSpiritLevels } from './RuneSpirits'
 import { getShopUpgradeEffects, useConsumable } from './Shop'
+import { allGoldenQuarkMultiplierStats } from './Statistics'
 import { getGQUpgradeEffect } from './singularity'
 import { getSingularityChallengeEffect } from './SingularityChallenges'
 import { player } from './Synergism'
 import { buyAllTalismanResources } from './Talismans'
-import { visualUpdateOcteracts } from './UpdateVisuals'
 import { Globals as G } from './Variables'
 
 type TimerInput =
@@ -53,8 +53,6 @@ type TimerInput =
   | 'autoPotion'
   | 'ambrosia'
   | 'redAmbrosia'
-
-const octeractGiveawayLevels = [160, 173, 185, 194, 204, 210, 219, 229, 240, 249]
 
 /**
  * addTimers will add (in milliseconds) time to the reset counters, and quark export timer
@@ -138,33 +136,36 @@ export const addTimers = (input: TimerInput, time = 0) => {
     case 'octeracts': {
       if (!getGQUpgradeEffect('octeractUnlock', 'unlocked')) {
         return
-      } else {
-        player.octeractTimer += time * timeMultiplier
       }
-      if (player.octeractTimer >= 1) {
-        const amountOfGiveaways = player.octeractTimer - (player.octeractTimer % 1)
-        player.octeractTimer %= 1
-
-        const perSecond = calculateOcteractMultiplier()
-        player.wowOcteracts += amountOfGiveaways * perSecond
-        player.totalWowOcteracts += amountOfGiveaways * perSecond
-
-        if (player.highestSingularityCount >= 160) {
-          const frac = 1e-6
-          let actualLevel = 0
-          for (const sing of octeractGiveawayLevels) {
-            if (player.highestSingularityCount >= sing) {
-              actualLevel += 1
-            }
-          }
-
-          for (let i = 0; i < amountOfGiveaways; i++) {
-            const quarkFraction = frac * actualLevel
-            player.goldenQuarks += quarkFraction * calculateGoldenQuarks()
-            player.quarksThisSingularity *= 1 - quarkFraction
-          }
-        }
-        visualUpdateOcteracts()
+      // Pre-eval the GQ multiplier product (stats 1..end, skipping the
+      // qts-dependent base at index 0) only when the GQ-giveaway block
+      // will run (≥ sing 160). Logic recomputes the base each iteration.
+      let goldenQuarksMultiplierExcludingBase = 1
+      if (player.highestSingularityCount >= 160) {
+        const gqStats = allGoldenQuarkMultiplierStats.map(s => s.stat())
+        goldenQuarksMultiplierExcludingBase = gqStats.slice(1).reduce((a, b) => a * b, 1)
+      }
+      const octeractResult = logicAdvanceOcteractTimer({
+        time,
+        timeMultiplier,
+        octeractUnlocked: true,
+        octeractTimer: player.octeractTimer,
+        wowOcteracts: player.wowOcteracts,
+        totalWowOcteracts: player.totalWowOcteracts,
+        goldenQuarks: player.goldenQuarks,
+        quarksThisSingularity: player.quarksThisSingularity,
+        perSecond: calculateOcteractMultiplier(),
+        highestSingularityCount: player.highestSingularityCount,
+        singularityCount: player.singularityCount,
+        goldenQuarksMultiplierExcludingBase
+      })
+      player.octeractTimer = octeractResult.octeractTimer
+      player.wowOcteracts = octeractResult.wowOcteracts
+      player.totalWowOcteracts = octeractResult.totalWowOcteracts
+      player.goldenQuarks = octeractResult.goldenQuarks
+      player.quarksThisSingularity = octeractResult.quarksThisSingularity
+      for (const event of octeractResult.events) {
+        dispatchTickEvent(event)
       }
       break
     }

--- a/packages/web_ui/src/Helper.ts
+++ b/packages/web_ui/src/Helper.ts
@@ -1,9 +1,11 @@
 import {
   addObtainium as logicAddObtainium,
   addOfferings as logicAddOfferings,
+  advanceAmbrosiaTimer as logicAdvanceAmbrosiaTimer,
   advanceAscensionTimer as logicAdvanceAscensionTimer,
   advanceGoldenQuarksTimer as logicAdvanceGoldenQuarksTimer,
   advanceQuarksTimer as logicAdvanceQuarksTimer,
+  advanceRedAmbrosiaTimer as logicAdvanceRedAmbrosiaTimer,
   advanceResetCounter as logicAdvanceResetCounter,
   advanceSingularityTimer as logicAdvanceSingularityTimer
 } from '@synergism/logic'
@@ -18,8 +20,6 @@ import {
   calculateOcteractMultiplier,
   calculateRedAmbrosiaGenerationSpeed,
   calculateRedAmbrosiaLuck,
-  calculateRequiredBlueberryTime,
-  calculateRequiredRedAmbrosiaTime,
   calculateResearchAutomaticObtainium
 } from './Calculate'
 import { sacrificeAnts } from './Features/Ants/AntSacrifice/sacrifice'
@@ -28,7 +28,7 @@ import { getLevelMilestone } from './Levels'
 import { getOcteractUpgradeEffect } from './Octeracts'
 import { quarkHandler } from './Quark'
 import { getRedAmbrosiaUpgradeEffects } from './RedAmbrosiaUpgrades'
-import { Seed, seededRandom } from './RNG'
+import { Seed } from './RNG'
 import { buyAllBlessingLevels } from './RuneBlessings'
 import { getNumberUnlockedRunes, indexToRune, type RuneKeys, runes, sacrificeOfferings } from './Runes'
 import { buyAllSpiritLevels } from './RuneSpirits'
@@ -220,78 +220,72 @@ export const addTimers = (input: TimerInput, time = 0) => {
       break
     }
     case 'ambrosia': {
-      if (player.singularityChallenges.noSingularityUpgrades.completions > 0) {
-        const compute = calculateAmbrosiaGenerationSpeed()
-        if (compute === 0) {
-          break
+      // Cheap gate first — feature locked when completions === 0. Mirrors
+      // logic's inner gate; avoids paying for the calc pre-evals every tick.
+      if (player.singularityChallenges.noSingularityUpgrades.completions <= 0) {
+        break
+      }
+      const ambrosiaResult = logicAdvanceAmbrosiaTimer({
+        time,
+        timeMultiplier,
+        noSingularityUpgradesCompletions: player.singularityChallenges.noSingularityUpgrades.completions,
+        ambrosiaGenerationSpeed: calculateAmbrosiaGenerationSpeed(),
+        ambrosiaTimerG: G.ambrosiaTimer,
+        blueberryTime: player.blueberryTime,
+        ambrosia: player.ambrosia,
+        lifetimeAmbrosia: player.lifetimeAmbrosia,
+        seed: player.seed[Seed.Ambrosia],
+        ambrosiaLuck: calculateAmbrosiaLuck(),
+        bonusAmbrosia: getSingularityChallengeEffect('noAmbrosiaUpgrades', 'bonusAmbrosia'),
+        timePerAmbrosia: G.TIME_PER_AMBROSIA,
+        acceleratorMult: getShopUpgradeEffects('shopAmbrosiaAccelerator', 'ambrosiaPointRequirementMult'),
+        brickOfLeadMult: getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'barRequirementMult')
+      })
+      G.ambrosiaTimer = ambrosiaResult.ambrosiaTimerG
+      player.blueberryTime = ambrosiaResult.blueberryTime
+      player.ambrosia = ambrosiaResult.ambrosia
+      player.lifetimeAmbrosia = ambrosiaResult.lifetimeAmbrosia
+      player.seed[Seed.Ambrosia] = ambrosiaResult.seed
+      for (const event of ambrosiaResult.events) {
+        if (event.kind === 'ambrosia-gained') {
+          visualUpdateAmbrosia()
         }
-
-        G.ambrosiaTimer += time * timeMultiplier
-
-        if (G.ambrosiaTimer < 0.125) {
-          break
-        }
-
-        const ambrosiaLuck = calculateAmbrosiaLuck()
-        const baseBlueberryTime = calculateAmbrosiaGenerationSpeed()
-        player.blueberryTime += Math.floor(8 * G.ambrosiaTimer) / 8 * baseBlueberryTime
-        G.ambrosiaTimer %= 0.125
-
-        let timeToAmbrosia = calculateRequiredBlueberryTime()
-
-        while (player.blueberryTime >= timeToAmbrosia) {
-          const RNG = seededRandom(Seed.Ambrosia)
-          const ambrosiaMult = Math.floor(ambrosiaLuck / 100)
-          const luckMult = RNG < ambrosiaLuck / 100 - Math.floor(ambrosiaLuck / 100) ? 1 : 0
-          const bonusAmbrosia = getSingularityChallengeEffect('noAmbrosiaUpgrades', 'bonusAmbrosia')
-          const ambrosiaToGain = (ambrosiaMult + luckMult) + bonusAmbrosia
-
-          player.ambrosia += ambrosiaToGain
-          player.lifetimeAmbrosia += ambrosiaToGain
-          player.blueberryTime -= timeToAmbrosia
-
-          timeToAmbrosia = calculateRequiredBlueberryTime()
-        }
-
-        visualUpdateAmbrosia()
       }
       break
     }
     case 'redAmbrosia': {
-      if (player.singularityChallenges.noAmbrosiaUpgrades.completions > 0) {
-        const speed = calculateRedAmbrosiaGenerationSpeed()
-        G.redAmbrosiaTimer += time * timeMultiplier
-        if (G.redAmbrosiaTimer < 0.125) {
-          break
-        }
-
-        player.redAmbrosiaTime += Math.floor(8 * G.redAmbrosiaTimer) / 8 * speed
-        G.redAmbrosiaTimer %= 0.125
-        let timeToRedAmbrosia = calculateRequiredRedAmbrosiaTime()
-
-        let ambrosiaTimeToGrant = 0
-        const timeCoeff = getRedAmbrosiaUpgradeEffects('redAmbrosiaAccelerator', 'ambrosiaTimePerRedAmbrosia')
-
-        while (player.redAmbrosiaTime >= timeToRedAmbrosia) {
-          const redAmbrosiaLuck = calculateRedAmbrosiaLuck()
-          const RNG = seededRandom(Seed.RedAmbrosia)
-          const redAmbrosiaMult = Math.floor(redAmbrosiaLuck / 100)
-          const luckMult = RNG < redAmbrosiaLuck / 100 - Math.floor(redAmbrosiaLuck / 100) ? 1 : 0
-          const redAmbrosiaToGain = redAmbrosiaMult + luckMult
-
-          player.redAmbrosia += redAmbrosiaToGain
-          player.lifetimeRedAmbrosia += redAmbrosiaToGain
-          ambrosiaTimeToGrant += redAmbrosiaToGain * timeCoeff
-          player.redAmbrosiaTime -= timeToRedAmbrosia
-          timeToRedAmbrosia = calculateRequiredRedAmbrosiaTime()
-        }
-
-        if (ambrosiaTimeToGrant > 0) {
-          addTimers('ambrosia', ambrosiaTimeToGrant)
-        }
-
-        visualUpdateAmbrosia()
+      if (player.singularityChallenges.noAmbrosiaUpgrades.completions <= 0) {
+        break
       }
+      const redAmbrosiaResult = logicAdvanceRedAmbrosiaTimer({
+        time,
+        timeMultiplier,
+        noAmbrosiaUpgradesCompletions: player.singularityChallenges.noAmbrosiaUpgrades.completions,
+        redAmbrosiaGenerationSpeed: calculateRedAmbrosiaGenerationSpeed(),
+        redAmbrosiaTimerG: G.redAmbrosiaTimer,
+        redAmbrosiaTime: player.redAmbrosiaTime,
+        redAmbrosia: player.redAmbrosia,
+        lifetimeRedAmbrosia: player.lifetimeRedAmbrosia,
+        seed: player.seed[Seed.RedAmbrosia],
+        redAmbrosiaLuck: calculateRedAmbrosiaLuck(),
+        ambrosiaTimePerRedAmbrosia: getRedAmbrosiaUpgradeEffects('redAmbrosiaAccelerator', 'ambrosiaTimePerRedAmbrosia'),
+        timePerRedAmbrosia: G.TIME_PER_RED_AMBROSIA,
+        barRequirementMultiplier: getSingularityChallengeEffect('limitedTime', 'barRequirementMultiplier')
+      })
+      G.redAmbrosiaTimer = redAmbrosiaResult.redAmbrosiaTimerG
+      player.redAmbrosiaTime = redAmbrosiaResult.redAmbrosiaTime
+      player.redAmbrosia = redAmbrosiaResult.redAmbrosia
+      player.lifetimeRedAmbrosia = redAmbrosiaResult.lifetimeRedAmbrosia
+      player.seed[Seed.RedAmbrosia] = redAmbrosiaResult.seed
+      if (redAmbrosiaResult.bonusAmbrosiaTime > 0) {
+        addTimers('ambrosia', redAmbrosiaResult.bonusAmbrosiaTime)
+      }
+      for (const event of redAmbrosiaResult.events) {
+        if (event.kind === 'red-ambrosia-gained') {
+          visualUpdateAmbrosia()
+        }
+      }
+      break
     }
   }
 }

--- a/packages/web_ui/src/Helper.ts
+++ b/packages/web_ui/src/Helper.ts
@@ -1,4 +1,6 @@
 import {
+  addObtainium as logicAddObtainium,
+  addOfferings as logicAddOfferings,
   advanceAscensionTimer as logicAdvanceAscensionTimer,
   advanceGoldenQuarksTimer as logicAdvanceGoldenQuarksTimer,
   advanceQuarksTimer as logicAdvanceQuarksTimer,
@@ -319,38 +321,35 @@ let autoSacrificeInterval = 1
 export const automaticTools = (input: AutoToolInput, time: number) => {
   switch (input) {
     case 'addObtainium': {
-      // If in challenge 14, abort and do not award obtainium
-      if (player.currentChallenge.ascension === 14) {
-        break
-      }
-
-      let obtainiumGain = calculateResearchAutomaticObtainium(time)
-      if (
-        player.singularityChallenges.taxmanLastStand.enabled
-        && player.singularityChallenges.taxmanLastStand.completions >= 2
-      ) {
-        obtainiumGain = Decimal.min(
-          obtainiumGain,
-          player.obtainium.times(100).plus(1)
-        )
-      }
-
-      // Add Obtainium
-      player.obtainium = player.obtainium.add(obtainiumGain)
-      // Update visual displays if appropriate
-      if (G.currentTab === Tabs.Research) {
-        visualUpdateResearch()
+      const obtainiumResult = logicAddObtainium({
+        obtainium: player.obtainium,
+        obtainiumGain: calculateResearchAutomaticObtainium(time),
+        ascensionChallenge: player.currentChallenge.ascension,
+        taxmanLastStandEnabled: player.singularityChallenges.taxmanLastStand.enabled,
+        taxmanLastStandCompletions: player.singularityChallenges.taxmanLastStand.completions
+      })
+      player.obtainium = obtainiumResult.obtainium
+      for (const event of obtainiumResult.events) {
+        if (event.kind === 'auto-tool-fired' && event.tool === 'addObtainium') {
+          if (G.currentTab === Tabs.Research) {
+            visualUpdateResearch()
+          }
+        }
       }
       break
     }
-    case 'addOfferings':
+    case 'addOfferings': {
       // This counter can be increased through challenge 3 reward
       // As well as cube upgrade 1x2 (2).
-      G.autoOfferingCounter += time
-      // Any time this exceeds 1 it adds an offering
-      player.offerings = player.offerings.add(Math.floor(G.autoOfferingCounter))
-      G.autoOfferingCounter %= 1
+      const offeringsResult = logicAddOfferings({
+        time,
+        autoOfferingCounter: G.autoOfferingCounter,
+        offerings: player.offerings
+      })
+      G.autoOfferingCounter = offeringsResult.autoOfferingCounter
+      player.offerings = offeringsResult.offerings
       break
+    }
     case 'runeSacrifice':
       // Every real life second this will trigger
       player.sacrificeTimer += time

--- a/packages/web_ui/src/RNG.ts
+++ b/packages/web_ui/src/RNG.ts
@@ -1,20 +1,24 @@
-import { MersenneTwister } from 'fast-mersenne-twister'
+import {
+  Seed,
+  seededBetween as logicSeededBetween,
+  seededRandom as logicSeededRandom,
+  type SeedValues
+} from '@synergism/logic'
 import { player } from './Synergism'
 
-export const seededRandom = (index: SeedValues) => MersenneTwister(player.seed[index]++).random()
+export { Seed }
+
+export const seededRandom = (index: SeedValues): number => {
+  const { value, newSeed } = logicSeededRandom(player.seed[index])
+  player.seed[index] = newSeed
+  return value
+}
 
 /**
  * Generates a random number (inclusive) between {@param min} and {@param max}.
- * @param min min
- * @param max max
  */
-export const seededBetween = (index: SeedValues, min: number, max: number) =>
-  Math.floor(seededRandom(index) * (max - min + 1) + min)
-
-export const Seed = {
-  PromoCodes: 0,
-  Ambrosia: 1,
-  RedAmbrosia: 2
-} as const
-
-type SeedValues = typeof Seed[keyof typeof Seed]
+export const seededBetween = (index: SeedValues, min: number, max: number): number => {
+  const { value, newSeed } = logicSeededBetween(player.seed[index], min, max)
+  player.seed[index] = newSeed
+  return value
+}

--- a/packages/web_ui/src/Synergism.ts
+++ b/packages/web_ui/src/Synergism.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-unassigned-import
 import '@ungap/custom-elements'
 import {
+  applyAutoResets as logicApplyAutoResets,
   calculateBuildingPower as logicCalculateBuildingPower,
   calculateBuildingPowerCoinMultiplier as logicCalculateBuildingPowerCoinMultiplier,
   calculateCrystalCoinMultiplier as logicCalculateCrystalCoinMultiplier,
@@ -4132,96 +4133,60 @@ const tack = (dt: number) => {
   // Challenge Sweep State Machine
   tickChallengeSweep(dt)
 
-  // Check for automatic resets
-  // Auto Prestige.
-  if (player.resetToggleModes.prestige === AutoResetModes.amount) {
-    if (
-      player.toggles[15]
-      && getLevelMilestone('autoPrestige') === 1
-      && G.prestigePointGain.gte(
-        player.prestigePoints.times(Decimal.pow(10, player.prestigeamount))
-      )
-      && player.coinsThisPrestige.gte(1e16)
-    ) {
-      resetAchievementCheck('prestige')
+  // Check for automatic resets — pure decision logic lives in
+  // @synergism/logic; this shim translates fired events into
+  // resetAchievementCheck + reset calls.
+  const autoResetResult = logicApplyAutoResets({
+    dt,
+    prestigeMode: player.resetToggleModes.prestige === AutoResetModes.amount ? 'amount' : 'time',
+    toggle15: player.toggles[15],
+    autoPrestigeMilestone: getLevelMilestone('autoPrestige'),
+    prestigePoints: player.prestigePoints,
+    prestigePointGain: G.prestigePointGain,
+    prestigeamount: player.prestigeamount,
+    coinsThisPrestige: player.coinsThisPrestige,
+    autoResetTimerPrestige: G.autoResetTimers.prestige,
+    transcendMode: player.resetToggleModes.transcend === AutoResetModes.amount ? 'amount' : 'time',
+    toggle21: player.toggles[21],
+    upgrade89: player.upgrades[89],
+    transcendPoints: player.transcendPoints,
+    transcendPointGain: G.transcendPointGain,
+    transcendamount: player.transcendamount,
+    coinsThisTranscension: player.coinsThisTranscension,
+    autoResetTimerTranscension: G.autoResetTimers.transcension,
+    reincarnationMode: player.resetToggleModes.reincarnation === AutoResetModes.amount ? 'amount' : 'time',
+    toggle27: player.toggles[27],
+    research46: player.researches[46],
+    reincarnationPoints: player.reincarnationPoints,
+    reincarnationPointGain: G.reincarnationPointGain,
+    reincarnationamount: player.reincarnationamount,
+    transcendShards: player.transcendShards,
+    autoResetTimerReincarnation: G.autoResetTimers.reincarnation,
+    ascensionChallenge: player.currentChallenge.ascension,
+    transcensionChallenge: player.currentChallenge.transcension,
+    reincarnationChallenge: player.currentChallenge.reincarnation
+  })
+  G.autoResetTimers.prestige = autoResetResult.autoResetTimerPrestige
+  G.autoResetTimers.transcension = autoResetResult.autoResetTimerTranscension
+  G.autoResetTimers.reincarnation = autoResetResult.autoResetTimerReincarnation
+  for (const event of autoResetResult.events) {
+    if (event.kind !== 'auto-reset-triggered') continue
+    if (event.tier === 'prestige') {
+      // Bug-for-bug parity: legacy prestige time mode awards the
+      // 'transcension' achievement check; amount mode awards 'prestige'.
+      // See packages/logic/src/tick/autoReset.ts header for context.
+      if (event.mode === 'time') {
+        resetAchievementCheck('transcension')
+      } else {
+        resetAchievementCheck('prestige')
+      }
       reset('prestige', true)
-    }
-  }
-  if (player.resetToggleModes.prestige === AutoResetModes.time) {
-    G.autoResetTimers.prestige += dt
-    const time = Math.max(0.01, player.prestigeamount)
-    if (
-      player.toggles[15]
-      && getLevelMilestone('autoPrestige') === 1
-      && G.autoResetTimers.prestige >= time
-      && player.coinsThisPrestige.gte(1e16)
-    ) {
-      resetAchievementCheck('transcension')
-      reset('prestige', true)
-    }
-  }
-
-  if (player.resetToggleModes.transcend === AutoResetModes.amount) {
-    if (
-      player.toggles[21]
-      && player.upgrades[89] === 1
-      && G.transcendPointGain.gte(
-        player.transcendPoints.times(Decimal.pow(10, player.transcendamount))
-      )
-      && player.coinsThisTranscension.gte(1e100)
-      && player.currentChallenge.transcension === 0
-    ) {
+    } else if (event.tier === 'transcension') {
       resetAchievementCheck('transcension')
       reset('transcension', true)
-    }
-  }
-  if (player.resetToggleModes.transcend === AutoResetModes.time) {
-    G.autoResetTimers.transcension += dt
-    const time = Math.max(0.01, player.transcendamount)
-    if (
-      player.toggles[21]
-      && player.upgrades[89] === 1
-      && G.autoResetTimers.transcension >= time
-      && player.coinsThisTranscension.gte(1e100)
-      && player.currentChallenge.transcension === 0
-    ) {
-      resetAchievementCheck('transcension')
-      reset('transcension', true)
-    }
-  }
-
-  if (player.currentChallenge.ascension !== 12) {
-    G.autoResetTimers.reincarnation += dt
-    if (player.resetToggleModes.reincarnation === AutoResetModes.time) {
-      const time = Math.max(0.01, player.reincarnationamount)
-      if (
-        player.toggles[27]
-        && player.researches[46] > 0.5
-        && player.transcendShards.gte('1e300')
-        && G.autoResetTimers.reincarnation >= time
-        && player.currentChallenge.transcension === 0
-        && player.currentChallenge.reincarnation === 0
-      ) {
-        resetAchievementCheck('reincarnation')
-        reset('reincarnation', true)
-      }
-    }
-    if (player.resetToggleModes.reincarnation === AutoResetModes.amount) {
-      if (
-        player.toggles[27]
-        && player.researches[46] > 0.5
-        && G.reincarnationPointGain.gte(
-          player.reincarnationPoints
-            .add(1)
-            .times(Decimal.pow(10, player.reincarnationamount))
-        )
-        && player.transcendShards.gte(1e300)
-        && player.currentChallenge.transcension === 0
-        && player.currentChallenge.reincarnation === 0
-      ) {
-        resetAchievementCheck('reincarnation')
-        reset('reincarnation', true)
-      }
+    } else if (event.tier === 'reincarnation') {
+      resetAchievementCheck('reincarnation')
+      reset('reincarnation', true)
     }
   }
   calculateOfferings()

--- a/packages/web_ui/src/Synergism.ts
+++ b/packages/web_ui/src/Synergism.ts
@@ -1,19 +1,18 @@
 // eslint-disable-next-line no-unassigned-import
 import '@ungap/custom-elements'
 import {
-  applyAutoResets as logicApplyAutoResets,
   calculateBuildingPower as logicCalculateBuildingPower,
   calculateBuildingPowerCoinMultiplier as logicCalculateBuildingPowerCoinMultiplier,
   calculateCrystalCoinMultiplier as logicCalculateCrystalCoinMultiplier,
   calculateCrystalExponent as logicCalculateCrystalExponent,
   computeGlobalMultipliers as logicComputeGlobalMultipliers,
-  type CoreEvent,
   crystalUpgrade3Base as logicCrystalUpgrade3Base,
   crystalUpgrade3CrystalMultiplier as logicCrystalUpgrade3CrystalMultiplier,
   crystalUpgrade3MaxBase as logicCrystalUpgrade3MaxBase,
   crystalUpgrade4MaxExponent as logicCrystalUpgrade4MaxExponent,
   resetCurrency as logicResetCurrency,
   resourceGain as logicResourceGain,
+  tackTail as logicTackTail,
   updateAllMultiplier as logicUpdateAllMultiplier,
   updateAllTick as logicUpdateAllTick
 } from '@synergism/logic'
@@ -21,6 +20,7 @@ import Decimal, { type DecimalSource } from 'break_infinity.js'
 import LZString from 'lz-string'
 
 import {
+  applySweepResult,
   autoAscensionChallengeSweepUnlock,
   CalcECC,
   challenge15ScoreMultiplier,
@@ -31,8 +31,9 @@ import {
   getMaxChallenges,
   getNextAscensionChallenge,
   highestChallengeRewards,
-  tickChallengeSweep
+  prepareSweepInputForTackTail
 } from './Challenges'
+import { dispatchTickEvent } from './tickEventHandlers'
 import { btoa } from './Utility'
 import { freshBlankGlobals, Globals as G } from './Variables'
 
@@ -2708,20 +2709,6 @@ export const multipliers = (): void => {
   G.antMultiplier = result.antMultiplier
 }
 
-// Dispatches CoreEvents returned by logic resourceGain back into web_ui side
-// effects. Kept inline rather than a separate module so the data flow is
-// obvious next to the shim that emits them.
-const dispatchResourceGainEvents = (events: readonly CoreEvent[]): void => {
-  for (const ev of events) {
-    if (ev.kind === 'achievement-group-awarded') {
-      awardAchievementGroup(ev.group as 'constant')
-    } else if (ev.kind === 'challenge-auto-completed') {
-      challengeAchievementCheck(ev.challengeIndex)
-      updateChallengeLevel(ev.challengeIndex)
-    }
-  }
-}
-
 export const resourceGain = (dt: number): void => {
   // Pre-tick orchestration — populate G.* derived state that logic reads.
   calculateTotalAcceleratorBoost()
@@ -2915,7 +2902,9 @@ export const resourceGain = (dt: number): void => {
   G.ascendBuildingProduction.fourth = result.ascendBuildingProduction.fourth
   G.ascendBuildingProduction.fifth = result.ascendBuildingProduction.fifth
 
-  dispatchResourceGainEvents(result.events)
+  for (const event of result.events) {
+    dispatchTickEvent(event)
+  }
 
   // Terminal challenge resetCheck dispatch — async + modal-aware, stays in
   // web_ui. Reads the post-tick player state so threshold checks see the
@@ -4125,19 +4114,26 @@ const tack = (dt: number) => {
     }
   }
 
-  // Adds an offering every 2 seconds
-  if (player.highestchallengecompletions[3] > 0) {
-    automaticTools('addOfferings', dt / 2)
-  }
-
-  // Challenge Sweep State Machine
-  tickChallengeSweep(dt)
-
-  // Check for automatic resets — pure decision logic lives in
-  // @synergism/logic; this shim translates fired events into
-  // resetAchievementCheck + reset calls.
-  const autoResetResult = logicApplyAutoResets({
+  // Per-tick tail — single logic call composing addOfferings (when c3+) +
+  // tickChallengeSweep + applyAutoResets. Events flow through the central
+  // dispatcher in tickEventHandlers.ts.
+  const sweepInput = prepareSweepInputForTackTail()
+  const tailResult = logicTackTail({
     dt,
+    highestchallengecompletions3: player.highestchallengecompletions[3],
+    autoOfferingCounter: G.autoOfferingCounter,
+    offerings: player.offerings,
+    sweepState: sweepInput.sweepState,
+    timeSinceLastStateChange: sweepInput.timeSinceLastStateChange,
+    shouldRunSweep: sweepInput.shouldRunSweep,
+    timerStart: sweepInput.timerStart,
+    timerExit: sweepInput.timerExit,
+    timerEnter: sweepInput.timerEnter,
+    initialIndex: sweepInput.initialIndex,
+    nextRegularChallengeFromInitial: sweepInput.nextRegularChallengeFromInitial,
+    nextRegularChallengeFromActive: sweepInput.nextRegularChallengeFromActive,
+    challenge15AutoExponentCheck: sweepInput.challenge15AutoExponentCheck,
+    isFinishedStillValid: sweepInput.isFinishedStillValid,
     prestigeMode: player.resetToggleModes.prestige === AutoResetModes.amount ? 'amount' : 'time',
     toggle15: player.toggles[15],
     autoPrestigeMilestone: getLevelMilestone('autoPrestige'),
@@ -4166,28 +4162,14 @@ const tack = (dt: number) => {
     transcensionChallenge: player.currentChallenge.transcension,
     reincarnationChallenge: player.currentChallenge.reincarnation
   })
-  G.autoResetTimers.prestige = autoResetResult.autoResetTimerPrestige
-  G.autoResetTimers.transcension = autoResetResult.autoResetTimerTranscension
-  G.autoResetTimers.reincarnation = autoResetResult.autoResetTimerReincarnation
-  for (const event of autoResetResult.events) {
-    if (event.kind !== 'auto-reset-triggered') continue
-    if (event.tier === 'prestige') {
-      // Bug-for-bug parity: legacy prestige time mode awards the
-      // 'transcension' achievement check; amount mode awards 'prestige'.
-      // See packages/logic/src/tick/autoReset.ts header for context.
-      if (event.mode === 'time') {
-        resetAchievementCheck('transcension')
-      } else {
-        resetAchievementCheck('prestige')
-      }
-      reset('prestige', true)
-    } else if (event.tier === 'transcension') {
-      resetAchievementCheck('transcension')
-      reset('transcension', true)
-    } else if (event.tier === 'reincarnation') {
-      resetAchievementCheck('reincarnation')
-      reset('reincarnation', true)
-    }
+  G.autoOfferingCounter = tailResult.autoOfferingCounter
+  player.offerings = tailResult.offerings
+  applySweepResult(tailResult.sweepState, tailResult.timeSinceLastStateChange)
+  G.autoResetTimers.prestige = tailResult.autoResetTimerPrestige
+  G.autoResetTimers.transcension = tailResult.autoResetTimerTranscension
+  G.autoResetTimers.reincarnation = tailResult.autoResetTimerReincarnation
+  for (const event of tailResult.events) {
+    dispatchTickEvent(event)
   }
   calculateOfferings()
 }

--- a/packages/web_ui/src/tickEventHandlers.ts
+++ b/packages/web_ui/src/tickEventHandlers.ts
@@ -17,7 +17,7 @@ import { dispatchSweepTransition } from './Challenges'
 import type { CoreEvent } from '@synergism/logic'
 import { reset } from './Reset'
 import { Tabs } from './Tabs'
-import { visualUpdateAmbrosia, visualUpdateResearch } from './UpdateVisuals'
+import { visualUpdateAmbrosia, visualUpdateOcteracts, visualUpdateResearch } from './UpdateVisuals'
 import { revealStuff, updateChallengeLevel } from './UpdateHTML'
 import { Globals as G } from './Variables'
 
@@ -69,6 +69,11 @@ export function dispatchTickEvent (event: CoreEvent): void {
     case 'ambrosia-gained':
     case 'red-ambrosia-gained':
       visualUpdateAmbrosia()
+      return
+
+    // ─── octeract events ─────────────────────────────────────────────
+    case 'octeract-tick-fired':
+      visualUpdateOcteracts()
       return
 
     // ─── autoReset events ────────────────────────────────────────────

--- a/packages/web_ui/src/tickEventHandlers.ts
+++ b/packages/web_ui/src/tickEventHandlers.ts
@@ -1,0 +1,101 @@
+// Central CoreEvent dispatcher for the per-tick body. Replaces the six
+// scattered inline dispatchers that were growing across Synergism.ts,
+// Helper.ts, and Challenges.ts as more subsystems migrated to logic.
+//
+// Pattern: every shim that calls into @synergism/logic and receives an
+// events[] array dispatches it through `dispatchTickEvent` here. The
+// event kinds form a discriminated union (see
+// packages/logic/src/events/types.ts); each case maps to the
+// corresponding web_ui side effect — async resetCheck, achievement
+// awards, visual refreshes, modal triggers, etc.
+//
+// New event kinds should be added here in one place when the logic
+// emits them.
+
+import { type AchievementGroups, awardAchievementGroup, challengeAchievementCheck, resetAchievementCheck } from './Achievements'
+import { dispatchSweepTransition } from './Challenges'
+import type { CoreEvent } from '@synergism/logic'
+import { reset } from './Reset'
+import { Tabs } from './Tabs'
+import { visualUpdateAmbrosia, visualUpdateResearch } from './UpdateVisuals'
+import { revealStuff, updateChallengeLevel } from './UpdateHTML'
+import { Globals as G } from './Variables'
+
+/**
+ * Translate one CoreEvent into its web_ui side effect. No return value —
+ * the event was already produced by logic, this just plays its UI
+ * counterpart. Switch is exhaustive over the union so adding a new
+ * variant to CoreEvent surfaces as a TS error here.
+ */
+export function dispatchTickEvent (event: CoreEvent): void {
+  switch (event.kind) {
+    // ─── Purchase events ──────────────────────────────────────────────
+    // Emitted by purchase actions (acceleratorBoosts, multipliers, etc.).
+    // Not part of the tick body's event flow today — kept here so the
+    // central dispatcher is exhaustive over CoreEvent.
+    case 'accelerators-purchased':
+    case 'multipliers-purchased':
+    case 'particle-buildings-purchased':
+    case 'crystal-upgrade-purchased':
+    case 'upgrade-purchased':
+    case 'producers-purchased':
+    case 'tesseract-buildings-purchased':
+      return
+
+    // ─── resourceGain events ─────────────────────────────────────────
+    case 'resources-gained':
+      // Reserved for future use; resourceGain doesn't emit this yet.
+      return
+    case 'achievement-group-awarded':
+      awardAchievementGroup(event.group as AchievementGroups)
+      return
+    case 'challenge-auto-completed':
+      challengeAchievementCheck(event.challengeIndex)
+      updateChallengeLevel(event.challengeIndex)
+      return
+    case 'reveal-needed':
+      // Reserved for future resourceGain reveals (coinone-coinfour gates).
+      revealStuff()
+      return
+
+    // ─── automaticTools events ───────────────────────────────────────
+    case 'auto-tool-fired':
+      if (event.tool === 'addObtainium' && G.currentTab === Tabs.Research) {
+        visualUpdateResearch()
+      }
+      return
+
+    // ─── ambrosia events ─────────────────────────────────────────────
+    case 'ambrosia-gained':
+    case 'red-ambrosia-gained':
+      visualUpdateAmbrosia()
+      return
+
+    // ─── autoReset events ────────────────────────────────────────────
+    case 'auto-reset-triggered':
+      if (event.tier === 'prestige') {
+        // Bug-for-bug parity: legacy prestige *time* mode awards the
+        // 'transcension' achievement check; amount mode awards 'prestige'.
+        // Documented in packages/logic/src/tick/autoReset.ts header.
+        if (event.mode === 'time') {
+          resetAchievementCheck('transcension')
+        } else {
+          resetAchievementCheck('prestige')
+        }
+        reset('prestige', true)
+      } else if (event.tier === 'transcension') {
+        resetAchievementCheck('transcension')
+        reset('transcension', true)
+      } else if (event.tier === 'reincarnation') {
+        resetAchievementCheck('reincarnation')
+        reset('reincarnation', true)
+      }
+      // 'ascension' tier is forward-looking and not emitted today.
+      return
+
+    // ─── challengeSweep events ───────────────────────────────────────
+    case 'challenge-sweep-transitioned':
+      dispatchSweepTransition(event.from, event.to)
+      return
+  }
+}


### PR DESCRIPTION
## Summary

Closes the bulk of the remaining tick-body migration plan into `@synergism/logic`. Six commits, each independently green (tsc + tests). Together they take the per-tick body from "lots of inline logic" to "shims + central event dispatcher + a partial pure-composition tail."

- **Phase 3c/3d/3e** ([9457b31e](../../commit/9457b31e)) — `automaticTools` (addObtainium + addOfferings; rune/ant sacrifice deferred), `applyAutoResets` (full prestige/transcend/reincarnation × amount/time, with the legacy "prestige time mode awards 'transcension' achievement check" bug preserved bug-for-bug), `tickChallengeSweep` + `SweepStates` (full state machine + 4 enable/disable paths). Event type `challenge-sweep-transitioned` upgraded to carry full `SweepStates` from/to.
- **Phase 3.5** ([b3aa273a](../../commit/b3aa273a)) — `seededRandom` + `seededBetween` migrated as pure `(seed) → { value, newSeed }` (web_ui RNG.ts now a thin shim); `ambrosia` + `redAmbrosia` addTimers cases (both use the seeded RNG, both with chunked 1/8s timer + inner luck-roll loop with `calculateRequiredBlueberry/RedAmbrosiaTime` called per-iteration on mutating lifetime).
- **Phase 4** ([7d3a88f2](../../commit/7d3a88f2)) — `logic.tackTail` bundles `addOfferings` + `tickChallengeSweep` + `applyAutoResets` into a single pure composition (the contiguous all-migrated tail of `tack`). `web_ui/tickEventHandlers.ts` provides a single exhaustive `dispatchTickEvent(event: CoreEvent)` that replaces 6 scattered inline dispatchers across Synergism.ts / Helper.ts / Challenges.ts.
- **Phase 5 partial** ([313bd18f](../../commit/313bd18f)) — N=1000-tick fixture parity harness for `tackTail` over 3 scenarios (idle, sweep cycling, auto-prestige firing). Covers the migrated tail only; full pre-migration tack body comparison would require reconstructing the legacy body and is out of scope here.
- **octeracts addTimers** ([a9449397](../../commit/a9449397)) — closes the third addTimers deferral. The legacy code calls `calculateGoldenQuarks()` inside a giveaway loop that mutates `quarksThisSingularity`; logic pre-evaluates the product of GQ stats 1..end (qts-independent) and recomputes `calculateBaseGoldenQuarks` per-iteration with the current qts.
- **generateAntsAndCrumbs producer loop** ([db04d3d3](../../commit/db04d3d3)) — closes the largest remaining hole. The producer cascade has a real iteration dependency (iter N writes to tier (N-1).generated; iter (N-1) reads it); logic preserves this via a local mutable array. `activateELO` stays in web_ui (depends on Date.now / DOM / quark crediting).

## Numbers
- **+136 parity tests** (32,583 → 32,719 total logic tests passing)
- `tsc --build && tsc --noEmit -p web_ui && tsc --noEmit -p desktop_ui` — clean
- All 6 commits land green with pre-commit lint + build hooks passing

## Documented remaining holes (not in this PR)
Each needs its own subsystem migration:
- `autoPotion` addTimers — `useConsumable` has DOM/modal side effects
- `runeSacrifice` automaticTools — 4 dependent rune/talisman subsystems
- `antSacrifice` automaticTools — `sacrificeAnts` is a large function
- `activateELO` (called after migrated generateAntsAndCrumbs) — Date.now / server state / DOM / quark crediting
- Auto-research single-buy + Roomba — `buyResearch` DOM side effects
- `calculateObtainium` else-branch + `calculateOfferings()` tail — likely vestigial; worth a separate audit before removal

## Test plan
- [x] `npm test --workspace=@synergism/logic` — 32,719 tests pass
- [x] `npm run check:tsc` — clean across logic + web_ui + desktop_ui
- [x] Pre-commit hooks (lint + csslint + htmllint + tsc + build) pass on every commit
- [ ] Smoke-test in browser: idle production, auto-prestige trigger, auto-transcend, ant sacrifice, challenge entry/exit, sweep cycle
- [ ] Singularity reset cycle — most state-touching path in the game
- [ ] Offline calculation (`calculateOffline`) — verify offline gains match

🤖 Generated with [Claude Code](https://claude.com/claude-code)