### PR TITLE
feat: advance AutomationPre retirement — speed + ambrosia mults self-derive

### DIFF
--- a/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
@@ -8,9 +8,11 @@
 //!
 //! Ported subset: the rewards consumed by the Phase-2 aggregator
 //! `*Pre` bundles (`coinExponent`, `exponent`, `constantBonus`,
-//! `accelerator`, `multiplier`) plus the tax-phase reward (`taxes`).
-//! Other c15 rewards (`runeExp`, `antSpeed`, `globalSpeed`, …) land with
-//! the chunks that consume them.
+//! `accelerator`, `multiplier`), the tax-phase reward (`taxes`), and the
+//! speed rewards (`globalSpeed`, `ascensionSpeed`) that feed the
+//! global / ascension speed StatLine products. Other c15 rewards
+//! (`runeExp`, `antSpeed`, `blessingBonus`, …) land with the chunks that
+//! consume them.
 
 use crate::math::sigmoid::calculate_sigmoid;
 
@@ -80,6 +82,30 @@ pub fn exponent_reward(exponent: f64) -> f64 {
     }
 }
 
+/// `challenge15Rewards.globalSpeed.value` — multiplied into the global
+/// speed StatLine product. Requirement `1e7`. Legacy formula
+/// `1 + (1/20) * log2(e / 2.5e6)`.
+#[must_use]
+pub fn global_speed(exponent: f64) -> f64 {
+    if exponent >= 1e7 {
+        1.0 + (1.0 / 20.0) * (exponent / 2.5e6).log2()
+    } else {
+        1.0
+    }
+}
+
+/// `challenge15Rewards.ascensionSpeed.value` — multiplied into the
+/// ascension speed StatLine product. Requirement `1.5e18`. Legacy
+/// formula `1 + 5/100 + 2 * log2(e / 1.5e18) / 100`.
+#[must_use]
+pub fn ascension_speed(exponent: f64) -> f64 {
+    if exponent >= 1.5e18 {
+        1.0 + 5.0 / 100.0 + 2.0 * (exponent / 1.5e18).log2() / 100.0
+    } else {
+        1.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,8 +118,13 @@ mod tests {
         assert_eq!(multiplier(0.0), 1.0);
         assert_eq!(constant_bonus(0.0), 1.0);
         assert_eq!(exponent_reward(0.0), 1.0);
+        assert_eq!(global_speed(0.0), 1.0);
+        assert_eq!(ascension_speed(0.0), 1.0);
         // Just under the taxes requirement → still identity.
         assert_eq!(taxes(4_999.0), 1.0);
+        // Just under the speed requirements → still identity.
+        assert_eq!(global_speed(9.9e6), 1.0);
+        assert_eq!(ascension_speed(1.4e18), 1.0);
     }
 
     #[test]
@@ -124,5 +155,15 @@ mod tests {
     fn constant_bonus_scales_above_requirement() {
         // e = 1e8 → 1 + (1/5)*(1)^(2/3) = 1.2
         assert!((constant_bonus(1e8) - 1.2).abs() < 1e-12);
+    }
+
+    #[test]
+    fn speed_rewards_scale_above_requirement() {
+        // global: e = 1e7 → 1 + (1/20)*log2(1e7/2.5e6) = 1 + (1/20)*log2(4) = 1.1
+        assert!((global_speed(1e7) - 1.1).abs() < 1e-12);
+        // ascension: e = 1.5e18 → 1.05 + 0.02*log2(1) = 1.05
+        assert!((ascension_speed(1.5e18) - 1.05).abs() < 1e-12);
+        // ascension: e = 3e18 → 1.05 + 0.02*log2(2) = 1.07
+        assert!((ascension_speed(3e18) - 1.07).abs() < 1e-12);
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/corruptions.rs
+++ b/crates/synergismforkd_logic/src/mechanics/corruptions.rs
@@ -145,6 +145,42 @@ pub fn deflation_multiplier_at_level(level: u32) -> f64 {
         .unwrap_or(0.0)
 }
 
+/// `G.dilationMultiplier` lookup table — global-speed scaler indexed by
+/// `player.corruptions.used.dilation` corruption level. 17 entries
+/// (`0..=16`). Verbatim port of the constant in
+/// `legacy/core_split/packages/web_ui/src/Variables.ts`. The dilation
+/// corruption feeds only the global-speed StatLine product (not
+/// ascension speed).
+pub const DILATION_MULTIPLIER: [f64; 17] = [
+    1.0,
+    1.0 / 3.0,
+    1.0 / 10.0,
+    1.0 / 40.0,
+    1.0 / 200.0,
+    1.0 / 3e4,
+    1.0 / 3e6,
+    1.0 / 3e9,
+    1.0 / 3e12,
+    1.0 / 1e15,
+    1.0 / 1e19,
+    1.0 / 1e24,
+    1.0 / 1e34,
+    1.0 / 1e48,
+    1.0 / 1e65,
+    1.0 / 1e80,
+    1.0 / 1e100,
+];
+
+/// `G.dilationMultiplier[level]` with a safe out-of-range fallback to
+/// `0.0` (corruption levels are capped within the table in practice).
+#[must_use]
+pub fn dilation_multiplier_at_level(level: u32) -> f64 {
+    DILATION_MULTIPLIER
+        .get(level as usize)
+        .copied()
+        .unwrap_or(0.0)
+}
+
 /// Inputs to [`viscosity_effect`].
 #[derive(Debug, Clone, Copy)]
 pub struct ViscosityEffectInput {
@@ -347,6 +383,20 @@ mod tests {
         assert_eq!(deflation_multiplier_at_level(15), 0.0);
         // Past the last entry — saturates to 0.
         assert_eq!(deflation_multiplier_at_level(100), 0.0);
+    }
+
+    #[test]
+    fn dilation_multiplier_table_matches_legacy() {
+        // Legacy `G.dilationMultiplier` from `Variables.ts` (17 entries).
+        assert_eq!(dilation_multiplier_at_level(0), 1.0);
+        assert!((dilation_multiplier_at_level(1) - 1.0 / 3.0).abs() < 1e-15);
+        assert!((dilation_multiplier_at_level(2) - 0.1).abs() < 1e-15);
+        assert!((dilation_multiplier_at_level(4) - 1.0 / 200.0).abs() < 1e-15);
+        assert!((dilation_multiplier_at_level(5) - 1.0 / 3e4).abs() < 1e-12);
+        assert!((dilation_multiplier_at_level(16) - 1.0 / 1e100).abs() < 1e-115);
+        // Past the last entry — saturates to 0.
+        assert_eq!(dilation_multiplier_at_level(17), 0.0);
+        assert_eq!(dilation_multiplier_at_level(100), 0.0);
     }
 
     fn baseline_max_input() -> MaxCorruptionLevelInput {

--- a/crates/synergismforkd_logic/src/state/ambrosia.rs
+++ b/crates/synergismforkd_logic/src/state/ambrosia.rs
@@ -19,8 +19,90 @@ pub struct AmbrosiaUpgrade {
     pub free_level: f64,
 }
 
-/// Fixed cardinality of the ambrosia-upgrade array. Tier B item 12.
-pub const AMBROSIA_UPGRADES_LEN: usize = 35;
+/// Fixed cardinality of the ambrosia-upgrade array — one slot per key of
+/// the legacy `ambrosiaUpgrades` const
+/// (`legacy/core_split/packages/web_ui/src/BlueberryUpgrades.ts`), verified
+/// by brace-walk against both legacy snapshots (36 keys, identical order).
+pub const AMBROSIA_UPGRADES_LEN: usize = 36;
+
+// Ambrosia (blueberry) upgrade name → index convention. Index `i` is the
+// i-th key of the legacy `ambrosiaUpgrades` const (the object
+// `player.ambrosiaUpgrades` is built from). This is the canonical mapping
+// the UI tier must match; logic indexes `AmbrosiaState::upgrades` through
+// these constants. Const names drop the leading `ambrosia` and prefix
+// `AMBROSIA_`.
+/// `ambrosiaTutorial` — index 0.
+pub const AMBROSIA_TUTORIAL: usize = 0;
+/// `ambrosiaQuarks1` — index 1.
+pub const AMBROSIA_QUARKS_1: usize = 1;
+/// `ambrosiaCubes1` — index 2.
+pub const AMBROSIA_CUBES_1: usize = 2;
+/// `ambrosiaLuck1` — index 3.
+pub const AMBROSIA_LUCK_1: usize = 3;
+/// `ambrosiaQuarkCube1` — index 4.
+pub const AMBROSIA_QUARK_CUBE_1: usize = 4;
+/// `ambrosiaLuckCube1` — index 5.
+pub const AMBROSIA_LUCK_CUBE_1: usize = 5;
+/// `ambrosiaCubeQuark1` — index 6.
+pub const AMBROSIA_CUBE_QUARK_1: usize = 6;
+/// `ambrosiaLuckQuark1` — index 7.
+pub const AMBROSIA_LUCK_QUARK_1: usize = 7;
+/// `ambrosiaCubeLuck1` — index 8.
+pub const AMBROSIA_CUBE_LUCK_1: usize = 8;
+/// `ambrosiaQuarkLuck1` — index 9.
+pub const AMBROSIA_QUARK_LUCK_1: usize = 9;
+/// `ambrosiaQuarks2` — index 10.
+pub const AMBROSIA_QUARKS_2: usize = 10;
+/// `ambrosiaCubes2` — index 11.
+pub const AMBROSIA_CUBES_2: usize = 11;
+/// `ambrosiaLuck2` — index 12.
+pub const AMBROSIA_LUCK_2: usize = 12;
+/// `ambrosiaQuarks3` — index 13.
+pub const AMBROSIA_QUARKS_3: usize = 13;
+/// `ambrosiaCubes3` — index 14.
+pub const AMBROSIA_CUBES_3: usize = 14;
+/// `ambrosiaLuck3` — index 15.
+pub const AMBROSIA_LUCK_3: usize = 15;
+/// `ambrosiaLuck4` — index 16.
+pub const AMBROSIA_LUCK_4: usize = 16;
+/// `ambrosiaPatreon` — index 17.
+pub const AMBROSIA_PATREON: usize = 17;
+/// `ambrosiaObtainium1` — index 18.
+pub const AMBROSIA_OBTAINIUM_1: usize = 18;
+/// `ambrosiaOffering1` — index 19.
+pub const AMBROSIA_OFFERING_1: usize = 19;
+/// `ambrosiaHyperflux` — index 20.
+pub const AMBROSIA_HYPERFLUX: usize = 20;
+/// `ambrosiaBaseOffering1` — index 21.
+pub const AMBROSIA_BASE_OFFERING_1: usize = 21;
+/// `ambrosiaBaseObtainium1` — index 22.
+pub const AMBROSIA_BASE_OBTAINIUM_1: usize = 22;
+/// `ambrosiaBaseOffering2` — index 23.
+pub const AMBROSIA_BASE_OFFERING_2: usize = 23;
+/// `ambrosiaBaseObtainium2` — index 24.
+pub const AMBROSIA_BASE_OBTAINIUM_2: usize = 24;
+/// `ambrosiaSingReduction1` — index 25.
+pub const AMBROSIA_SING_REDUCTION_1: usize = 25;
+/// `ambrosiaInfiniteShopUpgrades1` — index 26.
+pub const AMBROSIA_INFINITE_SHOP_UPGRADES_1: usize = 26;
+/// `ambrosiaInfiniteShopUpgrades2` — index 27.
+pub const AMBROSIA_INFINITE_SHOP_UPGRADES_2: usize = 27;
+/// `ambrosiaSingReduction2` — index 28.
+pub const AMBROSIA_SING_REDUCTION_2: usize = 28;
+/// `ambrosiaTalismanBonusRuneLevel` — index 29.
+pub const AMBROSIA_TALISMAN_BONUS_RUNE_LEVEL: usize = 29;
+/// `ambrosiaRuneOOMBonus` — index 30.
+pub const AMBROSIA_RUNE_OOM_BONUS: usize = 30;
+/// `ambrosiaBrickOfLead` — index 31.
+pub const AMBROSIA_BRICK_OF_LEAD: usize = 31;
+/// `ambrosiaFreeLuckUpgrades` — index 32.
+pub const AMBROSIA_FREE_LUCK_UPGRADES: usize = 32;
+/// `ambrosiaFreeGenerationUpgrades` — index 33.
+pub const AMBROSIA_FREE_GENERATION_UPGRADES: usize = 33;
+/// `ambrosiaFreeRedLuckUpgrades` — index 34.
+pub const AMBROSIA_FREE_RED_LUCK_UPGRADES: usize = 34;
+/// `ambrosiaFreeQuarkUpgrades` — index 35.
+pub const AMBROSIA_FREE_QUARK_UPGRADES: usize = 35;
 
 /// Slice of `GameState` for the ambrosia/blueberry feature.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -37,7 +119,8 @@ pub struct AmbrosiaState {
     /// `player.spentBlueberries` — count of blueberries allocated
     /// to upgrades.
     pub spent_blueberries: f64,
-    /// Per-upgrade state. UI maintains the name ↔ index mapping.
+    /// Per-upgrade state. Indexed by the `AMBROSIA_*` constants
+    /// (index = legacy `ambrosiaUpgrades` key order).
     #[serde(with = "BigArray")]
     pub upgrades: [AmbrosiaUpgrade; AMBROSIA_UPGRADES_LEN],
 }
@@ -60,9 +143,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_has_35_upgrade_slots() {
+    fn default_has_36_upgrade_slots() {
         let s = AmbrosiaState::default();
         assert_eq!(s.upgrades.len(), AMBROSIA_UPGRADES_LEN);
         assert_eq!(s.lifetime_ambrosia, 0.0);
+    }
+
+    #[test]
+    fn ambrosia_index_convention_sentinels() {
+        // Coverage: the last named slot pins the array length.
+        assert_eq!(AMBROSIA_FREE_QUARK_UPGRADES, AMBROSIA_UPGRADES_LEN - 1);
+        // Mult anchors (legacy `ambrosiaUpgrades` key order).
+        assert_eq!(AMBROSIA_LUCK_1, 3);
+        assert_eq!(AMBROSIA_PATREON, 17);
+        assert_eq!(AMBROSIA_BRICK_OF_LEAD, 31);
     }
 }

--- a/crates/synergismforkd_logic/src/state/golden_quarks.rs
+++ b/crates/synergismforkd_logic/src/state/golden_quarks.rs
@@ -7,7 +7,8 @@
 //! [`crate::mechanics::golden_quark_upgrades`].
 //!
 //! The legacy schema keys upgrades by name; this slice indexes them
-//! by position (caller maintains the name-to-id mapping). Each
+//! by position. The `GQ_*` constants below give the name → index
+//! mapping (index = legacy `goldenQuarkUpgrades` key order). Each
 //! entry carries the full GQ-upgrade shape (level, freeLevel,
 //! maxLevel, canExceedCap, qualityOfLife, specialCostForm) so the
 //! cost / effect dispatchers don't need to look it up elsewhere.
@@ -17,8 +18,176 @@ use serde_big_array::BigArray;
 
 use synergismforkd_bignum::Decimal;
 
-/// Fixed cardinality of the GQ-upgrade array. Tier B item 12.
+/// Fixed cardinality of the GQ-upgrade array — one slot per key of the
+/// legacy `goldenQuarkUpgrades` const
+/// (`legacy/core_split/packages/web_ui/src/singularity.ts`), verified by
+/// brace-walk against both legacy snapshots (80 keys, identical order).
 pub const GOLDEN_QUARK_UPGRADES_LEN: usize = 80;
+
+// GQ-upgrade name → index convention. Index `i` is the i-th key of the
+// legacy `goldenQuarkUpgrades` const (the object `player.goldenQuarkUpgrades`
+// is built from). This is the canonical mapping the UI tier must match;
+// logic indexes `GoldenQuarksState::upgrades` through these constants.
+/// `goldenQuarks1` — index 0.
+pub const GQ_GOLDEN_QUARKS_1: usize = 0;
+/// `goldenQuarks2` — index 1.
+pub const GQ_GOLDEN_QUARKS_2: usize = 1;
+/// `goldenQuarks3` — index 2.
+pub const GQ_GOLDEN_QUARKS_3: usize = 2;
+/// `starterPack` — index 3.
+pub const GQ_STARTER_PACK: usize = 3;
+/// `wowPass` — index 4.
+pub const GQ_WOW_PASS: usize = 4;
+/// `cookies` — index 5.
+pub const GQ_COOKIES: usize = 5;
+/// `cookies2` — index 6.
+pub const GQ_COOKIES_2: usize = 6;
+/// `cookies3` — index 7.
+pub const GQ_COOKIES_3: usize = 7;
+/// `cookies4` — index 8.
+pub const GQ_COOKIES_4: usize = 8;
+/// `cookies5` — index 9.
+pub const GQ_COOKIES_5: usize = 9;
+/// `ascensions` — index 10.
+pub const GQ_ASCENSIONS: usize = 10;
+/// `corruptionFourteen` — index 11.
+pub const GQ_CORRUPTION_FOURTEEN: usize = 11;
+/// `corruptionFifteen` — index 12.
+pub const GQ_CORRUPTION_FIFTEEN: usize = 12;
+/// `singOfferings1` — index 13.
+pub const GQ_SING_OFFERINGS_1: usize = 13;
+/// `singOfferings2` — index 14.
+pub const GQ_SING_OFFERINGS_2: usize = 14;
+/// `singOfferings3` — index 15.
+pub const GQ_SING_OFFERINGS_3: usize = 15;
+/// `singObtainium1` — index 16.
+pub const GQ_SING_OBTAINIUM_1: usize = 16;
+/// `singObtainium2` — index 17.
+pub const GQ_SING_OBTAINIUM_2: usize = 17;
+/// `singObtainium3` — index 18.
+pub const GQ_SING_OBTAINIUM_3: usize = 18;
+/// `singCubes1` — index 19.
+pub const GQ_SING_CUBES_1: usize = 19;
+/// `singCubes2` — index 20.
+pub const GQ_SING_CUBES_2: usize = 20;
+/// `singCubes3` — index 21.
+pub const GQ_SING_CUBES_3: usize = 21;
+/// `singCitadel` — index 22.
+pub const GQ_SING_CITADEL: usize = 22;
+/// `singCitadel2` — index 23.
+pub const GQ_SING_CITADEL_2: usize = 23;
+/// `octeractUnlock` — index 24.
+pub const GQ_OCTERACT_UNLOCK: usize = 24;
+/// `singOcteractPatreonBonus` — index 25.
+pub const GQ_SING_OCTERACT_PATREON_BONUS: usize = 25;
+/// `offeringAutomatic` — index 26.
+pub const GQ_OFFERING_AUTOMATIC: usize = 26;
+/// `intermediatePack` — index 27.
+pub const GQ_INTERMEDIATE_PACK: usize = 27;
+/// `advancedPack` — index 28.
+pub const GQ_ADVANCED_PACK: usize = 28;
+/// `expertPack` — index 29.
+pub const GQ_EXPERT_PACK: usize = 29;
+/// `masterPack` — index 30.
+pub const GQ_MASTER_PACK: usize = 30;
+/// `divinePack` — index 31.
+pub const GQ_DIVINE_PACK: usize = 31;
+/// `wowPass2` — index 32.
+pub const GQ_WOW_PASS_2: usize = 32;
+/// `wowPass3` — index 33.
+pub const GQ_WOW_PASS_3: usize = 33;
+/// `potionBuff` — index 34.
+pub const GQ_POTION_BUFF: usize = 34;
+/// `potionBuff2` — index 35.
+pub const GQ_POTION_BUFF_2: usize = 35;
+/// `potionBuff3` — index 36.
+pub const GQ_POTION_BUFF_3: usize = 36;
+/// `singChallengeExtension` — index 37.
+pub const GQ_SING_CHALLENGE_EXTENSION: usize = 37;
+/// `singChallengeExtension2` — index 38.
+pub const GQ_SING_CHALLENGE_EXTENSION_2: usize = 38;
+/// `singChallengeExtension3` — index 39.
+pub const GQ_SING_CHALLENGE_EXTENSION_3: usize = 39;
+/// `singQuarkImprover1` — index 40.
+pub const GQ_SING_QUARK_IMPROVER_1: usize = 40;
+/// `singQuarkHepteract` — index 41.
+pub const GQ_SING_QUARK_HEPTERACT: usize = 41;
+/// `singQuarkHepteract2` — index 42.
+pub const GQ_SING_QUARK_HEPTERACT_2: usize = 42;
+/// `singQuarkHepteract3` — index 43.
+pub const GQ_SING_QUARK_HEPTERACT_3: usize = 43;
+/// `singOcteractGain` — index 44.
+pub const GQ_SING_OCTERACT_GAIN: usize = 44;
+/// `singOcteractGain2` — index 45.
+pub const GQ_SING_OCTERACT_GAIN_2: usize = 45;
+/// `singOcteractGain3` — index 46.
+pub const GQ_SING_OCTERACT_GAIN_3: usize = 46;
+/// `singOcteractGain4` — index 47.
+pub const GQ_SING_OCTERACT_GAIN_4: usize = 47;
+/// `singOcteractGain5` — index 48.
+pub const GQ_SING_OCTERACT_GAIN_5: usize = 48;
+/// `platonicTau` — index 49.
+pub const GQ_PLATONIC_TAU: usize = 49;
+/// `platonicAlpha` — index 50.
+pub const GQ_PLATONIC_ALPHA: usize = 50;
+/// `platonicDelta` — index 51.
+pub const GQ_PLATONIC_DELTA: usize = 51;
+/// `platonicPhi` — index 52.
+pub const GQ_PLATONIC_PHI: usize = 52;
+/// `singFastForward` — index 53.
+pub const GQ_SING_FAST_FORWARD: usize = 53;
+/// `singFastForward2` — index 54.
+pub const GQ_SING_FAST_FORWARD_2: usize = 54;
+/// `singAscensionSpeed` — index 55.
+pub const GQ_SING_ASCENSION_SPEED: usize = 55;
+/// `singAscensionSpeed2` — index 56.
+pub const GQ_SING_ASCENSION_SPEED_2: usize = 56;
+/// `ultimatePen` — index 57.
+pub const GQ_ULTIMATE_PEN: usize = 57;
+/// `halfMind` — index 58.
+pub const GQ_HALF_MIND: usize = 58;
+/// `oneMind` — index 59.
+pub const GQ_ONE_MIND: usize = 59;
+/// `wowPass4` — index 60.
+pub const GQ_WOW_PASS_4: usize = 60;
+/// `blueberries` — index 61.
+pub const GQ_BLUEBERRIES: usize = 61;
+/// `singAmbrosiaLuck` — index 62.
+pub const GQ_SING_AMBROSIA_LUCK: usize = 62;
+/// `singAmbrosiaLuck2` — index 63.
+pub const GQ_SING_AMBROSIA_LUCK_2: usize = 63;
+/// `singAmbrosiaLuck3` — index 64.
+pub const GQ_SING_AMBROSIA_LUCK_3: usize = 64;
+/// `singAmbrosiaLuck4` — index 65.
+pub const GQ_SING_AMBROSIA_LUCK_4: usize = 65;
+/// `singAmbrosiaGeneration` — index 66.
+pub const GQ_SING_AMBROSIA_GENERATION: usize = 66;
+/// `singAmbrosiaGeneration2` — index 67.
+pub const GQ_SING_AMBROSIA_GENERATION_2: usize = 67;
+/// `singAmbrosiaGeneration3` — index 68.
+pub const GQ_SING_AMBROSIA_GENERATION_3: usize = 68;
+/// `singAmbrosiaGeneration4` — index 69.
+pub const GQ_SING_AMBROSIA_GENERATION_4: usize = 69;
+/// `singBonusTokens1` — index 70.
+pub const GQ_SING_BONUS_TOKENS_1: usize = 70;
+/// `singBonusTokens2` — index 71.
+pub const GQ_SING_BONUS_TOKENS_2: usize = 71;
+/// `singBonusTokens3` — index 72.
+pub const GQ_SING_BONUS_TOKENS_3: usize = 72;
+/// `singBonusTokens4` — index 73.
+pub const GQ_SING_BONUS_TOKENS_4: usize = 73;
+/// `singInfiniteShopUpgrades` — index 74.
+pub const GQ_SING_INFINITE_SHOP_UPGRADES: usize = 74;
+/// `singTalismanBonusRunes1` — index 75.
+pub const GQ_SING_TALISMAN_BONUS_RUNES_1: usize = 75;
+/// `singTalismanBonusRunes2` — index 76.
+pub const GQ_SING_TALISMAN_BONUS_RUNES_2: usize = 76;
+/// `singTalismanBonusRunes3` — index 77.
+pub const GQ_SING_TALISMAN_BONUS_RUNES_3: usize = 77;
+/// `singTalismanBonusRunes4` — index 78.
+pub const GQ_SING_TALISMAN_BONUS_RUNES_4: usize = 78;
+/// `favoriteUpgrade` — index 79.
+pub const GQ_FAVORITE_UPGRADE: usize = 79;
 
 /// Special-cost-form selector for one GQ upgrade — pinned here
 /// alongside the state so the storage matches the dispatch shape
@@ -70,8 +239,8 @@ pub struct GoldenQuarksState {
     /// `player.goldenQuarksTimer` — GQ-export accumulator (seconds);
     /// disabled when `export_gq_per_hour == 0`, else clamped to 168 h.
     pub golden_quarks_timer: f64,
-    /// Per-upgrade state. The UI/tier maintains the name ↔ index
-    /// mapping; this slice holds the values.
+    /// Per-upgrade state. Indexed by the `GQ_*` constants (index =
+    /// legacy `goldenQuarkUpgrades` key order).
     #[serde(with = "BigArray")]
     pub upgrades: [GoldenQuarkUpgrade; GOLDEN_QUARK_UPGRADES_LEN],
 }
@@ -96,6 +265,16 @@ mod tests {
         let s = GoldenQuarksState::default();
         assert_eq!(s.upgrades.len(), GOLDEN_QUARK_UPGRADES_LEN);
         assert_eq!(s.golden_quarks.to_number(), 0.0);
+    }
+
+    #[test]
+    fn gq_index_convention_sentinels() {
+        // Coverage: the last named slot pins the array length.
+        assert_eq!(GQ_FAVORITE_UPGRADE, GOLDEN_QUARK_UPGRADES_LEN - 1);
+        // StatLine anchors (legacy `goldenQuarkUpgrades` key order).
+        assert_eq!(GQ_INTERMEDIATE_PACK, 27);
+        assert_eq!(GQ_SING_ASCENSION_SPEED, 55);
+        assert_eq!(GQ_SING_ASCENSION_SPEED_2, 56);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/state/mod.rs
+++ b/crates/synergismforkd_logic/src/state/mod.rs
@@ -80,7 +80,10 @@ pub use runes::{
 };
 pub use shop::{ShopBuyMaxMode, ShopState};
 pub use singularity::{SingularityChallengeState, SingularityState};
-pub use talismans::{TalismanRuneAssignment, TalismansState, TALISMAN_COUNT};
+pub use talismans::{
+    TalismanRuneAssignment, TalismansState, TALISMAN_CHRONOS, TALISMAN_COUNT, TALISMAN_EXEMPTION,
+    TALISMAN_METAPHYSICS, TALISMAN_MIDAS, TALISMAN_MORTUUS, TALISMAN_PLASTIC, TALISMAN_POLYMATH,
+};
 pub use tesseract_buildings::{AscendBuildingState, TesseractBuildingsState};
 pub use upgrades::{UpgradesState, UPGRADES_DEFAULT_LEN};
 

--- a/crates/synergismforkd_logic/src/state/octeract_upgrades.rs
+++ b/crates/synergismforkd_logic/src/state/octeract_upgrades.rs
@@ -25,8 +25,111 @@ pub struct OcteractUpgrade {
     pub quality_of_life: bool,
 }
 
-/// Fixed cardinality of the octeract-upgrade array. Tier B item 12.
-pub const OCTERACT_UPGRADES_LEN: usize = 42;
+/// Fixed cardinality of the octeract-upgrade array — one slot per key
+/// of the legacy `octeractUpgrades` const
+/// (`legacy/core_split/packages/web_ui/src/Octeracts.ts`), verified by
+/// brace-walk against both legacy snapshots (47 keys, identical order).
+pub const OCTERACT_UPGRADES_LEN: usize = 47;
+
+// Octeract-upgrade name → index convention. Index `i` is the i-th key of
+// the legacy `octeractUpgrades` const (the object `player.octUpgrades` is
+// built from). This is the canonical mapping the UI tier must match;
+// logic indexes `OcteractUpgradesState::upgrades` through these constants.
+// Const names drop the leading `octeract` and prefix `OCTERACT_`.
+/// `octeractStarter` — index 0.
+pub const OCTERACT_STARTER: usize = 0;
+/// `octeractGain` — index 1.
+pub const OCTERACT_GAIN: usize = 1;
+/// `octeractGain2` — index 2.
+pub const OCTERACT_GAIN_2: usize = 2;
+/// `octeractQuarkGain` — index 3.
+pub const OCTERACT_QUARK_GAIN: usize = 3;
+/// `octeractQuarkGain2` — index 4.
+pub const OCTERACT_QUARK_GAIN_2: usize = 4;
+/// `octeractCorruption` — index 5.
+pub const OCTERACT_CORRUPTION: usize = 5;
+/// `octeractGQCostReduce` — index 6.
+pub const OCTERACT_GQ_COST_REDUCE: usize = 6;
+/// `octeractExportQuarks` — index 7.
+pub const OCTERACT_EXPORT_QUARKS: usize = 7;
+/// `octeractImprovedDaily` — index 8.
+pub const OCTERACT_IMPROVED_DAILY: usize = 8;
+/// `octeractImprovedDaily2` — index 9.
+pub const OCTERACT_IMPROVED_DAILY_2: usize = 9;
+/// `octeractImprovedDaily3` — index 10.
+pub const OCTERACT_IMPROVED_DAILY_3: usize = 10;
+/// `octeractImprovedQuarkHept` — index 11.
+pub const OCTERACT_IMPROVED_QUARK_HEPT: usize = 11;
+/// `octeractImprovedGlobalSpeed` — index 12.
+pub const OCTERACT_IMPROVED_GLOBAL_SPEED: usize = 12;
+/// `octeractImprovedAscensionSpeed` — index 13.
+pub const OCTERACT_IMPROVED_ASCENSION_SPEED: usize = 13;
+/// `octeractImprovedAscensionSpeed2` — index 14.
+pub const OCTERACT_IMPROVED_ASCENSION_SPEED_2: usize = 14;
+/// `octeractImprovedFree` — index 15.
+pub const OCTERACT_IMPROVED_FREE: usize = 15;
+/// `octeractImprovedFree2` — index 16.
+pub const OCTERACT_IMPROVED_FREE_2: usize = 16;
+/// `octeractImprovedFree3` — index 17.
+pub const OCTERACT_IMPROVED_FREE_3: usize = 17;
+/// `octeractImprovedFree4` — index 18.
+pub const OCTERACT_IMPROVED_FREE_4: usize = 18;
+/// `octeractSingUpgradeCap` — index 19.
+pub const OCTERACT_SING_UPGRADE_CAP: usize = 19;
+/// `octeractOfferings1` — index 20.
+pub const OCTERACT_OFFERINGS_1: usize = 20;
+/// `octeractObtainium1` — index 21.
+pub const OCTERACT_OBTAINIUM_1: usize = 21;
+/// `octeractAscensions` — index 22.
+pub const OCTERACT_ASCENSIONS: usize = 22;
+/// `octeractAscensions2` — index 23.
+pub const OCTERACT_ASCENSIONS_2: usize = 23;
+/// `octeractAscensionsOcteractGain` — index 24.
+pub const OCTERACT_ASCENSIONS_OCTERACT_GAIN: usize = 24;
+/// `octeractFastForward` — index 25.
+pub const OCTERACT_FAST_FORWARD: usize = 25;
+/// `octeractAutoPotionSpeed` — index 26.
+pub const OCTERACT_AUTO_POTION_SPEED: usize = 26;
+/// `octeractAutoPotionEfficiency` — index 27.
+pub const OCTERACT_AUTO_POTION_EFFICIENCY: usize = 27;
+/// `octeractOneMindImprover` — index 28.
+pub const OCTERACT_ONE_MIND_IMPROVER: usize = 28;
+/// `octeractAmbrosiaLuck` — index 29.
+pub const OCTERACT_AMBROSIA_LUCK: usize = 29;
+/// `octeractAmbrosiaLuck2` — index 30.
+pub const OCTERACT_AMBROSIA_LUCK_2: usize = 30;
+/// `octeractAmbrosiaLuck3` — index 31.
+pub const OCTERACT_AMBROSIA_LUCK_3: usize = 31;
+/// `octeractAmbrosiaLuck4` — index 32.
+pub const OCTERACT_AMBROSIA_LUCK_4: usize = 32;
+/// `octeractAmbrosiaGeneration` — index 33.
+pub const OCTERACT_AMBROSIA_GENERATION: usize = 33;
+/// `octeractAmbrosiaGeneration2` — index 34.
+pub const OCTERACT_AMBROSIA_GENERATION_2: usize = 34;
+/// `octeractAmbrosiaGeneration3` — index 35.
+pub const OCTERACT_AMBROSIA_GENERATION_3: usize = 35;
+/// `octeractAmbrosiaGeneration4` — index 36.
+pub const OCTERACT_AMBROSIA_GENERATION_4: usize = 36;
+/// `octeractBonusTokens1` — index 37.
+pub const OCTERACT_BONUS_TOKENS_1: usize = 37;
+/// `octeractBonusTokens2` — index 38.
+pub const OCTERACT_BONUS_TOKENS_2: usize = 38;
+/// `octeractBonusTokens3` — index 39.
+pub const OCTERACT_BONUS_TOKENS_3: usize = 39;
+/// `octeractBonusTokens4` — index 40.
+pub const OCTERACT_BONUS_TOKENS_4: usize = 40;
+/// `octeractBlueberries` — index 41.
+pub const OCTERACT_BLUEBERRIES: usize = 41;
+/// `octeractInfiniteShopUpgrades` — index 42.
+pub const OCTERACT_INFINITE_SHOP_UPGRADES: usize = 42;
+/// `octeractTalismanLevelCap1` — index 43.
+pub const OCTERACT_TALISMAN_LEVEL_CAP_1: usize = 43;
+/// `octeractTalismanLevelCap2` — index 44.
+pub const OCTERACT_TALISMAN_LEVEL_CAP_2: usize = 44;
+/// `octeractTalismanLevelCap3` — index 45.
+pub const OCTERACT_TALISMAN_LEVEL_CAP_3: usize = 45;
+/// `octeractTalismanLevelCap4` — index 46.
+pub const OCTERACT_TALISMAN_LEVEL_CAP_4: usize = 46;
 
 /// Slice of `GameState` for the octeract upgrades + octeract timer.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -34,8 +137,8 @@ pub struct OcteractUpgradesState {
     /// `player.octeractTimer` — accumulator that drives octeract
     /// generation.
     pub octeract_timer: f64,
-    /// Per-upgrade state. The UI/tier maintains the name ↔ index
-    /// mapping.
+    /// Per-upgrade state. Indexed by the `OCTERACT_*` constants
+    /// (index = legacy `octeractUpgrades` key order).
     #[serde(with = "BigArray")]
     pub upgrades: [OcteractUpgrade; OCTERACT_UPGRADES_LEN],
 }
@@ -54,8 +157,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_has_42_upgrade_slots() {
+    fn default_has_47_upgrade_slots() {
         let s = OcteractUpgradesState::default();
         assert_eq!(s.upgrades.len(), OCTERACT_UPGRADES_LEN);
+    }
+
+    #[test]
+    fn octeract_index_convention_sentinels() {
+        // Coverage: the last named slot pins the array length.
+        assert_eq!(OCTERACT_TALISMAN_LEVEL_CAP_4, OCTERACT_UPGRADES_LEN - 1);
+        // StatLine anchors (legacy `octeractUpgrades` key order).
+        assert_eq!(OCTERACT_IMPROVED_GLOBAL_SPEED, 12);
+        assert_eq!(OCTERACT_IMPROVED_ASCENSION_SPEED, 13);
+        assert_eq!(OCTERACT_IMPROVED_ASCENSION_SPEED_2, 14);
+        assert_eq!(OCTERACT_AUTO_POTION_SPEED, 26);
     }
 }

--- a/crates/synergismforkd_logic/src/state/red_ambrosia.rs
+++ b/crates/synergismforkd_logic/src/state/red_ambrosia.rs
@@ -17,10 +17,77 @@ pub struct RedAmbrosiaUpgrade {
     pub level: f64,
 }
 
-/// Fixed cardinality of the red-ambrosia-upgrade array. Tier B item 12.
-/// (27 fits inside serde's default 0..=32 length window — no `BigArray`
-/// attribute needed.)
-pub const RED_AMBROSIA_UPGRADES_LEN: usize = 27;
+/// Fixed cardinality of the red-ambrosia-upgrade array — one slot per key
+/// of the legacy `redAmbrosiaUpgrades` const
+/// (`legacy/core_split/packages/web_ui/src/RedAmbrosiaUpgrades.ts`),
+/// verified by brace-walk against both legacy snapshots (29 keys, identical
+/// order). (29 fits inside serde's default 0..=32 length window — no
+/// `BigArray` attribute needed.)
+pub const RED_AMBROSIA_UPGRADES_LEN: usize = 29;
+
+// Red-ambrosia upgrade name → index convention. Index `i` is the i-th key
+// of the legacy `redAmbrosiaUpgrades` const (the object
+// `player.redAmbrosiaUpgrades` is built from). This is the canonical
+// mapping the UI tier must match; logic indexes `RedAmbrosiaState::upgrades`
+// through these constants.
+/// `tutorial` — index 0.
+pub const RED_AMBROSIA_TUTORIAL: usize = 0;
+/// `conversionImprovement1` — index 1.
+pub const RED_AMBROSIA_CONVERSION_IMPROVEMENT_1: usize = 1;
+/// `conversionImprovement2` — index 2.
+pub const RED_AMBROSIA_CONVERSION_IMPROVEMENT_2: usize = 2;
+/// `conversionImprovement3` — index 3.
+pub const RED_AMBROSIA_CONVERSION_IMPROVEMENT_3: usize = 3;
+/// `freeTutorialLevels` — index 4.
+pub const RED_AMBROSIA_FREE_TUTORIAL_LEVELS: usize = 4;
+/// `freeLevelsRow2` — index 5.
+pub const RED_AMBROSIA_FREE_LEVELS_ROW_2: usize = 5;
+/// `freeLevelsRow3` — index 6.
+pub const RED_AMBROSIA_FREE_LEVELS_ROW_3: usize = 6;
+/// `freeLevelsRow4` — index 7.
+pub const RED_AMBROSIA_FREE_LEVELS_ROW_4: usize = 7;
+/// `freeLevelsRow5` — index 8.
+pub const RED_AMBROSIA_FREE_LEVELS_ROW_5: usize = 8;
+/// `blueberryGenerationSpeed` — index 9.
+pub const RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED: usize = 9;
+/// `regularLuck` — index 10.
+pub const RED_AMBROSIA_REGULAR_LUCK: usize = 10;
+/// `redGenerationSpeed` — index 11.
+pub const RED_AMBROSIA_RED_GENERATION_SPEED: usize = 11;
+/// `redLuck` — index 12.
+pub const RED_AMBROSIA_RED_LUCK: usize = 12;
+/// `redAmbrosiaCube` — index 13.
+pub const RED_AMBROSIA_RED_AMBROSIA_CUBE: usize = 13;
+/// `redAmbrosiaObtainium` — index 14.
+pub const RED_AMBROSIA_RED_AMBROSIA_OBTAINIUM: usize = 14;
+/// `redAmbrosiaOffering` — index 15.
+pub const RED_AMBROSIA_RED_AMBROSIA_OFFERING: usize = 15;
+/// `redAmbrosiaCubeImprover` — index 16.
+pub const RED_AMBROSIA_RED_AMBROSIA_CUBE_IMPROVER: usize = 16;
+/// `viscount` — index 17.
+pub const RED_AMBROSIA_VISCOUNT: usize = 17;
+/// `infiniteShopUpgrades` — index 18.
+pub const RED_AMBROSIA_INFINITE_SHOP_UPGRADES: usize = 18;
+/// `redAmbrosiaAccelerator` — index 19.
+pub const RED_AMBROSIA_RED_AMBROSIA_ACCELERATOR: usize = 19;
+/// `regularLuck2` — index 20.
+pub const RED_AMBROSIA_REGULAR_LUCK_2: usize = 20;
+/// `blueberryGenerationSpeed2` — index 21.
+pub const RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED_2: usize = 21;
+/// `salvageYinYang` — index 22.
+pub const RED_AMBROSIA_SALVAGE_YIN_YANG: usize = 22;
+/// `blueberries` — index 23.
+pub const RED_AMBROSIA_BLUEBERRIES: usize = 23;
+/// `redAmbrosiaFreeAccumulator` — index 24.
+pub const RED_AMBROSIA_RED_AMBROSIA_FREE_ACCUMULATOR: usize = 24;
+/// `freeOfferingUpgrades` — index 25.
+pub const RED_AMBROSIA_FREE_OFFERING_UPGRADES: usize = 25;
+/// `freeObtainiumUpgrades` — index 26.
+pub const RED_AMBROSIA_FREE_OBTAINIUM_UPGRADES: usize = 26;
+/// `freeCubeUpgrades` — index 27.
+pub const RED_AMBROSIA_FREE_CUBE_UPGRADES: usize = 27;
+/// `freeSpeedUpgrades` — index 28.
+pub const RED_AMBROSIA_FREE_SPEED_UPGRADES: usize = 28;
 
 /// Slice of `GameState` for the red-ambrosia feature.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -36,7 +103,8 @@ pub struct RedAmbrosiaState {
     pub red_ambrosia_timer_g: f64,
     /// `player.spentRedAmbrosia` — count allocated to upgrades.
     pub spent_red_ambrosia: f64,
-    /// Per-upgrade state. UI maintains the name ↔ index mapping.
+    /// Per-upgrade state. Indexed by the `RED_AMBROSIA_*` constants
+    /// (index = legacy `redAmbrosiaUpgrades` key order).
     pub upgrades: [RedAmbrosiaUpgrade; RED_AMBROSIA_UPGRADES_LEN],
 }
 
@@ -58,8 +126,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_has_27_upgrade_slots() {
+    fn default_has_29_upgrade_slots() {
         let s = RedAmbrosiaState::default();
         assert_eq!(s.upgrades.len(), RED_AMBROSIA_UPGRADES_LEN);
+    }
+
+    #[test]
+    fn red_ambrosia_index_convention_sentinels() {
+        // Coverage: the last named slot pins the array length.
+        assert_eq!(
+            RED_AMBROSIA_FREE_SPEED_UPGRADES,
+            RED_AMBROSIA_UPGRADES_LEN - 1
+        );
+        // Mult anchors (legacy `redAmbrosiaUpgrades` key order).
+        assert_eq!(RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED, 9);
+        assert_eq!(RED_AMBROSIA_REGULAR_LUCK, 10);
+        assert_eq!(RED_AMBROSIA_VISCOUNT, 17);
     }
 }

--- a/crates/synergismforkd_logic/src/state/shop.rs
+++ b/crates/synergismforkd_logic/src/state/shop.rs
@@ -18,15 +18,189 @@ pub enum ShopBuyMaxMode {
     Max,
 }
 
-/// Fixed cardinality of the shop-upgrade array. Tier B item 12 /
-/// Anvil F4.
+/// Fixed cardinality of the shop-upgrade array — one slot per key of
+/// the legacy `player.shopUpgrades` object
+/// (`legacy/core_split/packages/web_ui/src/Synergism.ts`), verified by
+/// brace-walk against both legacy snapshots (83 keys, identical order).
 pub const SHOP_UPGRADES_LEN: usize = 83;
+
+// Shop-upgrade name → index convention. Index `i` is the i-th key of the
+// legacy `player.shopUpgrades` object; this is the canonical mapping the
+// UI tier must match. Logic indexes `ShopState::upgrades` through these
+// constants. Const names follow the legacy key verbatim (the leading
+// `shop` is not doubled).
+/// `offeringPotion` — index 0.
+pub const SHOP_OFFERING_POTION: usize = 0;
+/// `obtainiumPotion` — index 1.
+pub const SHOP_OBTAINIUM_POTION: usize = 1;
+/// `offeringEX` — index 2.
+pub const SHOP_OFFERING_EX: usize = 2;
+/// `offeringAuto` — index 3.
+pub const SHOP_OFFERING_AUTO: usize = 3;
+/// `obtainiumEX` — index 4.
+pub const SHOP_OBTAINIUM_EX: usize = 4;
+/// `obtainiumAuto` — index 5.
+pub const SHOP_OBTAINIUM_AUTO: usize = 5;
+/// `instantChallenge` — index 6.
+pub const SHOP_INSTANT_CHALLENGE: usize = 6;
+/// `antSpeed` — index 7.
+pub const SHOP_ANT_SPEED: usize = 7;
+/// `cashGrab` — index 8.
+pub const SHOP_CASH_GRAB: usize = 8;
+/// `shopTalisman` — index 9.
+pub const SHOP_TALISMAN: usize = 9;
+/// `seasonPass` — index 10.
+pub const SHOP_SEASON_PASS: usize = 10;
+/// `challengeExtension` — index 11.
+pub const SHOP_CHALLENGE_EXTENSION: usize = 11;
+/// `challengeTome` — index 12.
+pub const SHOP_CHALLENGE_TOME: usize = 12;
+/// `cubeToQuark` — index 13.
+pub const SHOP_CUBE_TO_QUARK: usize = 13;
+/// `tesseractToQuark` — index 14.
+pub const SHOP_TESSERACT_TO_QUARK: usize = 14;
+/// `hypercubeToQuark` — index 15.
+pub const SHOP_HYPERCUBE_TO_QUARK: usize = 15;
+/// `seasonPass2` — index 16.
+pub const SHOP_SEASON_PASS_2: usize = 16;
+/// `seasonPass3` — index 17.
+pub const SHOP_SEASON_PASS_3: usize = 17;
+/// `chronometer` — index 18.
+pub const SHOP_CHRONOMETER: usize = 18;
+/// `infiniteAscent` — index 19.
+pub const SHOP_INFINITE_ASCENT: usize = 19;
+/// `calculator` — index 20.
+pub const SHOP_CALCULATOR: usize = 20;
+/// `calculator2` — index 21.
+pub const SHOP_CALCULATOR_2: usize = 21;
+/// `calculator3` — index 22.
+pub const SHOP_CALCULATOR_3: usize = 22;
+/// `calculator4` — index 23.
+pub const SHOP_CALCULATOR_4: usize = 23;
+/// `calculator5` — index 24.
+pub const SHOP_CALCULATOR_5: usize = 24;
+/// `calculator6` — index 25.
+pub const SHOP_CALCULATOR_6: usize = 25;
+/// `calculator7` — index 26.
+pub const SHOP_CALCULATOR_7: usize = 26;
+/// `constantEX` — index 27.
+pub const SHOP_CONSTANT_EX: usize = 27;
+/// `powderEX` — index 28.
+pub const SHOP_POWDER_EX: usize = 28;
+/// `chronometer2` — index 29.
+pub const SHOP_CHRONOMETER_2: usize = 29;
+/// `chronometer3` — index 30.
+pub const SHOP_CHRONOMETER_3: usize = 30;
+/// `seasonPassY` — index 31.
+pub const SHOP_SEASON_PASS_Y: usize = 31;
+/// `seasonPassZ` — index 32.
+pub const SHOP_SEASON_PASS_Z: usize = 32;
+/// `challengeTome2` — index 33.
+pub const SHOP_CHALLENGE_TOME_2: usize = 33;
+/// `instantChallenge2` — index 34.
+pub const SHOP_INSTANT_CHALLENGE_2: usize = 34;
+/// `cashGrab2` — index 35.
+pub const SHOP_CASH_GRAB_2: usize = 35;
+/// `chronometerZ` — index 36.
+pub const SHOP_CHRONOMETER_Z: usize = 36;
+/// `cubeToQuarkAll` — index 37.
+pub const SHOP_CUBE_TO_QUARK_ALL: usize = 37;
+/// `offeringEX2` — index 38.
+pub const SHOP_OFFERING_EX_2: usize = 38;
+/// `obtainiumEX2` — index 39.
+pub const SHOP_OBTAINIUM_EX_2: usize = 39;
+/// `seasonPassLost` — index 40.
+pub const SHOP_SEASON_PASS_LOST: usize = 40;
+/// `powderAuto` — index 41.
+pub const SHOP_POWDER_AUTO: usize = 41;
+/// `challenge15Auto` — index 42.
+pub const SHOP_CHALLENGE_15_AUTO: usize = 42;
+/// `extraWarp` — index 43.
+pub const SHOP_EXTRA_WARP: usize = 43;
+/// `autoWarp` — index 44.
+pub const SHOP_AUTO_WARP: usize = 44;
+/// `improveQuarkHept` — index 45.
+pub const SHOP_IMPROVE_QUARK_HEPT: usize = 45;
+/// `improveQuarkHept2` — index 46.
+pub const SHOP_IMPROVE_QUARK_HEPT_2: usize = 46;
+/// `improveQuarkHept3` — index 47.
+pub const SHOP_IMPROVE_QUARK_HEPT_3: usize = 47;
+/// `improveQuarkHept4` — index 48.
+pub const SHOP_IMPROVE_QUARK_HEPT_4: usize = 48;
+/// `shopImprovedDaily` — index 49.
+pub const SHOP_IMPROVED_DAILY: usize = 49;
+/// `shopImprovedDaily2` — index 50.
+pub const SHOP_IMPROVED_DAILY_2: usize = 50;
+/// `shopImprovedDaily3` — index 51.
+pub const SHOP_IMPROVED_DAILY_3: usize = 51;
+/// `shopImprovedDaily4` — index 52.
+pub const SHOP_IMPROVED_DAILY_4: usize = 52;
+/// `offeringEX3` — index 53.
+pub const SHOP_OFFERING_EX_3: usize = 53;
+/// `obtainiumEX3` — index 54.
+pub const SHOP_OBTAINIUM_EX_3: usize = 54;
+/// `improveQuarkHept5` — index 55.
+pub const SHOP_IMPROVE_QUARK_HEPT_5: usize = 55;
+/// `seasonPassInfinity` — index 56.
+pub const SHOP_SEASON_PASS_INFINITY: usize = 56;
+/// `chronometerInfinity` — index 57.
+pub const SHOP_CHRONOMETER_INFINITY: usize = 57;
+/// `shopSingularityPenaltyDebuff` — index 58.
+pub const SHOP_SINGULARITY_PENALTY_DEBUFF: usize = 58;
+/// `shopAmbrosiaLuckMultiplier4` — index 59.
+pub const SHOP_AMBROSIA_LUCK_MULTIPLIER_4: usize = 59;
+/// `shopOcteractAmbrosiaLuck` — index 60.
+pub const SHOP_OCTERACT_AMBROSIA_LUCK: usize = 60;
+/// `shopAmbrosiaGeneration1` — index 61.
+pub const SHOP_AMBROSIA_GENERATION_1: usize = 61;
+/// `shopAmbrosiaGeneration2` — index 62.
+pub const SHOP_AMBROSIA_GENERATION_2: usize = 62;
+/// `shopAmbrosiaGeneration3` — index 63.
+pub const SHOP_AMBROSIA_GENERATION_3: usize = 63;
+/// `shopAmbrosiaGeneration4` — index 64.
+pub const SHOP_AMBROSIA_GENERATION_4: usize = 64;
+/// `shopAmbrosiaLuck1` — index 65.
+pub const SHOP_AMBROSIA_LUCK_1: usize = 65;
+/// `shopAmbrosiaLuck2` — index 66.
+pub const SHOP_AMBROSIA_LUCK_2: usize = 66;
+/// `shopAmbrosiaLuck3` — index 67.
+pub const SHOP_AMBROSIA_LUCK_3: usize = 67;
+/// `shopAmbrosiaLuck4` — index 68.
+pub const SHOP_AMBROSIA_LUCK_4: usize = 68;
+/// `shopCashGrabUltra` — index 69.
+pub const SHOP_CASH_GRAB_ULTRA: usize = 69;
+/// `shopAmbrosiaAccelerator` — index 70.
+pub const SHOP_AMBROSIA_ACCELERATOR: usize = 70;
+/// `shopEXUltra` — index 71.
+pub const SHOP_EX_ULTRA: usize = 71;
+/// `shopChronometerS` — index 72.
+pub const SHOP_CHRONOMETER_S: usize = 72;
+/// `shopAmbrosiaUltra` — index 73.
+pub const SHOP_AMBROSIA_ULTRA: usize = 73;
+/// `shopSingularitySpeedup` — index 74.
+pub const SHOP_SINGULARITY_SPEEDUP: usize = 74;
+/// `shopSingularityPotency` — index 75.
+pub const SHOP_SINGULARITY_POTENCY: usize = 75;
+/// `shopSadisticRune` — index 76.
+pub const SHOP_SADISTIC_RUNE: usize = 76;
+/// `shopRedLuck1` — index 77.
+pub const SHOP_RED_LUCK_1: usize = 77;
+/// `shopRedLuck2` — index 78.
+pub const SHOP_RED_LUCK_2: usize = 78;
+/// `shopRedLuck3` — index 79.
+pub const SHOP_RED_LUCK_3: usize = 79;
+/// `shopInfiniteShopUpgrades` — index 80.
+pub const SHOP_INFINITE_SHOP_UPGRADES: usize = 80;
+/// `shopHorseShoe` — index 81.
+pub const SHOP_HORSE_SHOE: usize = 81;
+/// `shopPanthema` — index 82.
+pub const SHOP_PANTHEMA: usize = 82;
 
 /// Slice of `GameState` for the shop feature.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ShopState {
-    /// Per-upgrade purchased level. UI maintains the name ↔ index
-    /// mapping.
+    /// Per-upgrade purchased level. Indexed by the `SHOP_*` constants
+    /// (index = legacy `player.shopUpgrades` key order).
     #[serde(with = "BigArray")]
     pub upgrades: [f64; SHOP_UPGRADES_LEN],
     /// `player.shopPotionsConsumed` — lifetime potion-use count.
@@ -54,5 +228,22 @@ mod tests {
         let s = ShopState::default();
         assert_eq!(s.upgrades.len(), SHOP_UPGRADES_LEN);
         assert!(matches!(s.shop_buy_max_toggle, ShopBuyMaxMode::One));
+    }
+
+    #[test]
+    fn shop_index_convention_sentinels() {
+        // Coverage: the last named slot pins the array length.
+        assert_eq!(SHOP_PANTHEMA, SHOP_UPGRADES_LEN - 1);
+        // StatLine anchors (legacy `player.shopUpgrades` key order).
+        assert_eq!(SHOP_OFFERING_POTION, 0);
+        assert_eq!(SHOP_OBTAINIUM_POTION, 1);
+        assert_eq!(SHOP_OFFERING_AUTO, 3);
+        assert_eq!(SHOP_CONSTANT_EX, 27);
+        assert_eq!(SHOP_CHRONOMETER, 18);
+        assert_eq!(SHOP_CHRONOMETER_2, 29);
+        assert_eq!(SHOP_CHRONOMETER_3, 30);
+        assert_eq!(SHOP_CHRONOMETER_Z, 36);
+        assert_eq!(SHOP_CHRONOMETER_INFINITY, 57);
+        assert_eq!(SHOP_CHRONOMETER_S, 72);
     }
 }

--- a/crates/synergismforkd_logic/src/state/talismans.rs
+++ b/crates/synergismforkd_logic/src/state/talismans.rs
@@ -6,13 +6,30 @@
 //! [`crate::mechanics::talisman_levels`], and
 //! [`crate::mechanics::talisman_effects`].
 
-/// Number of talismans in the legacy synergism build. Seven named:
-/// Exemption, Chronos, Midas, Metaphysics, PolymathPharaoh,
-/// Mortuus, Plastic (and the order matches the legacy `Talismans`
-/// enum).
 use serde::{Deserialize, Serialize};
 
+/// Number of talismans in the legacy synergism build. Seven named:
+/// Exemption, Chronos, Midas, Metaphysics, Polymath, Mortuus, Plastic.
+/// The order matches the legacy `talismans` const
+/// (`legacy/core_split/packages/web_ui/src/Talismans.ts`); index `i` is
+/// the i-th talisman, and the `TALISMAN_*` constants below give the
+/// name → index mapping the UI tier must match.
 pub const TALISMAN_COUNT: usize = 7;
+
+/// `exemption` — index 0.
+pub const TALISMAN_EXEMPTION: usize = 0;
+/// `chronos` — index 1.
+pub const TALISMAN_CHRONOS: usize = 1;
+/// `midas` — index 2.
+pub const TALISMAN_MIDAS: usize = 2;
+/// `metaphysics` — index 3.
+pub const TALISMAN_METAPHYSICS: usize = 3;
+/// `polymath` — index 4.
+pub const TALISMAN_POLYMATH: usize = 4;
+/// `mortuus` — index 5.
+pub const TALISMAN_MORTUUS: usize = 5;
+/// `plastic` — index 6.
+pub const TALISMAN_PLASTIC: usize = 6;
 
 /// Per-talisman fragment-allocation state. Mirrors the legacy
 /// `player.talismanOne..Seven` arrays: a small fixed slot list
@@ -78,5 +95,15 @@ mod tests {
         let s = TalismansState::default();
         assert_eq!(s.talisman_levels.len(), 7);
         assert_eq!(s.rune_assignments[0].len(), 5);
+    }
+
+    #[test]
+    fn talisman_index_convention_sentinels() {
+        // Coverage: the last named slot pins the array length.
+        assert_eq!(TALISMAN_PLASTIC, TALISMAN_COUNT - 1);
+        // StatLine anchors (legacy `talismans` const order).
+        assert_eq!(TALISMAN_EXEMPTION, 0);
+        assert_eq!(TALISMAN_CHRONOS, 1);
+        assert_eq!(TALISMAN_POLYMATH, 4);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -364,9 +364,11 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     cache.automation_pre.prestige_point_gain = reset_gains.prestige_point_gain;
     cache.automation_pre.transcend_point_gain = reset_gains.transcend_point_gain;
     cache.automation_pre.reincarnation_point_gain = reset_gains.reincarnation_point_gain;
-    // Global-speed multiplier (legacy `G.timeMultiplier`) — self-derived
-    // from state, replacing the caller-provided AutomationPre value.
+    // Speed multipliers (legacy `G.timeMultiplier` / `ascensionSpeedMult`) —
+    // self-derived from state, replacing the caller-provided AutomationPre
+    // values.
     cache.automation_pre.global_time_multiplier = compute_global_speed_mult_pre(state);
+    cache.automation_pre.ascension_speed_multi = compute_ascension_speed_mult_pre(state);
     phase_player_input(state, input, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &cache, input, &mut output);
@@ -1217,6 +1219,168 @@ fn compute_global_speed_mult_pre(state: &GameState) -> f64 {
     })
 }
 
+/// Ascension-speed multiplier (legacy `calculateAscensionSpeedMult`),
+/// self-derived from `&GameState`.
+///
+/// Reduces the legacy `allAscensionSpeedStats` array with [`product_f64`]
+/// into a `base`, then applies the exponent spread (the sum of GQ
+/// `singAscensionSpeed`, `singAscensionSpeed2`, and shop
+/// `chronometerInfinity`) via [`calculate_ascension_speed_mult`]. Replaces
+/// the caller-provided `AutomationPre::ascension_speed_multi`. When the
+/// `oneMind` GQ upgrade is unlocked the speed is a flat ×10 (legacy
+/// `addTimers('ascension')`), bypassing the StatLine reduction.
+///
+/// Three lines are neutral `1.0` pending unported inputs — each is exactly
+/// `1.0` at the current play state, so this stays faithful now: the shop
+/// `panthema` line (needs the unported infinite-shop-upgrade bonus levels),
+/// the singularity-debuff line (the singularity layer is paused), and the
+/// event-buff line (UI-tier).
+fn compute_ascension_speed_mult_pre(state: &GameState) -> f64 {
+    use crate::mechanics::ant_upgrades::mortuus_2_ant_upgrade_effect;
+    use crate::mechanics::calculate::{
+        calculate_ascension_speed_exponent_spread, calculate_ascension_speed_mult, product_f64,
+        AscensionSpeedMultInput,
+    };
+    use crate::mechanics::challenge_15_rewards;
+    use crate::mechanics::exalt_penalties::{
+        calculate_exalt_3_penalty, CalculateExalt3PenaltyInput,
+    };
+    use crate::mechanics::golden_quark_upgrades::{
+        intermediate_pack_effect, one_mind_effect, sing_ascension_speed_2_effect,
+        sing_ascension_speed_effect, IntermediatePackKey,
+    };
+    use crate::mechanics::hepteract_effects::chronos_hepteract_effects;
+    use crate::mechanics::octeracts::{
+        octeract_improved_ascension_speed_2_effect, octeract_improved_ascension_speed_effect,
+    };
+    use crate::mechanics::shop_upgrades::{
+        chronometer_2_effect, chronometer_3_effect, chronometer_effect,
+        chronometer_infinity_effect, chronometer_z_effect, shop_chronometer_s_effect,
+        ChronometerInfinityKey,
+    };
+    use crate::mechanics::singularity_challenges::{
+        limited_ascensions_effect, limited_time_effect, LimitedAscensionsKey, LimitedTimeKey,
+        SingularityEffectValue,
+    };
+    use crate::mechanics::talisman_effects::polymath_talisman_effects;
+    use crate::state::golden_quarks::{
+        GQ_INTERMEDIATE_PACK, GQ_ONE_MIND, GQ_SING_ASCENSION_SPEED, GQ_SING_ASCENSION_SPEED_2,
+    };
+    use crate::state::octeract_upgrades::{
+        OCTERACT_IMPROVED_ASCENSION_SPEED, OCTERACT_IMPROVED_ASCENSION_SPEED_2,
+    };
+    use crate::state::shop::{
+        SHOP_CHRONOMETER, SHOP_CHRONOMETER_2, SHOP_CHRONOMETER_3, SHOP_CHRONOMETER_INFINITY,
+        SHOP_CHRONOMETER_S, SHOP_CHRONOMETER_Z,
+    };
+    use crate::state::TALISMAN_POLYMATH;
+
+    const ANT_UPGRADE_MORTUUS_2: usize = 15;
+    const CUBE_UPGRADE_COOKIE_9: usize = 59;
+    const PLATONIC_UPGRADE_OMEGA: usize = 15;
+
+    let sing = state.singularity.singularity_count;
+    let shop = &state.shop.upgrades;
+    let gq = &state.golden_quarks.upgrades;
+    let oct = &state.octeract_upgrades.upgrades;
+
+    // `oneMind` locks ascension speed to a flat ×10, bypassing the StatLine
+    // reduction entirely (legacy Helper.ts `addTimers('ascension')`).
+    if one_mind_effect(gq[GQ_ONE_MIND].level) {
+        return 10.0;
+    }
+
+    let scalar = |v: SingularityEffectValue| match v {
+        SingularityEffectValue::Scalar(s) => s,
+        SingularityEffectValue::Unlock(_) => 1.0,
+    };
+
+    // Platonic OMEGA: 0.002 × (Σ used corruption levels) × platonicUpgrades[15].
+    let corruption_total_levels: f64 = state
+        .corruptions
+        .used
+        .levels
+        .iter()
+        .map(|&l| f64::from(l))
+        .sum();
+    let platonic_omega = 1.0
+        + 0.002
+            * corruption_total_levels
+            * state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_OMEGA];
+
+    // EXALT limitedAscensions buff: effect ^ (1 + max(0, ⌊log10(ascensions)⌋)).
+    let ascension_count = state.reset_counters.ascension_count;
+    let limited_ascensions_mult = scalar(limited_ascensions_effect(
+        state.singularity.limited_ascensions.completions,
+        LimitedAscensionsKey::AscensionSpeedMult,
+    ));
+    let exalt_buff =
+        limited_ascensions_mult.powf(1.0 + 0.0_f64.max(ascension_count.log10().floor()));
+
+    // EXALT limitedAscensions debuff: 1 / Exalt-3 penalty (1 outside Exalt 3).
+    let exalt_3_debuff = 1.0
+        / calculate_exalt_3_penalty(&CalculateExalt3PenaltyInput {
+            limited_ascensions_enabled: state.singularity.limited_ascensions.enabled,
+            limited_ascensions_completions: state.singularity.limited_ascensions.completions,
+            ascension_count,
+        });
+
+    // Base StatLine product — legacy `allAscensionSpeedStats`.
+    let base = product_f64(&[
+        mortuus_2_ant_upgrade_effect(state.ants.upgrades[ANT_UPGRADE_MORTUUS_2]).ascension_speed,
+        polymath_talisman_effects(state.talismans.talisman_rarity[TALISMAN_POLYMATH] as i32)
+            .ascension_speed_bonus,
+        chronometer_effect(shop[SHOP_CHRONOMETER]),
+        chronometer_2_effect(shop[SHOP_CHRONOMETER_2]),
+        chronometer_3_effect(shop[SHOP_CHRONOMETER_3]),
+        chronos_hepteract_effects(state.hepteracts.chronos.bal).ascension_speed,
+        platonic_omega,
+        challenge_15_rewards::ascension_speed(state.challenges.challenge15_exponent),
+        1.0 + (1.0 / 400.0) * state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_COOKIE_9],
+        intermediate_pack_effect(
+            gq[GQ_INTERMEDIATE_PACK].level,
+            IntermediatePackKey::AscensionSpeedMult,
+        ),
+        chronometer_z_effect(shop[SHOP_CHRONOMETER_Z], sing),
+        octeract_improved_ascension_speed_effect(
+            oct[OCTERACT_IMPROVED_ASCENSION_SPEED].level,
+            sing,
+        ),
+        octeract_improved_ascension_speed_2_effect(
+            oct[OCTERACT_IMPROVED_ASCENSION_SPEED_2].level,
+            sing,
+        ),
+        chronometer_infinity_effect(
+            shop[SHOP_CHRONOMETER_INFINITY],
+            ChronometerInfinityKey::AscensionSpeedMult,
+        ),
+        exalt_buff,
+        1.0, // shop panthema (Jack): infinite-shop-upgrade bonus levels unported → 1.0
+        scalar(limited_time_effect(
+            state.singularity.limited_time.completions,
+            LimitedTimeKey::AscensionSpeed,
+        )),
+        shop_chronometer_s_effect(shop[SHOP_CHRONOMETER_S], sing),
+        exalt_3_debuff,
+        1.0, // singularity debuff: singularity layer paused → 1.0 (sing == 0)
+        1.0, // event buff: UI-tier (wall-clock event calendar) → 1.0
+    ]);
+
+    let exponent_spread = calculate_ascension_speed_exponent_spread(
+        sing_ascension_speed_effect(gq[GQ_SING_ASCENSION_SPEED].level),
+        sing_ascension_speed_2_effect(gq[GQ_SING_ASCENSION_SPEED_2].level),
+        chronometer_infinity_effect(
+            shop[SHOP_CHRONOMETER_INFINITY],
+            ChronometerInfinityKey::ExponentSpread,
+        ),
+    );
+
+    calculate_ascension_speed_mult(&AscensionSpeedMultInput {
+        base,
+        exponent_spread,
+    })
+}
+
 /// Compute the per-tick reset-currency point gains (prestige / transcend /
 /// reincarnation) from `&GameState` plus the Phase-2 accelerator effect.
 ///
@@ -1973,6 +2137,36 @@ mod tests {
         // the (1, 100] no-DR band, so the mult is exactly 3.0.
         state.researches.researches[121] = 100.0;
         assert!((compute_global_speed_mult_pre(&state) - 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ascension_speed_mult_pre_is_one_at_default() {
+        let state = GameState::default();
+        // Every base line is the multiplicative identity and the exponent
+        // spread is 0 at the default state → mult is exactly 1.
+        assert_eq!(compute_ascension_speed_mult_pre(&state), 1.0);
+    }
+
+    #[test]
+    fn ascension_speed_mult_pre_applies_exponent_spread() {
+        let mut state = GameState::default();
+        // Chronometer (shop[18]) adds `1 + 0.012n` to the base; n = 100 → 2.2.
+        state.shop.upgrades[18] = 100.0;
+        // GQ singAscensionSpeed (gq[55]) contributes 0.03 to the exponent
+        // spread once its level > 0, so the result is base^(1 + 0.03).
+        state.golden_quarks.upgrades[55].level = 1.0;
+        let expected = (1.0 + 0.012 * 100.0_f64).powf(1.0 + 0.03);
+        assert!((compute_ascension_speed_mult_pre(&state) - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ascension_speed_mult_pre_one_mind_locks_to_ten() {
+        let mut state = GameState::default();
+        // A large chronometer base would otherwise dominate, but oneMind
+        // (gq[59]) locks ascension speed to a flat ×10.
+        state.shop.upgrades[18] = 1_000.0;
+        state.golden_quarks.upgrades[59].level = 1.0;
+        assert_eq!(compute_ascension_speed_mult_pre(&state), 10.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -364,6 +364,9 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     cache.automation_pre.prestige_point_gain = reset_gains.prestige_point_gain;
     cache.automation_pre.transcend_point_gain = reset_gains.transcend_point_gain;
     cache.automation_pre.reincarnation_point_gain = reset_gains.reincarnation_point_gain;
+    // Global-speed multiplier (legacy `G.timeMultiplier`) — self-derived
+    // from state, replacing the caller-provided AutomationPre value.
+    cache.automation_pre.global_time_multiplier = compute_global_speed_mult_pre(state);
     phase_player_input(state, input, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &cache, input, &mut output);
@@ -1083,6 +1086,137 @@ fn phase_tax(state: &mut GameState, agg: &AggregatorOutputs) -> TaxOutputs {
     }
 }
 
+/// Global-speed multiplier (legacy `G.timeMultiplier` /
+/// `calculateGlobalSpeedMult`), self-derived from `&GameState`.
+///
+/// Reduces the two legacy StatLine arrays — `allGlobalSpeedStats`
+/// (DR-enabled "normal" leg) and `allGlobalSpeedIgnoreDRStats` (DR-ignored
+/// "immaculate" leg) — with [`product_f64`] and combines them through
+/// [`calculate_global_speed_mult`] using the platonic-7 DR power. Replaces
+/// the caller-provided `AutomationPre::global_time_multiplier`.
+///
+/// Three lines are neutral `1.0` pending unported inputs — each is exactly
+/// `1.0` at the current play state, so this stays faithful now:
+/// - obtainium-log line: `maxObtainium` is not tracked in state (and
+///   `upgrades[70] == 0`);
+/// - speed-spirit line: effective rune-spirit power needs the unported
+///   `spiritMultiplier` chain (cf. the prism-spirit caveat);
+/// - singularity-debuff line: the singularity layer is paused
+///   (`calculate_singularity_debuff` has no production caller yet).
+///
+/// The event-buff line is `1.0` (no wall-clock event calendar in logic).
+fn compute_global_speed_mult_pre(state: &GameState) -> f64 {
+    use crate::mechanics::ant_upgrades::mortuus_ant_upgrade_effect;
+    use crate::mechanics::calculate::{
+        calculate_global_speed_mult, calculate_platonic_7_upgrade_power, product_f64,
+        GlobalSpeedMultInput,
+    };
+    use crate::mechanics::cube_blessings::calculate_global_speed_cube_blessing;
+    use crate::mechanics::golden_quark_upgrades::{intermediate_pack_effect, IntermediatePackKey};
+    use crate::mechanics::hypercube_blessings::calculate_global_speed_hypercube_blessing;
+    use crate::mechanics::octeracts::octeract_improved_global_speed_effect;
+    use crate::mechanics::platonic_blessings::{
+        calculate_global_speed_platonic_blessing,
+        calculate_hypercube_blessing_multiplier_platonic_blessing,
+    };
+    use crate::mechanics::rune_blessing_effects::speed_rune_blessing_effects;
+    use crate::mechanics::rune_effects::{speed_rune_effects, SpeedRuneKey};
+    use crate::mechanics::shop_upgrades::shop_chronometer_s_effect;
+    use crate::mechanics::singularity_challenges::{
+        limited_time_effect, LimitedTimeKey, SingularityEffectValue,
+    };
+    use crate::mechanics::talisman_effects::chronos_talisman_effects;
+    use crate::mechanics::tesseract_blessings::calculate_global_speed_tesseract_blessing;
+    use crate::mechanics::{challenge_15_rewards, corruptions::dilation_multiplier_at_level};
+    use crate::state::golden_quarks::GQ_INTERMEDIATE_PACK;
+    use crate::state::octeract_upgrades::OCTERACT_IMPROVED_GLOBAL_SPEED;
+    use crate::state::shop::SHOP_CHRONOMETER_S;
+    use crate::state::{DILATION_INDEX, RUNE_SPEED, TALISMAN_CHRONOS};
+
+    // Ant-upgrade index (legacy `AntUpgrades.Mortuus`) + the cube upgrades
+    // touching global speed (legacy `player.cubeUpgrades[18|34|52]`).
+    const ANT_UPGRADE_MORTUUS: usize = 11;
+    const CUBE_UPGRADE_2X8: usize = 18;
+    const CUBE_UPGRADE_GLOBAL_SPEED_BLESSING: usize = 34;
+    const CUBE_UPGRADE_CX2: usize = 52;
+
+    let sing = state.singularity.singularity_count;
+    let researches = &state.researches.researches;
+    let cube_upgrades = &state.cube_upgrade_levels.cube_upgrades;
+
+    // Cube-blessing chain platonic → hypercube → tesseract → cube, mirroring
+    // the legacy `calculateGlobalSpeedCubeBlessing` call chain in `Cubes.ts`.
+    let platonic_amplifier =
+        calculate_hypercube_blessing_multiplier_platonic_blessing(&state.platonic_blessings);
+    let hypercube_blessing =
+        calculate_global_speed_hypercube_blessing(&state.hypercube_blessings, platonic_amplifier);
+    let tesseract_blessing =
+        calculate_global_speed_tesseract_blessing(&state.tesseract_blessings, hypercube_blessing);
+    let chronos_cube = calculate_global_speed_cube_blessing(
+        &state.cube_blessings,
+        tesseract_blessing,
+        cube_upgrades[CUBE_UPGRADE_GLOBAL_SPEED_BLESSING],
+    );
+
+    let limited_time = match limited_time_effect(
+        state.singularity.limited_time.completions,
+        LimitedTimeKey::AscensionSpeed,
+    ) {
+        SingularityEffectValue::Scalar(v) => v,
+        SingularityEffectValue::Unlock(_) => 1.0,
+    };
+
+    // DR-enabled ("normal") leg — legacy `allGlobalSpeedStats`.
+    let normal_mult = product_f64(&[
+        speed_rune_effects(
+            state.runes.rune_levels[RUNE_SPEED],
+            SpeedRuneKey::GlobalSpeed,
+        ),
+        1.0, // obtainium-log: maxObtainium untracked → 1.0 (upgrades[70] == 0)
+        1.0 + researches[121] / 50.0,
+        1.0 + 0.015 * researches[136],
+        1.0 + 0.012 * researches[151],
+        1.0 + 0.009 * researches[166],
+        1.0 + 0.006 * researches[181],
+        1.0 + 0.003 * researches[196],
+        speed_rune_blessing_effects(state.runes.rune_blessing_levels[RUNE_SPEED]).global_speed,
+        1.0, // speed spirit: effective spirit power unported → 1.0
+        chronos_cube,
+        1.0 + cube_upgrades[CUBE_UPGRADE_2X8] / 5.0,
+        mortuus_ant_upgrade_effect(state.ants.upgrades[ANT_UPGRADE_MORTUUS]).global_speed,
+        chronos_talisman_effects(state.talismans.talisman_rarity[TALISMAN_CHRONOS] as i32)
+            .global_speed,
+        challenge_15_rewards::global_speed(state.challenges.challenge15_exponent),
+        1.0 + 0.01 * cube_upgrades[CUBE_UPGRADE_CX2],
+        dilation_multiplier_at_level(state.corruptions.used.levels[DILATION_INDEX]),
+    ]);
+
+    // DR-ignored ("immaculate") leg — legacy `allGlobalSpeedIgnoreDRStats`.
+    let immaculate_mult = product_f64(&[
+        calculate_global_speed_platonic_blessing(&state.platonic_blessings),
+        1.0, // singularity debuff: singularity layer paused → 1.0 (sing == 0)
+        intermediate_pack_effect(
+            state.golden_quarks.upgrades[GQ_INTERMEDIATE_PACK].level,
+            IntermediatePackKey::GlobalSpeedMult,
+        ),
+        octeract_improved_global_speed_effect(
+            state.octeract_upgrades.upgrades[OCTERACT_IMPROVED_GLOBAL_SPEED].level,
+            sing,
+        ),
+        limited_time,
+        shop_chronometer_s_effect(state.shop.upgrades[SHOP_CHRONOMETER_S], sing),
+        1.0, // event buff: UI-tier (wall-clock event calendar) → 1.0
+    ]);
+
+    calculate_global_speed_mult(&GlobalSpeedMultInput {
+        normal_mult,
+        immaculate_mult,
+        dr_power: calculate_platonic_7_upgrade_power(
+            state.cube_upgrade_levels.platonic_upgrades[7],
+        ),
+    })
+}
+
 /// Compute the per-tick reset-currency point gains (prestige / transcend /
 /// reincarnation) from `&GameState` plus the Phase-2 accelerator effect.
 ///
@@ -1782,6 +1916,12 @@ mod tests {
         let mut state = GameState::default();
         let input = TackInput {
             dt: 2.0,
+            ..TackInput::default()
+        };
+        // `tack` now self-derives `global_time_multiplier`; drive
+        // `phase_automation` directly with a controlled cache so this stays a
+        // focused test of timer advancement under known multipliers.
+        let cache = CrossMechanicCache {
             automation_pre: AutomationPre {
                 global_time_multiplier: 3.0,
                 ascension_speed_multi: 5.0,
@@ -1790,9 +1930,9 @@ mod tests {
                 export_gq_per_hour: 1.0,
                 ..AutomationPre::default()
             },
-            ..TackInput::default()
         };
-        let output = tack(&mut state, &input);
+        let mut output = TickOutput::default();
+        phase_automation(&mut state, &cache, &input, &mut output);
 
         // Reset counters advance by dt × global_time_multiplier (2 × 3).
         assert_eq!(state.reset_counters.prestige_counter, 6.0);
@@ -1815,6 +1955,24 @@ mod tests {
             output.events[0],
             CoreEvent::ObtainiumMultiplierRecomputeRequested
         ));
+    }
+
+    #[test]
+    fn global_speed_mult_pre_is_one_at_default() {
+        let state = GameState::default();
+        // Every contributing line is the multiplicative identity at the
+        // default state, so the self-derived global-speed mult is exactly 1.
+        assert_eq!(compute_global_speed_mult_pre(&state), 1.0);
+    }
+
+    #[test]
+    fn global_speed_mult_pre_scales_with_research() {
+        let mut state = GameState::default();
+        // Research 5x21 (`researches[121]`) adds `1 + n/50` to the DR-enabled
+        // leg. n = 100 → factor 3.0; nothing else is active and 3.0 sits in
+        // the (1, 100] no-DR band, so the mult is exactly 3.0.
+        state.researches.researches[121] = 100.0;
+        assert!((compute_global_speed_mult_pre(&state) - 3.0).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -370,6 +370,13 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     cache.automation_pre.global_time_multiplier = compute_global_speed_mult_pre(state);
     cache.automation_pre.ascension_speed_multi = compute_ascension_speed_mult_pre(state);
     cache.automation_pre.singularity_speed_multi = compute_singularity_speed_mult_pre(state);
+    // Non-speed timer fields (auto-potion + GQ export), self-derived.
+    let (offering_potions, obtainium_potions, auto_potion_speed, export_gq) =
+        compute_auto_timer_fields(state);
+    cache.automation_pre.offering_potion_count = offering_potions;
+    cache.automation_pre.obtainium_potion_count = obtainium_potions;
+    cache.automation_pre.auto_potion_speed_mult = auto_potion_speed;
+    cache.automation_pre.export_gq_per_hour = export_gq;
     phase_player_input(state, input, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &cache, input, &mut output);
@@ -1408,6 +1415,30 @@ fn compute_singularity_speed_mult_pre(state: &GameState) -> f64 {
     )
 }
 
+/// Pure-state non-speed `AutomationPre` timer fields, from the legacy
+/// Helper.ts `addTimers('autoPotion' | 'goldenQuarks')` cases: the
+/// offering/obtainium potion counts (`player.shopUpgrades.{offering,obtainium}Potion`),
+/// the auto-potion speed (`octeractAutoPotionSpeed`), and the GQ export
+/// rate (`goldenQuarks3`'s `exportGQPerHour`). Returned as
+/// `(offering_potion_count, obtainium_potion_count, auto_potion_speed_mult,
+/// export_gq_per_hour)`.
+fn compute_auto_timer_fields(state: &GameState) -> (f64, f64, f64, f64) {
+    use crate::mechanics::golden_quark_upgrades::golden_quarks_3_effect;
+    use crate::mechanics::octeracts::octeract_auto_potion_speed_effect;
+    use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+    use crate::state::octeract_upgrades::OCTERACT_AUTO_POTION_SPEED;
+    use crate::state::shop::{SHOP_OBTAINIUM_POTION, SHOP_OFFERING_POTION};
+
+    (
+        state.shop.upgrades[SHOP_OFFERING_POTION],
+        state.shop.upgrades[SHOP_OBTAINIUM_POTION],
+        octeract_auto_potion_speed_effect(
+            state.octeract_upgrades.upgrades[OCTERACT_AUTO_POTION_SPEED].level,
+        ),
+        golden_quarks_3_effect(state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3].level),
+    )
+}
+
 /// Compute the per-tick reset-currency point gains (prestige / transcend /
 /// reincarnation) from `&GameState` plus the Phase-2 accelerator effect.
 ///
@@ -2208,6 +2239,24 @@ mod tests {
         // ambrosiaBrickOfLead (ambrosia[31]) singularitySpeedMult = 1 - n/100.
         state.ambrosia.upgrades[31].level = 25.0;
         assert!((compute_singularity_speed_mult_pre(&state) - 0.75).abs() < 1e-12);
+    }
+
+    #[test]
+    fn auto_timer_fields_at_default() {
+        let state = GameState::default();
+        assert_eq!(compute_auto_timer_fields(&state), (0.0, 0.0, 1.0, 0.0));
+    }
+
+    #[test]
+    fn auto_timer_fields_track_upgrades() {
+        let mut state = GameState::default();
+        state.shop.upgrades[0] = 3.0; // offeringPotion
+        state.shop.upgrades[1] = 5.0; // obtainiumPotion
+        state.octeract_upgrades.upgrades[26].level = 10.0; // 1 + 4*10/100 = 1.4
+        state.golden_quarks.upgrades[2].level = 4.0; // 4*5/2 = 10
+        let (off, obt, speed, export) = compute_auto_timer_fields(&state);
+        assert_eq!((off, obt, export), (3.0, 5.0, 10.0));
+        assert!((speed - 1.4).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -378,6 +378,7 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     cache.automation_pre.auto_potion_speed_mult = auto_potion_speed;
     cache.automation_pre.export_gq_per_hour = export_gq;
     cache.automation_pre.ambrosia_luck = compute_ambrosia_luck_pre(state);
+    cache.automation_pre.ambrosia_generation_speed = compute_ambrosia_generation_speed_pre(state);
     phase_player_input(state, input, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &cache, input, &mut output);
@@ -1613,6 +1614,139 @@ fn compute_ambrosia_luck_pre(state: &GameState) -> f64 {
     calculate_ambrosia_luck(raw_luck, multiplier)
 }
 
+/// Ambrosia generation speed (legacy `calculateAmbrosiaGenerationSpeed`),
+/// self-derived from `&GameState`.
+///
+/// `raw_speed × blueberries`, where `raw_speed = Π allAmbrosiaGenerationSpeedStats`
+/// (a **product** — the `Default` gate `0|1` × multipliers) and `blueberries
+/// = Σ allAmbrosiaBlueberryStats` (a **sum** — additive blueberry count).
+/// Replaces the caller-provided `AutomationPre::ambrosia_generation_speed`.
+/// The `Default` gate is `0` until `noSingularityUpgrades.completions > 0`,
+/// so this is exactly `0` at the default state (ambrosia locked) — matching
+/// the old default.
+///
+/// Multiplicative lines whose context is unported are neutral `1.0`
+/// (planar-coin, campaign bonus [campaign-token total not tracked], shop
+/// `panthema`, patreon [quark-bonus arg], event); the additive blueberry
+/// lines neutral `0`. All are inert at the current play state.
+fn compute_ambrosia_generation_speed_pre(state: &GameState) -> f64 {
+    use crate::mechanics::ambrosia::{
+        calculate_number_of_thresholds, calculate_singularity_milestone_blueberries,
+    };
+    use crate::mechanics::calculate::{calculate_ambrosia_generation_speed, product_f64, sum_f64};
+    use crate::mechanics::golden_quark_upgrades::{
+        blueberries_effect as gq_blueberries_effect, sing_ambrosia_generation_2_effect,
+        sing_ambrosia_generation_3_effect, sing_ambrosia_generation_4_effect,
+        sing_ambrosia_generation_effect,
+    };
+    use crate::mechanics::octeracts::{
+        octeract_ambrosia_generation_2_effect, octeract_ambrosia_generation_3_effect,
+        octeract_ambrosia_generation_4_effect, octeract_ambrosia_generation_effect,
+        octeract_blueberries_effect,
+    };
+    use crate::mechanics::red_ambrosia_upgrades::{
+        blueberries_effect as red_blueberries_effect, blueberry_generation_speed_2_effect,
+        blueberry_generation_speed_effect,
+    };
+    use crate::mechanics::shop_upgrades::{
+        shop_ambrosia_generation_1_effect, shop_ambrosia_generation_2_effect,
+        shop_ambrosia_generation_3_effect, shop_ambrosia_generation_4_effect,
+        shop_cash_grab_ultra_effect, ShopCashGrabUltraKey,
+    };
+    use crate::mechanics::singularity_challenges::{
+        no_ambrosia_upgrades_effect, one_challenge_cap_effect, NoAmbrosiaUpgradesKey,
+        OneChallengeCapKey, SingularityEffectValue,
+    };
+    use crate::state::golden_quarks::{
+        GQ_BLUEBERRIES, GQ_SING_AMBROSIA_GENERATION, GQ_SING_AMBROSIA_GENERATION_2,
+        GQ_SING_AMBROSIA_GENERATION_3, GQ_SING_AMBROSIA_GENERATION_4,
+    };
+    use crate::state::octeract_upgrades::{
+        OCTERACT_AMBROSIA_GENERATION, OCTERACT_AMBROSIA_GENERATION_2,
+        OCTERACT_AMBROSIA_GENERATION_3, OCTERACT_AMBROSIA_GENERATION_4, OCTERACT_BLUEBERRIES,
+    };
+    use crate::state::red_ambrosia::{
+        RED_AMBROSIA_BLUEBERRIES, RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED,
+        RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED_2,
+    };
+    use crate::state::shop::{
+        SHOP_AMBROSIA_GENERATION_1, SHOP_AMBROSIA_GENERATION_2, SHOP_AMBROSIA_GENERATION_3,
+        SHOP_AMBROSIA_GENERATION_4, SHOP_CASH_GRAB_ULTRA,
+    };
+
+    const CUBE_UPGRADE_COOKIE_26: usize = 76; // legacy player.cubeUpgrades[76]
+
+    let shop = &state.shop.upgrades;
+    let cube = &state.cube_upgrade_levels.cube_upgrades;
+    let highest_sing = state.singularity.highest_singularity_count;
+    let lifetime_amb = state.ambrosia.lifetime_ambrosia;
+    let no_sing = state.singularity.no_singularity_upgrades.completions;
+    let no_amb = state.singularity.no_ambrosia_upgrades.completions;
+    let gq = |i: usize| {
+        state.golden_quarks.upgrades[i].level + state.golden_quarks.upgrades[i].free_level
+    };
+    let oct = |i: usize| {
+        state.octeract_upgrades.upgrades[i].level + state.octeract_upgrades.upgrades[i].free_level
+    };
+    let red = |i: usize| state.red_ambrosia.upgrades[i].level;
+    // Multiplicative context → a missing singularity-effect value is 1.
+    let mc = |v: SingularityEffectValue| match v {
+        SingularityEffectValue::Scalar(s) => s,
+        SingularityEffectValue::Unlock(_) => 1.0,
+    };
+
+    let raw_speed = product_f64(&[
+        if no_sing > 0.0 { 1.0 } else { 0.0 }, // Default gate
+        1.0,                                   // PseudoCoins (planar, unported)
+        1.0,                                   // Campaign (token total not tracked)
+        shop_ambrosia_generation_1_effect(shop[SHOP_AMBROSIA_GENERATION_1]),
+        shop_ambrosia_generation_2_effect(shop[SHOP_AMBROSIA_GENERATION_2]),
+        shop_ambrosia_generation_3_effect(shop[SHOP_AMBROSIA_GENERATION_3]),
+        shop_ambrosia_generation_4_effect(shop[SHOP_AMBROSIA_GENERATION_4]),
+        1.0, // Jack (panthema)
+        sing_ambrosia_generation_effect(gq(GQ_SING_AMBROSIA_GENERATION))
+            * sing_ambrosia_generation_2_effect(gq(GQ_SING_AMBROSIA_GENERATION_2))
+            * sing_ambrosia_generation_3_effect(gq(GQ_SING_AMBROSIA_GENERATION_3))
+            * sing_ambrosia_generation_4_effect(gq(GQ_SING_AMBROSIA_GENERATION_4)),
+        octeract_ambrosia_generation_effect(oct(OCTERACT_AMBROSIA_GENERATION))
+            * octeract_ambrosia_generation_2_effect(oct(OCTERACT_AMBROSIA_GENERATION_2))
+            * octeract_ambrosia_generation_3_effect(oct(OCTERACT_AMBROSIA_GENERATION_3))
+            * octeract_ambrosia_generation_4_effect(oct(OCTERACT_AMBROSIA_GENERATION_4)),
+        1.0, // PatreonBonus (quark-bonus arg uncertain)
+        mc(one_challenge_cap_effect(
+            state.singularity.one_challenge_cap.completions,
+            OneChallengeCapKey::BlueberrySpeedMult,
+        )),
+        mc(no_ambrosia_upgrades_effect(
+            no_amb,
+            NoAmbrosiaUpgradesKey::BlueberrySpeedMult,
+        )),
+        blueberry_generation_speed_effect(red(RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED)),
+        blueberry_generation_speed_2_effect(red(RED_AMBROSIA_BLUEBERRY_GENERATION_SPEED_2)),
+        1.0 + 0.01 * cube[CUBE_UPGRADE_COOKIE_26] * calculate_number_of_thresholds(lifetime_amb),
+        shop_cash_grab_ultra_effect(
+            shop[SHOP_CASH_GRAB_ULTRA],
+            ShopCashGrabUltraKey::AmbrosiaGenerationMult,
+            lifetime_amb,
+        ),
+        1.0, // Event (UI-tier)
+    ]);
+
+    let blueberries = sum_f64(&[
+        if no_sing > 0.0 { 3.0 } else { 0.0 }, // E1x1Clear
+        gq_blueberries_effect(gq(GQ_BLUEBERRIES)),
+        octeract_blueberries_effect(oct(OCTERACT_BLUEBERRIES)),
+        red_blueberries_effect(red(RED_AMBROSIA_BLUEBERRIES)),
+        calculate_singularity_milestone_blueberries(highest_sing),
+        match no_ambrosia_upgrades_effect(no_amb, NoAmbrosiaUpgradesKey::Blueberries) {
+            SingularityEffectValue::Scalar(s) => s,
+            SingularityEffectValue::Unlock(_) => 0.0,
+        },
+    ]);
+
+    calculate_ambrosia_generation_speed(raw_speed, blueberries)
+}
+
 /// Compute the per-tick reset-currency point gains (prestige / transcend /
 /// reincarnation) from `&GameState` plus the Phase-2 accelerator effect.
 ///
@@ -2428,6 +2562,21 @@ mod tests {
         // shopAmbrosiaLuck1 (shop[65]) adds to the raw-luck sum.
         state.shop.upgrades[65] = 10.0;
         assert!(compute_ambrosia_luck_pre(&state) > 100.0);
+    }
+
+    #[test]
+    fn ambrosia_generation_speed_pre_is_zero_when_locked() {
+        let state = GameState::default();
+        // Ambrosia gated (noSingularityUpgrades completions == 0) → 0.
+        assert_eq!(compute_ambrosia_generation_speed_pre(&state), 0.0);
+    }
+
+    #[test]
+    fn ambrosia_generation_speed_pre_unlocks_with_e1x1() {
+        let mut state = GameState::default();
+        // Gate open → raw_speed 1; E1x1 grants +3 blueberries → 1 × 3 = 3.
+        state.singularity.no_singularity_upgrades.completions = 1.0;
+        assert!((compute_ambrosia_generation_speed_pre(&state) - 3.0).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -968,13 +968,11 @@ fn phase_tax(state: &mut GameState, agg: &AggregatorOutputs) -> TaxOutputs {
     use crate::mechanics::talisman_effects::exemption_talisman_effects;
     use crate::mechanics::tax::{calculate_tax, CalculateTaxInput};
     use crate::mechanics::{campaign_token_rewards, challenge_15_rewards};
-    use crate::state::{RUNE_DUPLICATION, RUNE_THRIFT};
+    use crate::state::{RUNE_DUPLICATION, RUNE_THRIFT, TALISMAN_EXEMPTION};
 
     /// Ant-upgrade indices (legacy `AntUpgrades` enum): Coins / Taxes.
     const ANT_UPGRADE_COINS: usize = 1;
     const ANT_UPGRADE_TAXES: usize = 2;
-    /// Exemption talisman — index 0 in the talisman ordering.
-    const TALISMAN_EXEMPTION: usize = 0;
 
     let g = &agg.global_multipliers;
     let coin = &state.coin_producers.tiers;

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -377,6 +377,7 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     cache.automation_pre.obtainium_potion_count = obtainium_potions;
     cache.automation_pre.auto_potion_speed_mult = auto_potion_speed;
     cache.automation_pre.export_gq_per_hour = export_gq;
+    cache.automation_pre.ambrosia_luck = compute_ambrosia_luck_pre(state);
     phase_player_input(state, input, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &cache, input, &mut output);
@@ -1439,6 +1440,179 @@ fn compute_auto_timer_fields(state: &GameState) -> (f64, f64, f64, f64) {
     )
 }
 
+/// Ambrosia-luck multiplier (legacy `calculateAmbrosiaLuck`), self-derived
+/// from `&GameState`.
+///
+/// `raw_luck × multiplier`, where BOTH legs are **sums** (additive luck):
+/// `raw_luck = Σ allAmbrosiaLuckStats` (base 100) and `multiplier =
+/// Σ allAdditiveLuckMultStats` (base 1). Replaces the caller-provided
+/// `AutomationPre::ambrosia_luck` (which the ambrosia timer consumes, gated
+/// by `noSingularityUpgrades.completions > 0` — so it is inert at default).
+///
+/// Ambrosia/GQ/octeract effect inputs use the stored effective level
+/// (`level + free_level`). Lines whose extra context is unported or
+/// uncertain are neutral `0` (faithful at the current play state, where the
+/// owning upgrade is `0` anyway): the planar-coin / campaign-luck / shop
+/// `panthema` lines, the cube-/quark-luck synergy modules (need
+/// `wow_cube_log_sum` / `worlds`), `ambrosiaLuck3` (needs the blueberry
+/// inventory), `ambrosiaUltra` (needs the EXALT-completion sum), the
+/// horseshoe rune/talisman lines, and the event buff (UI-tier).
+fn compute_ambrosia_luck_pre(state: &GameState) -> f64 {
+    use crate::mechanics::achievement_levels::achievement_level_from_points;
+    use crate::mechanics::blueberry_upgrades::{
+        ambrosia_brick_of_lead_effect, ambrosia_luck_1_effect, ambrosia_luck_2_effect,
+        ambrosia_luck_4_effect, AmbrosiaBrickOfLeadEffectKey,
+    };
+    use crate::mechanics::calculate::{calculate_ambrosia_luck, sum_f64};
+    use crate::mechanics::golden_quark_upgrades::{
+        sing_ambrosia_luck_2_effect, sing_ambrosia_luck_3_effect, sing_ambrosia_luck_4_effect,
+        sing_ambrosia_luck_effect,
+    };
+    use crate::mechanics::level_rewards::{get_level_reward, LevelRewardKey};
+    use crate::mechanics::octeracts::{
+        octeract_ambrosia_luck_2_effect, octeract_ambrosia_luck_3_effect,
+        octeract_ambrosia_luck_4_effect, octeract_ambrosia_luck_effect,
+    };
+    use crate::mechanics::red_ambrosia_bonuses::{
+        calculate_cookie_upgrade_29_luck, CalculateCookieUpgrade29LuckInput,
+    };
+    use crate::mechanics::red_ambrosia_upgrades::{
+        regular_luck_2_effect, regular_luck_effect, viscount_effect, ViscountEffectKey,
+        ViscountEffectValue,
+    };
+    use crate::mechanics::shop_upgrades::{
+        shop_ambrosia_luck_1_effect, shop_ambrosia_luck_2_effect, shop_ambrosia_luck_3_effect,
+        shop_ambrosia_luck_4_effect, shop_ambrosia_luck_multiplier_4_effect,
+        shop_octeract_ambrosia_luck_effect,
+    };
+    use crate::mechanics::singularity_challenges::{
+        no_ambrosia_upgrades_effect, no_singularity_upgrades_effect, NoAmbrosiaUpgradesKey,
+        NoSingularityUpgradesKey, SingularityEffectValue,
+    };
+    use crate::mechanics::singularity_milestones::{
+        calculate_dilated_five_leaf_bonus, calculate_singularity_ambrosia_luck_milestone_bonus,
+    };
+    use crate::state::ambrosia::{
+        AMBROSIA_BRICK_OF_LEAD, AMBROSIA_LUCK_1, AMBROSIA_LUCK_2, AMBROSIA_LUCK_4,
+    };
+    use crate::state::golden_quarks::{
+        GQ_SING_AMBROSIA_LUCK, GQ_SING_AMBROSIA_LUCK_2, GQ_SING_AMBROSIA_LUCK_3,
+        GQ_SING_AMBROSIA_LUCK_4,
+    };
+    use crate::state::octeract_upgrades::{
+        OCTERACT_AMBROSIA_LUCK, OCTERACT_AMBROSIA_LUCK_2, OCTERACT_AMBROSIA_LUCK_3,
+        OCTERACT_AMBROSIA_LUCK_4,
+    };
+    use crate::state::red_ambrosia::{
+        RED_AMBROSIA_REGULAR_LUCK, RED_AMBROSIA_REGULAR_LUCK_2, RED_AMBROSIA_VISCOUNT,
+    };
+    use crate::state::shop::{
+        SHOP_AMBROSIA_LUCK_1, SHOP_AMBROSIA_LUCK_2, SHOP_AMBROSIA_LUCK_3, SHOP_AMBROSIA_LUCK_4,
+        SHOP_AMBROSIA_LUCK_MULTIPLIER_4, SHOP_OCTERACT_AMBROSIA_LUCK,
+    };
+
+    // Legacy `player.cubeUpgrades[77|79]` (Cookie 5 / Cookie 29 gate).
+    const CUBE_UPGRADE_COOKIE_5: usize = 77;
+    const CUBE_UPGRADE_COOKIE_29: usize = 79;
+
+    let shop = &state.shop.upgrades;
+    let cube = &state.cube_upgrade_levels.cube_upgrades;
+    let highest_sing = state.singularity.highest_singularity_count;
+    let amb = |i: usize| state.ambrosia.upgrades[i].level + state.ambrosia.upgrades[i].free_level;
+    let gq = |i: usize| {
+        state.golden_quarks.upgrades[i].level + state.golden_quarks.upgrades[i].free_level
+    };
+    let oct = |i: usize| {
+        state.octeract_upgrades.upgrades[i].level + state.octeract_upgrades.upgrades[i].free_level
+    };
+    let red = |i: usize| state.red_ambrosia.upgrades[i].level;
+    // Additive (luck) context → a missing singularity-effect value is 0.
+    let sc = |v: SingularityEffectValue| match v {
+        SingularityEffectValue::Scalar(s) => s,
+        SingularityEffectValue::Unlock(_) => 0.0,
+    };
+
+    let raw_luck = sum_f64(&[
+        100.0, // Base
+        0.0,   // PseudoCoins — planar-coin AMBROSIA_LUCK_BUFF (unported)
+        get_level_reward(
+            LevelRewardKey::AmbrosiaLuck,
+            achievement_level_from_points(state.achievements.achievement_points),
+        ),
+        0.0, // Campaign — player.campaigns.ambrosiaLuckBonus (unported)
+        calculate_singularity_ambrosia_luck_milestone_bonus(highest_sing),
+        shop_ambrosia_luck_1_effect(shop[SHOP_AMBROSIA_LUCK_1]),
+        shop_ambrosia_luck_2_effect(shop[SHOP_AMBROSIA_LUCK_2]),
+        shop_ambrosia_luck_3_effect(shop[SHOP_AMBROSIA_LUCK_3]),
+        shop_ambrosia_luck_4_effect(shop[SHOP_AMBROSIA_LUCK_4]),
+        0.0, // Jack — shopPanthema (needs ShopPanthemaBonusLevels)
+        sing_ambrosia_luck_effect(gq(GQ_SING_AMBROSIA_LUCK))
+            + sing_ambrosia_luck_2_effect(gq(GQ_SING_AMBROSIA_LUCK_2))
+            + sing_ambrosia_luck_3_effect(gq(GQ_SING_AMBROSIA_LUCK_3))
+            + sing_ambrosia_luck_4_effect(gq(GQ_SING_AMBROSIA_LUCK_4)),
+        octeract_ambrosia_luck_effect(oct(OCTERACT_AMBROSIA_LUCK))
+            + octeract_ambrosia_luck_2_effect(oct(OCTERACT_AMBROSIA_LUCK_2))
+            + octeract_ambrosia_luck_3_effect(oct(OCTERACT_AMBROSIA_LUCK_3))
+            + octeract_ambrosia_luck_4_effect(oct(OCTERACT_AMBROSIA_LUCK_4)),
+        ambrosia_luck_1_effect(amb(AMBROSIA_LUCK_1)),
+        ambrosia_luck_2_effect(amb(AMBROSIA_LUCK_2), amb(AMBROSIA_LUCK_1)),
+        0.0, // AmbrosiaLuck3 — needs the blueberry inventory
+        0.0, // AmbrosiaCubeLuck1 — needs wow_cube_log_sum
+        0.0, // AmbrosiaQuarkLuck1 — needs `worlds`
+        if highest_sing >= 131.0 { 131.0 } else { 0.0 },
+        if highest_sing >= 269.0 { 269.0 } else { 0.0 },
+        shop_octeract_ambrosia_luck_effect(
+            shop[SHOP_OCTERACT_AMBROSIA_LUCK],
+            state.cube_balances.wow_octeracts.to_number(),
+        ),
+        sc(no_ambrosia_upgrades_effect(
+            state.singularity.no_ambrosia_upgrades.completions,
+            NoAmbrosiaUpgradesKey::AmbrosiaLuck,
+        )),
+        regular_luck_effect(red(RED_AMBROSIA_REGULAR_LUCK)),
+        regular_luck_2_effect(red(RED_AMBROSIA_REGULAR_LUCK_2)),
+        match viscount_effect(red(RED_AMBROSIA_VISCOUNT), ViscountEffectKey::LuckBonus) {
+            ViscountEffectValue::Scalar(s) => s,
+            ViscountEffectValue::RoleUnlock(_) => 0.0,
+        },
+        2.0 * cube[CUBE_UPGRADE_COOKIE_5],
+        calculate_cookie_upgrade_29_luck(&CalculateCookieUpgrade29LuckInput {
+            cube_upgrade_79: cube[CUBE_UPGRADE_COOKIE_29],
+            lifetime_red_ambrosia: state.red_ambrosia.lifetime_red_ambrosia,
+        }),
+        0.0, // AmbrosiaUltra — shopAmbrosiaUltra (needs the EXALT-completion sum)
+        0.0, // HorseShoeRune — horseshoe-rune level source unported
+    ]);
+
+    let multiplier = sum_f64(&[
+        1.0, // Base
+        sc(no_singularity_upgrades_effect(
+            state.singularity.no_singularity_upgrades.completions,
+            NoSingularityUpgradesKey::AdditiveLuckMult,
+        )),
+        calculate_dilated_five_leaf_bonus(highest_sing),
+        shop_ambrosia_luck_multiplier_4_effect(shop[SHOP_AMBROSIA_LUCK_MULTIPLIER_4]),
+        sc(no_ambrosia_upgrades_effect(
+            state.singularity.no_ambrosia_upgrades.completions,
+            NoAmbrosiaUpgradesKey::AdditiveLuckMult,
+        )),
+        0.001 * cube[CUBE_UPGRADE_COOKIE_5],
+        ambrosia_luck_4_effect(
+            amb(AMBROSIA_LUCK_4),
+            state.red_ambrosia.lifetime_red_ambrosia,
+            state.ambrosia.lifetime_ambrosia,
+        ),
+        ambrosia_brick_of_lead_effect(
+            amb(AMBROSIA_BRICK_OF_LEAD),
+            AmbrosiaBrickOfLeadEffectKey::AdditiveLuckMult,
+        ),
+        0.0, // HorseShoeTalisman — level source unported
+        0.0, // Event buff — UI-tier
+    ]);
+
+    calculate_ambrosia_luck(raw_luck, multiplier)
+}
+
 /// Compute the per-tick reset-currency point gains (prestige / transcend /
 /// reincarnation) from `&GameState` plus the Phase-2 accelerator effect.
 ///
@@ -2242,6 +2416,21 @@ mod tests {
     }
 
     #[test]
+    fn ambrosia_luck_pre_is_one_hundred_at_default() {
+        let state = GameState::default();
+        // Base raw luck 100 × base multiplier 1 = 100.
+        assert_eq!(compute_ambrosia_luck_pre(&state), 100.0);
+    }
+
+    #[test]
+    fn ambrosia_luck_pre_grows_with_shop_luck() {
+        let mut state = GameState::default();
+        // shopAmbrosiaLuck1 (shop[65]) adds to the raw-luck sum.
+        state.shop.upgrades[65] = 10.0;
+        assert!(compute_ambrosia_luck_pre(&state) > 100.0);
+    }
+
+    #[test]
     fn auto_timer_fields_at_default() {
         let state = GameState::default();
         assert_eq!(compute_auto_timer_fields(&state), (0.0, 0.0, 1.0, 0.0));
@@ -2328,15 +2517,21 @@ mod tests {
         state.singularity.no_singularity_upgrades.completions = 1.0;
         let input = TackInput {
             dt: 1000.0,
+            ..TackInput::default()
+        };
+        // `tack` now self-derives ambrosia_luck (+ the speed mults); drive
+        // phase_automation directly with a controlled cache so this stays a
+        // focused test of ambrosia generation.
+        let cache = CrossMechanicCache {
             automation_pre: AutomationPre {
                 ambrosia_generation_speed: 1.0,
                 ambrosia_luck: 200.0,
                 time_per_ambrosia: 45.0,
                 ..AutomationPre::default()
             },
-            ..TackInput::default()
         };
-        let output = tack(&mut state, &input);
+        let mut output = TickOutput::default();
+        phase_automation(&mut state, &cache, &input, &mut output);
 
         assert!(state.ambrosia.ambrosia > 0.0);
         assert!(state.ambrosia.lifetime_ambrosia > 0.0);

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -369,6 +369,7 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     // values.
     cache.automation_pre.global_time_multiplier = compute_global_speed_mult_pre(state);
     cache.automation_pre.ascension_speed_multi = compute_ascension_speed_mult_pre(state);
+    cache.automation_pre.singularity_speed_multi = compute_singularity_speed_mult_pre(state);
     phase_player_input(state, input, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &cache, input, &mut output);
@@ -1381,6 +1382,32 @@ fn compute_ascension_speed_mult_pre(state: &GameState) -> f64 {
     })
 }
 
+/// Singularity-speed multiplier, self-derived from `&GameState`.
+///
+/// Legacy Helper.ts `addTimers('singularity')` sets this to
+/// `getAmbrosiaUpgradeEffects('ambrosiaBrickOfLead', 'singularitySpeedMult')`
+/// — NOT a StatLine reduction — i.e. `1 - effectiveLevel / 100` (= 1 at
+/// level 0). Replaces the caller-provided
+/// `AutomationPre::singularity_speed_multi`.
+///
+/// Uses the stored effective level (`level + free_level`). The live
+/// effective-level refinements — the red-ambrosia free-level chain
+/// (`extraLevelCalc`) and the `noAmbrosiaUpgrades` / `sadisticPrequel` EXALT
+/// gate that zeroes it — are not applied; both are inert at the current
+/// play state, so this stays faithful now.
+fn compute_singularity_speed_mult_pre(state: &GameState) -> f64 {
+    use crate::mechanics::blueberry_upgrades::{
+        ambrosia_brick_of_lead_effect, AmbrosiaBrickOfLeadEffectKey,
+    };
+    use crate::state::ambrosia::AMBROSIA_BRICK_OF_LEAD;
+
+    let u = &state.ambrosia.upgrades[AMBROSIA_BRICK_OF_LEAD];
+    ambrosia_brick_of_lead_effect(
+        u.level + u.free_level,
+        AmbrosiaBrickOfLeadEffectKey::SingularitySpeedMult,
+    )
+}
+
 /// Compute the per-tick reset-currency point gains (prestige / transcend /
 /// reincarnation) from `&GameState` plus the Phase-2 accelerator effect.
 ///
@@ -2167,6 +2194,20 @@ mod tests {
         state.shop.upgrades[18] = 1_000.0;
         state.golden_quarks.upgrades[59].level = 1.0;
         assert_eq!(compute_ascension_speed_mult_pre(&state), 10.0);
+    }
+
+    #[test]
+    fn singularity_speed_mult_pre_is_one_at_default() {
+        let state = GameState::default();
+        assert_eq!(compute_singularity_speed_mult_pre(&state), 1.0);
+    }
+
+    #[test]
+    fn singularity_speed_mult_pre_decreases_with_brick_of_lead() {
+        let mut state = GameState::default();
+        // ambrosiaBrickOfLead (ambrosia[31]) singularitySpeedMult = 1 - n/100.
+        state.ambrosia.upgrades[31].level = 25.0;
+        assert!((compute_singularity_speed_mult_pre(&state) - 0.75).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Continues the `AutomationPre` `*Pre`-bundle retirement (after #244): **twelve `AutomationPre` fields now self-derive from `&GameState`** inside `tack()`, so the tick no longer needs the caller to supply them. Also establishes two upgrade **name→index conventions** in `synergismforkd_logic::state` (the prerequisite for the speed/ambrosia StatLine ports) and fixes two latent out-of-bounds array-sizing bugs.

## `AutomationPre` fields now self-deriving
- **Speed mults:** `global_time_multiplier` (`calculateGlobalSpeedMult`), `ascension_speed_multi` (`calculateAscensionSpeedMult`, incl. the `oneMind` flat-×10 override), `singularity_speed_multi` (`ambrosiaBrickOfLead`)
- **Ambrosia mults:** `ambrosia_luck` (additive `sum × sum`), `ambrosia_generation_speed` (gated `product × blueberry-sum`)
- **Timer fields:** `offering_potion_count`, `obtainium_potion_count`, `auto_potion_speed_mult`, `export_gq_per_hour`

Each reduces the legacy StatLine arrays via `product_f64`/`sum_f64` + the already-ported combining fns, and **equals its old `AutomationPre::default()` at the default game state** so the headless sim and existing tests are undisturbed. Lines whose inputs are unported or UI-tier (event buffs, planar coins, `panthema` bonus levels, the paused singularity layer, …) are neutral-defaulted — each is exactly identity at the current play state, documented per orchestrator.

## Conventions + sizing fixes
- **shop / GQ / octeract / talisman** name→index constants — index = the i-th key of the legacy object, brace-walked from `legacy/core_split` and cross-checked against `legacy/original`. **Octeract array resized 42 → 47** (both snapshots have 47; the mechanics already defined all 47 cost formulas, so indices 42–46 were unstorable).
- **ambrosia / red-ambrosia** name→index constants. **Resized 35 → 36 and 27 → 29** (same latent-OOB shape).
- Also ports the c15 global/ascension speed rewards + the corruption dilation table.

No save migration needed (SaveV1 round-trips from `::default()`; red-ambrosia stays ≤ 32 slots).

## Verification
`cargo test --workspace` (986 logic tests), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, and `cargo build -p synergismforkd_ui_web --target wasm32-unknown-unknown` — **all green at every commit**.

## Remaining to fully drop `AutomationPre`
red-ambrosia luck/gen → the small ambrosia/red timer fields → `octeract_unlocked` → the heavy non-mult fields (`calculateOcteractMultiplier`, `quarkHandler`, ELO/obtainium gains) → ant speed (the deepest) → drop the bundle. Full scoping is recorded for the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
