### PR TITLE
feat(logic): retire *Pre fields (achievements, accelerator spine, challenge-15)

### DIFF
--- a/crates/synergismforkd_logic/src/mechanics/accelerators.rs
+++ b/crates/synergismforkd_logic/src/mechanics/accelerators.rs
@@ -358,6 +358,7 @@ mod tests {
     fn empty_state() -> AcceleratorState {
         AcceleratorState {
             accelerator_bought: 0.0,
+            accelerator_boost_bought: 0.0,
             accelerator_cost: get_cost_accelerator(1.0, baseline()),
             prestige_no_accelerator: true,
             transcend_no_accelerator: true,

--- a/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
@@ -78,6 +78,10 @@ const MULTIPLIERS_FLAT: [(usize, f64); 8] = [
     (161, 10.0),
 ];
 
+/// `+getAchievementReward('accelBoosts')` — additive. Coin-tier
+/// achievements grant `floor(owned / 2000)`.
+const ACCEL_BOOSTS_COIN: [(usize, usize); 5] = [(7, 0), (14, 1), (21, 2), (28, 3), (35, 4)];
+
 /// Legacy index of the lone `crystalMultiplier` achievement (#37):
 /// `() => Math.max(1, Decimal.log(prestigePoints, e))`.
 const CRYSTAL_MULTIPLIER_INDEX: usize = 37;
@@ -128,6 +132,18 @@ pub fn multipliers(input: &AchievementRewardInput) -> f64 {
     for (index, value) in MULTIPLIERS_FLAT {
         if earned(input.achievements, index) {
             sum += value;
+        }
+    }
+    sum
+}
+
+/// `getAchievementReward('accelBoosts')`.
+#[must_use]
+pub fn accel_boosts(input: &AchievementRewardInput) -> f64 {
+    let mut sum = 0.0;
+    for (index, tier) in ACCEL_BOOSTS_COIN {
+        if earned(input.achievements, index) {
+            sum += (input.coin_owned[tier] / 2000.0).floor();
         }
     }
     sum
@@ -232,5 +248,18 @@ mod tests {
             prestige_points: Decimal::one(),
         };
         assert_eq!(crystal_multiplier(&input), 1.0);
+    }
+
+    #[test]
+    fn accel_boosts_sums_coin_floors() {
+        // idx 7 = floor(coin[0]/2000); idx 35 = floor(coin[4]/2000).
+        let a = earned_array(&[7, 35]);
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [5000.0, 0.0, 0.0, 0.0, 9000.0],
+            prestige_points: Decimal::zero(),
+        };
+        // floor(5000/2000)=2, floor(9000/2000)=4 → 6
+        assert_eq!(accel_boosts(&input), 6.0);
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
@@ -1,0 +1,236 @@
+//! Achievement reward aggregators — the **numeric** subset of the legacy
+//! `getAchievementReward` from
+//! `legacy/core_split/packages/web_ui/src/Achievements.ts`.
+//!
+//! In the TS split this lived in `web_ui` (tangled with achievement
+//! tooltips / i18n), so the `logic` aggregators received the reward
+//! totals as caller-packed `*Pre` fields. Porting the pure numeric part
+//! down into `logic` is what lets the tick self-derive those fields from
+//! `&GameState`; the achievement *messages* stay a UI concern.
+//!
+//! Each reward total is a reduce over the achievements that grant it:
+//! `getAchievementReward` builds `achievementsByReward[type]` (the list
+//! of achievement indices whose `reward` object has that key) and sums
+//! (additive rewards) or multiplies (multiplicative rewards) the
+//! per-achievement formula, gated by `player.achievements[index]`.
+//! Indices are 0-based array positions into the core_split `achievements`
+//! array, matching [`crate::state::AchievementsState::achievements`].
+//!
+//! This module ports the keys consumed by the Phase 2 aggregator
+//! `*Pre` bundles (`accelerators`, `acceleratorPower`, `multipliers`,
+//! `crystalMultiplier`). Further keys (`accelBoosts`, `taxReduction`,
+//! `particleGain`, `antSacrificeUnlock`, …) land alongside the chunks
+//! that consume them.
+
+use synergismforkd_bignum::Decimal;
+
+use crate::state::ACHIEVEMENTS_LEN;
+
+/// Inputs to the achievement-reward aggregators. Groups the earned-flag
+/// array with the cross-state values the reward formulas read.
+#[derive(Debug, Clone, Copy)]
+pub struct AchievementRewardInput<'a> {
+    /// `player.achievements` — 0 = unowned, non-zero = unlocked.
+    pub achievements: &'a [u8; ACHIEVEMENTS_LEN],
+    /// `player.{first,second,third,fourth,fifth}OwnedCoin` — coin
+    /// producer owned counts, indexed 0..5.
+    pub coin_owned: [f64; 5],
+    /// `player.prestigePoints` (Diamonds prestige currency).
+    pub prestige_points: Decimal,
+}
+
+/// `+getAchievementReward('acceleratorPower')` — additive. All flat
+/// per-achievement constants (no state dependence).
+/// Legacy indices 3 / 10 / 17 / 24 / 31 / 149.
+const ACCELERATOR_POWER: [(usize, f64); 6] = [
+    (3, 0.001),
+    (10, 0.0015),
+    (17, 0.002),
+    (24, 0.002),
+    (31, 0.003),
+    (149, 0.01),
+];
+
+/// `+getAchievementReward('accelerators')` — additive. Coin-tier
+/// achievements grant `floor(owned / 500)`; the rest are flat.
+const ACCELERATORS_COIN: [(usize, usize); 5] = [(5, 0), (12, 1), (19, 2), (26, 3), (33, 4)];
+const ACCELERATORS_FLAT: [(usize, f64); 7] = [
+    (60, 2.0),
+    (61, 4.0),
+    (62, 8.0),
+    (151, 5.0),
+    (152, 12.0),
+    (153, 25.0),
+    (154, 50.0),
+];
+
+/// `+getAchievementReward('multipliers')` — additive. Coin-tier
+/// achievements grant `floor(owned / 1000)`; the rest are flat.
+const MULTIPLIERS_COIN: [(usize, usize); 5] = [(6, 0), (13, 1), (20, 2), (27, 3), (34, 4)];
+const MULTIPLIERS_FLAT: [(usize, f64); 8] = [
+    (57, 1.0),
+    (58, 2.0),
+    (59, 4.0),
+    (156, 1.0),
+    (158, 1.0),
+    (159, 3.0),
+    (160, 6.0),
+    (161, 10.0),
+];
+
+/// Legacy index of the lone `crystalMultiplier` achievement (#37):
+/// `() => Math.max(1, Decimal.log(prestigePoints, e))`.
+const CRYSTAL_MULTIPLIER_INDEX: usize = 37;
+
+#[inline]
+fn earned(achievements: &[u8; ACHIEVEMENTS_LEN], index: usize) -> bool {
+    achievements[index] != 0
+}
+
+/// `getAchievementReward('acceleratorPower')`.
+#[must_use]
+pub fn accelerator_power(input: &AchievementRewardInput) -> f64 {
+    let mut sum = 0.0;
+    for (index, value) in ACCELERATOR_POWER {
+        if earned(input.achievements, index) {
+            sum += value;
+        }
+    }
+    sum
+}
+
+/// `getAchievementReward('accelerators')`.
+#[must_use]
+pub fn accelerators(input: &AchievementRewardInput) -> f64 {
+    let mut sum = 0.0;
+    for (index, tier) in ACCELERATORS_COIN {
+        if earned(input.achievements, index) {
+            sum += (input.coin_owned[tier] / 500.0).floor();
+        }
+    }
+    for (index, value) in ACCELERATORS_FLAT {
+        if earned(input.achievements, index) {
+            sum += value;
+        }
+    }
+    sum
+}
+
+/// `getAchievementReward('multipliers')`.
+#[must_use]
+pub fn multipliers(input: &AchievementRewardInput) -> f64 {
+    let mut sum = 0.0;
+    for (index, tier) in MULTIPLIERS_COIN {
+        if earned(input.achievements, index) {
+            sum += (input.coin_owned[tier] / 1000.0).floor();
+        }
+    }
+    for (index, value) in MULTIPLIERS_FLAT {
+        if earned(input.achievements, index) {
+            sum += value;
+        }
+    }
+    sum
+}
+
+/// `getAchievementReward('crystalMultiplier')` — multiplicative (base 1).
+/// The single contributing achievement grants
+/// `max(1, ln(prestigePoints))`.
+#[must_use]
+pub fn crystal_multiplier(input: &AchievementRewardInput) -> f64 {
+    if earned(input.achievements, CRYSTAL_MULTIPLIER_INDEX) {
+        // `Decimal.log(x, e)` is the natural log; `ln(0)`/`ln(<1)`
+        // floors to 1 via the `max`, so default state yields 1.
+        1.0_f64.max(input.prestige_points.ln().to_number())
+    } else {
+        1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn earned_array(indices: &[usize]) -> [u8; ACHIEVEMENTS_LEN] {
+        let mut a = [0u8; ACHIEVEMENTS_LEN];
+        for &i in indices {
+            a[i] = 1;
+        }
+        a
+    }
+
+    #[test]
+    fn defaults_are_identity() {
+        let a = [0u8; ACHIEVEMENTS_LEN];
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [0.0; 5],
+            prestige_points: Decimal::zero(),
+        };
+        assert_eq!(accelerator_power(&input), 0.0);
+        assert_eq!(accelerators(&input), 0.0);
+        assert_eq!(multipliers(&input), 0.0);
+        assert_eq!(crystal_multiplier(&input), 1.0); // product identity
+    }
+
+    #[test]
+    fn accelerator_power_sums_earned_constants() {
+        let a = earned_array(&[3, 31, 149]); // 0.001 + 0.003 + 0.01
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [0.0; 5],
+            prestige_points: Decimal::zero(),
+        };
+        assert!((accelerator_power(&input) - 0.014).abs() < 1e-9);
+    }
+
+    #[test]
+    fn accelerators_mixes_coin_floor_and_flat() {
+        // idx 5 = floor(coin[0]/500); idx 60 = +2; idx 154 = +50.
+        let a = earned_array(&[5, 60, 154]);
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [1500.0, 0.0, 0.0, 0.0, 0.0],
+            prestige_points: Decimal::zero(),
+        };
+        // floor(1500/500)=3, +2, +50 = 55
+        assert_eq!(accelerators(&input), 55.0);
+    }
+
+    #[test]
+    fn multipliers_mixes_coin_floor_and_flat() {
+        // idx 6 = floor(coin[0]/1000); idx 59 = +4; idx 161 = +10.
+        let a = earned_array(&[6, 59, 161]);
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [2500.0, 0.0, 0.0, 0.0, 0.0],
+            prestige_points: Decimal::zero(),
+        };
+        // floor(2500/1000)=2, +4, +10 = 16
+        assert_eq!(multipliers(&input), 16.0);
+    }
+
+    #[test]
+    fn crystal_multiplier_uses_ln_when_earned() {
+        let a = earned_array(&[CRYSTAL_MULTIPLIER_INDEX]);
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [0.0; 5],
+            prestige_points: Decimal::from_finite(1e100),
+        };
+        // ln(1e100) = 100 * ln(10) ≈ 230.2585
+        assert!((crystal_multiplier(&input) - 230.2585).abs() < 0.01);
+    }
+
+    #[test]
+    fn crystal_multiplier_floors_at_one() {
+        // earned but tiny prestige → max(1, ln(1)) = max(1, 0) = 1.
+        let a = earned_array(&[CRYSTAL_MULTIPLIER_INDEX]);
+        let input = AchievementRewardInput {
+            achievements: &a,
+            coin_owned: [0.0; 5],
+            prestige_points: Decimal::one(),
+        };
+        assert_eq!(crystal_multiplier(&input), 1.0);
+    }
+}

--- a/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
@@ -1,0 +1,102 @@
+//! Challenge-15 reward values — the numeric subset of the legacy
+//! `c15RewardFormulae` (`Variables.ts`) gated by `c15RewardUpdate`
+//! (`Statistics.ts`). Each reward is its `baseValue` (1) until
+//! `player.challenge15Exponent` reaches the reward's `requirement`,
+//! after which it follows the per-reward scaling formula of the
+//! exponent. Below the requirement the reward is the multiplicative
+//! identity (1), matching the bundles' previous forwarded defaults.
+//!
+//! Ported subset: the rewards consumed by the Phase-2 aggregator
+//! `*Pre` bundles (`coinExponent`, `exponent`, `constantBonus`,
+//! `accelerator`, `multiplier`). Other c15 rewards (`taxes`, `runeExp`,
+//! `antSpeed`, `globalSpeed`, …) land with the chunks that consume them.
+
+use crate::math::sigmoid::calculate_sigmoid;
+
+/// `challenge15Rewards.coinExponent.value` — exponent applied to the
+/// global coin multiplier. Requirement `3000`.
+#[must_use]
+pub fn coin_exponent(exponent: f64) -> f64 {
+    if exponent >= 3_000.0 {
+        1.0 + (1.0 / 150.0) * (exponent / 750.0).log2()
+    } else {
+        1.0
+    }
+}
+
+/// `challenge15Rewards.accelerator.value`. Requirement `10000`.
+#[must_use]
+pub fn accelerator(exponent: f64) -> f64 {
+    if exponent >= 10_000.0 {
+        1.0 + (1.0 / 20.0) * (exponent / 2_500.0).log2()
+    } else {
+        1.0
+    }
+}
+
+/// `challenge15Rewards.multiplier.value` — identical formula to
+/// [`accelerator`]. Requirement `10000`.
+#[must_use]
+pub fn multiplier(exponent: f64) -> f64 {
+    if exponent >= 10_000.0 {
+        1.0 + (1.0 / 20.0) * (exponent / 2_500.0).log2()
+    } else {
+        1.0
+    }
+}
+
+/// `challenge15Rewards.constantBonus.value` — multiplied into
+/// `globalConstantMult`. Requirement `1e8`.
+#[must_use]
+pub fn constant_bonus(exponent: f64) -> f64 {
+    if exponent >= 1e8 {
+        1.0 + (1.0 / 5.0) * (exponent / 1e8).powf(2.0 / 3.0)
+    } else {
+        1.0
+    }
+}
+
+/// `challenge15Rewards.exponent.value` — sigmoid bonus feeding
+/// `constUpgrade2`. Requirement `2e16`.
+#[must_use]
+pub fn exponent_reward(exponent: f64) -> f64 {
+    if exponent >= 2e16 {
+        calculate_sigmoid(1.05, exponent, 1e18)
+    } else {
+        1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn below_requirement_is_identity() {
+        assert_eq!(coin_exponent(0.0), 1.0);
+        assert_eq!(accelerator(0.0), 1.0);
+        assert_eq!(multiplier(0.0), 1.0);
+        assert_eq!(constant_bonus(0.0), 1.0);
+        assert_eq!(exponent_reward(0.0), 1.0);
+    }
+
+    #[test]
+    fn coin_exponent_scales_above_requirement() {
+        // e = 3000 → 1 + (1/150)*log2(3000/750) = 1 + (1/150)*log2(4) = 1 + 2/150
+        assert!((coin_exponent(3_000.0) - (1.0 + 2.0 / 150.0)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn accelerator_and_multiplier_match_and_scale() {
+        // e = 10000 → 1 + (1/20)*log2(4) = 1.1
+        let v = accelerator(10_000.0);
+        assert!((v - 1.1).abs() < 1e-12);
+        assert_eq!(multiplier(10_000.0), v);
+    }
+
+    #[test]
+    fn constant_bonus_scales_above_requirement() {
+        // e = 1e8 → 1 + (1/5)*(1)^(2/3) = 1.2
+        assert!((constant_bonus(1e8) - 1.2).abs() < 1e-12);
+    }
+}

--- a/crates/synergismforkd_logic/src/mechanics/mod.rs
+++ b/crates/synergismforkd_logic/src/mechanics/mod.rs
@@ -20,6 +20,7 @@ pub mod ascensions;
 pub mod blueberry_upgrades;
 pub mod calculate;
 pub mod campaign_token_rewards;
+pub mod challenge_15_rewards;
 pub mod challenges;
 pub mod coin_production;
 pub mod corruptions;

--- a/crates/synergismforkd_logic/src/mechanics/mod.rs
+++ b/crates/synergismforkd_logic/src/mechanics/mod.rs
@@ -7,6 +7,7 @@ pub mod accelerator_multipliers;
 pub mod accelerators;
 pub mod achievement_levels;
 pub mod achievement_points;
+pub mod achievement_rewards;
 pub mod ambrosia;
 pub mod ant_masteries;
 pub mod ant_producers;

--- a/crates/synergismforkd_logic/src/state/accelerator.rs
+++ b/crates/synergismforkd_logic/src/state/accelerator.rs
@@ -27,6 +27,11 @@ pub struct AcceleratorState {
     /// Total accelerators owned. Walked past `MAX_SAFE_INTEGER` in the
     /// high-end binary-search branch.
     pub accelerator_bought: f64,
+    /// `player.acceleratorBoostBought` — accelerator-boosts purchased.
+    /// Feeds `calculate_total_accelerator_boost` (the `bought + free`
+    /// total). Defaults to 0; set by the (not-yet-ported) buy-boost
+    /// action.
+    pub accelerator_boost_bought: f64,
     /// Cost of the next accelerator (cached so the UI can render without
     /// recomputing).
     pub accelerator_cost: Decimal,
@@ -45,6 +50,7 @@ impl Default for AcceleratorState {
     fn default() -> Self {
         Self {
             accelerator_bought: 0.0,
+            accelerator_boost_bought: 0.0,
             accelerator_cost: Decimal::zero(),
             prestige_no_accelerator: true,
             transcend_no_accelerator: true,

--- a/crates/synergismforkd_logic/src/state/achievements.rs
+++ b/crates/synergismforkd_logic/src/state/achievements.rs
@@ -20,16 +20,19 @@ pub struct ProgressiveAchievementCache {
     pub cached_points: f64,
 }
 
-/// Fixed cardinality of the achievement bitmap — `280 + 1` for the
-/// legacy 1-indexed convention (index 0 unused). Tier B item 12 /
-/// Anvil F4.
-pub const ACHIEVEMENTS_LEN: usize = 281;
+/// Fixed cardinality of the achievement bitmap — one slot per entry in
+/// the legacy core_split `achievements` array (509 entries, 0-indexed;
+/// index 0 is the always-on "Free Achievement"). Verified against
+/// `legacy/core_split/packages/web_ui/src/Achievements.ts` (509 entries
+/// by pointValue / unlockCondition / group / brace-depth counts).
+pub const ACHIEVEMENTS_LEN: usize = 509;
 
 /// Slice of `GameState` read/written by achievement mechanics.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct AchievementsState {
     /// `player.achievements[i]` — 0 = unowned, non-zero = unlocked.
-    /// 1-indexed (index 0 unused) to match legacy.
+    /// 0-indexed to match core_split's `achievements` array; index 0 is
+    /// the always-on "Free Achievement".
     #[serde(with = "BigArray")]
     pub achievements: [u8; ACHIEVEMENTS_LEN],
     /// Total achievement points earned.
@@ -58,8 +61,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_has_281_slots() {
+    fn default_has_509_slots() {
         let s = AchievementsState::default();
+        assert_eq!(s.achievements.len(), 509);
         assert_eq!(s.achievements.len(), ACHIEVEMENTS_LEN);
         assert_eq!(s.achievement_points, 0.0);
     }

--- a/crates/synergismforkd_logic/src/state/challenges.rs
+++ b/crates/synergismforkd_logic/src/state/challenges.rs
@@ -24,6 +24,9 @@ pub struct ChallengesState {
     pub current_reincarnation_challenge: u32,
     /// Active ascension challenge ID (`0` = none). Range `11..=15`.
     pub current_ascension_challenge: u32,
+    /// `player.challenge15Exponent` — cumulative Challenge-15 exponent;
+    /// gates the c15 reward tiers (`mechanics::challenge_15_rewards`).
+    pub challenge15_exponent: f64,
 }
 
 impl Default for ChallengesState {
@@ -34,6 +37,7 @@ impl Default for ChallengesState {
             current_transcension_challenge: 0,
             current_reincarnation_challenge: 0,
             current_ascension_challenge: 0,
+            challenge15_exponent: 0.0,
         }
     }
 }

--- a/crates/synergismforkd_logic/src/state/mod.rs
+++ b/crates/synergismforkd_logic/src/state/mod.rs
@@ -42,7 +42,7 @@ pub mod tesseract_buildings;
 pub mod upgrades;
 
 pub use accelerator::AcceleratorState;
-pub use achievements::{AchievementsState, ProgressiveAchievementCache};
+pub use achievements::{AchievementsState, ProgressiveAchievementCache, ACHIEVEMENTS_LEN};
 pub use ambrosia::{AmbrosiaState, AmbrosiaUpgrade};
 pub use ants::{
     AntsState, AntsToggles, AutoSacrificeMode, PlayerAntMastery, PlayerAntProducer, RebornELOEntry,

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -36,6 +36,7 @@ use synergismforkd_bignum::Decimal;
 use crate::events::{CoreEvent, ProducerType};
 use crate::mechanics::accelerators::{buy_accelerator, BuyAcceleratorInput};
 use crate::mechanics::achievement_rewards;
+use crate::mechanics::challenge_15_rewards;
 use crate::mechanics::crystal_upgrades::{buy_crystal_upgrades, BuyCrystalUpgradesInput};
 use crate::mechanics::global_multipliers::{
     compute_global_multipliers, GlobalMultipliersPreEvaluated, GlobalMultipliersResult,
@@ -567,9 +568,9 @@ fn compute_total_accelerator_boost(state: &GameState) -> f64 {
 /// - `total_multiplier`                 ✓ injected by phase_global_state (aggregator output)
 /// - `total_accelerator`                ✓ injected by phase_global_state (aggregator output)
 /// - `total_accelerator_boost`          ✓ injected by precompute (calculate_total_accelerator_boost)
-/// - `challenge_15_coin_exponent`       forwarded (challenge-15 rewards)
-/// - `challenge_15_exponent_value`      forwarded (challenge-15 rewards)
-/// - `challenge_15_constant_bonus`      forwarded (challenge-15 rewards)
+/// - `challenge_15_coin_exponent`       ✓ state-derived (challenge_15_rewards)
+/// - `challenge_15_exponent_value`      ✓ state-derived (challenge_15_rewards)
+/// - `challenge_15_constant_bonus`      ✓ state-derived (challenge_15_rewards)
 #[must_use]
 fn compute_global_multipliers_pre(
     state: &GameState,
@@ -601,6 +602,7 @@ fn compute_global_multipliers_pre(
     });
     let recession_level = state.corruptions.used.levels[RECESSION_INDEX];
     let ach = achievement_reward_input(state);
+    let c15_exponent = state.challenges.challenge15_exponent;
 
     GlobalMultipliersPreEvaluated {
         prism_production_log10: prism_rune_effects(prism_level, PrismRuneKey::ProductionLog10),
@@ -624,9 +626,9 @@ fn compute_global_multipliers_pre(
         total_multiplier: fallback.total_multiplier,
         total_accelerator: fallback.total_accelerator,
         total_accelerator_boost: fallback.total_accelerator_boost,
-        challenge_15_coin_exponent: fallback.challenge_15_coin_exponent,
-        challenge_15_exponent_value: fallback.challenge_15_exponent_value,
-        challenge_15_constant_bonus: fallback.challenge_15_constant_bonus,
+        challenge_15_coin_exponent: challenge_15_rewards::coin_exponent(c15_exponent),
+        challenge_15_exponent_value: challenge_15_rewards::exponent_reward(c15_exponent),
+        challenge_15_constant_bonus: challenge_15_rewards::constant_bonus(c15_exponent),
     }
 }
 
@@ -648,7 +650,7 @@ fn compute_global_multipliers_pre(
 /// - `multipliers_achievement`          ✓ state-derived (achievement_rewards)
 /// - `total_accelerator_boost`          ✓ injected by precompute (calculate_total_accelerator_boost)
 /// - `taxdivisor`                       forwarded (cross-mechanic tax pipeline)
-/// - `challenge_15_reward_multiplier`   forwarded (challenge-15 rewards not ported)
+/// - `challenge_15_reward_multiplier`   ✓ state-derived (challenge_15_rewards)
 #[must_use]
 fn compute_update_all_multiplier_pre(
     state: &GameState,
@@ -717,7 +719,9 @@ fn compute_update_all_multiplier_pre(
         multipliers_achievement: achievement_rewards::multipliers(&ach),
         total_accelerator_boost: fallback.total_accelerator_boost,
         taxdivisor: fallback.taxdivisor,
-        challenge_15_reward_multiplier: fallback.challenge_15_reward_multiplier,
+        challenge_15_reward_multiplier: challenge_15_rewards::multiplier(
+            state.challenges.challenge15_exponent,
+        ),
     }
 }
 
@@ -735,7 +739,7 @@ fn compute_update_all_multiplier_pre(
 /// - `accelerator_power_achievement`    ✓ state-derived (achievement_rewards)
 /// - `total_accelerator_boost`          ✓ injected by precompute (calculate_total_accelerator_boost)
 /// - `accelerator_multiplier`           ✓ state-derived (calculate_accelerator_multiplier)
-/// - `challenge_15_reward_accelerator`  forwarded (challenge-15 rewards)
+/// - `challenge_15_reward_accelerator`  ✓ state-derived (challenge_15_rewards)
 #[must_use]
 fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -> UpdateAllTickPre {
     use crate::mechanics::corruptions::viscosity_power_at_level;
@@ -786,7 +790,9 @@ fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -
         accelerator_power_achievement: achievement_rewards::accelerator_power(&ach),
         total_accelerator_boost: fallback.total_accelerator_boost,
         accelerator_multiplier,
-        challenge_15_reward_accelerator: fallback.challenge_15_reward_accelerator,
+        challenge_15_reward_accelerator: challenge_15_rewards::accelerator(
+            state.challenges.challenge15_exponent,
+        ),
     }
 }
 

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -401,16 +401,22 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
 /// shrinks. The cache is the migration target; `TackInput` is the
 /// temporary input mechanism.
 fn phase_cross_mechanic_precompute(state: &GameState, input: &TackInput) -> CrossMechanicCache {
+    // `total_accelerator_boost` is a pure function of state but is read by
+    // all three Phase-2 aggregators; compute it once and inject it into
+    // each bundle (overriding the now-vestigial caller value).
+    let total_accelerator_boost = compute_total_accelerator_boost(state);
+    let mut global_multipliers_pre =
+        compute_global_multipliers_pre(state, &input.global_multipliers_pre);
+    global_multipliers_pre.total_accelerator_boost = total_accelerator_boost;
+    let mut update_all_multiplier_pre =
+        compute_update_all_multiplier_pre(state, &input.update_all_multiplier_pre);
+    update_all_multiplier_pre.total_accelerator_boost = total_accelerator_boost;
+    let mut update_all_tick_pre = compute_update_all_tick_pre(state, &input.update_all_tick_pre);
+    update_all_tick_pre.total_accelerator_boost = total_accelerator_boost;
     CrossMechanicCache {
-        global_multipliers_pre: compute_global_multipliers_pre(
-            state,
-            &input.global_multipliers_pre,
-        ),
-        update_all_multiplier_pre: compute_update_all_multiplier_pre(
-            state,
-            &input.update_all_multiplier_pre,
-        ),
-        update_all_tick_pre: compute_update_all_tick_pre(state, &input.update_all_tick_pre),
+        global_multipliers_pre,
+        update_all_multiplier_pre,
+        update_all_tick_pre,
         resource_gain_pre: input.resource_gain_pre,
         automation_pre: input.automation_pre,
     }
@@ -434,6 +440,110 @@ fn achievement_reward_input(state: &GameState) -> achievement_rewards::Achieveme
     }
 }
 
+/// State-derive `G.acceleratorMultiplier` via the legacy
+/// `calculateAcceleratorMultiplier` formula — research/upgrade
+/// compounding, the `21..=25` upgrade pentad, and the in-challenge
+/// `upgrade[50]` bonus. Pure function of `&GameState`.
+fn compute_accelerator_multiplier(state: &GameState) -> f64 {
+    use crate::mechanics::accelerator_multipliers::{
+        calculate_accelerator_multiplier, CalculateAcceleratorMultiplierInput,
+    };
+    let upgrade = |i: usize| f64::from(state.upgrades.upgrades[i]);
+    let research = |i: usize| state.researches.researches[i];
+    calculate_accelerator_multiplier(&CalculateAcceleratorMultiplierInput {
+        research_1: research(1),
+        challenge_completions_14: state.challenges.challenge_completions[14],
+        research_6: research(6),
+        research_7: research(7),
+        research_8: research(8),
+        research_9: research(9),
+        research_10: research(10),
+        research_86: research(86),
+        research_126: research(126),
+        research_141: research(141),
+        research_156: research(156),
+        research_171: research(171),
+        research_186: research(186),
+        research_200: research(200),
+        cube_upgrade_50: state.cube_upgrade_levels.cube_upgrades[50],
+        upgrade_21: upgrade(21),
+        upgrade_22: upgrade(22),
+        upgrade_23: upgrade(23),
+        upgrade_24: upgrade(24),
+        upgrade_25: upgrade(25),
+        upgrade_50: upgrade(50),
+        in_transcension_or_reincarnation_challenge: state.challenges.current_transcension_challenge
+            != 0
+            || state.challenges.current_reincarnation_challenge != 0,
+    })
+}
+
+/// State-derive `G.totalAcceleratorBoost` via the legacy
+/// `calculateTotalAcceleratorBoost` (free boost from upgrades /
+/// researches / runes / ant + hepteract effects, then `+ bought`).
+/// Pure function of `&GameState`. Injected into all three aggregator
+/// `*Pre` bundles by [`phase_cross_mechanic_precompute`].
+fn compute_total_accelerator_boost(state: &GameState) -> f64 {
+    use crate::mechanics::accelerator_multipliers::{
+        calculate_total_accelerator_boost, CalculateTotalAcceleratorBoostInput,
+    };
+    use crate::mechanics::ant_upgrades::accelerator_boosts_ant_upgrade_effect;
+    use crate::mechanics::calculate::{calculate_total_coin_owned, CalculateTotalCoinOwnedInput};
+    use crate::mechanics::hepteract_values::{hepteract_effective, HepteractEffectiveInput};
+
+    /// Ant-upgrade index for "AcceleratorBoosts" (legacy `AntUpgrades` = 3).
+    const ANT_UPGRADE_ACCELERATOR_BOOSTS: usize = 3;
+
+    let upgrade = |i: usize| f64::from(state.upgrades.upgrades[i]);
+    let research = |i: usize| state.researches.researches[i];
+    let coin = &state.coin_producers.tiers;
+    let total_coin_owned = calculate_total_coin_owned(&CalculateTotalCoinOwnedInput {
+        first_owned_coin: coin[0].owned,
+        second_owned_coin: coin[1].owned,
+        third_owned_coin: coin[2].owned,
+        fourth_owned_coin: coin[3].owned,
+        fifth_owned_coin: coin[4].owned,
+    });
+    let sum_of_rune_levels: f64 = state.runes.rune_levels.iter().sum();
+    // acceleratorBoost hepteract: LIMIT 1000, DR 1/5, DR_INCREASE = 0.
+    let hepteract_effective_accelerator_boost = hepteract_effective(&HepteractEffectiveInput {
+        raw_amount: state.hepteracts.accelerator_boost.bal,
+        limit: 1000.0,
+        dr_exponent: 1.0 / 5.0,
+        is_quark: false,
+    });
+    let ach = achievement_reward_input(state);
+
+    calculate_total_accelerator_boost(&CalculateTotalAcceleratorBoostInput {
+        upgrade_26: upgrade(26),
+        upgrade_31: upgrade(31),
+        total_coin_owned,
+        achievement_accel_boosts: achievement_rewards::accel_boosts(&ach),
+        research_93: research(93),
+        sum_of_rune_levels,
+        research_3: research(3),
+        challenge_completions_14: state.challenges.challenge_completions[14],
+        research_16: research(16),
+        research_17: research(17),
+        research_88: research(88),
+        ant_building_accelerator_boost_mult: accelerator_boosts_ant_upgrade_effect(
+            state.ants.upgrades[ANT_UPGRADE_ACCELERATOR_BOOSTS],
+        ),
+        research_127: research(127),
+        research_142: research(142),
+        research_157: research(157),
+        research_172: research(172),
+        research_187: research(187),
+        research_200: research(200),
+        cube_upgrade_50: state.cube_upgrade_levels.cube_upgrades[50],
+        hepteract_effective_accelerator_boost,
+        upgrade_73: upgrade(73),
+        in_reincarnation_challenge: state.challenges.current_reincarnation_challenge != 0,
+        accelerator_boost_bought: state.accelerator.accelerator_boost_bought,
+    })
+    .total_accelerator_boost
+}
+
 /// State-derive the [`GlobalMultipliersPreEvaluated`] fields whose
 /// upstream is a pure function of [`GameState`] and existing ported
 /// mechanic helpers.
@@ -452,11 +562,11 @@ fn achievement_reward_input(state: &GameState) -> achievement_rewards::Achieveme
 /// - `const_upgrade_2_buff_achievement` ✓ always 0 (no achievement grants it)
 /// - `constant_ex_max_percent_increase` forwarded (shop-effect table not ported)
 /// - `ascend_building_dr_value`         forwarded (formula not yet ported)
-/// - `multiplier_effect`                forwarded (G.*, cross-aggregator)
-/// - `accelerator_effect`               forwarded (G.*, cross-aggregator)
-/// - `total_multiplier`                 forwarded (G.*, cross-aggregator)
-/// - `total_accelerator`                forwarded (G.*, cross-aggregator)
-/// - `total_accelerator_boost`          forwarded (G.*, cross-aggregator)
+/// - `multiplier_effect`                ✓ injected by phase_global_state (aggregator output)
+/// - `accelerator_effect`               ✓ injected by phase_global_state (aggregator output)
+/// - `total_multiplier`                 ✓ injected by phase_global_state (aggregator output)
+/// - `total_accelerator`                ✓ injected by phase_global_state (aggregator output)
+/// - `total_accelerator_boost`          ✓ injected by precompute (calculate_total_accelerator_boost)
 /// - `challenge_15_coin_exponent`       forwarded (challenge-15 rewards)
 /// - `challenge_15_exponent_value`      forwarded (challenge-15 rewards)
 /// - `challenge_15_constant_bonus`      forwarded (challenge-15 rewards)
@@ -536,7 +646,7 @@ fn compute_global_multipliers_pre(
 /// - `viscosity_power`                  ✓ state-derived (G.viscosityPower table)
 /// - `multiplier_cube_blessing`         ✓ state-derived (full blessing chain)
 /// - `multipliers_achievement`          ✓ state-derived (achievement_rewards)
-/// - `total_accelerator_boost`          forwarded (G.*, cross-aggregator)
+/// - `total_accelerator_boost`          ✓ injected by precompute (calculate_total_accelerator_boost)
 /// - `taxdivisor`                       forwarded (cross-mechanic tax pipeline)
 /// - `challenge_15_reward_multiplier`   forwarded (challenge-15 rewards not ported)
 #[must_use]
@@ -623,8 +733,8 @@ fn compute_update_all_multiplier_pre(
 /// - `accelerator_cube_blessing`        ✓ state-derived (full blessing chain)
 /// - `accelerators_achievement`         ✓ state-derived (achievement_rewards)
 /// - `accelerator_power_achievement`    ✓ state-derived (achievement_rewards)
-/// - `total_accelerator_boost`          forwarded (G.*, cross-aggregator)
-/// - `accelerator_multiplier`           forwarded (G.*, cross-aggregator)
+/// - `total_accelerator_boost`          ✓ injected by precompute (calculate_total_accelerator_boost)
+/// - `accelerator_multiplier`           ✓ state-derived (calculate_accelerator_multiplier)
 /// - `challenge_15_reward_accelerator`  forwarded (challenge-15 rewards)
 #[must_use]
 fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -> UpdateAllTickPre {
@@ -659,6 +769,7 @@ fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -
         state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_ACCELERATOR_BLESSING],
     );
     let ach = achievement_reward_input(state);
+    let accelerator_multiplier = compute_accelerator_multiplier(state);
 
     UpdateAllTickPre {
         multiplicative_accelerators_rune: speed_rune_effects(
@@ -674,7 +785,7 @@ fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -
         accelerators_achievement: achievement_rewards::accelerators(&ach),
         accelerator_power_achievement: achievement_rewards::accelerator_power(&ach),
         total_accelerator_boost: fallback.total_accelerator_boost,
-        accelerator_multiplier: fallback.accelerator_multiplier,
+        accelerator_multiplier,
         challenge_15_reward_accelerator: fallback.challenge_15_reward_accelerator,
     }
 }
@@ -688,7 +799,10 @@ fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -
 /// `global_crystal_multiplier` and `mythosupgrade_13` directly,
 /// instead of forwarding them from `TackInput`.
 fn phase_global_state(state: &mut GameState, cache: &CrossMechanicCache) -> AggregatorOutputs {
-    let global_multipliers = compute_global_multipliers(state, &cache.global_multipliers_pre);
+    // Legacy dependency order: `updateAllMultiplier`, then `updateAllTick`
+    // (which consumes `total_multiplier`), then `globalMultipliers` last —
+    // reading the multiplier/tick `G.*` outputs. The aggregators are pure
+    // (no production state writes), so the reorder is behaviour-preserving.
     let update_all_multiplier_result =
         update_all_multiplier(state, &cache.update_all_multiplier_pre);
     let update_all_tick_result = update_all_tick(
@@ -696,6 +810,16 @@ fn phase_global_state(state: &mut GameState, cache: &CrossMechanicCache) -> Aggr
         &cache.update_all_tick_pre,
         update_all_multiplier_result.total_multiplier,
     );
+
+    // Inject the multiplier/tick aggregator outputs into the global-
+    // multipliers bundle (these were forwarded from `TackInput` before).
+    let mut global_multipliers_pre = cache.global_multipliers_pre;
+    global_multipliers_pre.multiplier_effect = update_all_multiplier_result.multiplier_effect;
+    global_multipliers_pre.total_multiplier = update_all_multiplier_result.total_multiplier;
+    global_multipliers_pre.accelerator_effect = update_all_tick_result.accelerator_effect;
+    global_multipliers_pre.total_accelerator = update_all_tick_result.total_accelerator;
+    let global_multipliers = compute_global_multipliers(state, &global_multipliers_pre);
+
     AggregatorOutputs {
         global_multipliers,
         update_all_multiplier: update_all_multiplier_result,

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -35,6 +35,7 @@ use synergismforkd_bignum::Decimal;
 
 use crate::events::{CoreEvent, ProducerType};
 use crate::mechanics::accelerators::{buy_accelerator, BuyAcceleratorInput};
+use crate::mechanics::achievement_rewards;
 use crate::mechanics::crystal_upgrades::{buy_crystal_upgrades, BuyCrystalUpgradesInput};
 use crate::mechanics::global_multipliers::{
     compute_global_multipliers, GlobalMultipliersPreEvaluated, GlobalMultipliersResult,
@@ -415,6 +416,24 @@ fn phase_cross_mechanic_precompute(state: &GameState, input: &TackInput) -> Cros
     }
 }
 
+/// Build the shared achievement-reward input from `&GameState` — the
+/// earned-flag array plus the cross-state values the reward formulas
+/// read (coin-producer owned counts, prestige points).
+fn achievement_reward_input(state: &GameState) -> achievement_rewards::AchievementRewardInput<'_> {
+    let coin = &state.coin_producers.tiers;
+    achievement_rewards::AchievementRewardInput {
+        achievements: &state.achievements.achievements,
+        coin_owned: [
+            coin[0].owned,
+            coin[1].owned,
+            coin[2].owned,
+            coin[3].owned,
+            coin[4].owned,
+        ],
+        prestige_points: state.upgrades.prestige_points,
+    }
+}
+
 /// State-derive the [`GlobalMultipliersPreEvaluated`] fields whose
 /// upstream is a pure function of [`GameState`] and existing ported
 /// mechanic helpers.
@@ -428,9 +447,9 @@ fn phase_cross_mechanic_precompute(state: &GameState, input: &TackInput) -> Cros
 /// - `building_power`                   forwarded (multi-input formula)
 /// - `building_power_mult`              forwarded (depends on building_power)
 /// - `crystal_upgrade_3_multiplier`     forwarded (depends on crystal_upgrade_3_base)
-/// - `crystal_multiplier_achievement`   forwarded (achievement-reward table)
-/// - `const_upgrade_1_buff_achievement` forwarded (achievement-reward table)
-/// - `const_upgrade_2_buff_achievement` forwarded (achievement-reward table)
+/// - `crystal_multiplier_achievement`   ✓ state-derived (achievement_rewards)
+/// - `const_upgrade_1_buff_achievement` ✓ always 0 (no achievement grants it)
+/// - `const_upgrade_2_buff_achievement` ✓ always 0 (no achievement grants it)
 /// - `constant_ex_max_percent_increase` forwarded (shop-effect table not ported)
 /// - `ascend_building_dr_value`         forwarded (formula not yet ported)
 /// - `multiplier_effect`                forwarded (G.*, cross-aggregator)
@@ -471,6 +490,7 @@ fn compute_global_multipliers_pre(
         crumbs: state.ants.crumbs,
     });
     let recession_level = state.corruptions.used.levels[RECESSION_INDEX];
+    let ach = achievement_reward_input(state);
 
     GlobalMultipliersPreEvaluated {
         prism_production_log10: prism_rune_effects(prism_level, PrismRuneKey::ProductionLog10),
@@ -482,9 +502,11 @@ fn compute_global_multipliers_pre(
         building_power: fallback.building_power,
         building_power_mult: fallback.building_power_mult,
         crystal_upgrade_3_multiplier: fallback.crystal_upgrade_3_multiplier,
-        crystal_multiplier_achievement: fallback.crystal_multiplier_achievement,
-        const_upgrade_1_buff_achievement: fallback.const_upgrade_1_buff_achievement,
-        const_upgrade_2_buff_achievement: fallback.const_upgrade_2_buff_achievement,
+        crystal_multiplier_achievement: achievement_rewards::crystal_multiplier(&ach),
+        // No achievement grants `constUpgrade1Buff`/`constUpgrade2Buff` in
+        // the legacy table — the additive reward is always 0.
+        const_upgrade_1_buff_achievement: 0.0,
+        const_upgrade_2_buff_achievement: 0.0,
         constant_ex_max_percent_increase: fallback.constant_ex_max_percent_increase,
         ascend_building_dr_value: fallback.ascend_building_dr_value,
         multiplier_effect: fallback.multiplier_effect,
@@ -513,7 +535,7 @@ fn compute_global_multipliers_pre(
 /// - `hepteract_multiplier_mult`        ✓ state-derived
 /// - `viscosity_power`                  ✓ state-derived (G.viscosityPower table)
 /// - `multiplier_cube_blessing`         ✓ state-derived (full blessing chain)
-/// - `multipliers_achievement`          forwarded (achievement-reward table not ported)
+/// - `multipliers_achievement`          ✓ state-derived (achievement_rewards)
 /// - `total_accelerator_boost`          forwarded (G.*, cross-aggregator)
 /// - `taxdivisor`                       forwarded (cross-mechanic tax pipeline)
 /// - `challenge_15_reward_multiplier`   forwarded (challenge-15 rewards not ported)
@@ -558,6 +580,7 @@ fn compute_update_all_multiplier_pre(
         tesseract_blessing,
         state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_MULTIPLIER_BLESSING],
     );
+    let ach = achievement_reward_input(state);
 
     UpdateAllMultiplierPre {
         sum_of_rune_levels,
@@ -581,7 +604,7 @@ fn compute_update_all_multiplier_pre(
         viscosity_power: viscosity_power_at_level(viscosity_level),
         multiplier_cube_blessing: cube_blessing,
         // Forwarded — upstream mechanic not yet plumbed.
-        multipliers_achievement: fallback.multipliers_achievement,
+        multipliers_achievement: achievement_rewards::multipliers(&ach),
         total_accelerator_boost: fallback.total_accelerator_boost,
         taxdivisor: fallback.taxdivisor,
         challenge_15_reward_multiplier: fallback.challenge_15_reward_multiplier,
@@ -598,8 +621,8 @@ fn compute_update_all_multiplier_pre(
 /// - `hepteract_accelerator_mult`       ✓ state-derived
 /// - `viscosity_power`                  ✓ state-derived (G.viscosityPower table)
 /// - `accelerator_cube_blessing`        ✓ state-derived (full blessing chain)
-/// - `accelerators_achievement`         forwarded (achievement-reward table)
-/// - `accelerator_power_achievement`    forwarded (achievement-reward table)
+/// - `accelerators_achievement`         ✓ state-derived (achievement_rewards)
+/// - `accelerator_power_achievement`    ✓ state-derived (achievement_rewards)
 /// - `total_accelerator_boost`          forwarded (G.*, cross-aggregator)
 /// - `accelerator_multiplier`           forwarded (G.*, cross-aggregator)
 /// - `challenge_15_reward_accelerator`  forwarded (challenge-15 rewards)
@@ -635,6 +658,7 @@ fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -
         tesseract_blessing,
         state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_ACCELERATOR_BLESSING],
     );
+    let ach = achievement_reward_input(state);
 
     UpdateAllTickPre {
         multiplicative_accelerators_rune: speed_rune_effects(
@@ -647,8 +671,8 @@ fn compute_update_all_tick_pre(state: &GameState, fallback: &UpdateAllTickPre) -
         viscosity_power: viscosity_power_at_level(viscosity_level),
         accelerator_cube_blessing: cube_blessing,
         // Forwarded — upstream mechanic not yet plumbed.
-        accelerators_achievement: fallback.accelerators_achievement,
-        accelerator_power_achievement: fallback.accelerator_power_achievement,
+        accelerators_achievement: achievement_rewards::accelerators(&ach),
+        accelerator_power_achievement: achievement_rewards::accelerator_power(&ach),
         total_accelerator_boost: fallback.total_accelerator_boost,
         accelerator_multiplier: fallback.accelerator_multiplier,
         challenge_15_reward_accelerator: fallback.challenge_15_reward_accelerator,


### PR DESCRIPTION
## Summary

First three chunks of the **`*Pre`-bundle retirement** — making `tack()` self-driving from `&GameState` by porting the TS aggregators whose values were previously hand-packed by callers into `TackInput`'s five `*Pre` bundles. Pattern: each `compute_*_pre` derives fields from state instead of forwarding `fallback.x`; `phase_cross_mechanic_precompute` injects cross-cutting values; `phase_global_state` threads aggregator outputs.

- **Chunk 1** (`aa565efe`) — achievement rewards: ported the numeric subset of `getAchievementReward` → `mechanics/achievement_rewards.rs`; retired 6 `*_achievement` fields across the three aggregator bundles.
- **Chunk 2** (`bff020ad`) — accelerator spine: `accelerator_multiplier` + `total_accelerator_boost` state-derived; reordered `phase_global_state` (updateAllMultiplier → updateAllTick → globalMultipliers) so globalMultipliers consumes the aggregator outputs. Retired the 6 cross-aggregator fields. Aggregators are pure → reorder is behaviour-preserving (0 test shifts).
- **Chunk 3** (`726da15c`) — challenge-15 rewards → `mechanics/challenge_15_rewards.rs`; retired 5 `challenge_15_*` fields.

## Bundle drain status

| `*Pre` bundle | status |
|---|---|
| `UpdateAllTickPre` | **fully state-derived — ready to drop from `TackInput`** |
| `UpdateAllMultiplierPre` | 1 field left (`taxdivisor`) |
| `GlobalMultipliersPreEvaluated` | crystal/building pipeline + (overridden) aggregator outputs |
| `ResourceGainPre` | tax + producer-rate ports + reset gains |
| `AutomationPre` | untouched (speed-mults, ambrosia, octeract, ant) |

## State-schema changes

Standing maintainer approval; save format is fresh (no migration, no version bump).

| Field / change | Slice | Default | Why |
|---|---|---|---|
| `achievements` resized `[u8;281]→[u8;509]`, 0-indexed | `AchievementsState` | all-zero | Game defines 509 achievements; 281 couldn't track 228 of them (latent bug) |
| `accelerator_boost_bought: f64` | `AcceleratorState` | `0.0` | `player.acceleratorBoostBought` for `calculate_total_accelerator_boost` |
| `challenge15_exponent: f64` | `ChallengesState` | `0.0` | `player.challenge15Exponent`, gates the c15 reward tiers |

## Verification

Host: **962 tests**, `clippy --workspace --all-targets -D warnings`, `fmt --check` — all green. wasm32 `ui_web` builds locally. CI verifies the 3-OS matrix + cargo-deny.

## Note

This is **incremental** — more chunks (tax, producer rates, reset_currency, crystal/building, then `AutomationPre`) will follow toward fully dropping all five bundles. Each commit is self-contained and green, so this can be merged as-is or held open while the effort continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
