### PR TITLE
feat(logic): port reset execution for the lower tiers (prestige/transcension/reincarnation)

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -292,6 +292,18 @@ pub enum CoreEvent {
         /// Whether the threshold check was point-amount based or wall-clock based.
         mode: AutoResetMode,
     },
+    /// A reset tier was *executed* this tick — the player's currencies,
+    /// producers, and counters have already been mutated and the
+    /// prestige-family currency credited. Distinct from
+    /// [`Self::AutoResetTriggered`], which is only the auto-reset *intent*
+    /// (nothing applies it yet). Emitted by the manual-reset dispatch.
+    ResetPerformed {
+        /// Which reset tier executed.
+        tier: AutoResetTier,
+        /// Prestige-family points credited by the reset (`0` for an empty
+        /// reset — the execution is ungated).
+        points_gained: Decimal,
+    },
     /// One of the four `automaticTools()` branches fired this tick.
     ///
     /// Emitted by the auto-tool state machine (tick-side, not yet

--- a/crates/synergismforkd_logic/src/tick/auto_reset.rs
+++ b/crates/synergismforkd_logic/src/tick/auto_reset.rs
@@ -3,8 +3,10 @@
 //!
 //! Decides whether prestige / transcend / reincarnation auto-resets fire
 //! this tick, accumulates the time-mode counters, and emits
-//! `AutoResetTriggered` intents. The actual `reset(tier, true)` side
-//! effect lives in the UI tier.
+//! `AutoResetTriggered` intents. Execution now lives in the tick tier:
+//! `phase_automation` performs the **prestige** reset
+//! (`perform_prestige_reset`) when a prestige intent fires. Transcension /
+//! reincarnation remain intent-only until those tiers port.
 
 use smallvec::SmallVec;
 

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -282,15 +282,21 @@ pub enum BuyRequest {
 }
 
 /// Per-tier dispatcher for a manual reset, mirroring [`BuyRequest`]. Only
-/// [`Self::Prestige`] is wired today; the higher tiers (transcension /
-/// reincarnation / ascension / singularity) cascade on top of the
-/// prestige base and port behind the regroup.
+/// [`Self::Prestige`] / [`Self::Transcension`] / [`Self::Reincarnation`]
+/// are wired today; the ascension / singularity tiers cascade on top and
+/// port later.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ResetRequest {
     /// Manual prestige reset — the always-runs base reset
     /// (`reset('prestige')`).
     Prestige,
+    /// Manual transcension reset — base + transcension layer
+    /// (`reset('transcension')`).
+    Transcension,
+    /// Manual reincarnation reset — base + transcension + reincarnation
+    /// layers (`reset('reincarnation')`).
+    Reincarnation,
 }
 
 /// Result of [`tack`]. The accumulated event stream is the only output
@@ -4021,19 +4027,26 @@ fn phase_automation(
     // amount-mode gate compared against (and equals the manual path's
     // `reset_gains.prestige_point_gain`).
     use crate::events::AutoResetTier;
+    use crate::mechanics::reset_currency::ResetCurrencyResult;
+    let auto_gains = ResetCurrencyResult {
+        prestige_point_gain: pre.prestige_point_gain,
+        transcend_point_gain: pre.transcend_point_gain,
+        reincarnation_point_gain: pre.reincarnation_point_gain,
+    };
     let mut performed: SmallVec<[CoreEvent; 2]> = SmallVec::new();
     for event in &resets.events {
-        if matches!(
-            event,
-            CoreEvent::AutoResetTriggered {
-                tier: AutoResetTier::Prestige,
-                ..
+        if let CoreEvent::AutoResetTriggered { tier, .. } = event {
+            let request = match tier {
+                AutoResetTier::Prestige => Some(ResetRequest::Prestige),
+                AutoResetTier::Transcension => Some(ResetRequest::Transcension),
+                AutoResetTier::Reincarnation => Some(ResetRequest::Reincarnation),
+                // Ascension execution is not ported (cubes / hepteracts /
+                // corruptions); the intent still flows to the UI below.
+                AutoResetTier::Ascension => None,
+            };
+            if let Some(request) = request {
+                performed.extend(reset::perform_reset(state, request, &auto_gains));
             }
-        ) {
-            performed.extend(reset::perform_prestige_reset(
-                state,
-                pre.prestige_point_gain,
-            ));
         }
     }
     // Intent (`AutoResetTriggered`) before effect (`ResetPerformed`).
@@ -4954,6 +4967,54 @@ mod tests {
         assert_eq!(state.upgrades.upgrades[5], 0);
         assert_eq!(state.reset_counters.prestige_count, 1.0);
         assert!(state.reset_counters.prestige_unlocked);
+    }
+
+    #[test]
+    fn tack_dispatches_manual_transcension_reset() {
+        use synergismforkd_bignum::Decimal;
+
+        use crate::events::AutoResetTier;
+
+        let mut state = GameState::default();
+        // 1e200 coins-this-transcension ⇒ floor((1e200 / 1e100) ^ 0.03)
+        // = floor(10^3) = 1000 transcend points.
+        state.coin_counters.coins_this_transcension = Decimal::from_finite(1e200);
+        // Dirty a diamond-producer cost + a transcension-tier upgrade slot
+        // to prove the transcension layer clears them through `tack`. (Leave
+        // `owned` at 0 to avoid the Phase-4 generation residual.)
+        state.diamond_producers.tiers[0].cost = Decimal::from_finite(7.0);
+        state.upgrades.upgrades[30] = 1;
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Reset(ResetRequest::Transcension));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output.events.iter().any(|e| matches!(
+                e,
+                CoreEvent::ResetPerformed {
+                    tier: AutoResetTier::Transcension,
+                    ..
+                }
+            )),
+            "expected a transcension ResetPerformed, got {:?}",
+            output.events
+        );
+        assert_eq!(state.upgrades.transcend_points.to_number(), 1000.0);
+        assert_eq!(state.upgrades.prestige_points.to_number(), 0.0); // zeroed by transcension
+        assert_eq!(
+            state.coin_counters.coins_this_transcension.to_number(),
+            100.0
+        );
+        assert_eq!(state.diamond_producers.tiers[0].cost.to_number(), 100.0);
+        assert_eq!(state.upgrades.upgrades[30], 0);
+        assert_eq!(state.reset_counters.transcend_count, 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1873,8 +1873,10 @@ fn compute_base_obtainium(state: &GameState) -> f64 {
 /// `immaculate · baseMults^DR · timeMultiplier`, floored by `baseObtainium`,
 /// with the c14 zero-out and taxman clamp.
 ///
-/// `time_multiplier` is `1.0` — the caller passes `timeMultUsed = false`
-/// (the auto-research path). `base_mults` is the Decimal product of
+/// `time_multiplier` is supplied by the caller (the legacy `timeMultUsed`
+/// branch): `1.0` for the auto-research path, or the
+/// `offeringObtainiumTimeModifiers` product (`compute_obtainium_time_multiplier`)
+/// for the reincarnation-reset award. `base_mults` is the Decimal product of
 /// `allObtainiumStats` times `calculateObtainiumCubeBlessing()` — the cube
 /// blessing also appears as the `CubeBonus` line, so it is applied twice,
 /// verbatim with the legacy `calculateObtainiumDecimal`.
@@ -1892,6 +1894,7 @@ fn compute_obtainium(
     state: &GameState,
     base_obtainium: f64,
     reincarnation_point_gain: Decimal,
+    time_multiplier: f64,
 ) -> Decimal {
     use crate::mechanics::achievement_levels::achievement_level_from_points;
     use crate::mechanics::achievement_rewards::obtainium_bonus;
@@ -2173,13 +2176,51 @@ fn compute_obtainium(
         base_obtainium,
         immaculate,
         dr,
-        time_multiplier: 1.0, // timeMultUsed = false (the auto-research path)
+        time_multiplier,
         base_mults,
         in_ascension_challenge_14: state.challenges.current_ascension_challenge == 14,
         taxman_last_stand_enabled: state.singularity.taxman_last_stand.enabled,
         taxman_last_stand_completions: state.singularity.taxman_last_stand.completions,
         current_obtainium: state.researches.obtainium,
     })
+}
+
+/// `offeringObtainiumTimeModifiers(reincarnationcounter, reincarnationCount >= 5)`
+/// reduced to a product (Statistics.ts:1727) — the `timeMultUsed = true`
+/// obtainium time multiplier used by the reincarnation-reset award.
+///
+/// Three lines: `ThresholdPenalty` (`min(1, (t/threshold)^2)`, ≤1, penalises
+/// resets faster than the threshold), `TimeMultiplier` (`max(1, t/threshold)`
+/// once `reincarnationCount >= 5`, else 1, rewarding longer resets), and
+/// `HalfMind` (`globalSpeedMult / 10` when the half-mind GQ upgrade is
+/// unlocked, else 1). `threshold` uses `campaignTimeThresholdReduction = 0`
+/// (campaign subsystem unported → threshold 10).
+fn compute_obtainium_time_multiplier(state: &GameState) -> f64 {
+    use crate::mechanics::golden_quark_upgrades::half_mind_effect;
+    use crate::mechanics::reset_time_and_auto_obtainium::{
+        reset_time_threshold, ResetTimeThresholdInput,
+    };
+    use crate::state::golden_quarks::GQ_HALF_MIND;
+
+    let threshold = reset_time_threshold(&ResetTimeThresholdInput {
+        campaign_time_threshold_reduction: 0.0,
+    });
+    let time = state.reset_counters.reincarnation_counter;
+    let ratio = time / threshold;
+
+    let threshold_penalty = 1.0_f64.min(ratio.powi(2));
+    let time_multiplier = if state.reset_counters.reincarnation_count >= 5.0 {
+        1.0_f64.max(ratio)
+    } else {
+        1.0
+    };
+    let half_mind = if half_mind_effect(state.golden_quarks.upgrades[GQ_HALF_MIND].level) {
+        compute_global_speed_mult_pre(state) / 10.0
+    } else {
+        1.0
+    };
+
+    threshold_penalty * time_multiplier * half_mind
 }
 
 /// `obtainium_gain` — self-derived from `&GameState`.
@@ -2212,7 +2253,8 @@ fn compute_obtainium_gain(
 
     let cube = &state.cube_upgrade_levels.cube_upgrades;
     let base_obtainium = compute_base_obtainium(state);
-    let resource_mult = compute_obtainium(state, base_obtainium, reincarnation_point_gain);
+    // Auto-research path: legacy `calculateObtainium(false)` ⇒ timeMult 1.0.
+    let resource_mult = compute_obtainium(state, base_obtainium, reincarnation_point_gain, 1.0);
     let reset_time_divisor = reset_time_threshold(&ResetTimeThresholdInput {
         campaign_time_threshold_reduction: 0.0, // campaign subsystem unported → 0
     });

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -4012,7 +4012,33 @@ fn phase_automation(
     state.automation.auto_reset_timer_prestige = resets.auto_reset_timer_prestige;
     state.automation.auto_reset_timer_transcension = resets.auto_reset_timer_transcension;
     state.automation.auto_reset_timer_reincarnation = resets.auto_reset_timer_reincarnation;
+
+    // Execute the fired resets. Only the prestige tier is ported, so a
+    // transcension / reincarnation intent still resolves to emit-only —
+    // mirroring the manual dispatch in Phase 3. At default state
+    // `auto_prestige_enabled` is false, so this never fires and the sim
+    // stays unshifted. `pre.prestige_point_gain` is the same gain the
+    // amount-mode gate compared against (and equals the manual path's
+    // `reset_gains.prestige_point_gain`).
+    use crate::events::AutoResetTier;
+    let mut performed: SmallVec<[CoreEvent; 2]> = SmallVec::new();
+    for event in &resets.events {
+        if matches!(
+            event,
+            CoreEvent::AutoResetTriggered {
+                tier: AutoResetTier::Prestige,
+                ..
+            }
+        ) {
+            performed.extend(reset::perform_prestige_reset(
+                state,
+                pre.prestige_point_gain,
+            ));
+        }
+    }
+    // Intent (`AutoResetTriggered`) before effect (`ResetPerformed`).
     output.events.extend(resets.events);
+    output.events.extend(performed);
 }
 
 /// `player.insideSingularityChallenge` — true when the player is inside
@@ -4604,6 +4630,66 @@ mod tests {
                 amount_of_giveaways: 1
             }
         )));
+    }
+
+    #[test]
+    fn phase_automation_executes_prestige_auto_reset() {
+        use synergismforkd_bignum::Decimal;
+
+        use crate::events::AutoResetTier;
+
+        // Auto-prestige (amount mode) meets its gate, so the tail both emits
+        // the `AutoResetTriggered` intent AND now performs the reset.
+        let mut state = GameState::default();
+        state.automation.auto_prestige_enabled = true;
+        state.upgrades.prestige_points = Decimal::from_finite(1.0); // threshold = 1 × 10^0
+        state.coin_counters.coins_this_prestige = Decimal::from_finite(1e16);
+        state.coin_producers.tiers[0].cost = Decimal::from_finite(999.0);
+
+        // `auto_prestige_milestone` + `prestige_point_gain` are self-derived
+        // in `tack`; drive `phase_automation` directly with a controlled
+        // cache so this stays a focused test of the auto-reset → execution
+        // wiring. `time_warp` skips head/middle; the auto-reset tail runs.
+        let automation_pre = AutomationPre {
+            auto_prestige_milestone: 1.0,
+            prestige_point_gain: Decimal::from_finite(5.0),
+            ..AutomationPre::default()
+        };
+        let input = TackInput {
+            dt: 1.0,
+            time_warp: true,
+            ..TackInput::default()
+        };
+        let mut output = TickOutput::default();
+        phase_automation(&mut state, &automation_pre, &input, &mut output);
+
+        assert!(
+            output.events.iter().any(|e| matches!(
+                e,
+                CoreEvent::AutoResetTriggered {
+                    tier: AutoResetTier::Prestige,
+                    ..
+                }
+            )),
+            "expected the prestige intent, got {:?}",
+            output.events
+        );
+        assert!(
+            output.events.iter().any(|e| matches!(
+                e,
+                CoreEvent::ResetPerformed {
+                    tier: AutoResetTier::Prestige,
+                    ..
+                }
+            )),
+            "expected the reset to execute, got {:?}",
+            output.events
+        );
+        // prestige_points: 1 + 5 (awarded gain) = 6; coin economy reset.
+        assert_eq!(state.upgrades.prestige_points.to_number(), 6.0);
+        assert_eq!(state.coin_counters.coins_this_prestige.to_number(), 100.0);
+        assert_eq!(state.coin_producers.tiers[0].cost.to_number(), 100.0);
+        assert_eq!(state.reset_counters.prestige_count, 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -59,6 +59,7 @@ mod auto_research;
 mod auto_reset;
 mod automatic_tools;
 mod challenge_sweep;
+mod reset;
 mod timers;
 
 /// Pre-evaluated inputs for the Phase 5 automation layer — the speed
@@ -243,14 +244,16 @@ pub struct TackInput {
 }
 
 /// A single queued player input. Variants will expand as automation
-/// toggles and resets port (`ToggleAuto(AutoTool)`, `Reset(ResetRequest)`
-/// per the [[loom-tack-design]] memo).
+/// toggles port (`ToggleAuto(AutoTool)` per the [[loom-tack-design]] memo).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum PlayerAction {
     /// A buy click. Routes to one of the eight `buy_*` mutators based on
     /// the [`BuyRequest`] variant.
     Buy(BuyRequest),
+    /// A manual reset (prestige / transcension / …). Routes to the
+    /// reset executor based on the [`ResetRequest`] variant.
+    Reset(ResetRequest),
 }
 
 /// Per-mechanic dispatcher for the eight `buy_*` purchase loops. The
@@ -276,6 +279,18 @@ pub enum BuyRequest {
     /// Routes to [`buy_producer`] — manual-click loop across the producer
     /// family selected by `input.producer_type`.
     Producer(BuyProducerInput),
+}
+
+/// Per-tier dispatcher for a manual reset, mirroring [`BuyRequest`]. Only
+/// [`Self::Prestige`] is wired today; the higher tiers (transcension /
+/// reincarnation / ascension / singularity) cascade on top of the
+/// prestige base and port behind the regroup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ResetRequest {
+    /// Manual prestige reset — the always-runs base reset
+    /// (`reset('prestige')`).
+    Prestige,
 }
 
 /// Result of [`tack`]. The accumulated event stream is the only output
@@ -433,7 +448,7 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     // until ants unlock → whole product 0), vs the old AutomationPre default of
     // 1 — ant generation multiplies by this factor so it no-ops at 0 anyway.
     automation_pre.ant_speed_mult = compute_ant_speed_mult(state);
-    phase_player_input(state, input, &mut output);
+    phase_player_input(state, input, &reset_gains, &mut output);
     phase_generation(state, &resource_gain_pre, input.dt, &mut output);
     phase_automation(state, &automation_pre, input, &mut output);
 
@@ -3527,14 +3542,25 @@ fn compute_resource_gain_pre(
 
 /// **Phase 3** — Player input drain.
 ///
-/// Each queued [`PlayerAction`] dispatches into its corresponding `buy_*`
-/// mutator. Events flow into [`TickOutput::events`].
-fn phase_player_input(state: &mut GameState, input: &TackInput, output: &mut TickOutput) {
+/// Each queued [`PlayerAction`] dispatches into its corresponding mutator:
+/// [`BuyRequest`] → a `buy_*` loop, [`ResetRequest`] → the reset executor
+/// (which awards `reset_gains`, computed at the top of [`tack`]). Events
+/// flow into [`TickOutput::events`].
+fn phase_player_input(
+    state: &mut GameState,
+    input: &TackInput,
+    reset_gains: &crate::mechanics::reset_currency::ResetCurrencyResult,
+    output: &mut TickOutput,
+) {
     for action in &input.player_actions {
         match action {
             PlayerAction::Buy(req) => {
-                let events = dispatch_buy(state, req);
-                output.events.extend(events);
+                output.events.extend(dispatch_buy(state, req));
+            }
+            PlayerAction::Reset(req) => {
+                output
+                    .events
+                    .extend(reset::perform_reset(state, *req, reset_gains));
             }
         }
     }
@@ -4794,6 +4820,54 @@ mod tests {
             output.events
         );
         assert_eq!(state.upgrades.upgrades[5], 1);
+    }
+
+    #[test]
+    fn tack_dispatches_manual_prestige_reset() {
+        use synergismforkd_bignum::Decimal;
+
+        use crate::events::AutoResetTier;
+
+        let mut state = GameState::default();
+        // 1e18 coins-this-prestige ⇒ floor((1e18 / 1e12) ^ 0.5) = 1000 points.
+        state.coin_counters.coins_this_prestige = Decimal::from_finite(1e18);
+        // Dirty a producer cost + a coin upgrade to prove the reset clears
+        // them through `tack`. (Leave `owned` at 0: nonzero producers would
+        // credit one last coin batch in Phase 4 from the `produce_total`
+        // computed in Phase 2b, *before* the Phase-3 reset — a small
+        // same-tick generation residual, not a reset bug.)
+        state.coin_producers.tiers[0].cost = Decimal::from_finite(999.0);
+        state.upgrades.upgrades[5] = 1;
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Reset(ResetRequest::Prestige));
+
+        let output = tack(&mut state, &input);
+
+        // End-to-end through `tack`: the reset awards the tick's
+        // prestige_point_gain and clears the coin economy.
+        assert!(
+            output.events.iter().any(|e| matches!(
+                e,
+                CoreEvent::ResetPerformed {
+                    tier: AutoResetTier::Prestige,
+                    ..
+                }
+            )),
+            "expected ResetPerformed in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.upgrades.prestige_points.to_number(), 1000.0);
+        assert_eq!(state.coin_counters.coins_this_prestige.to_number(), 100.0);
+        assert_eq!(state.coin_producers.tiers[0].cost.to_number(), 100.0);
+        assert_eq!(state.upgrades.upgrades[5], 0);
+        assert_eq!(state.reset_counters.prestige_count, 1.0);
+        assert!(state.reset_counters.prestige_unlocked);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -1,0 +1,189 @@
+//! Manual reset *execution*. Ports the always-runs base of the legacy
+//! `reset()` (`legacy/core_split/packages/web_ui/src/Reset.ts:412`).
+//!
+//! Where [`auto_reset`](super::auto_reset) only *decides* whether a reset
+//! should fire (emitting a [`CoreEvent::AutoResetTriggered`] intent), this
+//! module actually *performs* the reset against `&mut GameState`. Today
+//! only the prestige tier — the always-runs base reset (Reset.ts:422-486)
+//! — is wired; the higher tiers (transcension / reincarnation / ascension
+//! / singularity) cascade on top of it and port behind the regroup.
+
+use smallvec::{smallvec, SmallVec};
+
+use synergismforkd_bignum::Decimal;
+
+use crate::events::{AutoResetTier, CoreEvent};
+use crate::mechanics::reset_currency::ResetCurrencyResult;
+use crate::state::GameState;
+use crate::tick::ResetRequest;
+
+/// Per-tier coin-producer base cost the prestige reset restores. Mirrors
+/// `player.{first..fifth}CostCoin` (Reset.ts:428-440).
+const COIN_BASE_COSTS: [f64; 5] = [100.0, 1_000.0, 20_000.0, 400_000.0, 8_000_000.0];
+
+/// Execute a manual reset. The dispatch mirrors
+/// [`dispatch_buy`](super::dispatch_buy); only [`ResetRequest::Prestige`]
+/// is wired today.
+pub(crate) fn perform_reset(
+    state: &mut GameState,
+    request: ResetRequest,
+    gains: &ResetCurrencyResult,
+) -> SmallVec<[CoreEvent; 2]> {
+    match request {
+        ResetRequest::Prestige => perform_prestige_reset(state, gains.prestige_point_gain),
+    }
+}
+
+/// Port of the always-runs base reset (`reset('prestige')`,
+/// Reset.ts:422-486): zero the coin economy, restore the prestige-tier
+/// producers, award `prestige_point_gain`, bump the prestige count, and
+/// clear the prestige timers + achievement gates. The award value is the
+/// tick's `G.prestigePointGain` (computed by `compute_reset_currency_gains`
+/// at the top of [`tack`](super::tack), before this phase runs).
+///
+/// Faithful to `reset()`, this is **ungated** — prestiging with too few
+/// coins simply awards `0`; any can-I-prestige guard is a UI-tier concern.
+///
+/// Deferred from the legacy (each faithful at current state, documented):
+/// - `resetOfferings()` (Runes.ts:934) — the per-reset offering award
+///   pulls in `calculateOfferings()`; offerings are left untouched.
+/// - the `updatePrestigeCount` multiplier
+///   (`getAchievementReward('prestigeCountMultiplier')` ×
+///   `1 + 0.05·CalcECC('transcend', completions[5])`) — both factors are
+///   `1` at default, so the count rises by exactly `1`.
+/// - `awardAchievementGroup('prestigeCount')` — achievement *awarding*
+///   (flag-setting) is a separate subsystem.
+/// - `G.generatorPower = 1` (recomputed per tick, not stored) and
+///   `player.fastestprestige` (a record-keeping stat with no state field).
+fn perform_prestige_reset(
+    state: &mut GameState,
+    prestige_point_gain: Decimal,
+) -> SmallVec<[CoreEvent; 2]> {
+    // ── Coin economy ────────────────────────────────────────────────
+    state.upgrades.coins = Decimal::from_finite(102.0);
+    state.coin_counters.coins_this_prestige = Decimal::from_finite(100.0);
+    for (tier, cost) in state.coin_producers.tiers.iter_mut().zip(COIN_BASE_COSTS) {
+        tier.owned = 0.0;
+        tier.generated = Decimal::zero();
+        tier.cost = Decimal::from_finite(cost);
+    }
+    // Prestige-tier (diamond) producers persist through a prestige; only
+    // their auto-generated cascade count resets (Reset.ts:441-445).
+    for tier in &mut state.diamond_producers.tiers {
+        tier.generated = Decimal::zero();
+    }
+    state.multiplier.multiplier_cost = Decimal::from_finite(10_000.0);
+    state.multiplier.multiplier_bought = 0.0;
+    state.accelerator.accelerator_cost = Decimal::from_finite(500.0);
+    state.accelerator.accelerator_bought = 0.0;
+
+    // ── resetUpgrades(1) (Reset.ts:1369-1377) — the always-runs slots ──
+    // Coin-tier upgrades 1..=20 plus the paired 106..=110 / 121..=125
+    // blocks. The `i > 1.5` / `i > 2.5` branches belong to higher tiers.
+    for slot in 1..=20 {
+        state.upgrades.upgrades[slot] = 0;
+    }
+    for slot in 106..=110 {
+        state.upgrades.upgrades[slot] = 0;
+    }
+    for slot in 121..=125 {
+        state.upgrades.upgrades[slot] = 0;
+    }
+
+    // ── Counters, currency award, achievement gates ─────────────────
+    state.reset_counters.prestige_count += 1.0;
+    state.upgrades.prestige_points += prestige_point_gain;
+    // `player.prestigeShards = 0`. The current-shards value lives in
+    // `crystal_upgrades`; `reset_counters.prestige_shards` is a
+    // (currently always-zero) read-base in `resource_gain` — zero both so
+    // the reset holds regardless of which the next tick reads.
+    state.crystal_upgrades.prestige_shards = Decimal::zero();
+    state.reset_counters.prestige_shards = Decimal::zero();
+    state.accelerator.prestige_no_accelerator = true;
+    state.multiplier.prestige_no_multiplier = true;
+    state.upgrades.prestige_no_coin_upgrades = true;
+    state.reset_counters.prestige_unlocked = true;
+    state.reset_counters.prestige_counter = 0.0;
+    state.automation.auto_reset_timer_prestige = 0.0;
+
+    smallvec![CoreEvent::ResetPerformed {
+        tier: AutoResetTier::Prestige,
+        points_gained: prestige_point_gain,
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fully self-contained prestige reset: dirty the coin economy +
+    /// some coin upgrades, then assert every base-reset field lands on its
+    /// post-reset value and the award is credited.
+    #[test]
+    fn prestige_reset_zeroes_coin_economy_and_awards_points() {
+        let mut state = GameState::default();
+        // Dirty everything the base reset is supposed to clear.
+        state.upgrades.coins = Decimal::from_finite(1e20);
+        state.coin_counters.coins_this_prestige = Decimal::from_finite(1e18);
+        state.coin_producers.tiers[0].owned = 42.0;
+        state.coin_producers.tiers[0].cost = Decimal::from_finite(999.0);
+        state.coin_producers.tiers[4].generated = Decimal::from_finite(7.0);
+        state.diamond_producers.tiers[2].generated = Decimal::from_finite(3.0);
+        state.diamond_producers.tiers[2].owned = 5.0; // must SURVIVE prestige
+        state.multiplier.multiplier_bought = 9.0;
+        state.accelerator.accelerator_bought = 9.0;
+        state.upgrades.upgrades[5] = 1; // coin upgrade — must reset
+        state.upgrades.upgrades[124] = 1; // paired block — must reset
+        state.upgrades.upgrades[50] = 1; // outside the prestige slots — survives
+        state.upgrades.prestige_no_coin_upgrades = false;
+        state.reset_counters.prestige_counter = 123.0;
+        state.automation.auto_reset_timer_prestige = 4.5;
+
+        let events = perform_prestige_reset(&mut state, Decimal::from_finite(1000.0));
+
+        assert_eq!(state.upgrades.coins.to_number(), 102.0);
+        assert_eq!(state.coin_counters.coins_this_prestige.to_number(), 100.0);
+        assert_eq!(state.coin_producers.tiers[0].owned, 0.0);
+        assert_eq!(state.coin_producers.tiers[0].cost.to_number(), 100.0);
+        assert_eq!(state.coin_producers.tiers[4].generated.to_number(), 0.0);
+        assert_eq!(state.diamond_producers.tiers[2].generated.to_number(), 0.0);
+        assert_eq!(state.diamond_producers.tiers[2].owned, 5.0); // survived
+        assert_eq!(state.multiplier.multiplier_bought, 0.0);
+        assert_eq!(state.multiplier.multiplier_cost.to_number(), 10_000.0);
+        assert_eq!(state.accelerator.accelerator_bought, 0.0);
+        assert_eq!(state.accelerator.accelerator_cost.to_number(), 500.0);
+        assert_eq!(state.upgrades.upgrades[5], 0);
+        assert_eq!(state.upgrades.upgrades[124], 0);
+        assert_eq!(state.upgrades.upgrades[50], 1); // untouched
+        assert_eq!(state.upgrades.prestige_points.to_number(), 1000.0);
+        assert!(state.upgrades.prestige_no_coin_upgrades);
+        assert_eq!(state.reset_counters.prestige_count, 1.0);
+        assert!(state.reset_counters.prestige_unlocked);
+        assert_eq!(state.reset_counters.prestige_counter, 0.0);
+        assert_eq!(state.automation.auto_reset_timer_prestige, 0.0);
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            CoreEvent::ResetPerformed {
+                tier: AutoResetTier::Prestige,
+                points_gained,
+            } if points_gained.to_number() == 1000.0
+        ));
+    }
+
+    /// Faithful to `reset()`: prestiging with no accumulated coins awards
+    /// `0` points but still performs the reset (the count still rises).
+    #[test]
+    fn prestige_reset_is_ungated_zero_gain_still_resets() {
+        let mut state = GameState::default();
+        state.coin_producers.tiers[0].owned = 10.0;
+
+        let events = perform_prestige_reset(&mut state, Decimal::zero());
+
+        assert_eq!(state.upgrades.prestige_points.to_number(), 0.0);
+        assert_eq!(state.coin_producers.tiers[0].owned, 0.0);
+        assert_eq!(state.reset_counters.prestige_count, 1.0);
+        assert_eq!(events.len(), 1);
+    }
+}

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -1,12 +1,18 @@
-//! Manual reset *execution*. Ports the always-runs base of the legacy
-//! `reset()` (`legacy/core_split/packages/web_ui/src/Reset.ts:412`).
+//! Reset *execution*. Ports the cascading legacy `reset()`
+//! (`legacy/core_split/packages/web_ui/src/Reset.ts:412`).
 //!
 //! Where [`auto_reset`](super::auto_reset) only *decides* whether a reset
 //! should fire (emitting a [`CoreEvent::AutoResetTriggered`] intent), this
-//! module actually *performs* the reset against `&mut GameState`. Today
-//! only the prestige tier — the always-runs base reset (Reset.ts:422-486)
-//! — is wired; the higher tiers (transcension / reincarnation / ascension
-//! / singularity) cascade on top of it and port behind the regroup.
+//! module actually *performs* the reset against `&mut GameState`.
+//!
+//! The legacy `reset()` is one function whose blocks cascade: a
+//! transcension also runs the prestige base, a reincarnation also runs the
+//! transcension block, etc. We mirror that with layered helpers
+//! ([`apply_base_reset`] → [`apply_transcension_layer`] →
+//! [`apply_reincarnation_layer`]), each composed by a public
+//! `perform_*_reset`. Tiers wired today: **prestige, transcension,
+//! reincarnation**. Ascension / singularity (cubes, hepteracts,
+//! corruptions, the paused singularity layer) are not ported yet.
 
 use smallvec::{smallvec, SmallVec};
 
@@ -14,16 +20,28 @@ use synergismforkd_bignum::Decimal;
 
 use crate::events::{AutoResetTier, CoreEvent};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
-use crate::state::GameState;
+use crate::state::{GameState, DEFLATION_INDEX};
 use crate::tick::ResetRequest;
 
 /// Per-tier coin-producer base cost the prestige reset restores. Mirrors
 /// `player.{first..fifth}CostCoin` (Reset.ts:428-440).
 const COIN_BASE_COSTS: [f64; 5] = [100.0, 1_000.0, 20_000.0, 400_000.0, 8_000_000.0];
+/// Diamond-producer base costs restored by the transcension layer
+/// (`player.{first..fifth}CostDiamonds`, Reset.ts:492-500).
+const DIAMOND_BASE_COSTS: [f64; 5] = [100.0, 1e5, 1e15, 1e40, 1e100];
+/// Mythos-producer base costs restored by the reincarnation layer
+/// (`player.{first..fifth}CostMythos`, Reset.ts:577-585).
+const MYTHOS_BASE_COSTS: [f64; 5] = [1.0, 1e2, 1e4, 1e8, 1e16];
+
+/// `coinsThisTranscension` floor for a transcension to credit a count
+/// (`transcensionCheck`, Reset.ts:416).
+const TRANSCEND_COUNT_THRESHOLD: f64 = 1e100;
+/// `transcendShards` floor for a reincarnation to credit obtainium + a
+/// count (`reincarnationCheck`, Reset.ts:417).
+const REINCARNATION_COUNT_THRESHOLD: f64 = 1e300;
 
 /// Execute a manual reset. The dispatch mirrors
-/// [`dispatch_buy`](super::dispatch_buy); only [`ResetRequest::Prestige`]
-/// is wired today.
+/// [`dispatch_buy`](super::dispatch_buy).
 pub(crate) fn perform_reset(
     state: &mut GameState,
     request: ResetRequest,
@@ -31,39 +49,47 @@ pub(crate) fn perform_reset(
 ) -> SmallVec<[CoreEvent; 2]> {
     match request {
         ResetRequest::Prestige => perform_prestige_reset(state, gains.prestige_point_gain),
+        ResetRequest::Transcension => perform_transcension_reset(state, gains),
+        ResetRequest::Reincarnation => perform_reincarnation_reset(state, gains),
     }
 }
 
-/// Port of the always-runs base reset (`reset('prestige')`,
-/// Reset.ts:422-486): zero the coin economy, restore the prestige-tier
-/// producers, award `prestige_point_gain`, bump the prestige count, and
-/// clear the prestige timers + achievement gates. The award value is the
-/// tick's `G.prestigePointGain` (computed by `compute_reset_currency_gains`
-/// at the top of [`tack`](super::tack), before this phase runs).
-///
-/// Faithful to `reset()`, this is **ungated** — prestiging with too few
-/// coins simply awards `0`; any can-I-prestige guard is a UI-tier concern.
-///
-/// Deferred from the legacy (each faithful at current state, documented):
-/// - `resetOfferings()` (Runes.ts:934) — the per-reset offering award
-///   pulls in `calculateOfferings()`; offerings are left untouched.
-/// - the `updatePrestigeCount` multiplier
-///   (`getAchievementReward('prestigeCountMultiplier')` ×
-///   `1 + 0.05·CalcECC('transcend', completions[5])`) — both factors are
-///   `1` at default, so the count rises by exactly `1`.
-/// - `awardAchievementGroup('prestigeCount')` — achievement *awarding*
-///   (flag-setting) is a separate subsystem.
-/// - `G.generatorPower = 1` (recomputed per tick, not stored) and
-///   `player.fastestprestige` (a record-keeping stat with no state field).
+// ─── Prestige ────────────────────────────────────────────────────────────
+
+/// `reset('prestige')` — the always-runs base reset, emitting a single
+/// [`CoreEvent::ResetPerformed`]. The award value is the tick's
+/// `G.prestigePointGain` (computed by `compute_reset_currency_gains` at the
+/// top of [`tack`](super::tack), before this phase runs).
 ///
 /// Invoked by both the manual dispatch ([`perform_reset`]) and the
-/// auto-reset tail in [`phase_automation`](super::phase_automation) when a
-/// prestige `AutoResetTriggered` fires.
+/// auto-reset tail in [`phase_automation`](super::phase_automation).
 pub(crate) fn perform_prestige_reset(
     state: &mut GameState,
     prestige_point_gain: Decimal,
 ) -> SmallVec<[CoreEvent; 2]> {
-    // ── Coin economy ────────────────────────────────────────────────
+    apply_base_reset(state, prestige_point_gain);
+    smallvec![CoreEvent::ResetPerformed {
+        tier: AutoResetTier::Prestige,
+        points_gained: prestige_point_gain,
+    }]
+}
+
+/// The always-runs base reset (Reset.ts:422-486) — no event. Zeroes the
+/// coin economy, restores the coin producers, awards `prestige_point_gain`,
+/// bumps the prestige count, and clears the prestige timers + gates.
+///
+/// Faithful to `reset()`, this is **ungated** — too-few coins simply award
+/// `0`; any can-I-reset guard is a UI-tier concern.
+///
+/// Deferred from the legacy (each faithful at current state):
+/// - `resetOfferings()` (Runes.ts:934) — pulls in `calculateOfferings()`.
+/// - the `updatePrestigeCount` multiplier — `1` at default, so the count
+///   rises by exactly `1`; the `transcendToPrestige` chain is `false`.
+/// - `awardAchievementGroup` — achievement *awarding* is a separate
+///   subsystem.
+/// - `G.generatorPower = 1` (recomputed per tick) and `fastestprestige`
+///   (a record-keeping stat with no state field).
+fn apply_base_reset(state: &mut GameState, prestige_point_gain: Decimal) {
     state.upgrades.coins = Decimal::from_finite(102.0);
     state.coin_counters.coins_this_prestige = Decimal::from_finite(100.0);
     for (tier, cost) in state.coin_producers.tiers.iter_mut().zip(COIN_BASE_COSTS) {
@@ -72,7 +98,7 @@ pub(crate) fn perform_prestige_reset(
         tier.cost = Decimal::from_finite(cost);
     }
     // Prestige-tier (diamond) producers persist through a prestige; only
-    // their auto-generated cascade count resets (Reset.ts:441-445).
+    // their auto-generated cascade count resets here (Reset.ts:441-445).
     for tier in &mut state.diamond_producers.tiers {
         tier.generated = Decimal::zero();
     }
@@ -81,26 +107,17 @@ pub(crate) fn perform_prestige_reset(
     state.accelerator.accelerator_cost = Decimal::from_finite(500.0);
     state.accelerator.accelerator_bought = 0.0;
 
-    // ── resetUpgrades(1) (Reset.ts:1369-1377) — the always-runs slots ──
-    // Coin-tier upgrades 1..=20 plus the paired 106..=110 / 121..=125
-    // blocks. The `i > 1.5` / `i > 2.5` branches belong to higher tiers.
-    for slot in 1..=20 {
-        state.upgrades.upgrades[slot] = 0;
-    }
-    for slot in 106..=110 {
-        state.upgrades.upgrades[slot] = 0;
-    }
-    for slot in 121..=125 {
-        state.upgrades.upgrades[slot] = 0;
-    }
+    // resetUpgrades(1) (Reset.ts:1369-1377) — the always-runs slots.
+    reset_upgrade_slots(state, 1..=20);
+    reset_upgrade_slots(state, 106..=110);
+    reset_upgrade_slots(state, 121..=125);
 
-    // ── Counters, currency award, achievement gates ─────────────────
     state.reset_counters.prestige_count += 1.0;
     state.upgrades.prestige_points += prestige_point_gain;
     // `player.prestigeShards = 0`. The current-shards value lives in
-    // `crystal_upgrades`; `reset_counters.prestige_shards` is a
-    // (currently always-zero) read-base in `resource_gain` — zero both so
-    // the reset holds regardless of which the next tick reads.
+    // `crystal_upgrades`; `reset_counters.prestige_shards` is a (currently
+    // always-zero) read-base in `resource_gain` — zero both so the reset
+    // holds regardless of which the next tick reads.
     state.crystal_upgrades.prestige_shards = Decimal::zero();
     state.reset_counters.prestige_shards = Decimal::zero();
     state.accelerator.prestige_no_accelerator = true;
@@ -109,24 +126,223 @@ pub(crate) fn perform_prestige_reset(
     state.reset_counters.prestige_unlocked = true;
     state.reset_counters.prestige_counter = 0.0;
     state.automation.auto_reset_timer_prestige = 0.0;
+}
 
+// ─── Transcension ──────────────────────────────────────────────────────────
+
+/// `reset('transcension')` — base reset + transcension layer, emitting one
+/// [`CoreEvent::ResetPerformed`].
+pub(crate) fn perform_transcension_reset(
+    state: &mut GameState,
+    gains: &ResetCurrencyResult,
+) -> SmallVec<[CoreEvent; 2]> {
+    apply_base_reset(state, gains.prestige_point_gain);
+    apply_transcension_layer(state, gains.transcend_point_gain);
     smallvec![CoreEvent::ResetPerformed {
-        tier: AutoResetTier::Prestige,
-        points_gained: prestige_point_gain,
+        tier: AutoResetTier::Transcension,
+        points_gained: gains.transcend_point_gain,
     }]
+}
+
+/// The transcension block (Reset.ts:488-547) — no event. Assumes the base
+/// reset already ran. The base awards prestige points; this layer then
+/// zeroes them and converts to the transcend layer (faithful to the
+/// legacy award-then-zero ordering at lines 453 / 515).
+///
+/// Deferred (faithful at current state): the `resetUpgrades(2)`
+/// `crystalUpgradesCost` reset (costs aren't modeled), `acceleratorBoostCost`
+/// (no state field — the buy-boost action is unported), the `tierNCrystalAutobuy`
+/// level-milestone diamond grants (`0` at default), `awardAchievementGroup`,
+/// and `fastesttranscend`.
+fn apply_transcension_layer(state: &mut GameState, transcend_point_gain: Decimal) {
+    // `transcensionCheck` is the *pre-reset* coin total — capture it before
+    // this layer zeroes `coins_this_transcension`.
+    let transcension_check = state.coin_counters.coins_this_transcension
+        >= Decimal::from_finite(TRANSCEND_COUNT_THRESHOLD);
+
+    // resetUpgrades(2) — the `i > 1.5` additions on top of the base's
+    // always-runs slots (Reset.ts:1379-1408).
+    reset_upgrade_slots(state, 21..=40);
+    reset_upgrade_slots(state, 101..=105);
+    reset_upgrade_slots(state, 111..=115);
+    // Crystal-upgrade levels reset, with the legacy `+10` bonus when
+    // upgrade-73 is owned inside a reincarnation challenge (Reset.ts:1400-1407).
+    let crystal_level = if state.upgrades.upgrades[73] > 0
+        && state.challenges.current_reincarnation_challenge != 0
+    {
+        10.0
+    } else {
+        0.0
+    };
+    state.crystal_upgrades.crystal_upgrades = [crystal_level; 8];
+
+    state.coin_counters.coins_this_transcension = Decimal::from_finite(100.0);
+    for (tier, cost) in state
+        .diamond_producers
+        .tiers
+        .iter_mut()
+        .zip(DIAMOND_BASE_COSTS)
+    {
+        tier.owned = 0.0;
+        tier.cost = Decimal::from_finite(cost);
+    }
+    // Transcend-tier (mythos) producers persist; only their cascade resets.
+    for tier in &mut state.mythos_producers.tiers {
+        tier.generated = Decimal::zero();
+    }
+    state.accelerator.accelerator_boost_bought = 0.0;
+
+    // updateTranscensionCount(1) — multiplier is `1` at default, so +1.
+    if transcension_check {
+        state.reset_counters.transcend_count += 1.0;
+    }
+    state.upgrades.prestige_points = Decimal::zero();
+    state.upgrades.transcend_points += transcend_point_gain;
+    state.reset_counters.transcend_shards = Decimal::zero();
+    state.upgrades.transcend_no_coin_upgrades = true;
+    state.upgrades.transcend_no_coin_or_prestige_upgrades = true;
+    state.accelerator.transcend_no_accelerator = true;
+    state.multiplier.transcend_no_multiplier = true;
+    state.reset_counters.transcend_counter = 0.0;
+    state.automation.auto_reset_timer_transcension = 0.0;
+}
+
+// ─── Reincarnation ─────────────────────────────────────────────────────────
+
+/// `reset('reincarnation')` — base + transcension + reincarnation layers,
+/// emitting one [`CoreEvent::ResetPerformed`].
+pub(crate) fn perform_reincarnation_reset(
+    state: &mut GameState,
+    gains: &ResetCurrencyResult,
+) -> SmallVec<[CoreEvent; 2]> {
+    // `reincarnationCheck` is the *pre-reset* shard total — capture it
+    // before the transcension layer zeroes `transcend_shards`.
+    let reincarnation_check = state.reset_counters.transcend_shards
+        >= Decimal::from_finite(REINCARNATION_COUNT_THRESHOLD);
+    apply_base_reset(state, gains.prestige_point_gain);
+    apply_transcension_layer(state, gains.transcend_point_gain);
+    apply_reincarnation_layer(state, gains.reincarnation_point_gain, reincarnation_check);
+    smallvec![CoreEvent::ResetPerformed {
+        tier: AutoResetTier::Reincarnation,
+        points_gained: gains.reincarnation_point_gain,
+    }]
+}
+
+/// The reincarnation block (Reset.ts:549-626) — no event. Assumes the base
+/// + transcension layers already ran.
+///
+/// Deferred (faithful at current state): the **obtainium award**
+/// (`obtainium += calculateObtainium()`) — `calculateObtainium` needs the
+/// unported `calculateBaseObtainium`, and is `0` at default; the
+/// `instantChallenge` shop completion-restore (shop level `0`);
+/// `awardAchievementGroup` / `awardUngroupedAchievement`; and
+/// `fastestreincarnate`.
+fn apply_reincarnation_layer(
+    state: &mut GameState,
+    reincarnation_point_gain: Decimal,
+    reincarnation_check: bool,
+) {
+    // Deflation-corruption bonus (Reset.ts:550-552) — false at default
+    // (deflation level `0`, platonic upgrade `0`).
+    if state.corruptions.used.levels[DEFLATION_INDEX] > 10
+        && state.cube_upgrade_levels.platonic_upgrades[11] > 0.0
+    {
+        state.upgrades.prestige_points += reincarnation_point_gain;
+    }
+
+    if reincarnation_check {
+        // Obtainium award deferred (see fn doc): calculateObtainium unported.
+        // updateReincarnationCount(1) — multiplier is `1` at default, so +1.
+        state.reset_counters.reincarnation_count += 1.0;
+    }
+
+    state.challenges.current_transcension_challenge = 0;
+
+    // resetUpgrades(3) — the `i > 2.5` additions (Reset.ts:1336-1366).
+    for slot in 41..=60 {
+        if slot != 46 {
+            state.upgrades.upgrades[slot] = 0;
+        }
+    }
+    if state.researches.researches[41] == 0.0 {
+        state.upgrades.upgrades[46] = 0;
+        state.upgrades.upgrades[88] = 0;
+    }
+    if state.researches.researches[42] == 0.0 {
+        state.upgrades.upgrades[90] = 0;
+    }
+    if state.researches.researches[43] == 0.0 {
+        state.upgrades.upgrades[91] = 0;
+    }
+    if state.researches.researches[44] == 0.0 {
+        state.upgrades.upgrades[92] = 0;
+    }
+    if state.researches.researches[45] == 0.0 {
+        state.upgrades.upgrades[93] = 0;
+    }
+    reset_upgrade_slots(state, 116..=120);
+
+    state.coin_counters.coins_this_reincarnation = Decimal::from_finite(100.0);
+    for (tier, cost) in state
+        .mythos_producers
+        .tiers
+        .iter_mut()
+        .zip(MYTHOS_BASE_COSTS)
+    {
+        tier.owned = 0.0;
+        tier.cost = Decimal::from_finite(cost);
+    }
+    // Reincarnation-tier (particle) producers persist; only their cascade
+    // count resets.
+    for tier in &mut state.particle_producers.tiers {
+        tier.generated = Decimal::zero();
+    }
+
+    state.upgrades.transcend_points = Decimal::zero();
+    state.upgrades.reincarnation_points += reincarnation_point_gain;
+    state.reset_counters.reincarnation_shards = Decimal::zero();
+    for completion in &mut state.challenges.challenge_completions[1..=5] {
+        *completion = 0.0;
+    }
+    state.upgrades.reincarnate_no_coin_upgrades = true;
+    state.upgrades.reincarnate_no_coin_or_prestige_upgrades = true;
+    state
+        .upgrades
+        .reincarnate_no_coin_prestige_or_transcend_upgrades = true;
+    state
+        .upgrades
+        .reincarnate_no_coin_prestige_transcend_or_generator_upgrades = true;
+    state.accelerator.reincarnate_no_accelerator = true;
+    state.multiplier.reincarnate_no_multiplier = true;
+    state.reset_counters.reincarnation_counter = 0.0;
+    state.automation.auto_reset_timer_reincarnation = 0.0;
+}
+
+/// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
+/// loops). Indices are the legacy 1-based positions, in range for the
+/// `[u8; UPGRADES_DEFAULT_LEN]` bitmap.
+fn reset_upgrade_slots(state: &mut GameState, slots: std::ops::RangeInclusive<usize>) {
+    for slot in slots {
+        state.upgrades.upgrades[slot] = 0;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mechanics::reset_currency::ResetCurrencyResult;
 
-    /// A fully self-contained prestige reset: dirty the coin economy +
-    /// some coin upgrades, then assert every base-reset field lands on its
-    /// post-reset value and the award is credited.
+    fn gains(prestige: f64, transcend: f64, reincarnation: f64) -> ResetCurrencyResult {
+        ResetCurrencyResult {
+            prestige_point_gain: Decimal::from_finite(prestige),
+            transcend_point_gain: Decimal::from_finite(transcend),
+            reincarnation_point_gain: Decimal::from_finite(reincarnation),
+        }
+    }
+
     #[test]
     fn prestige_reset_zeroes_coin_economy_and_awards_points() {
         let mut state = GameState::default();
-        // Dirty everything the base reset is supposed to clear.
         state.upgrades.coins = Decimal::from_finite(1e20);
         state.coin_counters.coins_this_prestige = Decimal::from_finite(1e18);
         state.coin_producers.tiers[0].owned = 42.0;
@@ -176,8 +392,6 @@ mod tests {
         ));
     }
 
-    /// Faithful to `reset()`: prestiging with no accumulated coins awards
-    /// `0` points but still performs the reset (the count still rises).
     #[test]
     fn prestige_reset_is_ungated_zero_gain_still_resets() {
         let mut state = GameState::default();
@@ -189,5 +403,95 @@ mod tests {
         assert_eq!(state.coin_producers.tiers[0].owned, 0.0);
         assert_eq!(state.reset_counters.prestige_count, 1.0);
         assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn transcension_reset_resets_diamond_layer_and_converts_points() {
+        let mut state = GameState::default();
+        // Above the transcension count threshold (1e100).
+        state.coin_counters.coins_this_transcension = Decimal::from_finite(1e120);
+        state.diamond_producers.tiers[0].owned = 8.0;
+        state.diamond_producers.tiers[0].cost = Decimal::from_finite(7.0);
+        state.mythos_producers.tiers[1].generated = Decimal::from_finite(4.0);
+        state.mythos_producers.tiers[1].owned = 6.0; // transcend producers SURVIVE
+        state.crystal_upgrades.crystal_upgrades = [3.0; 8];
+        state.upgrades.upgrades[30] = 1; // resetUpgrades(2) slot — must reset
+        state.accelerator.accelerator_boost_bought = 4.0;
+
+        let events = perform_transcension_reset(&mut state, &gains(50.0, 25.0, 0.0));
+
+        // Base ran (prestige economy reset) then transcension layered on.
+        assert_eq!(state.coin_counters.coins_this_prestige.to_number(), 100.0);
+        assert_eq!(
+            state.coin_counters.coins_this_transcension.to_number(),
+            100.0
+        );
+        assert_eq!(state.diamond_producers.tiers[0].owned, 0.0);
+        assert_eq!(state.diamond_producers.tiers[0].cost.to_number(), 100.0);
+        assert_eq!(state.mythos_producers.tiers[1].generated.to_number(), 0.0);
+        assert_eq!(state.mythos_producers.tiers[1].owned, 6.0); // survived
+        assert_eq!(state.crystal_upgrades.crystal_upgrades, [0.0; 8]);
+        assert_eq!(state.upgrades.upgrades[30], 0);
+        assert_eq!(state.accelerator.accelerator_boost_bought, 0.0);
+        // prestige points awarded by the base are zeroed by transcension;
+        // transcend points credited; transcend count bumped.
+        assert_eq!(state.upgrades.prestige_points.to_number(), 0.0);
+        assert_eq!(state.upgrades.transcend_points.to_number(), 25.0);
+        assert_eq!(state.reset_counters.transcend_count, 1.0);
+        assert_eq!(state.reset_counters.prestige_count, 1.0); // base still counted
+        assert_eq!(state.reset_counters.transcend_counter, 0.0);
+
+        assert!(matches!(
+            events[0],
+            CoreEvent::ResetPerformed {
+                tier: AutoResetTier::Transcension,
+                points_gained,
+            } if points_gained.to_number() == 25.0
+        ));
+    }
+
+    #[test]
+    fn reincarnation_reset_resets_mythos_layer_and_clears_challenges() {
+        let mut state = GameState::default();
+        // Above the reincarnation count threshold (1e300).
+        state.reset_counters.transcend_shards = Decimal::from_finite(1e305);
+        state.mythos_producers.tiers[0].owned = 9.0;
+        state.mythos_producers.tiers[0].cost = Decimal::from_finite(2.0);
+        state.particle_producers.tiers[2].generated = Decimal::from_finite(5.0);
+        state.particle_producers.tiers[2].owned = 7.0; // particle producers SURVIVE
+        state.challenges.challenge_completions[3] = 12.0; // c1-5 cleared
+        state.challenges.challenge_completions[7] = 4.0; // c7 survives
+        state.challenges.current_transcension_challenge = 2;
+        state.upgrades.upgrades[55] = 1; // resetUpgrades(3) slot — must reset
+
+        let events = perform_reincarnation_reset(&mut state, &gains(50.0, 25.0, 9.0));
+
+        // All three layers ran.
+        assert_eq!(
+            state.coin_counters.coins_this_reincarnation.to_number(),
+            100.0
+        );
+        assert_eq!(state.mythos_producers.tiers[0].owned, 0.0);
+        assert_eq!(state.mythos_producers.tiers[0].cost.to_number(), 1.0);
+        assert_eq!(state.particle_producers.tiers[2].generated.to_number(), 0.0);
+        assert_eq!(state.particle_producers.tiers[2].owned, 7.0); // survived
+        assert_eq!(state.challenges.challenge_completions[3], 0.0);
+        assert_eq!(state.challenges.challenge_completions[7], 4.0); // untouched
+        assert_eq!(state.challenges.current_transcension_challenge, 0);
+        assert_eq!(state.upgrades.upgrades[55], 0);
+        // transcend points (from the transcension layer) zeroed; reincarnation
+        // points credited; reincarnation count bumped.
+        assert_eq!(state.upgrades.transcend_points.to_number(), 0.0);
+        assert_eq!(state.upgrades.reincarnation_points.to_number(), 9.0);
+        assert_eq!(state.reset_counters.reincarnation_count, 1.0);
+        assert_eq!(state.reset_counters.reincarnation_counter, 0.0);
+
+        assert!(matches!(
+            events[0],
+            CoreEvent::ResetPerformed {
+                tier: AutoResetTier::Reincarnation,
+                points_gained,
+            } if points_gained.to_number() == 9.0
+        ));
     }
 }

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -221,14 +221,14 @@ pub(crate) fn perform_reincarnation_reset(
         >= Decimal::from_finite(REINCARNATION_COUNT_THRESHOLD);
     // Obtainium award (Reset.ts:418, 568-569): `calculateObtainium()` is
     // captured *before* the reset mutates challenge completions / counters
-    // (it reads them via `calc_ecc`). Reuses the ported `compute_obtainium`
-    // (base × immaculate × baseMults^DR); the `timeMultUsed` reset-time
-    // factor (`offeringObtainiumTimeModifiers`, an unported StatLine) is
-    // neutral-defaulted to 1 — faithful at the default `reincarnationcounter`
-    // of 0, where that factor is itself 1.
+    // (read via `calc_ecc`) and zeroes `reincarnation_counter` (the
+    // reset-time multiplier reads it). `timeMultUsed = true` here — the
+    // `offeringObtainiumTimeModifiers` product scales the award by reset
+    // length.
     let obtainium_to_gain = if reincarnation_check {
         let base = super::compute_base_obtainium(state);
-        super::compute_obtainium(state, base, gains.reincarnation_point_gain)
+        let time_mult = super::compute_obtainium_time_multiplier(state);
+        super::compute_obtainium(state, base, gains.reincarnation_point_gain, time_mult)
     } else {
         Decimal::zero()
     };
@@ -542,5 +542,32 @@ mod tests {
 
         assert_eq!(state.researches.obtainium.to_number(), 0.0);
         assert_eq!(state.reset_counters.reincarnation_count, 0.0);
+    }
+
+    #[test]
+    fn reincarnation_obtainium_scales_with_reset_time() {
+        // Two reincarnations identical except reset length. With
+        // reincarnationCount ≥ 5 the `offeringObtainiumTimeModifiers`
+        // TimeMultiplier line rewards the longer run, so it earns strictly
+        // more obtainium (whereas the instant reset takes the
+        // ThresholdPenalty of 0 and only the base-obtainium floor).
+        let make = |counter: f64| {
+            let mut state = GameState::default();
+            state.reset_counters.transcend_shards = Decimal::from_finite(1e305);
+            state.reset_counters.reincarnation_count = 5.0; // ≥ 5 ⇒ TimeMultiplier active
+            state.reset_counters.reincarnation_counter = counter;
+            perform_reincarnation_reset(&mut state, &gains(0.0, 0.0, 0.0));
+            state.researches.obtainium
+        };
+
+        let quick = make(0.0); // ratio 0 ⇒ ThresholdPenalty 0 ⇒ base floor only
+        let slow = make(1000.0); // well past the 10s threshold ⇒ large TimeMultiplier
+
+        assert!(
+            slow > quick,
+            "a longer reincarnation should earn more obtainium: slow={} quick={}",
+            slow.to_number(),
+            quick.to_number()
+        );
     }
 }

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -55,7 +55,11 @@ pub(crate) fn perform_reset(
 ///   (flag-setting) is a separate subsystem.
 /// - `G.generatorPower = 1` (recomputed per tick, not stored) and
 ///   `player.fastestprestige` (a record-keeping stat with no state field).
-fn perform_prestige_reset(
+///
+/// Invoked by both the manual dispatch ([`perform_reset`]) and the
+/// auto-reset tail in [`phase_automation`](super::phase_automation) when a
+/// prestige `AutoResetTriggered` fires.
+pub(crate) fn perform_prestige_reset(
     state: &mut GameState,
     prestige_point_gain: Decimal,
 ) -> SmallVec<[CoreEvent; 2]> {

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -219,9 +219,27 @@ pub(crate) fn perform_reincarnation_reset(
     // before the transcension layer zeroes `transcend_shards`.
     let reincarnation_check = state.reset_counters.transcend_shards
         >= Decimal::from_finite(REINCARNATION_COUNT_THRESHOLD);
+    // Obtainium award (Reset.ts:418, 568-569): `calculateObtainium()` is
+    // captured *before* the reset mutates challenge completions / counters
+    // (it reads them via `calc_ecc`). Reuses the ported `compute_obtainium`
+    // (base × immaculate × baseMults^DR); the `timeMultUsed` reset-time
+    // factor (`offeringObtainiumTimeModifiers`, an unported StatLine) is
+    // neutral-defaulted to 1 — faithful at the default `reincarnationcounter`
+    // of 0, where that factor is itself 1.
+    let obtainium_to_gain = if reincarnation_check {
+        let base = super::compute_base_obtainium(state);
+        super::compute_obtainium(state, base, gains.reincarnation_point_gain)
+    } else {
+        Decimal::zero()
+    };
     apply_base_reset(state, gains.prestige_point_gain);
     apply_transcension_layer(state, gains.transcend_point_gain);
-    apply_reincarnation_layer(state, gains.reincarnation_point_gain, reincarnation_check);
+    apply_reincarnation_layer(
+        state,
+        gains.reincarnation_point_gain,
+        reincarnation_check,
+        obtainium_to_gain,
+    );
     smallvec![CoreEvent::ResetPerformed {
         tier: AutoResetTier::Reincarnation,
         points_gained: gains.reincarnation_point_gain,
@@ -229,18 +247,17 @@ pub(crate) fn perform_reincarnation_reset(
 }
 
 /// The reincarnation block (Reset.ts:549-626) — no event. Assumes the base
-/// + transcension layers already ran.
+/// and transcension layers already ran. `obtainium_to_gain` is the
+/// pre-reset `calculateObtainium()` value computed by the caller.
 ///
-/// Deferred (faithful at current state): the **obtainium award**
-/// (`obtainium += calculateObtainium()`) — `calculateObtainium` needs the
-/// unported `calculateBaseObtainium`, and is `0` at default; the
-/// `instantChallenge` shop completion-restore (shop level `0`);
-/// `awardAchievementGroup` / `awardUngroupedAchievement`; and
-/// `fastestreincarnate`.
+/// Deferred (faithful at current state): the `instantChallenge` shop
+/// completion-restore (shop level `0`), `awardAchievementGroup` /
+/// `awardUngroupedAchievement`, and `fastestreincarnate`.
 fn apply_reincarnation_layer(
     state: &mut GameState,
     reincarnation_point_gain: Decimal,
     reincarnation_check: bool,
+    obtainium_to_gain: Decimal,
 ) {
     // Deflation-corruption bonus (Reset.ts:550-552) — false at default
     // (deflation level `0`, platonic upgrade `0`).
@@ -251,7 +268,9 @@ fn apply_reincarnation_layer(
     }
 
     if reincarnation_check {
-        // Obtainium award deferred (see fn doc): calculateObtainium unported.
+        // Obtainium award (Reset.ts:568-569) — `obtainium_to_gain` was
+        // computed pre-reset by `perform_reincarnation_reset`.
+        state.researches.obtainium += obtainium_to_gain;
         // updateReincarnationCount(1) — multiplier is `1` at default, so +1.
         state.reset_counters.reincarnation_count += 1.0;
     }
@@ -493,5 +512,35 @@ mod tests {
                 points_gained,
             } if points_gained.to_number() == 9.0
         ));
+    }
+
+    #[test]
+    fn reincarnation_reset_credits_obtainium_above_threshold() {
+        let mut state = GameState::default();
+        // transcendShards ≥ 1e300 ⇒ reincarnationCheck true.
+        state.reset_counters.transcend_shards = Decimal::from_finite(1e305);
+        assert_eq!(state.researches.obtainium.to_number(), 0.0);
+
+        perform_reincarnation_reset(&mut state, &gains(0.0, 0.0, 9.0));
+
+        // `calculateObtainium` has a constant Base line of 1.0, so even at
+        // default the award is strictly positive.
+        assert!(
+            state.researches.obtainium.to_number() > 0.0,
+            "expected an obtainium award, got {}",
+            state.researches.obtainium.to_number()
+        );
+    }
+
+    #[test]
+    fn reincarnation_reset_skips_obtainium_below_threshold() {
+        let mut state = GameState::default();
+        // transcendShards < 1e300 ⇒ reincarnationCheck false ⇒ no award / count.
+        state.reset_counters.transcend_shards = Decimal::from_finite(1e200);
+
+        perform_reincarnation_reset(&mut state, &gains(0.0, 0.0, 9.0));
+
+        assert_eq!(state.researches.obtainium.to_number(), 0.0);
+        assert_eq!(state.reset_counters.reincarnation_count, 0.0);
     }
 }


### PR DESCRIPTION
## What

Ports **`reset()` execution for the three lower tiers** (prestige, transcension, reincarnation) into the logic crate, firing from **both** triggers:
- a manual `PlayerAction::Reset(ResetRequest::{Prestige,Transcension,Reincarnation})` (Phase 3), and
- the **auto-reset** path (Phase 5) — `phase_automation` performs the reset for each tier whose `AutoResetTriggered` intent fires (Ascension stays intent-only).

The coins→producers→prestige→transcend→reincarnate loop is now driveable end-to-end through `tack()`, manually and via automation. **No new state fields.**

## Why this was bigger than a dispatch arm

Reset *execution* was unported. `auto_reset` only emitted `AutoResetTriggered` intents that **nothing applied**; `reset_currency` is gains-only. There was no code that performed a reset.

## Changes
- **`tick/reset.rs`** (new) — mirrors the legacy cascading `reset()` with layered helpers: `apply_base_reset` (prestige, Reset.ts:422-486) → `apply_transcension_layer` (488-547) → `apply_reincarnation_layer` (549-626), each composed by a public `perform_*_reset` emitting one `ResetPerformed`. Faithful to the legacy award-then-zero cascade; count bumps gated by pre-reset thresholds (coinsThisTranscension≥1e100, transcendShards≥1e300).
- **Reincarnation obtainium award** — fully wired: a reincarnation credits `calculateObtainium()` (reusing the ported `compute_base_obtainium` + `compute_obtainium`), captured pre-reset and **scaled by reset length** via a port of `offeringObtainiumTimeModifiers` (the `timeMultUsed=true` ThresholdPenalty × TimeMultiplier × HalfMind product).
- **`tick/mod.rs`** — `PlayerAction::Reset(ResetRequest)` + dispatch; `ResetRequest` gains Transcension/Reincarnation; `phase_automation` maps each fired `AutoResetTier` → `ResetRequest` and executes it; `compute_obtainium` takes a `time_multiplier` param (auto-research passes 1.0).
- **`events/mod.rs`** — `CoreEvent::ResetPerformed { tier, points_gained }`.
- **`tick/auto_reset.rs`** — module doc updated (execution now lives in the tick tier).

## Deferred (documented, faithful no-ops at current state)
- `resetOfferings` award; the count multipliers (=1 at default → counts rise by 1); achievement awarding; `G.generatorPower`/`fastest{prestige,transcend,reincarnate}`; `crystalUpgradesCost`/`acceleratorBoostCost` (not modeled); `tierNCrystalAutobuy` grants + `instantChallenge` restore (0 at default).
- Ascension / singularity tiers (cubes, hepteracts, corruptions, paused singularity layer).
- Known minor artifact: a *manual* reset mid-tick credits one last sliver of coin production (computed in Phase 2b, before the Phase-3 reset). Auto-reset (Phase 5) is unaffected.

## Test plan
- +13 tests across 5 commits (unit per tier, obtainium-award gating + reset-time scaling, end-to-end `tack` for manual prestige/transcension, a `phase_automation` auto-reset test). **1037 logic tests pass.**
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, `cargo build -p synergismforkd_ui_web --target wasm32-unknown-unknown` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)