### PR TITLE
feat(logic): ascension reset tier + manual research/cube-upgrade buy-paths

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -233,6 +233,17 @@ pub enum CoreEvent {
         /// Wow cubes removed from the player's balance.
         spent: f64,
     },
+    /// One platonic upgrade gained a level. The spend spans seven resources
+    /// (obtainium / offerings / cubes / tesseracts / hypercubes / platonics /
+    /// abyssals), so no single `spent` value is carried.
+    PlatonicUpgradePurchased {
+        /// 1-based platonic-upgrade index (1..=20).
+        index: u8,
+        /// Level before the purchase.
+        before: f64,
+        /// Level after the purchase.
+        after: f64,
+    },
     /// One golden-quark (singularity) upgrade gained a level. `spent` is in
     /// golden quarks — an `f64` mirroring the legacy `Number(goldenQuarks)`
     /// cost comparison.

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -257,6 +257,19 @@ pub enum CoreEvent {
         /// Golden quarks removed from the player's balance.
         spent: f64,
     },
+    /// One shop upgrade gained a level (or a consumable a unit of stock —
+    /// the buy is uniform). `spent` is in quarks — an `f64` mirroring the
+    /// legacy `Number(player.worlds)` cost comparison.
+    ShopUpgradePurchased {
+        /// Shop-upgrade index (0..83, via the `SHOP_*` constants).
+        index: u32,
+        /// Level / stock before the purchase.
+        before: f64,
+        /// Level / stock after the purchase.
+        after: f64,
+        /// Quarks removed from the player's balance.
+        spent: f64,
+    },
     /// One research slot was leveled up (zero-or-more levels at once via
     /// the closed-form max-affordable solve). `spent` is in obtainium.
     ResearchPurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -220,6 +220,18 @@ pub enum CoreEvent {
         /// Prestige shards removed from the player's balance.
         spent: Decimal,
     },
+    /// One research slot was leveled up (zero-or-more levels at once via
+    /// the closed-form max-affordable solve). `spent` is in obtainium.
+    ResearchPurchased {
+        /// 1-based research index.
+        index: u32,
+        /// Level before the purchase.
+        before: f64,
+        /// Level after the purchase.
+        after: f64,
+        /// Obtainium removed from the player's balance.
+        spent: Decimal,
+    },
     /// A single-bit upgrade was purchased. The `spent` value is the cost
     /// in the tier's currency.
     UpgradePurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -220,6 +220,19 @@ pub enum CoreEvent {
         /// Prestige shards removed from the player's balance.
         spent: Decimal,
     },
+    /// One cube upgrade was leveled up (zero-or-more levels at once via the
+    /// summation cost solver). `spent` is in wow cubes — an `f64` mirroring
+    /// the legacy `Number(player.wowCubes)` cost comparison.
+    CubeUpgradePurchased {
+        /// 1-based cube-upgrade index (1..=80).
+        index: u8,
+        /// Level before the purchase.
+        before: f64,
+        /// Level after the purchase.
+        after: f64,
+        /// Wow cubes removed from the player's balance.
+        spent: f64,
+    },
     /// One research slot was leveled up (zero-or-more levels at once via
     /// the closed-form max-affordable solve). `spent` is in obtainium.
     ResearchPurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -233,6 +233,19 @@ pub enum CoreEvent {
         /// Wow cubes removed from the player's balance.
         spent: f64,
     },
+    /// One golden-quark (singularity) upgrade gained a level. `spent` is in
+    /// golden quarks — an `f64` mirroring the legacy `Number(goldenQuarks)`
+    /// cost comparison.
+    GoldenQuarkUpgradePurchased {
+        /// GQ-upgrade index (0..80, via the `GQ_*` constants).
+        index: u32,
+        /// Level before the purchase.
+        before: f64,
+        /// Level after the purchase.
+        after: f64,
+        /// Golden quarks removed from the player's balance.
+        spent: f64,
+    },
     /// One research slot was leveled up (zero-or-more levels at once via
     /// the closed-form max-affordable solve). `spent` is in obtainium.
     ResearchPurchased {

--- a/crates/synergismforkd_logic/src/mechanics/cube_upgrades.rs
+++ b/crates/synergismforkd_logic/src/mechanics/cube_upgrades.rs
@@ -7,9 +7,14 @@
 //! `buyCubeUpgrades`) stay in the UI — logic owns just the pure
 //! cost-curve and cap math.
 
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
 use crate::math::summations::{
     calculate_cubic_sum_data, calculate_summation_non_linear, SummationError,
 };
+use crate::state::CubeUpgradeLevelsState;
 
 // ─── Truth tables ──────────────────────────────────────────────────────────
 
@@ -235,6 +240,79 @@ pub fn get_cube_cost(input: &GetCubeCostInput) -> Result<GetCubeCostResult, Summ
     })
 }
 
+// ─── buy_cube_upgrade ──────────────────────────────────────────────────────
+
+/// Inputs to [`buy_cube_upgrade`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyCubeUpgradeInput {
+    /// 1-based cube-upgrade index (`1..=80`). Out-of-range is a no-op.
+    pub index: u8,
+    /// `player.cubeUpgradesBuyMaxToggle` — buy to the cap (else one level).
+    pub buy_max: bool,
+    /// Mirrors [`GetCubeCostInput::singularity_debuff`]:
+    /// `calculateSingularityDebuff('Cube Upgrades')` for `index <= 50`,
+    /// `1.0` for `index > 50` (the cubic branch ignores it). Caller
+    /// pre-evaluates (UI-tier).
+    pub singularity_debuff: f64,
+}
+
+/// Buy cube upgrade `index` with wow cubes. Port of `buyCubeUpgrades`
+/// (`Cubes.ts:138`) built on the logic-side [`get_cube_max`] /
+/// [`get_cube_cost`] solvers. Spends `cost` from `wow_cubes` and sets the
+/// level to `level_can_buy` when affordable and not maxed, emitting
+/// [`CoreEvent::CubeUpgradePurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - the `index > 50` GQ-cookie unlock gate is UI-tier
+///   (`getGQUpgradeEffect`), so — like the other `buy_*` helpers — this is
+///   ungated on unlock (the caller dispatches only unlocked upgrades);
+/// - the buy-time regrants for upgrades 4/5/6 (legacy sets
+///   `player.upgrades[94..=100]`) and the `i == 51` cookie-autos / `i == 57`
+///   background side effects are not applied here. The 4/5/6 regrants are
+///   re-applied by the ascension reset from `cube_upgrades[4/5/6]`.
+#[must_use]
+pub fn buy_cube_upgrade(
+    levels: &mut CubeUpgradeLevelsState,
+    wow_cubes: &mut Decimal,
+    input: BuyCubeUpgradeInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if !matches!(input.index, 1..=80) {
+        return events;
+    }
+    let idx = usize::from(input.index);
+    let before = levels.cube_upgrades[idx];
+    let max_level = get_cube_max(&GetCubeMaxInput {
+        cube_upgrade_index: input.index,
+        cube_upgrade_57: levels.cube_upgrades[57],
+    });
+
+    let Ok(meta) = get_cube_cost(&GetCubeCostInput {
+        cube_upgrade_index: input.index,
+        buy_max: input.buy_max,
+        current_level: before,
+        max_level,
+        wow_cubes: wow_cubes.to_number(),
+        singularity_debuff: input.singularity_debuff,
+    }) else {
+        // Unsolvable cubic (unreachable in normal play) → no purchase.
+        return events;
+    };
+
+    // Legacy gate: affordable AND not already maxed.
+    if wow_cubes.to_number() >= meta.cost && before < max_level {
+        *wow_cubes -= Decimal::from_finite(meta.cost);
+        levels.cube_upgrades[idx] = meta.level_can_buy;
+        events.push(CoreEvent::CubeUpgradePurchased {
+            index: input.index,
+            before,
+            after: meta.level_can_buy,
+            spent: meta.cost,
+        });
+    }
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -329,5 +407,123 @@ mod tests {
         })
         .unwrap();
         assert!(result.level_can_buy > 0.0);
+    }
+
+    // ─── buy_cube_upgrade ───────────────────────────────────────────────
+    // Cube upgrade 1: base_cost 200, max_level 3, flat per-level (c = 0).
+
+    #[test]
+    fn buy_cube_upgrade_levels_up_and_spends() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut cubes = Decimal::from_finite(1e12);
+        let events = buy_cube_upgrade(
+            &mut levels,
+            &mut cubes,
+            BuyCubeUpgradeInput {
+                index: 1,
+                buy_max: false,
+                singularity_debuff: 1.0,
+            },
+        );
+        assert_eq!(levels.cube_upgrades[1], 1.0);
+        assert!(cubes.to_number() < 1e12); // spent ~200
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CoreEvent::CubeUpgradePurchased {
+                index,
+                before,
+                after,
+                spent,
+            } => {
+                assert_eq!(*index, 1);
+                assert_eq!(*before, 0.0);
+                assert_eq!(*after, 1.0);
+                assert!(*spent > 0.0);
+            }
+            other => panic!("expected CubeUpgradePurchased, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn buy_cube_upgrade_max_reaches_cap() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut cubes = Decimal::from_finite(1e12);
+        let _ = buy_cube_upgrade(
+            &mut levels,
+            &mut cubes,
+            BuyCubeUpgradeInput {
+                index: 1,
+                buy_max: true,
+                singularity_debuff: 1.0,
+            },
+        );
+        let max = get_cube_max(&GetCubeMaxInput {
+            cube_upgrade_index: 1,
+            cube_upgrade_57: 0.0,
+        });
+        assert_eq!(levels.cube_upgrades[1], max); // 3.0
+    }
+
+    #[test]
+    fn buy_cube_upgrade_insufficient_cubes_is_noop() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut cubes = Decimal::from_finite(1.0); // base cost is 200
+        let events = buy_cube_upgrade(
+            &mut levels,
+            &mut cubes,
+            BuyCubeUpgradeInput {
+                index: 1,
+                buy_max: false,
+                singularity_debuff: 1.0,
+            },
+        );
+        assert_eq!(levels.cube_upgrades[1], 0.0);
+        assert_eq!(cubes.to_number(), 1.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_cube_upgrade_maxed_is_noop() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        levels.cube_upgrades[1] = 3.0; // max for cube upgrade 1
+        let mut cubes = Decimal::from_finite(1e12);
+        let events = buy_cube_upgrade(
+            &mut levels,
+            &mut cubes,
+            BuyCubeUpgradeInput {
+                index: 1,
+                buy_max: true,
+                singularity_debuff: 1.0,
+            },
+        );
+        assert_eq!(levels.cube_upgrades[1], 3.0);
+        assert_eq!(cubes.to_number(), 1e12);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_cube_upgrade_out_of_range_is_noop() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut cubes = Decimal::from_finite(1e12);
+        assert!(buy_cube_upgrade(
+            &mut levels,
+            &mut cubes,
+            BuyCubeUpgradeInput {
+                index: 0,
+                buy_max: true,
+                singularity_debuff: 1.0,
+            }
+        )
+        .is_empty());
+        assert!(buy_cube_upgrade(
+            &mut levels,
+            &mut cubes,
+            BuyCubeUpgradeInput {
+                index: 81,
+                buy_max: true,
+                singularity_debuff: 1.0,
+            }
+        )
+        .is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/gq_upgrade_cost.rs
+++ b/crates/synergismforkd_logic/src/mechanics/gq_upgrade_cost.rs
@@ -22,6 +22,12 @@
 //!
 //! Returns `0` when `level == computed_max_level` (fully maxed).
 
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::{GoldenQuarksState, StoredSpecialCostForm};
+
 /// Cost-form selector for a GQ upgrade.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GQUpgradeSpecialCostForm {
@@ -92,6 +98,82 @@ pub fn gq_upgrade_cost_tnl(input: &GQUpgradeCostTNLInput) -> f64 {
             (input.cost_per_level * (1.0 + input.level) * cost_multiplier).ceil()
         }
     }
+}
+
+// ─── buy_gq_upgrade ─────────────────────────────────────────────────────────
+
+impl From<StoredSpecialCostForm> for GQUpgradeSpecialCostForm {
+    fn from(form: StoredSpecialCostForm) -> Self {
+        match form {
+            StoredSpecialCostForm::Exponential2 => Self::Exponential2,
+            StoredSpecialCostForm::Cubic => Self::Cubic,
+            StoredSpecialCostForm::Quadratic => Self::Quadratic,
+            StoredSpecialCostForm::None => Self::None,
+        }
+    }
+}
+
+/// Inputs to [`buy_gq_upgrade`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyGQUpgradeInput {
+    /// GQ-upgrade index (`0..80`, via the `GQ_*` constants). Out-of-range
+    /// is a no-op.
+    pub index: usize,
+    /// `computeGQUpgradeMaxLevel(k)` — base cap + overclock perks + octeract
+    /// cap bonus. Caller pre-evaluates (UI-tier); with no bonuses this equals
+    /// the upgrade's `max_level`. Used for the maxed check and the cost
+    /// overcap.
+    pub computed_max_level: f64,
+}
+
+/// Buy one level of golden-quark upgrade `index` with golden quarks — the
+/// per-level step of the legacy `singularity.ts` buy loop (the
+/// `getGQUpgradeCostTNL` → spend → `level += 1` body). Every cost input is
+/// read from the upgrade's own [`GoldenQuarkUpgrade`] state; only
+/// `computed_max_level` is caller-provided. Emits
+/// [`CoreEvent::GoldenQuarkUpgradePurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - **buy-max**: the legacy loops `maxPurchasable` levels (a buy-amount
+///   toggle + budget cap); this buys a single level (the buy-amount-1 case);
+/// - the `minimumSingularity` prerequisite is UI-tier (not in logic state),
+///   so — like the other `buy_*` helpers — this is ungated on it;
+/// - per-upgrade buy-time special effects (e.g. `oneMind` zeroing the
+///   ascension counters) and `goldenQuarksInvested` respec tracking (no logic
+///   field) are not applied — both unreachable at low singularity.
+#[must_use]
+pub fn buy_gq_upgrade(
+    state: &mut GoldenQuarksState,
+    input: BuyGQUpgradeInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if input.index >= state.upgrades.len() {
+        return events;
+    }
+    let upgrade = state.upgrades[input.index];
+    let cost = gq_upgrade_cost_tnl(&GQUpgradeCostTNLInput {
+        level: upgrade.level,
+        max_level: upgrade.max_level,
+        computed_max_level: input.computed_max_level,
+        cost_per_level: upgrade.cost_per_level,
+        special_cost_form: upgrade.special_cost_form.into(),
+    });
+
+    // Legacy gate: not maxed AND affordable. The cap only applies to bounded
+    // upgrades (`maxLevel > 0`); `maxLevel <= 0` is the unlimited sentinel.
+    let not_maxed = upgrade.max_level <= 0.0 || upgrade.level < input.computed_max_level;
+    if not_maxed && state.golden_quarks.to_number() >= cost {
+        let before = upgrade.level;
+        state.golden_quarks -= Decimal::from_finite(cost);
+        state.upgrades[input.index].level += 1.0;
+        events.push(CoreEvent::GoldenQuarkUpgradePurchased {
+            index: input.index as u32,
+            before,
+            after: state.upgrades[input.index].level,
+            spent: cost,
+        });
+    }
+    events
 }
 
 #[cfg(test)]
@@ -189,5 +271,111 @@ mod tests {
             special_cost_form: GQUpgradeSpecialCostForm::None,
         });
         assert_eq!(result, 12_832.0);
+    }
+
+    // ─── buy_gq_upgrade ──────────────────────────────────────────────────
+
+    use crate::state::GoldenQuarkUpgrade;
+
+    fn gq_state(golden_quarks: f64, cost_per_level: f64, max_level: f64) -> GoldenQuarksState {
+        let mut state = GoldenQuarksState {
+            golden_quarks: Decimal::from_finite(golden_quarks),
+            ..GoldenQuarksState::default()
+        };
+        state.upgrades[0] = GoldenQuarkUpgrade {
+            cost_per_level,
+            max_level,
+            ..GoldenQuarkUpgrade::default()
+        };
+        state
+    }
+
+    #[test]
+    fn buy_gq_upgrade_levels_up_and_spends() {
+        let mut state = gq_state(500.0, 100.0, 10.0);
+        let events = buy_gq_upgrade(
+            &mut state,
+            BuyGQUpgradeInput {
+                index: 0,
+                computed_max_level: 10.0,
+            },
+        );
+        // None-form at level 0: cost = ceil(100 * 1 * 1) = 100.
+        assert_eq!(state.upgrades[0].level, 1.0);
+        assert_eq!(state.golden_quarks.to_number(), 400.0);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CoreEvent::GoldenQuarkUpgradePurchased {
+                index,
+                before,
+                after,
+                spent,
+            } => {
+                assert_eq!(*index, 0);
+                assert_eq!(*before, 0.0);
+                assert_eq!(*after, 1.0);
+                assert_eq!(*spent, 100.0);
+            }
+            other => panic!("expected GoldenQuarkUpgradePurchased, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn buy_gq_upgrade_unaffordable_is_noop() {
+        let mut state = gq_state(50.0, 100.0, 10.0); // 50 < cost 100
+        let events = buy_gq_upgrade(
+            &mut state,
+            BuyGQUpgradeInput {
+                index: 0,
+                computed_max_level: 10.0,
+            },
+        );
+        assert_eq!(state.upgrades[0].level, 0.0);
+        assert_eq!(state.golden_quarks.to_number(), 50.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_gq_upgrade_maxed_is_noop() {
+        let mut state = gq_state(1e9, 100.0, 10.0);
+        state.upgrades[0].level = 10.0; // at the cap
+        let events = buy_gq_upgrade(
+            &mut state,
+            BuyGQUpgradeInput {
+                index: 0,
+                computed_max_level: 10.0,
+            },
+        );
+        assert_eq!(state.upgrades[0].level, 10.0);
+        assert_eq!(state.golden_quarks.to_number(), 1e9);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_gq_upgrade_unlimited_ignores_cap() {
+        // max_level == -1 (unlimited sentinel): the cap gate is skipped.
+        let mut state = gq_state(1000.0, 1.0, -1.0);
+        let events = buy_gq_upgrade(
+            &mut state,
+            BuyGQUpgradeInput {
+                index: 0,
+                computed_max_level: -1.0,
+            },
+        );
+        assert_eq!(state.upgrades[0].level, 1.0);
+        assert!(!events.is_empty());
+    }
+
+    #[test]
+    fn buy_gq_upgrade_out_of_range_is_noop() {
+        let mut state = gq_state(1e9, 100.0, 10.0);
+        assert!(buy_gq_upgrade(
+            &mut state,
+            BuyGQUpgradeInput {
+                index: 80,
+                computed_max_level: 10.0,
+            }
+        )
+        .is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/platonic_upgrade_costs.rs
+++ b/crates/synergismforkd_logic/src/mechanics/platonic_upgrade_costs.rs
@@ -21,6 +21,12 @@
 //! auto-mode flag exempts obtainium / offerings from the check
 //! (auto-buy doesn't actually consume those for platonic upgrades).
 
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::{CubeBalancesState, CubeUpgradeLevelsState};
+
 /// Per-platonic-upgrade base costs across all 7 resources, plus the
 /// `max_level` cap and the optional `price_mult` for level-scaling
 /// upgrades.
@@ -464,6 +470,91 @@ pub fn check_platonic_upgrade_affordability(
     checks
 }
 
+// ─── buy_platonic_upgrade ────────────────────────────────────────────────────
+
+/// Inputs to [`buy_platonic_upgrade`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyPlatonicUpgradeInput {
+    /// Platonic-upgrade index (`1..=20`). Out-of-range is a no-op.
+    pub index: u8,
+    /// `calculateSingularityDebuff('Platonic Costs')` — caller pre-evaluates
+    /// (UI-tier); `1.0` with no singularity penalty.
+    pub singularity_debuff: f64,
+}
+
+/// Buy one level of platonic upgrade `index`, spending across all seven
+/// resources (obtainium / offerings / cubes / tesseracts / hypercubes /
+/// platonics / abyssals). Port of the per-level body of `buyPlatonicUpgrades`
+/// (`Platonic.ts:163`) in **manual** mode (`auto = false`), assembled from the
+/// logic-side [`platonic_upgrade_base_cost`] /
+/// [`platonic_upgrade_price_multiplier`] /
+/// [`check_platonic_upgrade_affordability`]. Per-resource cost is
+/// `floor(base * priceMultiplier)`; emits [`CoreEvent::PlatonicUpgradePurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - **buy-max**: the legacy loops while `singularityCount > 0 && maxPlatToggle`;
+///   at `singularityCount == 0` (reachable state) it always buys a single level,
+///   which is what this does;
+/// - the `index == 20` first-purchase alert (UI).
+#[must_use]
+pub fn buy_platonic_upgrade(
+    levels: &mut CubeUpgradeLevelsState,
+    obtainium: &mut Decimal,
+    offerings: &mut Decimal,
+    balances: &mut CubeBalancesState,
+    input: BuyPlatonicUpgradeInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if !matches!(input.index, 1..=20) {
+        return events;
+    }
+    let idx = usize::from(input.index);
+    let before = levels.platonic_upgrades[idx];
+    let base = platonic_upgrade_base_cost(input.index);
+    let price_multiplier =
+        platonic_upgrade_price_multiplier(&PlatonicUpgradePriceMultiplierInput {
+            price_mult: base.price_mult,
+            current_level: before,
+            max_level: base.max_level,
+            singularity_debuff: input.singularity_debuff,
+        });
+
+    let affordability = check_platonic_upgrade_affordability(&CheckPlatonicUpgradeInput {
+        index: input.index,
+        current_level: before,
+        price_multiplier,
+        auto_mode: false,
+        current_resources: PlatonicResourceBalances {
+            obtainium: obtainium.to_number(),
+            offerings: offerings.to_number(),
+            cubes: balances.wow_cubes.to_number(),
+            tesseracts: balances.wow_tesseracts.to_number(),
+            hypercubes: balances.wow_hypercubes.to_number(),
+            platonics: balances.wow_platonic_cubes.to_number(),
+        },
+        abyssal_balance: balances.wow_abyssals,
+    });
+
+    if affordability.can_buy {
+        let cost = |base_resource: f64| -> f64 { (base_resource * price_multiplier).floor() };
+        levels.platonic_upgrades[idx] = before + 1.0;
+        // Manual mode (`auto = false`) consumes obtainium + offerings too.
+        *obtainium -= Decimal::from_finite(cost(base.obtainium));
+        *offerings -= Decimal::from_finite(cost(base.offerings));
+        balances.wow_cubes -= Decimal::from_finite(cost(base.cubes));
+        balances.wow_tesseracts -= Decimal::from_finite(cost(base.tesseracts));
+        balances.wow_hypercubes -= Decimal::from_finite(cost(base.hypercubes));
+        balances.wow_platonic_cubes -= Decimal::from_finite(cost(base.platonics));
+        balances.wow_abyssals -= cost(base.abyssals);
+        events.push(CoreEvent::PlatonicUpgradePurchased {
+            index: input.index,
+            before,
+            after: levels.platonic_upgrades[idx],
+        });
+    }
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -632,5 +723,118 @@ mod tests {
         assert!(!result_no_abyssal.can_buy);
         assert!(result_with_abyssal.abyssals);
         assert!(result_with_abyssal.can_buy);
+    }
+
+    // ─── buy_platonic_upgrade ────────────────────────────────────────────
+    // Upgrade 1 at level 0 (priceMult = 2^0 × 1 = 1) ⇒ costs = base:
+    // obtainium 1, offerings 1e45, cubes 1e13, tesseracts 1e6, hypercubes
+    // 1e5, platonics 1e4, abyssals 0; max_level 300.
+
+    fn rich_balances() -> CubeBalancesState {
+        CubeBalancesState {
+            wow_cubes: Decimal::from_finite(1e50),
+            wow_tesseracts: Decimal::from_finite(1e50),
+            wow_hypercubes: Decimal::from_finite(1e50),
+            wow_platonic_cubes: Decimal::from_finite(2e4),
+            wow_abyssals: 0.0,
+            ..CubeBalancesState::default()
+        }
+    }
+
+    #[test]
+    fn buy_platonic_upgrade_spends_all_resources_and_levels_up() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut obtainium = Decimal::from_finite(10.0);
+        let mut offerings = Decimal::from_finite(1e50);
+        let mut balances = rich_balances();
+
+        let events = buy_platonic_upgrade(
+            &mut levels,
+            &mut obtainium,
+            &mut offerings,
+            &mut balances,
+            BuyPlatonicUpgradeInput {
+                index: 1,
+                singularity_debuff: 1.0,
+            },
+        );
+
+        assert_eq!(levels.platonic_upgrades[1], 1.0);
+        assert_eq!(obtainium.to_number(), 9.0); // 10 − cost 1
+        assert_eq!(balances.wow_platonic_cubes.to_number(), 1e4); // 2e4 − cost 1e4
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            CoreEvent::PlatonicUpgradePurchased { index: 1, before, after }
+                if before == 0.0 && after == 1.0
+        ));
+    }
+
+    #[test]
+    fn buy_platonic_upgrade_blocked_when_one_resource_short() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut obtainium = Decimal::from_finite(10.0);
+        let mut offerings = Decimal::zero(); // 0 < offerings cost 1e45
+        let mut balances = rich_balances();
+
+        let events = buy_platonic_upgrade(
+            &mut levels,
+            &mut obtainium,
+            &mut offerings,
+            &mut balances,
+            BuyPlatonicUpgradeInput {
+                index: 1,
+                singularity_debuff: 1.0,
+            },
+        );
+
+        assert_eq!(levels.platonic_upgrades[1], 0.0);
+        assert_eq!(obtainium.to_number(), 10.0); // untouched
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_platonic_upgrade_maxed_is_noop() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        levels.platonic_upgrades[1] = 300.0; // max_level
+        let mut obtainium = Decimal::from_finite(1e60);
+        let mut offerings = Decimal::from_finite(1e60);
+        let mut balances = rich_balances();
+        balances.wow_platonic_cubes = Decimal::from_finite(1e60); // resources all pass; only the cap blocks
+
+        let events = buy_platonic_upgrade(
+            &mut levels,
+            &mut obtainium,
+            &mut offerings,
+            &mut balances,
+            BuyPlatonicUpgradeInput {
+                index: 1,
+                singularity_debuff: 1.0,
+            },
+        );
+
+        assert_eq!(levels.platonic_upgrades[1], 300.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_platonic_upgrade_out_of_range_is_noop() {
+        let mut levels = CubeUpgradeLevelsState::default();
+        let mut obtainium = Decimal::from_finite(1e50);
+        let mut offerings = Decimal::from_finite(1e50);
+        let mut balances = rich_balances();
+        for index in [0, 21] {
+            assert!(buy_platonic_upgrade(
+                &mut levels,
+                &mut obtainium,
+                &mut offerings,
+                &mut balances,
+                BuyPlatonicUpgradeInput {
+                    index,
+                    singularity_debuff: 1.0,
+                },
+            )
+            .is_empty());
+        }
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/researches.rs
+++ b/crates/synergismforkd_logic/src/mechanics/researches.rs
@@ -12,7 +12,11 @@
 //! `RESEARCH_BASE_COSTS[0] == f64::INFINITY` and
 //! `RESEARCH_MAX_LEVELS[0] == 0`.
 
+use smallvec::SmallVec;
 use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::ResearchesState;
 
 /// Per-research base cost. Index 0 is `f64::INFINITY` (1-based
 /// convention).
@@ -175,6 +179,69 @@ pub fn research_polynomial_degree(index: u32) -> f64 {
     }
 }
 
+// ─── Purchase ──────────────────────────────────────────────────────────────
+
+/// Inputs to [`buy_research`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyResearchInput {
+    /// 1-based research index (`1..=200`). Out-of-range indices are a no-op.
+    pub index: u32,
+    /// `player.researchBuyMaxToggle || auto || hover` — buy up to the max
+    /// affordable level when `true`, otherwise a single level.
+    pub buy_max: bool,
+}
+
+/// Buy research `index` with the player's obtainium, advancing its level
+/// toward the max. Port of `buyResearch` (`Research.ts:218`) built on the
+/// already-ported [`poly_buy_to_level`] / [`poly_cost_for_levels`] solvers
+/// (the legacy `getBuyableResearchLevel` / `getCostForResearchLevels`).
+///
+/// The legacy `isResearchUnlocked` gate is **UI-tier** (it closes over
+/// `player.*` / `runes.*`), so — like the other `buy_*` helpers and the
+/// resets — this is ungated on unlock: the caller dispatches only unlocked
+/// researches. The `isResearchMaxed` and affordability gates ARE applied; a
+/// cumulative cost of `0` (next level unaffordable) is a no-op, matching the
+/// legacy `canBuy = researchCost.gt(0)`.
+#[must_use]
+pub fn buy_research(
+    state: &mut ResearchesState,
+    input: BuyResearchInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    let index = input.index as usize;
+    if index == 0 || index >= RESEARCH_MAX_LEVELS.len() {
+        return events;
+    }
+
+    let max_level = RESEARCH_MAX_LEVELS[index];
+    let before = state.researches[index];
+    // isResearchMaxed gate.
+    if before >= max_level {
+        return events;
+    }
+
+    let degree = research_polynomial_degree(input.index);
+    let base_cost = Decimal::from_finite(RESEARCH_BASE_COSTS[index]);
+
+    // levelToBuy = min(maxLevel, buyableLevel, currentLevel + buyAmount).
+    let buyable = poly_buy_to_level(degree, state.obtainium, base_cost, before, max_level);
+    let buy_amount = if input.buy_max { f64::INFINITY } else { 1.0 };
+    let after = max_level.min(buyable).min(before + buy_amount);
+
+    let cost = poly_cost_for_levels(degree, base_cost, before, after);
+    if cost > Decimal::zero() {
+        state.researches[index] = after;
+        state.obtainium -= cost;
+        events.push(CoreEvent::ResearchPurchased {
+            index: input.index,
+            before,
+            after,
+            spent: cost,
+        });
+    }
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,5 +322,126 @@ mod tests {
     fn poly_cost_for_levels_at_curr_returns_zero() {
         let result = poly_cost_for_levels(1.0, Decimal::from_finite(100.0), 5.0, 5.0);
         assert_eq!(result, Decimal::zero());
+    }
+
+    // ─── buy_research ────────────────────────────────────────────────────
+    // Research 6: base_cost 1, max_level 10, degree 1.
+    // Research 7: base_cost 1e2, max_level 10. Research 1: max_level 1.
+
+    fn obtainium_state(obtainium: f64) -> ResearchesState {
+        ResearchesState {
+            obtainium: Decimal::from_finite(obtainium),
+            ..ResearchesState::default()
+        }
+    }
+
+    #[test]
+    fn buy_research_single_level_spends_base_cost() {
+        let mut state = obtainium_state(5.0);
+        let events = buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 6,
+                buy_max: false,
+            },
+        );
+        assert_eq!(state.researches[6], 1.0);
+        assert_eq!(state.obtainium.to_number(), 4.0); // spent 1
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            CoreEvent::ResearchPurchased {
+                index,
+                before,
+                after,
+                spent,
+            } => {
+                assert_eq!(*index, 6);
+                assert_eq!(*before, 0.0);
+                assert_eq!(*after, 1.0);
+                assert_eq!(spent.to_number(), 1.0);
+            }
+            other => panic!("expected ResearchPurchased, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn buy_research_max_buys_to_affordable_level() {
+        let mut state = obtainium_state(5.0);
+        // Budget 5 at base_cost 1 ⇒ reach level 5 for a cumulative cost of 5.
+        let _ = buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 6,
+                buy_max: true,
+            },
+        );
+        assert_eq!(state.researches[6], 5.0);
+        assert_eq!(state.obtainium.to_number(), 0.0);
+    }
+
+    #[test]
+    fn buy_research_caps_at_max_level() {
+        let mut state = obtainium_state(1e9);
+        let _ = buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 6,
+                buy_max: true,
+            },
+        );
+        assert_eq!(state.researches[6], 10.0); // max_level, not 1e9
+    }
+
+    #[test]
+    fn buy_research_maxed_is_noop() {
+        let mut state = obtainium_state(1e9);
+        state.researches[1] = 1.0; // research 1 max_level is 1 → already maxed
+        let events = buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 1,
+                buy_max: true,
+            },
+        );
+        assert_eq!(state.researches[1], 1.0);
+        assert_eq!(state.obtainium.to_number(), 1e9); // untouched
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_research_unaffordable_next_level_is_noop() {
+        // Research 7 base_cost 1e2; budget 50 < 100 ⇒ cumulative cost 0.
+        let mut state = obtainium_state(50.0);
+        let events = buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 7,
+                buy_max: false,
+            },
+        );
+        assert_eq!(state.researches[7], 0.0);
+        assert_eq!(state.obtainium.to_number(), 50.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_research_out_of_range_is_noop() {
+        let mut state = obtainium_state(1e9);
+        assert!(buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 0,
+                buy_max: true
+            }
+        )
+        .is_empty());
+        assert!(buy_research(
+            &mut state,
+            BuyResearchInput {
+                index: 250,
+                buy_max: true
+            }
+        )
+        .is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/shop_costs.rs
+++ b/crates/synergismforkd_logic/src/mechanics/shop_costs.rs
@@ -13,6 +13,12 @@
 //!   `price + price_increase * current_level` — linear in the
 //!   current level.
 
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::ShopState;
+
 /// Inputs to [`shop_cost`].
 #[derive(Debug, Clone, Copy)]
 pub struct ShopCostInput {
@@ -39,6 +45,70 @@ pub fn shop_cost(input: &ShopCostInput) -> f64 {
         return input.price;
     }
     input.price + input.price_increase * input.current_level
+}
+
+// ─── buy_shop ────────────────────────────────────────────────────────────────
+
+/// Inputs to [`buy_shop`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyShopInput {
+    /// Shop-upgrade index (`0..83`, via the `SHOP_*` constants). Out-of-range
+    /// is a no-op.
+    pub index: usize,
+    /// `shopUpgrades[k].type === CONSUMABLE` — consumables are flat-priced.
+    pub is_consumable: bool,
+    /// `shopUpgrades[k].maxLevel` (or stock capacity for consumables).
+    pub max_level: f64,
+    /// `shopUpgrades[k].price`.
+    pub price: f64,
+    /// `shopUpgrades[k].priceIncrease`.
+    pub price_increase: f64,
+}
+
+/// Buy one level of shop upgrade `index` with quarks (`worlds`) — the
+/// `shopBuyMaxToggle === false` case of `buyShopUpgrades` (`Shop.ts:2131`).
+/// The buy is uniform across leveled upgrades and consumables: both increment
+/// `shop.upgrades[index]` (a level or a unit of stock) and spend the
+/// [`shop_cost`]. The per-upgrade data table (price / priceIncrease / maxLevel
+/// / type) is UI-tier, so the caller passes the snapshot; the cost itself is
+/// computed here. Emits [`CoreEvent::ShopUpgradePurchased`].
+///
+/// Faithful-at-current-state deferrals: the `shopBuyMaxToggle` "buy 10 / buy
+/// max" summation, and the UI-tier `isUnlocked` gate (the caller dispatches
+/// only unlocked upgrades, as with the other `buy_*` helpers).
+#[must_use]
+pub fn buy_shop(
+    shop: &mut ShopState,
+    worlds: &mut Decimal,
+    input: BuyShopInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if input.index >= shop.upgrades.len() {
+        return events;
+    }
+    let before = shop.upgrades[input.index];
+    if before >= input.max_level {
+        return events;
+    }
+    let cost = shop_cost(&ShopCostInput {
+        is_consumable: input.is_consumable,
+        max_level: input.max_level,
+        price: input.price,
+        price_increase: input.price_increase,
+        current_level: before,
+    });
+    if worlds.to_number() >= cost {
+        *worlds -= Decimal::from_finite(cost);
+        let after = before + 1.0;
+        shop.upgrades[input.index] = after;
+        events.push(CoreEvent::ShopUpgradePurchased {
+            index: input.index as u32,
+            before,
+            after,
+            spent: cost,
+        });
+    }
+    events
 }
 
 #[cfg(test)]
@@ -81,5 +151,81 @@ mod tests {
         };
         // 100 + 25*4 = 200
         assert_eq!(shop_cost(&input), 200.0);
+    }
+
+    // ─── buy_shop ────────────────────────────────────────────────────────
+
+    fn stacked_input(index: usize) -> BuyShopInput {
+        BuyShopInput {
+            index,
+            is_consumable: false,
+            max_level: 10.0,
+            price: 100.0,
+            price_increase: 25.0,
+        }
+    }
+
+    #[test]
+    fn buy_shop_levels_up_and_spends() {
+        let mut shop = ShopState::default();
+        let mut worlds = Decimal::from_finite(500.0);
+        let events = buy_shop(&mut shop, &mut worlds, stacked_input(8));
+        // Level 0: cost = 100 + 25*0 = 100.
+        assert_eq!(shop.upgrades[8], 1.0);
+        assert_eq!(worlds.to_number(), 400.0);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            CoreEvent::ShopUpgradePurchased { index: 8, before, after, spent }
+                if before == 0.0 && after == 1.0 && spent == 100.0
+        ));
+    }
+
+    #[test]
+    fn buy_shop_consumable_increments_stock_at_flat_price() {
+        let mut shop = ShopState::default();
+        let mut worlds = Decimal::from_finite(200.0);
+        let events = buy_shop(
+            &mut shop,
+            &mut worlds,
+            BuyShopInput {
+                index: 0,
+                is_consumable: true,
+                max_level: 100.0,
+                price: 50.0,
+                price_increase: 0.0,
+            },
+        );
+        assert_eq!(shop.upgrades[0], 1.0); // stock += 1
+        assert_eq!(worlds.to_number(), 150.0); // flat 50 spent
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_shop_unaffordable_is_noop() {
+        let mut shop = ShopState::default();
+        let mut worlds = Decimal::from_finite(50.0); // 50 < cost 100
+        let events = buy_shop(&mut shop, &mut worlds, stacked_input(8));
+        assert_eq!(shop.upgrades[8], 0.0);
+        assert_eq!(worlds.to_number(), 50.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_shop_maxed_is_noop() {
+        let mut shop = ShopState::default();
+        shop.upgrades[8] = 10.0; // == max_level
+        let mut worlds = Decimal::from_finite(1e9);
+        let events = buy_shop(&mut shop, &mut worlds, stacked_input(8));
+        assert_eq!(shop.upgrades[8], 10.0);
+        assert_eq!(worlds.to_number(), 1e9);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_shop_out_of_range_is_noop() {
+        let mut shop = ShopState::default();
+        let mut worlds = Decimal::from_finite(1e9);
+        assert!(buy_shop(&mut shop, &mut worlds, stacked_input(83)).is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/tick/auto_reset.rs
+++ b/crates/synergismforkd_logic/src/tick/auto_reset.rs
@@ -1,18 +1,23 @@
-//! Per-tick auto-reset state machine. Direct port of
-//! `legacy/core_split/packages/logic/src/tick/autoReset.ts`.
+//! Per-tick auto-reset state machine. The prestige / transcend /
+//! reincarnation blocks are a direct port of
+//! `legacy/core_split/packages/logic/src/tick/autoReset.ts`; the
+//! **auto-ascension** block ports the web_ui-tier decision at
+//! `legacy/core_split/packages/web_ui/src/Synergism.ts:3867-3909` (the logic
+//! `autoReset.ts` has no ascension block), lifted here so the tick can decide
+//! it without the UI tier.
 //!
-//! Decides whether prestige / transcend / reincarnation auto-resets fire
-//! this tick, accumulates the time-mode counters, and emits
-//! `AutoResetTriggered` intents. Execution now lives in the tick tier:
-//! `phase_automation` performs the **prestige** reset
-//! (`perform_prestige_reset`) when a prestige intent fires. Transcension /
-//! reincarnation remain intent-only until those tiers port.
+//! Decides whether prestige / transcend / reincarnation / ascension
+//! auto-resets fire this tick, accumulates the time-mode counters, and emits
+//! `AutoResetTriggered` intents. Execution lives in the tick tier:
+//! `phase_automation` performs the matching reset (`perform_*_reset`) for
+//! every fired intent — all four tiers are wired today.
 
 use smallvec::SmallVec;
 
 use synergismforkd_bignum::Decimal;
 
 use crate::events::{AutoResetMode, AutoResetTier, CoreEvent};
+use crate::state::AutoAscendMode;
 
 /// `coinsThisPrestige` floor for a prestige auto-reset.
 const PRESTIGE_COINS_THRESHOLD: f64 = 1e16;
@@ -24,6 +29,15 @@ const REINCARNATION_SHARDS_THRESHOLD: f64 = 1e300;
 const RESET_TIME_FLOOR: f64 = 0.01;
 /// Ascension challenge that fully suppresses the reincarnation block.
 const ASCENSION_CHALLENGE_NO_REINCARNATION: u32 = 12;
+/// Reincarnation challenge that suppresses the auto-ascension block
+/// (`currentChallenge.reincarnation !== 10`, Synergism.ts:3871).
+const REINCARNATION_CHALLENGE_NO_ASCENSION: u32 = 10;
+/// Lower bound on the auto-ascension threshold in `c10Completions` mode
+/// (`max(1, autoAscendThreshold)`, Synergism.ts:3876).
+const AUTO_ASCEND_C10_FLOOR: f64 = 1.0;
+/// Lower bound on the auto-ascension threshold in `realAscensionTime` mode
+/// (`max(0.1, autoAscendThreshold)`, Synergism.ts:3883).
+const AUTO_ASCEND_TIME_FLOOR: f64 = 0.1;
 
 /// Inputs to [`apply_auto_resets`]. Mirrors the legacy
 /// `ApplyAutoResetsInput` field-for-field.
@@ -87,13 +101,33 @@ pub(crate) struct ApplyAutoResetsInput {
     pub auto_reset_timer_reincarnation: f64,
 
     // ─── Shared challenge gates ──────────────────────────────────────
-    /// `player.currentChallenge.ascension` — `12` suppresses reincarnation.
+    /// `player.currentChallenge.ascension` — `12` suppresses reincarnation;
+    /// the auto-ascension block also requires it to be `0` (plain ascension).
     pub ascension_challenge: u32,
     /// `player.currentChallenge.transcension` — must be `0` for transcend
     /// or reincarnation.
     pub transcension_challenge: u32,
-    /// `player.currentChallenge.reincarnation` — must be `0` for reincarnation.
+    /// `player.currentChallenge.reincarnation` — must be `0` for reincarnation
+    /// and `!= 10` for auto-ascension.
     pub reincarnation_challenge: u32,
+
+    // ─── Auto-ascension (Synergism.ts:3867-3909) ─────────────────────
+    /// `player.autoAscend`.
+    pub auto_ascend: bool,
+    /// `player.autoAscendMode` — completions vs real-ascension-time.
+    pub auto_ascend_mode: AutoAscendMode,
+    /// `player.autoAscendThreshold`.
+    pub auto_ascend_threshold: f64,
+    /// `player.challengecompletions[10]` — the ascension unlock gate (must
+    /// be `> 0`) and the `c10Completions`-mode comparand.
+    pub challenge_completions_10: f64,
+    /// `player.challengecompletions[11]` — outer guard, must be `> 0`.
+    pub challenge_completions_11: f64,
+    /// `player.cubeUpgrades[10]` — outer guard, must be `> 0`.
+    pub cube_upgrade_10: f64,
+    /// `player.ascensionCounterRealReal` — the `realAscensionTime`-mode
+    /// comparand (advanced by the timer phase; no accumulation here).
+    pub ascension_counter_real_real: f64,
 }
 
 /// Result of [`apply_auto_resets`].
@@ -108,10 +142,11 @@ pub(crate) struct ApplyAutoResetsResult {
     pub events: SmallVec<[CoreEvent; 3]>,
 }
 
-/// Check all three reset tiers for auto-fire conditions, in legacy order:
+/// Check the reset tiers for auto-fire conditions, in legacy order:
 /// prestige (amount/time) → transcend (amount/time) → reincarnation
-/// (gated by `ascension_challenge != 12`, time then amount). The
-/// reincarnation amount mode uses the unique `(points + 1)` shift.
+/// (gated by `ascension_challenge != 12`, time then amount) → ascension
+/// (Synergism.ts, gated by the challenge-11 / cube-upgrade-10 outer guard).
+/// The reincarnation amount mode uses the unique `(points + 1)` shift.
 pub(crate) fn apply_auto_resets(input: &ApplyAutoResetsInput) -> ApplyAutoResetsResult {
     let mut events = SmallVec::new();
     let mut auto_reset_timer_prestige = input.auto_reset_timer_prestige;
@@ -222,6 +257,47 @@ pub(crate) fn apply_auto_resets(input: &ApplyAutoResetsInput) -> ApplyAutoResets
         }
     }
 
+    // ─── Auto-ascension (Synergism.ts:3867-3909) ────────────────────
+    // Inert at default — the outer guard needs `challengecompletions[11] > 0`
+    // and `cubeUpgrades[10] > 0`. Only the plain `reset('ascension')` path is
+    // ported (`currentChallenge.ascension == 0`); with an ascension challenge
+    // active the legacy rotates / `reset('ascensionChallenge')` through helpers
+    // that aren't ported, so we emit nothing there (deferred). No timer
+    // accumulates — `realAscensionTime` reads the timer-phase counter directly.
+    if input.auto_ascend
+        && input.challenge_completions_11 > 0.0
+        && input.cube_upgrade_10 > 0.0
+        && input.reincarnation_challenge != REINCARNATION_CHALLENGE_NO_ASCENSION
+        && input.ascension_challenge == 0
+    {
+        let fires = match input.auto_ascend_mode {
+            AutoAscendMode::C10Completions => {
+                input.challenge_completions_10
+                    >= AUTO_ASCEND_C10_FLOOR.max(input.auto_ascend_threshold)
+            }
+            AutoAscendMode::RealAscensionTime => {
+                input.ascension_counter_real_real
+                    >= AUTO_ASCEND_TIME_FLOOR.max(input.auto_ascend_threshold)
+            }
+        };
+        // The `&& c10 > 0` gate mirrors the legacy `if (ascension && c10 > 0)`
+        // — redundant in `C10Completions` mode (`c10 >= max(1, …) ⇒ c10 > 0`)
+        // but load-bearing in `RealAscensionTime` mode.
+        if fires && input.challenge_completions_10 > 0.0 {
+            events.push(CoreEvent::AutoResetTriggered {
+                tier: AutoResetTier::Ascension,
+                // Ascension's native modes (`C10Completions` /
+                // `RealAscensionTime`) don't map onto `AutoResetMode`; the
+                // dispatch ignores `mode`, so we record the closest analogue
+                // for the UI (`Amount` ≈ completions, `Time` ≈ real time).
+                mode: match input.auto_ascend_mode {
+                    AutoAscendMode::C10Completions => AutoResetMode::Amount,
+                    AutoAscendMode::RealAscensionTime => AutoResetMode::Time,
+                },
+            });
+        }
+    }
+
     ApplyAutoResetsResult {
         auto_reset_timer_prestige,
         auto_reset_timer_transcension,
@@ -266,6 +342,13 @@ mod tests {
             ascension_challenge: 0,
             transcension_challenge: 0,
             reincarnation_challenge: 0,
+            auto_ascend: false,
+            auto_ascend_mode: AutoAscendMode::C10Completions,
+            auto_ascend_threshold: 1.0,
+            challenge_completions_10: 0.0,
+            challenge_completions_11: 0.0,
+            cube_upgrade_10: 0.0,
+            ascension_counter_real_real: 0.0,
         }
     }
 
@@ -363,5 +446,110 @@ mod tests {
         )));
         // Timer is NOT accumulated in c12.
         assert_eq!(r.auto_reset_timer_reincarnation, 0.0);
+    }
+
+    // ─── Auto-ascension ──────────────────────────────────────────────
+
+    /// Outer guard satisfied + a met mode threshold. `auto_prestige_enabled`
+    /// is cleared so only the ascension intent can fire.
+    fn ascend_base() -> ApplyAutoResetsInput {
+        ApplyAutoResetsInput {
+            auto_prestige_enabled: false,
+            auto_ascend: true,
+            challenge_completions_11: 1.0,
+            cube_upgrade_10: 1.0,
+            ..base()
+        }
+    }
+
+    fn fired_ascension(r: &ApplyAutoResetsResult) -> bool {
+        r.events.iter().any(|e| {
+            matches!(
+                e,
+                CoreEvent::AutoResetTriggered {
+                    tier: AutoResetTier::Ascension,
+                    ..
+                }
+            )
+        })
+    }
+
+    #[test]
+    fn auto_ascend_c10_mode_fires_when_completions_meet_threshold() {
+        let r = apply_auto_resets(&ApplyAutoResetsInput {
+            auto_ascend_mode: AutoAscendMode::C10Completions,
+            auto_ascend_threshold: 3.0,
+            challenge_completions_10: 3.0, // >= max(1, 3) = 3
+            ..ascend_base()
+        });
+        assert!(r.events.iter().any(|e| is_reset(
+            e,
+            AutoResetTier::Ascension,
+            AutoResetMode::Amount
+        )));
+    }
+
+    #[test]
+    fn auto_ascend_realtime_mode_fires_when_time_meets_threshold() {
+        let r = apply_auto_resets(&ApplyAutoResetsInput {
+            auto_ascend_mode: AutoAscendMode::RealAscensionTime,
+            auto_ascend_threshold: 5.0,
+            ascension_counter_real_real: 5.0, // >= max(0.1, 5) = 5
+            challenge_completions_10: 1.0,    // unlock gate
+            ..ascend_base()
+        });
+        assert!(r.events.iter().any(|e| is_reset(
+            e,
+            AutoResetTier::Ascension,
+            AutoResetMode::Time
+        )));
+    }
+
+    #[test]
+    fn auto_ascend_blocked_without_challenge_11_or_cube_10() {
+        // Mode threshold met, but the outer guard fails.
+        let r = apply_auto_resets(&ApplyAutoResetsInput {
+            challenge_completions_10: 5.0,
+            challenge_completions_11: 0.0, // outer guard fails
+            ..ascend_base()
+        });
+        assert!(!fired_ascension(&r));
+    }
+
+    #[test]
+    fn auto_ascend_deferred_inside_ascension_challenge() {
+        // With an ascension challenge active, the legacy takes the
+        // `reset('ascensionChallenge')` / sweep-rotation branch we don't port.
+        let r = apply_auto_resets(&ApplyAutoResetsInput {
+            challenge_completions_10: 5.0,
+            ascension_challenge: 11,
+            ..ascend_base()
+        });
+        assert!(!fired_ascension(&r));
+    }
+
+    #[test]
+    fn auto_ascend_realtime_still_requires_c10_unlock() {
+        // Real-time threshold met, but challenge 10 is not yet completed, so
+        // ascension is not unlocked.
+        let r = apply_auto_resets(&ApplyAutoResetsInput {
+            auto_ascend_mode: AutoAscendMode::RealAscensionTime,
+            auto_ascend_threshold: 5.0,
+            ascension_counter_real_real: 100.0,
+            challenge_completions_10: 0.0, // not unlocked
+            ..ascend_base()
+        });
+        assert!(!fired_ascension(&r));
+    }
+
+    #[test]
+    fn auto_ascend_suppressed_in_reincarnation_challenge_10() {
+        let r = apply_auto_resets(&ApplyAutoResetsInput {
+            auto_ascend_mode: AutoAscendMode::C10Completions,
+            challenge_completions_10: 5.0,
+            reincarnation_challenge: 10, // outer guard: reincarnation !== 10
+            ..ascend_base()
+        });
+        assert!(!fired_ascension(&r));
     }
 }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -50,6 +50,7 @@ use crate::mechanics::platonic_upgrade_costs::{buy_platonic_upgrade, BuyPlatonic
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
 use crate::mechanics::researches::{buy_research, BuyResearchInput};
 use crate::mechanics::resource_gain::{resource_gain, ResourceGainPre};
+use crate::mechanics::shop_costs::{buy_shop, BuyShopInput};
 use crate::mechanics::tesseract_buildings::{buy_tesseract_building, BuyTesseractBuildingInput};
 use crate::mechanics::update_all_multiplier::{
     update_all_multiplier, UpdateAllMultiplierPre, UpdateAllMultiplierResult,
@@ -271,6 +272,8 @@ pub enum BuyRequest {
     Research(BuyResearchInput),
     /// Routes to [`buy_gq_upgrade`].
     GoldenQuarkUpgrade(BuyGQUpgradeInput),
+    /// Routes to [`buy_shop`].
+    Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
     Multiplier(BuyMultiplierInput),
     /// Routes to [`buy_accelerator`].
@@ -4149,6 +4152,7 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
         BuyRequest::Upgrade(inp) => buy_upgrades(&mut state.upgrades, *inp),
         BuyRequest::Research(inp) => buy_research(&mut state.researches, *inp),
         BuyRequest::GoldenQuarkUpgrade(inp) => buy_gq_upgrade(&mut state.golden_quarks, *inp),
+        BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
         }
@@ -5145,6 +5149,40 @@ mod tests {
             output.events
         );
         assert_eq!(state.cube_upgrade_levels.platonic_upgrades[1], 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_shop_action() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.quarks.worlds = Decimal::from_finite(500.0);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::Shop(BuyShopInput {
+                index: 8,
+                is_consumable: false,
+                max_level: 10.0,
+                price: 100.0,
+                price_increase: 25.0,
+            })));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::ShopUpgradePurchased { .. })),
+            "expected ShopUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.shop.upgrades[8], 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -281,10 +281,10 @@ pub enum BuyRequest {
     Producer(BuyProducerInput),
 }
 
-/// Per-tier dispatcher for a manual reset, mirroring [`BuyRequest`]. Only
-/// [`Self::Prestige`] / [`Self::Transcension`] / [`Self::Reincarnation`]
-/// are wired today; the ascension / singularity tiers cascade on top and
-/// port later.
+/// Per-tier dispatcher for a manual reset, mirroring [`BuyRequest`].
+/// [`Self::Prestige`] / [`Self::Transcension`] / [`Self::Reincarnation`] /
+/// [`Self::Ascension`] are wired today; the singularity tier cascades on
+/// top and ports later.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ResetRequest {
@@ -297,6 +297,11 @@ pub enum ResetRequest {
     /// Manual reincarnation reset — base + transcension + reincarnation
     /// layers (`reset('reincarnation')`).
     Reincarnation,
+    /// Manual ascension reset — base + transcension + reincarnation +
+    /// ascension layers (`reset('ascension')`). The c10-gated cube /
+    /// hepteract awards and the auto-ascend *decision* remain deferred (see
+    /// [`reset::perform_ascension_reset`]).
+    Ascension,
 }
 
 /// Result of [`tack`]. The accumulated event stream is the only output
@@ -4061,13 +4066,13 @@ fn phase_automation(
     state.automation.auto_reset_timer_transcension = resets.auto_reset_timer_transcension;
     state.automation.auto_reset_timer_reincarnation = resets.auto_reset_timer_reincarnation;
 
-    // Execute the fired resets. Only the prestige tier is ported, so a
-    // transcension / reincarnation intent still resolves to emit-only —
-    // mirroring the manual dispatch in Phase 3. At default state
-    // `auto_prestige_enabled` is false, so this never fires and the sim
-    // stays unshifted. `pre.prestige_point_gain` is the same gain the
-    // amount-mode gate compared against (and equals the manual path's
-    // `reset_gains.prestige_point_gain`).
+    // Execute the fired resets. Prestige / transcension / reincarnation /
+    // ascension execution are all ported, so a fired intent dispatches to
+    // `perform_reset` — mirroring the manual dispatch in Phase 3. At default
+    // state the auto toggles are off, so this never fires and the sim stays
+    // unshifted. The `pre.*_point_gain` values are the same gains the
+    // amount-mode gates compared against (and equal the manual path's
+    // `reset_gains`).
     use crate::events::AutoResetTier;
     use crate::mechanics::reset_currency::ResetCurrencyResult;
     let auto_gains = ResetCurrencyResult {
@@ -4082,9 +4087,11 @@ fn phase_automation(
                 AutoResetTier::Prestige => Some(ResetRequest::Prestige),
                 AutoResetTier::Transcension => Some(ResetRequest::Transcension),
                 AutoResetTier::Reincarnation => Some(ResetRequest::Reincarnation),
-                // Ascension execution is not ported (cubes / hepteracts /
-                // corruptions); the intent still flows to the UI below.
-                AutoResetTier::Ascension => None,
+                // Ascension *execution* is ported; the auto-ascend *decision*
+                // that would emit this intent lives in the web_ui tier in
+                // legacy and is not yet ported, so no Ascension intent reaches
+                // here in practice. The arm readies the bridge for when it is.
+                AutoResetTier::Ascension => Some(ResetRequest::Ascension),
             };
             if let Some(request) = request {
                 performed.extend(reset::perform_reset(state, request, &auto_gains));

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -46,6 +46,7 @@ use crate::mechanics::global_multipliers::{
 use crate::mechanics::gq_upgrade_cost::{buy_gq_upgrade, BuyGQUpgradeInput};
 use crate::mechanics::multipliers::{buy_multiplier, BuyMultiplierInput};
 use crate::mechanics::particle_buildings::{buy_particle_building, BuyParticleBuildingInput};
+use crate::mechanics::platonic_upgrade_costs::{buy_platonic_upgrade, BuyPlatonicUpgradeInput};
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
 use crate::mechanics::researches::{buy_research, BuyResearchInput};
 use crate::mechanics::resource_gain::{resource_gain, ResourceGainPre};
@@ -278,6 +279,8 @@ pub enum BuyRequest {
     CrystalUpgrade(BuyCrystalUpgradesInput),
     /// Routes to [`buy_cube_upgrade`].
     CubeUpgrade(BuyCubeUpgradeInput),
+    /// Routes to [`buy_platonic_upgrade`].
+    PlatonicUpgrade(BuyPlatonicUpgradeInput),
     /// Routes to [`buy_particle_building`].
     ParticleBuilding(BuyParticleBuildingInput),
     /// Routes to [`buy_tesseract_building`].
@@ -4158,6 +4161,13 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
             &mut state.cube_balances.wow_cubes,
             *inp,
         ),
+        BuyRequest::PlatonicUpgrade(inp) => buy_platonic_upgrade(
+            &mut state.cube_upgrade_levels,
+            &mut state.researches.obtainium,
+            &mut state.automation.offerings,
+            &mut state.cube_balances,
+            *inp,
+        ),
         BuyRequest::ParticleBuilding(inp) => buy_particle_building(
             &mut state.particle_buildings,
             &mut state.upgrades.reincarnation_points,
@@ -5097,6 +5107,44 @@ mod tests {
             output.events
         );
         assert_eq!(state.golden_quarks.upgrades[0].level, 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_platonic_upgrade_action() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.researches.obtainium = Decimal::from_finite(1e50);
+        state.automation.offerings = Decimal::from_finite(1e50);
+        state.cube_balances.wow_cubes = Decimal::from_finite(1e50);
+        state.cube_balances.wow_tesseracts = Decimal::from_finite(1e50);
+        state.cube_balances.wow_hypercubes = Decimal::from_finite(1e50);
+        state.cube_balances.wow_platonic_cubes = Decimal::from_finite(1e50);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::PlatonicUpgrade(
+                BuyPlatonicUpgradeInput {
+                    index: 1,
+                    singularity_debuff: 1.0,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::PlatonicUpgradePurchased { .. })),
+            "expected PlatonicUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.cube_upgrade_levels.platonic_upgrades[1], 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -39,6 +39,7 @@ use crate::mechanics::accelerators::{buy_accelerator, BuyAcceleratorInput};
 use crate::mechanics::achievement_rewards;
 use crate::mechanics::challenge_15_rewards;
 use crate::mechanics::crystal_upgrades::{buy_crystal_upgrades, BuyCrystalUpgradesInput};
+use crate::mechanics::cube_upgrades::{buy_cube_upgrade, BuyCubeUpgradeInput};
 use crate::mechanics::global_multipliers::{
     compute_global_multipliers, GlobalMultipliersPreEvaluated, GlobalMultipliersResult,
 };
@@ -272,6 +273,8 @@ pub enum BuyRequest {
     Accelerator(BuyAcceleratorInput),
     /// Routes to [`buy_crystal_upgrades`].
     CrystalUpgrade(BuyCrystalUpgradesInput),
+    /// Routes to [`buy_cube_upgrade`].
+    CubeUpgrade(BuyCubeUpgradeInput),
     /// Routes to [`buy_particle_building`].
     ParticleBuilding(BuyParticleBuildingInput),
     /// Routes to [`buy_tesseract_building`].
@@ -4146,6 +4149,11 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
             buy_accelerator(&mut state.accelerator, &mut state.upgrades.coins, *inp)
         }
         BuyRequest::CrystalUpgrade(inp) => buy_crystal_upgrades(&mut state.crystal_upgrades, *inp),
+        BuyRequest::CubeUpgrade(inp) => buy_cube_upgrade(
+            &mut state.cube_upgrade_levels,
+            &mut state.cube_balances.wow_cubes,
+            *inp,
+        ),
         BuyRequest::ParticleBuilding(inp) => buy_particle_building(
             &mut state.particle_buildings,
             &mut state.upgrades.reincarnation_points,
@@ -5011,6 +5019,40 @@ mod tests {
         );
         // Research 6 (base_cost 1, max_level 10): budget 5 ⇒ buy to level 5.
         assert_eq!(state.researches.researches[6], 5.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_cube_upgrade_action() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.cube_balances.wow_cubes = Decimal::from_finite(1e12);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::CubeUpgrade(
+                BuyCubeUpgradeInput {
+                    index: 1,
+                    buy_max: false,
+                    singularity_debuff: 1.0,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::CubeUpgradePurchased { .. })),
+            "expected CubeUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.cube_upgrade_levels.cube_upgrades[1], 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -4061,6 +4061,13 @@ fn phase_automation(
         ascension_challenge: state.challenges.current_ascension_challenge,
         transcension_challenge: state.challenges.current_transcension_challenge,
         reincarnation_challenge: state.challenges.current_reincarnation_challenge,
+        auto_ascend: state.automation.auto_ascend,
+        auto_ascend_mode: state.automation.auto_ascend_mode,
+        auto_ascend_threshold: state.automation.auto_ascend_threshold,
+        challenge_completions_10: state.challenges.challenge_completions[10],
+        challenge_completions_11: state.challenges.challenge_completions[11],
+        cube_upgrade_10: state.cube_upgrade_levels.cube_upgrades[10],
+        ascension_counter_real_real: state.reset_counters.ascension_counter_real_real,
     });
     state.automation.auto_reset_timer_prestige = resets.auto_reset_timer_prestige;
     state.automation.auto_reset_timer_transcension = resets.auto_reset_timer_transcension;

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -45,6 +45,7 @@ use crate::mechanics::global_multipliers::{
 use crate::mechanics::multipliers::{buy_multiplier, BuyMultiplierInput};
 use crate::mechanics::particle_buildings::{buy_particle_building, BuyParticleBuildingInput};
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
+use crate::mechanics::researches::{buy_research, BuyResearchInput};
 use crate::mechanics::resource_gain::{resource_gain, ResourceGainPre};
 use crate::mechanics::tesseract_buildings::{buy_tesseract_building, BuyTesseractBuildingInput};
 use crate::mechanics::update_all_multiplier::{
@@ -263,6 +264,8 @@ pub enum PlayerAction {
 pub enum BuyRequest {
     /// Routes to [`buy_upgrades`].
     Upgrade(BuyUpgradeInput),
+    /// Routes to [`buy_research`].
+    Research(BuyResearchInput),
     /// Routes to [`buy_multiplier`].
     Multiplier(BuyMultiplierInput),
     /// Routes to [`buy_accelerator`].
@@ -4135,6 +4138,7 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
     // and prevent the second `&mut` for the currency.)
     match req {
         BuyRequest::Upgrade(inp) => buy_upgrades(&mut state.upgrades, *inp),
+        BuyRequest::Research(inp) => buy_research(&mut state.researches, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
         }
@@ -4975,6 +4979,38 @@ mod tests {
             output.events
         );
         assert_eq!(state.upgrades.upgrades[5], 1);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_research_action() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.researches.obtainium = Decimal::from_finite(5.0);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::Research(BuyResearchInput {
+                index: 6,
+                buy_max: true,
+            })));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::ResearchPurchased { .. })),
+            "expected ResearchPurchased in events, got {:?}",
+            output.events
+        );
+        // Research 6 (base_cost 1, max_level 10): budget 5 ⇒ buy to level 5.
+        assert_eq!(state.researches.researches[6], 5.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -43,6 +43,7 @@ use crate::mechanics::cube_upgrades::{buy_cube_upgrade, BuyCubeUpgradeInput};
 use crate::mechanics::global_multipliers::{
     compute_global_multipliers, GlobalMultipliersPreEvaluated, GlobalMultipliersResult,
 };
+use crate::mechanics::gq_upgrade_cost::{buy_gq_upgrade, BuyGQUpgradeInput};
 use crate::mechanics::multipliers::{buy_multiplier, BuyMultiplierInput};
 use crate::mechanics::particle_buildings::{buy_particle_building, BuyParticleBuildingInput};
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
@@ -267,6 +268,8 @@ pub enum BuyRequest {
     Upgrade(BuyUpgradeInput),
     /// Routes to [`buy_research`].
     Research(BuyResearchInput),
+    /// Routes to [`buy_gq_upgrade`].
+    GoldenQuarkUpgrade(BuyGQUpgradeInput),
     /// Routes to [`buy_multiplier`].
     Multiplier(BuyMultiplierInput),
     /// Routes to [`buy_accelerator`].
@@ -4142,6 +4145,7 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
     match req {
         BuyRequest::Upgrade(inp) => buy_upgrades(&mut state.upgrades, *inp),
         BuyRequest::Research(inp) => buy_research(&mut state.researches, *inp),
+        BuyRequest::GoldenQuarkUpgrade(inp) => buy_gq_upgrade(&mut state.golden_quarks, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
         }
@@ -5053,6 +5057,46 @@ mod tests {
             output.events
         );
         assert_eq!(state.cube_upgrade_levels.cube_upgrades[1], 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_gq_upgrade_action() {
+        use synergismforkd_bignum::Decimal;
+
+        use crate::state::GoldenQuarkUpgrade;
+
+        let mut state = GameState::default();
+        state.golden_quarks.golden_quarks = Decimal::from_finite(500.0);
+        state.golden_quarks.upgrades[0] = GoldenQuarkUpgrade {
+            cost_per_level: 100.0,
+            max_level: 10.0,
+            ..GoldenQuarkUpgrade::default()
+        };
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::GoldenQuarkUpgrade(
+                BuyGQUpgradeInput {
+                    index: 0,
+                    computed_max_level: 10.0,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::GoldenQuarkUpgradePurchased { .. })),
+            "expected GoldenQuarkUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.golden_quarks.upgrades[0].level, 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -12,10 +12,10 @@
 //! [`apply_reincarnation_layer`] → [`apply_ascension_layer`]), each
 //! composed by a public `perform_*_reset`. Tiers wired today: **prestige,
 //! transcension, reincarnation, ascension** (the ascension tier ports the
-//! structural reset + `resetResearches` / `resetChallengeSweep` / `resetRunes`
-//! / `resetAnts`; its c10-gated cube/hepteract awards and the (inert)
-//! `resetTalismanData` are neutral-defaulted and deferred; see
-//! [`apply_ascension_layer`]). The singularity layer is paused.
+//! structural reset + every per-feature sub-reset — `resetResearches` /
+//! `resetChallengeSweep` / `resetRunes` / `resetAnts` / `resetTalismanData`;
+//! only its c10-gated cube/hepteract awards are neutral-defaulted and deferred;
+//! see [`apply_ascension_layer`]). The singularity layer is paused.
 
 use smallvec::{smallvec, SmallVec};
 
@@ -23,7 +23,10 @@ use synergismforkd_bignum::Decimal;
 
 use crate::events::{AutoResetTier, CoreEvent, SweepState};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
-use crate::state::{AntsState, GameState, DEFLATION_INDEX, RUNE_ANTIQUITIES, RUNE_COUNT};
+use crate::state::{
+    AntsState, GameState, TalismansState, DEFLATION_INDEX, RUNE_ANTIQUITIES, RUNE_COUNT,
+    TALISMAN_COUNT,
+};
 use crate::tick::ResetRequest;
 
 /// Per-tier coin-producer base cost the prestige reset restores. Mirrors
@@ -438,9 +441,6 @@ pub(crate) fn perform_ascension_reset(
 /// - the `challengecompletions[10] > 0` reward block (`ascensionCount` +=
 ///   `calculateAscensionCount`, the `wow*` cube awards via
 ///   `CalcCorruptionStuff`) — gated off at default;
-/// - `resetTalismanData('ascension')` — `setTalismanRarity` needs the UI-tier
-///   `isUnlocked` predicate and talismans can't be leveled in the port yet, so
-///   it is inert at reachable state (`resetRunes` and `resetAnts` ARE ported);
 /// - the `autoChallengeIndex` / `roombaResearchIndex` / `autoResearch` UI
 ///   cursors (no logic field / UI-tier);
 /// - the C15 corruption override (needs the `c15Corruptions` constant) and
@@ -474,9 +474,8 @@ fn apply_ascension_layer(state: &mut GameState) {
     // resetAnts(AntSacrificeTiers.ascension) (Reset.ts:650).
     reset_ants_ascension(&mut state.ants);
 
-    // resetTalismanData('ascension') (651): DEFERRED — `setTalismanRarity`
-    // needs the UI-tier `isUnlocked` predicate, and talismans can't be leveled
-    // in the port yet (no buy path), so this is inert at reachable state.
+    // resetTalismanData('ascension') (Reset.ts:651).
+    reset_talismans_ascension(&mut state.talismans);
 
     // Reincarnation-tier currencies (Reset.ts:652-653).
     state.upgrades.reincarnation_points = Decimal::zero();
@@ -621,6 +620,27 @@ fn reset_ants_ascension(ants: &mut AntsState) {
     // Sacrifice timers (the `resetAnts` wrapper, reset.ts).
     ants.ant_sacrifice_timer = 0.0;
     ants.ant_sacrifice_timer_real = 0.0;
+}
+
+/// `resetTalismanData('ascension')` (`Talismans.ts:1067-1086`). All seven Rust
+/// talismans are ascension-tier, so each `resetSingleTalisman` runs: level → 0
+/// and a rarity recompute (`setTalismanRarity`). The recompute needs the
+/// UI-tier `isUnlocked()` predicate, which is `false` at reachable state
+/// (talismans have no unlock / level path in the port yet) ⇒ rarity 0 —
+/// faithful here; the unlocked-talisman rarity (`compute_talisman_rarity`
+/// returns 1 at level 0) is deferred. The shard balance and the six fragment
+/// pools zero; the rune-buff assignments (legacy `talismanOne..Seven`) are
+/// **not** touched, matching `resetSingleTalisman`.
+fn reset_talismans_ascension(talismans: &mut TalismansState) {
+    talismans.talisman_levels = [0.0; TALISMAN_COUNT];
+    talismans.talisman_rarity = [0.0; TALISMAN_COUNT];
+    talismans.talisman_shards = 0.0;
+    talismans.common_fragments = 0.0;
+    talismans.uncommon_fragments = 0.0;
+    talismans.rare_fragments = 0.0;
+    talismans.epic_fragments = 0.0;
+    talismans.legendary_fragments = 0.0;
+    talismans.mythical_fragments = 0.0;
 }
 
 /// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
@@ -1149,5 +1169,29 @@ mod tests {
         assert_eq!(state.ants.current_sacrifice_id, 6);
         assert_eq!(state.ants.ant_sacrifice_timer, 0.0);
         assert_eq!(state.ants.ant_sacrifice_timer_real, 0.0);
+    }
+
+    #[test]
+    fn ascension_reset_wipes_talisman_levels_and_fragments() {
+        let mut state = GameState::default();
+        state.talismans.talisman_levels = [50.0; TALISMAN_COUNT];
+        state.talismans.talisman_rarity = [4.0; TALISMAN_COUNT];
+        state.talismans.talisman_shards = 1e9;
+        state.talismans.common_fragments = 100.0;
+        state.talismans.mythical_fragments = 7.0;
+        // Rune-buff assignments survive — resetSingleTalisman leaves them.
+        state.talismans.rune_assignments[0][0].allocated = true;
+        state.talismans.rune_assignments[0][0].rune_id = 3;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        assert_eq!(state.talismans.talisman_levels, [0.0; TALISMAN_COUNT]);
+        assert_eq!(state.talismans.talisman_rarity, [0.0; TALISMAN_COUNT]);
+        assert_eq!(state.talismans.talisman_shards, 0.0);
+        assert_eq!(state.talismans.common_fragments, 0.0);
+        assert_eq!(state.talismans.mythical_fragments, 0.0);
+        // Rune-buff assignments untouched.
+        assert!(state.talismans.rune_assignments[0][0].allocated);
+        assert_eq!(state.talismans.rune_assignments[0][0].rune_id, 3);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -9,16 +9,19 @@
 //! transcension also runs the prestige base, a reincarnation also runs the
 //! transcension block, etc. We mirror that with layered helpers
 //! ([`apply_base_reset`] → [`apply_transcension_layer`] →
-//! [`apply_reincarnation_layer`]), each composed by a public
-//! `perform_*_reset`. Tiers wired today: **prestige, transcension,
-//! reincarnation**. Ascension / singularity (cubes, hepteracts,
-//! corruptions, the paused singularity layer) are not ported yet.
+//! [`apply_reincarnation_layer`] → [`apply_ascension_layer`]), each
+//! composed by a public `perform_*_reset`. Tiers wired today: **prestige,
+//! transcension, reincarnation, ascension** (the ascension tier ports the
+//! *structural* reset only — its c10-gated cube/hepteract awards and the
+//! heavier per-feature sub-resets for runes / talismans / ants are
+//! neutral-defaulted and deferred; see [`apply_ascension_layer`]). The
+//! singularity layer is paused.
 
 use smallvec::{smallvec, SmallVec};
 
 use synergismforkd_bignum::Decimal;
 
-use crate::events::{AutoResetTier, CoreEvent};
+use crate::events::{AutoResetTier, CoreEvent, SweepState};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
 use crate::state::{GameState, DEFLATION_INDEX};
 use crate::tick::ResetRequest;
@@ -32,6 +35,9 @@ const DIAMOND_BASE_COSTS: [f64; 5] = [100.0, 1e5, 1e15, 1e40, 1e100];
 /// Mythos-producer base costs restored by the reincarnation layer
 /// (`player.{first..fifth}CostMythos`, Reset.ts:577-585).
 const MYTHOS_BASE_COSTS: [f64; 5] = [1.0, 1e2, 1e4, 1e8, 1e16];
+/// Particle-producer base costs restored by the ascension layer
+/// (`player.{first..fifth}CostParticles`, Reset.ts:666-670).
+const PARTICLE_BASE_COSTS: [f64; 5] = [1.0, 100.0, 1e4, 1e8, 1e16];
 
 /// `coinsThisTranscension` floor for a transcension to credit a count
 /// (`transcensionCheck`, Reset.ts:416).
@@ -39,6 +45,25 @@ const TRANSCEND_COUNT_THRESHOLD: f64 = 1e100;
 /// `transcendShards` floor for a reincarnation to credit obtainium + a
 /// count (`reincarnationCheck`, Reset.ts:417).
 const REINCARNATION_COUNT_THRESHOLD: f64 = 1e300;
+
+/// `getResetResearches()` destroy-list (Reset.ts:1417-1431) — the research
+/// slots an ascension wipes. 1-based legacy indices, in range for the
+/// `[f64; RESEARCHES_LEN]` array.
+const RESET_RESEARCHES: &[usize] = &[
+    6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+    34, 35, 36, 37, 38, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 62, 63, 64, 65, 76, 81, 85, 86, 87,
+    88, 89, 90, 91, 92, 93, 94, 96, 97, 98, 101, 102, 103, 104, 106, 107, 108, 109, 110, 116, 117,
+    118, 121, 122, 123, 126, 127, 128, 129, 131, 132, 133, 134, 136, 137, 139, 141, 142, 143, 144,
+    146, 147, 148, 149, 151, 152, 154, 156, 157, 158, 159, 161, 162, 163, 164, 166, 167, 169, 171,
+    172, 173, 174, 176, 177, 178, 179, 181, 182, 184, 186, 187, 188, 189, 191, 192, 193, 194, 196,
+    197, 199,
+];
+/// Extra researches the destroy-list adds while `highestSingularityCount`
+/// is below 25 (Reset.ts:1433-1435).
+const RESET_RESEARCHES_PRE_SING25: &[usize] = &[138, 153, 168, 183, 198];
+/// `highestSingularityCount` threshold below which the pre-sing-25 extras
+/// are wiped too.
+const RESET_RESEARCHES_SING_THRESHOLD: f64 = 25.0;
 
 /// Execute a manual reset. The dispatch mirrors
 /// [`dispatch_buy`](super::dispatch_buy).
@@ -51,6 +76,7 @@ pub(crate) fn perform_reset(
         ResetRequest::Prestige => perform_prestige_reset(state, gains.prestige_point_gain),
         ResetRequest::Transcension => perform_transcension_reset(state, gains),
         ResetRequest::Reincarnation => perform_reincarnation_reset(state, gains),
+        ResetRequest::Ascension => perform_ascension_reset(state, gains),
     }
 }
 
@@ -239,6 +265,11 @@ pub(crate) fn perform_reincarnation_reset(
         gains.reincarnation_point_gain,
         reincarnation_check,
         obtainium_to_gain,
+        // The deflation→prestige-points quirk (Reset.ts:549-552) is guarded
+        // `input === 'reincarnation' | 'reincarnationChallenge'`, so it runs
+        // for a manual reincarnation but NOT when an ascension cascades
+        // through this layer.
+        true,
     );
     smallvec![CoreEvent::ResetPerformed {
         tier: AutoResetTier::Reincarnation,
@@ -250,6 +281,11 @@ pub(crate) fn perform_reincarnation_reset(
 /// and transcension layers already ran. `obtainium_to_gain` is the
 /// pre-reset `calculateObtainium()` value computed by the caller.
 ///
+/// `apply_deflation_prestige_quirk` gates the reincarnation-only
+/// deflation→prestige-points bonus (Reset.ts:549-552): `true` for a manual
+/// reincarnation, `false` when an ascension cascades through this layer
+/// (the legacy block guards that bonus to reincarnation inputs).
+///
 /// Deferred (faithful at current state): the `instantChallenge` shop
 /// completion-restore (shop level `0`), `awardAchievementGroup` /
 /// `awardUngroupedAchievement`, and `fastestreincarnate`.
@@ -258,10 +294,13 @@ fn apply_reincarnation_layer(
     reincarnation_point_gain: Decimal,
     reincarnation_check: bool,
     obtainium_to_gain: Decimal,
+    apply_deflation_prestige_quirk: bool,
 ) {
     // Deflation-corruption bonus (Reset.ts:550-552) — false at default
-    // (deflation level `0`, platonic upgrade `0`).
-    if state.corruptions.used.levels[DEFLATION_INDEX] > 10
+    // (deflation level `0`, platonic upgrade `0`). Reincarnation-only: the
+    // legacy guard excludes ascension.
+    if apply_deflation_prestige_quirk
+        && state.corruptions.used.levels[DEFLATION_INDEX] > 10
         && state.cube_upgrade_levels.platonic_upgrades[11] > 0.0
     {
         state.upgrades.prestige_points += reincarnation_point_gain;
@@ -335,6 +374,182 @@ fn apply_reincarnation_layer(
     state.multiplier.reincarnate_no_multiplier = true;
     state.reset_counters.reincarnation_counter = 0.0;
     state.automation.auto_reset_timer_reincarnation = 0.0;
+}
+
+// ─── Ascension ─────────────────────────────────────────────────────────────
+
+/// `reset('ascension')` — base + transcension + reincarnation + ascension
+/// layers, emitting one [`CoreEvent::ResetPerformed`].
+///
+/// The reincarnation layer runs with the deflation quirk **disabled** (the
+/// legacy bonus is guarded to reincarnation inputs); its obtainium award — if
+/// `reincarnationCheck` passes — is then wiped by [`apply_ascension_layer`]'s
+/// `resetResearches`, faithful to the legacy award-then-`obtainium = 0`
+/// ordering (Reset.ts:568 / 649). The pre-reset `reincarnationCheck` /
+/// obtainium are captured here exactly as [`perform_reincarnation_reset`] does.
+///
+/// `points_gained` is `0` at current state: the legacy `ascensionCount`
+/// award sits inside the `challengecompletions[10] > 0` gate alongside the
+/// cube awards (Reset.ts:687-694), which this slice neutral-defaults. When
+/// that block ports, the gained count populates the event.
+pub(crate) fn perform_ascension_reset(
+    state: &mut GameState,
+    gains: &ResetCurrencyResult,
+) -> SmallVec<[CoreEvent; 2]> {
+    let reincarnation_check = state.reset_counters.transcend_shards
+        >= Decimal::from_finite(REINCARNATION_COUNT_THRESHOLD);
+    let obtainium_to_gain = if reincarnation_check {
+        let base = super::compute_base_obtainium(state);
+        let time_mult = super::compute_obtainium_time_multiplier(state);
+        super::compute_obtainium(state, base, gains.reincarnation_point_gain, time_mult)
+    } else {
+        Decimal::zero()
+    };
+    apply_base_reset(state, gains.prestige_point_gain);
+    apply_transcension_layer(state, gains.transcend_point_gain);
+    apply_reincarnation_layer(
+        state,
+        gains.reincarnation_point_gain,
+        reincarnation_check,
+        obtainium_to_gain,
+        // Deflation quirk excluded for ascension inputs (Reset.ts:549 guard).
+        false,
+    );
+    apply_ascension_layer(state);
+    smallvec![CoreEvent::ResetPerformed {
+        tier: AutoResetTier::Ascension,
+        points_gained: Decimal::zero(),
+    }]
+}
+
+/// The ascension block (Reset.ts:628-794) — no event. Assumes the base,
+/// transcension, and reincarnation layers already ran. Ports the
+/// **structural** reset: challenge state, the particle-producer economy, the
+/// reincarnation-tier currencies, ascension counters, and the corruption
+/// loadout swap. Faithful at current state, where every deferred input is
+/// `0` / `false`.
+///
+/// Deferred (each documented inline at its site, neutral-default = no-op at
+/// default):
+/// - the `challengecompletions[10] > 0` reward block (`ascensionCount` +=
+///   `calculateAscensionCount`, the `wow*` cube awards via
+///   `CalcCorruptionStuff`) — gated off at default;
+/// - `resetRunes('ascension')` / `resetTalismanData('ascension')` /
+///   `resetAnts(ascension)` — per-entity reset-tier metadata, follow-up PR;
+/// - the `autoChallengeIndex` / `roombaResearchIndex` / `autoResearch` UI
+///   cursors (no logic field / UI-tier);
+/// - the C15 corruption override (needs the `c15Corruptions` constant) and
+///   every `highestSingularityCount`-gated convenience (campaigns, hepteract
+///   auto-craft, tesseract auto-buyer, auto-open) — inert at default.
+fn apply_ascension_layer(state: &mut GameState) {
+    // Clear the lower auto-challenge gates (Reset.ts:633-634). The ascension
+    // challenge gate itself is intentionally left untouched.
+    state.challenges.current_transcension_challenge = 0;
+    state.challenges.current_reincarnation_challenge = 0;
+
+    // resetChallengeSweep() (Reset.ts:636) — return the sweep machine to
+    // Idle. The legacy `OFF` text toggle is UI-tier.
+    state.automation.sweep_state = SweepState::Idle;
+    state.automation.sweep_time_since_last_change = 0.0;
+
+    // resetResearches() (Reset.ts:649) — zero obtainium (this also wipes the
+    // award the reincarnation layer just made) and the destroy-list research
+    // slots. The pre-sing-25 extras are included while
+    // `highestSingularityCount < 25` (true at default).
+    state.researches.obtainium = Decimal::zero();
+    for &slot in RESET_RESEARCHES {
+        state.researches.researches[slot] = 0.0;
+    }
+    if state.singularity.highest_singularity_count < RESET_RESEARCHES_SING_THRESHOLD {
+        for &slot in RESET_RESEARCHES_PRE_SING25 {
+            state.researches.researches[slot] = 0.0;
+        }
+    }
+
+    // resetAnts(ascension) (650) + resetTalismanData('ascension') (651):
+    // DEFERRED — per-entity reset-tier metadata, follow-up PR. Inert at
+    // default (ant / talisman state already zero).
+
+    // Reincarnation-tier currencies (Reset.ts:652-653).
+    state.upgrades.reincarnation_points = Decimal::zero();
+    state.reset_counters.reincarnation_shards = Decimal::zero();
+
+    // Upgrade slots the ascension wipes (Reset.ts:655-660).
+    reset_upgrade_slots(state, 61..=80);
+    reset_upgrade_slots(state, 94..=100);
+
+    // Particle producers fully reset (owned + cascade + cost), unlike the
+    // reincarnation layer which only zeroes their cascade (Reset.ts:661-670).
+    for (tier, cost) in state
+        .particle_producers
+        .tiers
+        .iter_mut()
+        .zip(PARTICLE_BASE_COSTS)
+    {
+        tier.owned = 0.0;
+        tier.generated = Decimal::zero();
+        tier.cost = Decimal::from_finite(cost);
+    }
+
+    state.automation.offerings = Decimal::zero(); // Reset.ts:671
+    state.crystal_upgrades.crystal_upgrades = [0.0; 8]; // Reset.ts:672
+
+    // resetRunes('ascension') (674): DEFERRED — per-rune reset-tier metadata
+    // + the `cubeUpgrades[26]` regrant, follow-up PR. Inert at default.
+
+    // cubeUpgrades[27] regrants one of each particle producer (676-682) —
+    // `0` at default, so inert; ported faithfully.
+    if state.cube_upgrade_levels.cube_upgrades[27] == 1.0 {
+        for tier in &mut state.particle_producers.tiers {
+            tier.owned = 1.0;
+        }
+    }
+
+    // c10-gated reward block (Reset.ts:687-694): DEFERRED no-op. At
+    // `challengecompletions[10] == 0` (default) the whole block — both the
+    // `ascensionCount` gain AND the `wow*` cube awards — does not run, so
+    // neutral-defaulting it is exactly faithful here. When `CalcCorruptionStuff`
+    // and the `ascensionCountMultStats` StatLine port, this gains a body:
+    //   if challenge_completions[10] > 0 { ascension_count += …; wow* += … }
+
+    // Challenge completions 1..=10 and their highs (Reset.ts:696-699).
+    for completion in &mut state.challenges.challenge_completions[1..=10] {
+        *completion = 0.0;
+    }
+    for highest in &mut state.challenges.highest_challenge_completions[1..=10] {
+        *highest = 0.0;
+    }
+
+    // roombaResearchIndex / autoResearch reset (701-703): UI cursors with no
+    // logic field — skipped.
+
+    // Ascension counters (Reset.ts:733-735).
+    state.reset_counters.ascension_counter = 0.0;
+    state.reset_counters.ascension_counter_real = 0.0;
+    state.reset_counters.ascension_counter_real_real = 0.0;
+
+    // cubeUpgrades 4/5/6 regrant the just-cleared upgrade slots 94..=100
+    // (Reset.ts:739-751) — `0` at default, inert; ported faithfully.
+    if state.cube_upgrade_levels.cube_upgrades[4] == 1.0 {
+        for slot in 94..=98 {
+            state.upgrades.upgrades[slot] = 1;
+        }
+    }
+    if state.cube_upgrade_levels.cube_upgrades[5] == 1.0 {
+        state.upgrades.upgrades[99] = 1;
+    }
+    if state.cube_upgrade_levels.cube_upgrades[6] == 1.0 {
+        state.upgrades.upgrades[100] = 1;
+    }
+
+    // Campaign reset (762-784) and the sing-gated conveniences block
+    // (796-877): DEFERRED — `highestSingularityCount`-gated, inert at default.
+
+    // Corruption loadout swap `used ← next` (Reset.ts:785). `CorruptionLoadout`
+    // is `Copy`, so this is a plain assignment. The C15 override (788-790) is
+    // deferred (needs `c15Corruptions`; inert unless inside ascension
+    // challenge 15).
+    state.corruptions.used = state.corruptions.next;
 }
 
 /// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
@@ -569,5 +784,190 @@ mod tests {
             slow.to_number(),
             quick.to_number()
         );
+    }
+
+    // ─── Ascension ───────────────────────────────────────────────────────
+
+    #[test]
+    fn ascension_reset_runs_full_cascade_and_resets_particle_economy() {
+        let mut state = GameState::default();
+        // Base-layer witness (the cascade must run apply_base_reset).
+        state.coin_producers.tiers[0].owned = 10.0;
+        // Particle producers fully reset by the ascension layer.
+        state.particle_producers.tiers[0].owned = 50.0;
+        state.particle_producers.tiers[0].cost = Decimal::from_finite(999.0);
+        state.particle_producers.tiers[0].generated = Decimal::from_finite(5.0);
+        // Reincarnation-tier currencies zeroed.
+        state.upgrades.reincarnation_points = Decimal::from_finite(1e50);
+        state.reset_counters.reincarnation_shards = Decimal::from_finite(1e40);
+        state.automation.offerings = Decimal::from_finite(1e30);
+        state.crystal_upgrades.crystal_upgrades = [3.0; 8];
+        // Challenge completions 1..=10 wiped; the ascension-challenge slot
+        // (index 11) and its high survive the `1..=10` bound.
+        state.challenges.challenge_completions[3] = 12.0;
+        state.challenges.challenge_completions[10] = 7.0;
+        state.challenges.challenge_completions[11] = 3.0;
+        state.challenges.highest_challenge_completions[5] = 8.0;
+        state.challenges.highest_challenge_completions[11] = 4.0;
+        // resetResearches: a destroy-list slot is wiped, a non-listed one survives.
+        state.researches.researches[7] = 5.0; // in RESET_RESEARCHES
+        state.researches.researches[50] = 9.0; // not listed → survives
+        state.researches.obtainium = Decimal::from_finite(99.0);
+        // Ascension counters.
+        state.reset_counters.ascension_counter = 123.0;
+        state.reset_counters.ascension_counter_real = 45.0;
+        state.reset_counters.ascension_counter_real_real = 67.0;
+        // Corruption loadout swap `used ← next`.
+        state.corruptions.used.levels[0] = 5;
+        state.corruptions.next.levels[0] = 9;
+
+        let events = perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        // Cascade ran the base.
+        assert_eq!(state.coin_counters.coins_this_prestige.to_number(), 100.0);
+        assert_eq!(state.coin_producers.tiers[0].owned, 0.0);
+        // Particle producers reset to base.
+        assert_eq!(state.particle_producers.tiers[0].owned, 0.0);
+        assert_eq!(state.particle_producers.tiers[0].cost.to_number(), 1.0);
+        assert_eq!(state.particle_producers.tiers[4].cost.to_number(), 1e16);
+        assert_eq!(state.particle_producers.tiers[0].generated.to_number(), 0.0);
+        assert_eq!(state.upgrades.reincarnation_points.to_number(), 0.0);
+        assert_eq!(state.reset_counters.reincarnation_shards.to_number(), 0.0);
+        assert_eq!(state.automation.offerings.to_number(), 0.0);
+        assert_eq!(state.crystal_upgrades.crystal_upgrades, [0.0; 8]);
+        assert_eq!(state.challenges.challenge_completions[3], 0.0);
+        assert_eq!(state.challenges.challenge_completions[10], 0.0);
+        assert_eq!(state.challenges.challenge_completions[11], 3.0); // survives
+        assert_eq!(state.challenges.highest_challenge_completions[5], 0.0);
+        assert_eq!(state.challenges.highest_challenge_completions[11], 4.0); // survives
+        assert_eq!(state.researches.researches[7], 0.0);
+        assert_eq!(state.researches.researches[50], 9.0); // survives
+        assert_eq!(state.researches.obtainium.to_number(), 0.0);
+        assert_eq!(state.reset_counters.ascension_counter, 0.0);
+        assert_eq!(state.reset_counters.ascension_counter_real, 0.0);
+        assert_eq!(state.reset_counters.ascension_counter_real_real, 0.0);
+        assert_eq!(state.corruptions.used.levels[0], 9); // swapped from next
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            CoreEvent::ResetPerformed {
+                tier: AutoResetTier::Ascension,
+                points_gained,
+            } if points_gained.to_number() == 0.0
+        ));
+    }
+
+    #[test]
+    fn ascension_reset_neutral_defaults_rewards_at_c10_zero() {
+        let mut state = GameState::default();
+        // c10 == 0 (default) ⇒ the reward block is a no-op: neither the cube
+        // balances nor the ascension count change.
+        state.cube_balances.wow_cubes = Decimal::from_finite(1e20);
+        state.reset_counters.ascension_count = 5.0;
+        assert_eq!(state.challenges.challenge_completions[10], 0.0);
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        assert_eq!(state.cube_balances.wow_cubes.to_number(), 1e20);
+        assert_eq!(state.reset_counters.ascension_count, 5.0);
+    }
+
+    #[test]
+    fn ascension_reset_zeroes_obtainium_even_when_reincarnation_layer_awards_it() {
+        let mut state = GameState::default();
+        // transcendShards ≥ 1e300 ⇒ the cascaded reincarnation layer awards
+        // obtainium; the ascension layer's resetResearches must then wipe it
+        // (faithful to the legacy award-then-`obtainium = 0` ordering).
+        state.reset_counters.transcend_shards = Decimal::from_finite(1e305);
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 9.0));
+
+        assert_eq!(state.researches.obtainium.to_number(), 0.0);
+    }
+
+    #[test]
+    fn ascension_reset_returns_challenge_sweep_to_idle() {
+        let mut state = GameState::default();
+        state.automation.sweep_state = SweepState::InitialWait;
+        state.automation.sweep_time_since_last_change = 5.0;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        assert_eq!(state.automation.sweep_state, SweepState::Idle);
+        assert_eq!(state.automation.sweep_time_since_last_change, 0.0);
+    }
+
+    #[test]
+    fn ascension_reset_swaps_corruption_loadout_used_from_next() {
+        let mut state = GameState::default();
+        state.corruptions.used.levels[2] = 1;
+        state.corruptions.next.levels[2] = 7;
+        state.corruptions.next.total_corruption_ascension_multiplier = 2.5;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        assert_eq!(state.corruptions.used.levels[2], 7);
+        assert_eq!(
+            state.corruptions.used.total_corruption_ascension_multiplier,
+            2.5
+        );
+    }
+
+    #[test]
+    fn ascension_reset_applies_cube_upgrade_regrants() {
+        let mut state = GameState::default();
+        // cubeUpgrades[27] → one of each particle producer after the reset.
+        state.cube_upgrade_levels.cube_upgrades[27] = 1.0;
+        // cubeUpgrades[4/5/6] → regrant upgrade slots 94..=98 / 99 / 100.
+        state.cube_upgrade_levels.cube_upgrades[4] = 1.0;
+        state.cube_upgrade_levels.cube_upgrades[5] = 1.0;
+        state.cube_upgrade_levels.cube_upgrades[6] = 1.0;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        for tier in &state.particle_producers.tiers {
+            assert_eq!(tier.owned, 1.0);
+        }
+        assert_eq!(state.upgrades.upgrades[94], 1);
+        assert_eq!(state.upgrades.upgrades[98], 1);
+        assert_eq!(state.upgrades.upgrades[99], 1);
+        assert_eq!(state.upgrades.upgrades[100], 1);
+    }
+
+    #[test]
+    fn ascension_skips_reincarnation_only_deflation_quirk() {
+        // deflation > 10 && platonicUpgrades[11] > 0 makes the reincarnation
+        // layer add the reincarnation gain to prestige points — but only for a
+        // reincarnation input. An ascension cascading through the layer must
+        // NOT apply it.
+        let seed = || {
+            let mut state = GameState::default();
+            state.corruptions.used.levels[DEFLATION_INDEX] = 11;
+            state.cube_upgrade_levels.platonic_upgrades[11] = 1.0;
+            state
+        };
+
+        let mut asc = seed();
+        perform_ascension_reset(&mut asc, &gains(0.0, 0.0, 7.0));
+        assert_eq!(asc.upgrades.prestige_points.to_number(), 0.0);
+
+        let mut rei = seed();
+        perform_reincarnation_reset(&mut rei, &gains(0.0, 0.0, 7.0));
+        assert_eq!(rei.upgrades.prestige_points.to_number(), 7.0);
+    }
+
+    #[test]
+    fn perform_reset_dispatches_ascension() {
+        let mut state = GameState::default();
+        let events = perform_reset(&mut state, ResetRequest::Ascension, &gains(0.0, 0.0, 0.0));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            CoreEvent::ResetPerformed {
+                tier: AutoResetTier::Ascension,
+                ..
+            }
+        ));
     }
 }

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -12,10 +12,10 @@
 //! [`apply_reincarnation_layer`] → [`apply_ascension_layer`]), each
 //! composed by a public `perform_*_reset`. Tiers wired today: **prestige,
 //! transcension, reincarnation, ascension** (the ascension tier ports the
-//! structural reset + `resetResearches` / `resetChallengeSweep` /
-//! `resetRunes`; its c10-gated cube/hepteract awards and the heavier
-//! `resetTalismanData` / `resetAnts` sub-resets are neutral-defaulted and
-//! deferred; see [`apply_ascension_layer`]). The singularity layer is paused.
+//! structural reset + `resetResearches` / `resetChallengeSweep` / `resetRunes`
+//! / `resetAnts`; its c10-gated cube/hepteract awards and the (inert)
+//! `resetTalismanData` are neutral-defaulted and deferred; see
+//! [`apply_ascension_layer`]). The singularity layer is paused.
 
 use smallvec::{smallvec, SmallVec};
 
@@ -23,7 +23,7 @@ use synergismforkd_bignum::Decimal;
 
 use crate::events::{AutoResetTier, CoreEvent, SweepState};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
-use crate::state::{GameState, DEFLATION_INDEX, RUNE_ANTIQUITIES, RUNE_COUNT};
+use crate::state::{AntsState, GameState, DEFLATION_INDEX, RUNE_ANTIQUITIES, RUNE_COUNT};
 use crate::tick::ResetRequest;
 
 /// Per-tier coin-producer base cost the prestige reset restores. Mirrors
@@ -64,6 +64,10 @@ const RESET_RESEARCHES_PRE_SING25: &[usize] = &[138, 153, 168, 183, 198];
 /// `highestSingularityCount` threshold below which the pre-sing-25 extras
 /// are wiped too.
 const RESET_RESEARCHES_SING_THRESHOLD: f64 = 25.0;
+/// The Mortuus2 ant upgrade (index 15) — the one ant upgrade an ascension's
+/// `resetAnts` leaves untouched, since it is singularity-tier while every
+/// lower index is sacrifice- or ascension-tier (`AntUpgrades` data table).
+const ANT_UPGRADE_MORTUUS2: usize = 15;
 
 /// Execute a manual reset. The dispatch mirrors
 /// [`dispatch_buy`](super::dispatch_buy).
@@ -434,9 +438,9 @@ pub(crate) fn perform_ascension_reset(
 /// - the `challengecompletions[10] > 0` reward block (`ascensionCount` +=
 ///   `calculateAscensionCount`, the `wow*` cube awards via
 ///   `CalcCorruptionStuff`) — gated off at default;
-/// - `resetTalismanData('ascension')` / `resetAnts(ascension)` — per-entity
-///   reset-tier metadata + sub-helpers (`setTalismanRarity`, the seven ant
-///   sub-resets), follow-up PR (`resetRunes('ascension')` IS ported below);
+/// - `resetTalismanData('ascension')` — `setTalismanRarity` needs the UI-tier
+///   `isUnlocked` predicate and talismans can't be leveled in the port yet, so
+///   it is inert at reachable state (`resetRunes` and `resetAnts` ARE ported);
 /// - the `autoChallengeIndex` / `roombaResearchIndex` / `autoResearch` UI
 ///   cursors (no logic field / UI-tier);
 /// - the C15 corruption override (needs the `c15Corruptions` constant) and
@@ -467,9 +471,12 @@ fn apply_ascension_layer(state: &mut GameState) {
         }
     }
 
-    // resetAnts(ascension) (650) + resetTalismanData('ascension') (651):
-    // DEFERRED — per-entity reset-tier metadata, follow-up PR. Inert at
-    // default (ant / talisman state already zero).
+    // resetAnts(AntSacrificeTiers.ascension) (Reset.ts:650).
+    reset_ants_ascension(&mut state.ants);
+
+    // resetTalismanData('ascension') (651): DEFERRED — `setTalismanRarity`
+    // needs the UI-tier `isUnlocked` predicate, and talismans can't be leveled
+    // in the port yet (no buy path), so this is inert at reachable state.
 
     // Reincarnation-tier currencies (Reset.ts:652-653).
     state.upgrades.reincarnation_points = Decimal::zero();
@@ -564,6 +571,56 @@ fn apply_ascension_layer(state: &mut GameState) {
     // deferred (needs `c15Corruptions`; inert unless inside ascension
     // challenge 15).
     state.corruptions.used = state.corruptions.next;
+}
+
+/// `resetAnts(AntSacrificeTiers.ascension)`
+/// (`Features/Ants/player/reset.ts`) — the ant sub-reset an ascension runs.
+/// Tier ordering is `sacrifice=0 < ascension=1 < singularity=2 < never=3`;
+/// each ant feature resets when `ascension >= its minimum reset tier`.
+///
+/// Deferred (inert at default): the `highestSingularityCount >= 10/15/20`
+/// crumb / producer / upgrade regrants, and the `preserveAnthillCount`
+/// achievement that would keep `ant_sacrifice_count` (no achievement is held
+/// at default, so the count resets — faithful).
+fn reset_ants_ascension(ants: &mut AntsState) {
+    // Crumbs reset to their default `1`; `crumbs_ever_made` is never-tier and
+    // survives (Crumbs/reset.ts).
+    ants.crumbs = Decimal::from_finite(1.0);
+    ants.crumbs_this_sacrifice = Decimal::from_finite(1.0);
+
+    // Every producer empties; every mastery *level* resets, but
+    // `highest_mastery` survives (AntProducers / AntMasteries reset.ts).
+    for producer in &mut ants.producers {
+        producer.purchased = 0.0;
+        producer.generated = Decimal::zero();
+    }
+    for mastery in &mut ants.masteries {
+        mastery.mastery = 0;
+    }
+
+    // Ant upgrades: every slot resets at ascension EXCEPT Mortuus2 (index 15,
+    // singularity-tier). Salvage(7) / Mortuus(11) / WowCubes(13) /
+    // AscensionScore(14) are ascension-tier; the rest sacrifice-tier
+    // (AntUpgrades reset.ts + data table).
+    for level in &mut ants.upgrades[..ANT_UPGRADE_MORTUUS2] {
+        *level = 0.0;
+    }
+
+    // Reborn ELO resets; the daily / ever leaderboards and the quark total are
+    // singularity-tier and survive. Immortal ELO is ascension-tier
+    // (RebornELO / ImmortalELO reset.ts).
+    ants.reborn_elo = 0.0;
+    ants.immortal_elo = 0.0;
+
+    // The sacrifice ID always advances (it backs the permanent leaderboard);
+    // the count resets, since no `preserveAnthillCount` achievement is held at
+    // default (AntSacrifice reset.ts).
+    ants.current_sacrifice_id += 1;
+    ants.ant_sacrifice_count = 0.0;
+
+    // Sacrifice timers (the `resetAnts` wrapper, reset.ts).
+    ants.ant_sacrifice_timer = 0.0;
+    ants.ant_sacrifice_timer_real = 0.0;
 }
 
 /// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
@@ -1028,5 +1085,69 @@ mod tests {
         assert_eq!(state.runes.rune_exp[0], 0.0);
         // Antiquities (singularity-tier) is untouched by the regrant.
         assert_eq!(state.runes.rune_levels[RUNE_ANTIQUITIES], 100.0);
+    }
+
+    #[test]
+    fn ascension_reset_wipes_ant_state_keeping_singularity_tier() {
+        let mut state = GameState::default();
+        for p in &mut state.ants.producers {
+            p.purchased = 50.0;
+            p.generated = Decimal::from_finite(9.0);
+        }
+        for m in &mut state.ants.masteries {
+            m.mastery = 8;
+            m.highest_mastery = 12; // survives (highest mastery never resets here)
+        }
+        for u in &mut state.ants.upgrades {
+            *u = 5.0;
+        }
+        state.ants.crumbs = Decimal::from_finite(1e30);
+        state.ants.crumbs_this_sacrifice = Decimal::from_finite(1e20);
+        state.ants.crumbs_ever_made = Decimal::from_finite(999.0); // never-tier, survives
+        state.ants.reborn_elo = 7777.0;
+        state.ants.immortal_elo = 8888.0;
+        state.ants.quarks_gained_from_ants = 42.0; // singularity-tier, survives
+        state
+            .ants
+            .highest_reborn_elo_daily
+            .push(crate::state::RebornELOEntry {
+                elo: 100.0,
+                sacrifice_id: 1,
+            }); // singularity-tier, survives
+        state.ants.ant_sacrifice_count = 33.0;
+        state.ants.current_sacrifice_id = 5;
+        state.ants.ant_sacrifice_timer = 4.0;
+        state.ants.ant_sacrifice_timer_real = 6.0;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        // Crumbs back to default 1; ever-made survives.
+        assert_eq!(state.ants.crumbs.to_number(), 1.0);
+        assert_eq!(state.ants.crumbs_this_sacrifice.to_number(), 1.0);
+        assert_eq!(state.ants.crumbs_ever_made.to_number(), 999.0);
+        // Producers empty; mastery levels reset, highest survives.
+        for p in &state.ants.producers {
+            assert_eq!(p.purchased, 0.0);
+            assert_eq!(p.generated.to_number(), 0.0);
+        }
+        for m in &state.ants.masteries {
+            assert_eq!(m.mastery, 0);
+            assert_eq!(m.highest_mastery, 12);
+        }
+        // Upgrades 0..=14 cleared; Mortuus2 (15, singularity) survives.
+        for i in 0..ANT_UPGRADE_MORTUUS2 {
+            assert_eq!(state.ants.upgrades[i], 0.0, "upgrade {i}");
+        }
+        assert_eq!(state.ants.upgrades[ANT_UPGRADE_MORTUUS2], 5.0);
+        // Reborn + immortal ELO reset; quark total and daily board survive.
+        assert_eq!(state.ants.reborn_elo, 0.0);
+        assert_eq!(state.ants.immortal_elo, 0.0);
+        assert_eq!(state.ants.quarks_gained_from_ants, 42.0);
+        assert_eq!(state.ants.highest_reborn_elo_daily.len(), 1);
+        // Sacrifice count reset; the ID advances; timers cleared.
+        assert_eq!(state.ants.ant_sacrifice_count, 0.0);
+        assert_eq!(state.ants.current_sacrifice_id, 6);
+        assert_eq!(state.ants.ant_sacrifice_timer, 0.0);
+        assert_eq!(state.ants.ant_sacrifice_timer_real, 0.0);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -12,10 +12,10 @@
 //! [`apply_reincarnation_layer`] → [`apply_ascension_layer`]), each
 //! composed by a public `perform_*_reset`. Tiers wired today: **prestige,
 //! transcension, reincarnation, ascension** (the ascension tier ports the
-//! *structural* reset only — its c10-gated cube/hepteract awards and the
-//! heavier per-feature sub-resets for runes / talismans / ants are
-//! neutral-defaulted and deferred; see [`apply_ascension_layer`]). The
-//! singularity layer is paused.
+//! structural reset + `resetResearches` / `resetChallengeSweep` /
+//! `resetRunes`; its c10-gated cube/hepteract awards and the heavier
+//! `resetTalismanData` / `resetAnts` sub-resets are neutral-defaulted and
+//! deferred; see [`apply_ascension_layer`]). The singularity layer is paused.
 
 use smallvec::{smallvec, SmallVec};
 
@@ -23,7 +23,7 @@ use synergismforkd_bignum::Decimal;
 
 use crate::events::{AutoResetTier, CoreEvent, SweepState};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
-use crate::state::{GameState, DEFLATION_INDEX};
+use crate::state::{GameState, DEFLATION_INDEX, RUNE_ANTIQUITIES, RUNE_COUNT};
 use crate::tick::ResetRequest;
 
 /// Per-tier coin-producer base cost the prestige reset restores. Mirrors
@@ -434,8 +434,9 @@ pub(crate) fn perform_ascension_reset(
 /// - the `challengecompletions[10] > 0` reward block (`ascensionCount` +=
 ///   `calculateAscensionCount`, the `wow*` cube awards via
 ///   `CalcCorruptionStuff`) — gated off at default;
-/// - `resetRunes('ascension')` / `resetTalismanData('ascension')` /
-///   `resetAnts(ascension)` — per-entity reset-tier metadata, follow-up PR;
+/// - `resetTalismanData('ascension')` / `resetAnts(ascension)` — per-entity
+///   reset-tier metadata + sub-helpers (`setTalismanRarity`, the seven ant
+///   sub-resets), follow-up PR (`resetRunes('ascension')` IS ported below);
 /// - the `autoChallengeIndex` / `roombaResearchIndex` / `autoResearch` UI
 ///   cursors (no logic field / UI-tier);
 /// - the C15 corruption override (needs the `c15Corruptions` constant) and
@@ -494,8 +495,21 @@ fn apply_ascension_layer(state: &mut GameState) {
     state.automation.offerings = Decimal::zero(); // Reset.ts:671
     state.crystal_upgrades.crystal_upgrades = [0.0; 8]; // Reset.ts:672
 
-    // resetRunes('ascension') (674): DEFERRED — per-rune reset-tier metadata
-    // + the `cubeUpgrades[26]` regrant, follow-up PR. Inert at default.
+    // resetRunes('ascension') (Runes.ts:917-932): the ascension-tier runes
+    // reset to level + EXP 0, then regrant level = 3 * cubeUpgrades[26]. That
+    // is every classic rune EXCEPT antiquities, which is singularity-tier
+    // (`resetTiers.ascension=4 < singularity=5`) and so survives. Blessings /
+    // spirits / free-levels are not touched (the legacy loop only zeroes
+    // level + EXP). The `setRuneLevel` EXP-sync for a regranted level > 0 is
+    // deferred — inert while `cubeUpgrades[26] == 0` at default.
+    let rune_regrant = 3.0 * state.cube_upgrade_levels.cube_upgrades[26];
+    for rune in 0..RUNE_COUNT {
+        if rune == RUNE_ANTIQUITIES {
+            continue;
+        }
+        state.runes.rune_levels[rune] = rune_regrant;
+        state.runes.rune_exp[rune] = 0.0;
+    }
 
     // cubeUpgrades[27] regrants one of each particle producer (676-682) —
     // `0` at default, so inert; ported faithfully.
@@ -969,5 +983,50 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn ascension_reset_wipes_ascension_tier_runes_but_keeps_antiquities() {
+        let mut state = GameState::default();
+        for i in 0..RUNE_COUNT {
+            state.runes.rune_levels[i] = 100.0;
+            state.runes.rune_exp[i] = 500.0;
+            state.runes.rune_blessing_levels[i] = 7.0;
+        }
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        for i in 0..RUNE_COUNT {
+            if i == RUNE_ANTIQUITIES {
+                // Singularity-tier ⇒ survives an ascension.
+                assert_eq!(state.runes.rune_levels[i], 100.0);
+                assert_eq!(state.runes.rune_exp[i], 500.0);
+            } else {
+                assert_eq!(state.runes.rune_levels[i], 0.0, "rune {i} level");
+                assert_eq!(state.runes.rune_exp[i], 0.0, "rune {i} exp");
+            }
+            // Blessings are outside the rune reset's scope.
+            assert_eq!(
+                state.runes.rune_blessing_levels[i], 7.0,
+                "rune {i} blessing"
+            );
+        }
+    }
+
+    #[test]
+    fn ascension_reset_rune_regrant_scales_with_cube_upgrade_26() {
+        let mut state = GameState::default();
+        state.cube_upgrade_levels.cube_upgrades[26] = 2.0; // regrant = 3 * 2 = 6
+        for i in 0..RUNE_COUNT {
+            state.runes.rune_levels[i] = 100.0;
+        }
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        // Ascension-tier runes (index 0 = speed) regrant to 6; EXP stays 0.
+        assert_eq!(state.runes.rune_levels[0], 6.0);
+        assert_eq!(state.runes.rune_exp[0], 0.0);
+        // Antiquities (singularity-tier) is untouched by the regrant.
+        assert_eq!(state.runes.rune_levels[RUNE_ANTIQUITIES], 100.0);
     }
 }


### PR DESCRIPTION
Ports the **ascension reset tier** end-to-end and adds the first five **manual buy-paths** beyond the original 7 wired families, all in the `synergismforkd_logic` crate. Logic tests **1037 → 1085** (+48); clippy `-D warnings`, `fmt --check`, and the wasm32 `ui_web` build are green on every commit. No new state-schema fields.

## Ascension reset tier (`tick/reset.rs`, `tick/auto_reset.rs`)
The reset cascade had prestige/transcension/reincarnation; this completes it through **ascension** (manual + auto), with every per-feature sub-reset ported.

- **`18f2c75b`** — structural ascension reset: `perform_ascension_reset` = the existing cascade + a new `apply_ascension_layer`, wired to manual `ResetRequest::Ascension` + the auto-dispatch bridge. Includes `resetResearches` + `resetChallengeSweep`. Caught two real faithfulness subtleties: the `ascensionCount`/cube reward block is c10-gated (neutral-defaulted as a unit), and the deflation→prestige quirk is reincarnation-only (a bool param skips it for the ascension cascade); the layer also zeroes obtainium to wipe the cascaded reincarnation award.
- **`7c822c43`** — `resetRunes('ascension')` (antiquities is singularity-tier, survives).
- **`b0fc3811`** — the auto-ascend **decision** (lifted from `Synergism.ts`; the logic-tier `autoReset.ts` lacked it).
- **`ba1c886e`** — `resetAnts('ascension')`.
- **`47bee179`** — `resetTalismanData('ascension')`.

Deferred (documented, inert at reachable state): the c10-gated `CalcCorruptionStuff` cube-**reward** engine, the singularity tier, and the `highestSingularityCount`-gated conveniences.

## Manual buy-paths (`mechanics/*`, `tick/mod.rs`, `events/mod.rs`)
The cost solvers were already ported, but the purchase *orchestration* lived UI-tier, so these couldn't be bought from logic. Each follows the established `BuyRequest` variant + `dispatch_buy` arm + `buy_*(&mut …, Input) -> SmallVec<[CoreEvent;4]>` pattern, ungated-on-unlock (caller/UI gates) with affordability + maxed gates in the mechanic.

- **`dde6a7b3`** — `buy_research`: `poly_buy_to_level`/`poly_cost_for_levels` → `buyResearch` (obtainium).
- **`598e0475`** — `buy_cube_upgrade`: `get_cube_max`/`get_cube_cost` → `buyCubeUpgrades` (wow cubes).
- **`786ad792`** — `buy_gq_upgrade`: `gq_upgrade_cost_tnl`; single-slice — `golden_quarks` holds the currency *and* the 80-entry upgrade map, all cost data in state.
- **`9d16381b`** — `buy_platonic_upgrade`: the first **multi-resource** buy — `floor(base × priceMultiplier)` across all 7 resources via a 4-slice dispatch.
- **`75b8e9d3`** — `buy_shop`: `shop_cost` from a caller snapshot (quarks). The buy is **uniform** across leveled upgrades and consumables (both increment the slot + spend; the distinction is only in the effect).

This grows the player-action surface from ~7 to ~13 wired families and establishes the recipe for the rest (cleanest families have cost data in logic-side tables or in state; the per-upgrade-formula families — octeract/blueberry — would be thinner caller-provides-cost buys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)