### PR TITLE
feat(logic): port the six remaining manual buy families

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -271,6 +271,21 @@ pub enum CoreEvent {
         /// Octeracts removed from the player's balance.
         spent: f64,
     },
+    /// One ambrosia (blueberry) upgrade gained a level — the single-level
+    /// step of the legacy `buyAmbrosiaUpgradeLevel` loop. `spent` is in
+    /// ambrosia (`f64`); the first level out of level 0 also debits the
+    /// upgrade's blueberry-slot cost to `spent_blueberries` (reflected in
+    /// state, not on this event).
+    AmbrosiaUpgradePurchased {
+        /// Ambrosia-upgrade index (0..36, via the `AMBROSIA_*` constants).
+        index: u32,
+        /// Level before the purchase.
+        before: f64,
+        /// Level after the purchase.
+        after: f64,
+        /// Ambrosia removed from the player's balance.
+        spent: f64,
+    },
     /// One shop upgrade gained a level (or a consumable a unit of stock —
     /// the buy is uniform). `spent` is in quarks — an `f64` mirroring the
     /// legacy `Number(player.worlds)` cost comparison.

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -373,6 +373,17 @@ pub enum CoreEvent {
         /// The new (doubled) cap.
         cap_after: f64,
     },
+    /// Talisman `index` gained a level — the legacy `buyTalismanLevel`. The
+    /// spend lands on the seven talisman resources (shards + six fragment
+    /// tiers) in state.
+    TalismanLevelPurchased {
+        /// Talisman index (0..7, via the `TALISMAN_*` constants).
+        index: u32,
+        /// Level before the buy.
+        before: f64,
+        /// Level after the buy.
+        after: f64,
+    },
     /// A single-bit upgrade was purchased. The `spent` value is the cost
     /// in the tier's currency.
     UpgradePurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -350,6 +350,29 @@ pub enum CoreEvent {
         /// Crumbs removed from the player's balance.
         spent: Decimal,
     },
+    /// Hepteract `index` was crafted toward its cap — the legacy
+    /// `craftHepteracts`. `before`/`after` are the craft's balance; `amount`
+    /// is the units crafted (the multi-resource spend lands on state).
+    HepteractCrafted {
+        /// Hepteract index (0..8, chronos..multiplier).
+        index: u32,
+        /// Balance before the craft.
+        before: f64,
+        /// Balance after the craft.
+        after: f64,
+        /// Units crafted this action.
+        amount: f64,
+    },
+    /// Hepteract `index` had its cap doubled, a full bar spent — the legacy
+    /// `expandHepteracts`.
+    HepteractCapExpanded {
+        /// Hepteract index (0..8, chronos..multiplier).
+        index: u32,
+        /// Balance left after spending one cap's worth.
+        bal_after: f64,
+        /// The new (doubled) cap.
+        cap_after: f64,
+    },
     /// A single-bit upgrade was purchased. The `spent` value is the cost
     /// in the tier's currency.
     UpgradePurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -311,6 +311,20 @@ pub enum CoreEvent {
         /// Obtainium removed from the player's balance.
         spent: Decimal,
     },
+    /// Rune `index` gained levels by spending offerings — the legacy
+    /// `sacrificeOfferings` flow. `before`/`after` are purchased levels (which
+    /// may be equal if the budget only banked partial EXP); `spent` is the
+    /// offerings consumed.
+    RuneLevelsPurchased {
+        /// Rune index (0..7, via the `RUNE_*` constants).
+        index: u32,
+        /// Purchased level before the spend.
+        before: f64,
+        /// Purchased level after the spend (re-derived from EXP).
+        after: f64,
+        /// Offerings removed from the player's balance.
+        spent: Decimal,
+    },
     /// A single-bit upgrade was purchased. The `spent` value is the cost
     /// in the tier's currency.
     UpgradePurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -325,6 +325,31 @@ pub enum CoreEvent {
         /// Offerings removed from the player's balance.
         spent: Decimal,
     },
+    /// One ant-producer tier was bought (single click or buy-max) — the
+    /// legacy `buyAntProducers`. `before`/`after` are the `purchased` count;
+    /// `spent` is in galactic crumbs.
+    AntProducersPurchased {
+        /// Ant-producer index (0..9, Workers..HolySpirit).
+        index: u32,
+        /// `purchased` count before the buy.
+        before: f64,
+        /// `purchased` count after the buy.
+        after: f64,
+        /// Crumbs removed from the player's balance.
+        spent: Decimal,
+    },
+    /// One ant upgrade gained level(s) (single click or buy-max) — the legacy
+    /// `buyAntUpgrade`. `spent` is in galactic crumbs.
+    AntUpgradePurchased {
+        /// Ant-upgrade index (0..16, AntSpeed..Mortuus2).
+        index: u32,
+        /// Level before the buy.
+        before: f64,
+        /// Level after the buy.
+        after: f64,
+        /// Crumbs removed from the player's balance.
+        spent: Decimal,
+    },
     /// A single-bit upgrade was purchased. The `spent` value is the cost
     /// in the tier's currency.
     UpgradePurchased {

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -257,6 +257,20 @@ pub enum CoreEvent {
         /// Golden quarks removed from the player's balance.
         spent: f64,
     },
+    /// One octeract upgrade gained a level — the single-level step of the
+    /// legacy `buyOcteractUpgradeLevel` loop. `spent` is in `wow_octeracts`,
+    /// an `f64` mirroring the legacy `player.wowOcteracts < cost` number
+    /// comparison.
+    OcteractUpgradePurchased {
+        /// Octeract-upgrade index (0..47, via the `OCTERACT_*` constants).
+        index: u32,
+        /// Level before the purchase.
+        before: f64,
+        /// Level after the purchase.
+        after: f64,
+        /// Octeracts removed from the player's balance.
+        spent: f64,
+    },
     /// One shop upgrade gained a level (or a consumable a unit of stock —
     /// the buy is uniform). `spent` is in quarks — an `f64` mirroring the
     /// legacy `Number(player.worlds)` cost comparison.

--- a/crates/synergismforkd_logic/src/mechanics/ant_producers.rs
+++ b/crates/synergismforkd_logic/src/mechanics/ant_producers.rs
@@ -13,7 +13,11 @@
 //! Breeders, etc.), not a log-10 exp. Formula:
 //! `cost_to_buy_nth = base_cost × cost_increase^(N - 1)`.
 
+use smallvec::SmallVec;
 use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::AntsState;
 
 /// Pure data fields for one ant producer.
 #[derive(Debug, Clone, Copy)]
@@ -208,6 +212,86 @@ pub fn get_cost_max_ant_producers(input: &AntProducerMaxCostInput) -> Decimal {
     max_cost - spent
 }
 
+// ─── Manual buy ───────────────────────────────────────────────────────────
+
+/// Inputs to [`buy_ant_producer`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyAntProducerInput {
+    /// Ant-producer index (`0..9`, Workers..HolySpirit). Out-of-range is a
+    /// no-op.
+    pub index: u8,
+    /// `true` = buy-max (shift-click): buy as many as the crumb budget
+    /// affords; `false` = a single producer.
+    pub max: bool,
+}
+
+/// Buy ant-producer tier `index` with galactic crumbs — a port of the legacy
+/// `buyAntProducers`. All cost data is logic-side (`ant_producer_data` and the
+/// cost solvers), so the buy self-computes from the index and state. Spends
+/// `ants.crumbs`; emits [`CoreEvent::AntProducersPurchased`].
+///
+/// Faithful-at-current-state deferral: the legacy fires
+/// `awardAchievementGroup('sacMult')` on the first producer bought — like the
+/// other buys, achievement side-effects are not applied here.
+#[must_use]
+pub fn buy_ant_producer(
+    ants: &mut AntsState,
+    input: BuyAntProducerInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    let idx = input.index as usize;
+    if idx >= ants.producers.len() {
+        return events;
+    }
+    let data = ant_producer_data(input.index);
+    let before = ants.producers[idx].purchased;
+
+    if input.max {
+        let buy_to = get_max_purchasable_ant_producers(&AntProducerMaxPurchasableInput {
+            base_cost: data.base_cost,
+            cost_increase: data.cost_increase,
+            purchased: before,
+            budget: ants.crumbs,
+        });
+        if buy_to <= before {
+            return events;
+        }
+        let cost = get_cost_max_ant_producers(&AntProducerMaxCostInput {
+            base_cost: data.base_cost,
+            cost_increase: data.cost_increase,
+            purchased: before,
+            max_buyable: buy_to,
+        });
+        if ants.crumbs >= cost {
+            ants.crumbs -= cost;
+            ants.producers[idx].purchased = buy_to;
+            events.push(CoreEvent::AntProducersPurchased {
+                index: input.index.into(),
+                before,
+                after: buy_to,
+                spent: cost,
+            });
+        }
+    } else {
+        let cost = get_cost_next_ant_producer(&AntProducerCostInput {
+            base_cost: data.base_cost,
+            cost_increase: data.cost_increase,
+            purchased: before,
+        });
+        if ants.crumbs >= cost {
+            ants.crumbs -= cost;
+            ants.producers[idx].purchased += 1.0;
+            events.push(CoreEvent::AntProducersPurchased {
+                index: input.index.into(),
+                before,
+                after: ants.producers[idx].purchased,
+                spent: cost,
+            });
+        }
+    }
+    events
+}
+
 // ─── Base production rate ─────────────────────────────────────────────────
 
 /// Inputs to [`calculate_base_ants_to_be_generated`].
@@ -317,5 +401,91 @@ mod tests {
         });
         // 10 * 0.01 * 2 * 1 = 0.2
         assert!((result.to_number() - 0.2).abs() < 1e-12);
+    }
+
+    // ─── Manual buy ───────────────────────────────────────────────────────
+
+    fn ants_with_crumbs(crumbs: f64) -> AntsState {
+        AntsState {
+            crumbs: Decimal::from_finite(crumbs),
+            ..AntsState::default()
+        }
+    }
+
+    #[test]
+    fn buy_ant_producer_single_spends_crumbs() {
+        // Workers (0): base_cost 1 → the first producer costs 1 crumb.
+        let mut ants = ants_with_crumbs(10.0);
+        let events = buy_ant_producer(
+            &mut ants,
+            BuyAntProducerInput {
+                index: 0,
+                max: false,
+            },
+        );
+        assert_eq!(ants.producers[0].purchased, 1.0);
+        assert!((ants.crumbs.to_number() - 9.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::AntProducersPurchased { index: 0, .. }]
+        ));
+    }
+
+    #[test]
+    fn buy_ant_producer_unaffordable_is_noop() {
+        let mut ants = ants_with_crumbs(0.5);
+        let events = buy_ant_producer(
+            &mut ants,
+            BuyAntProducerInput {
+                index: 0,
+                max: false,
+            },
+        );
+        assert_eq!(ants.producers[0].purchased, 0.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_ant_producer_max_buys_multiple() {
+        // Workers: base 1, cost_increase 3. Budget 1000 → reach 7 (cost 3^6 = 729).
+        let mut ants = ants_with_crumbs(1000.0);
+        let events = buy_ant_producer(
+            &mut ants,
+            BuyAntProducerInput {
+                index: 0,
+                max: true,
+            },
+        );
+        assert_eq!(ants.producers[0].purchased, 7.0);
+        assert!((ants.crumbs.to_number() - 271.0).abs() < 1e-6);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_ant_producer_max_zero_budget_is_noop() {
+        // buy_to floors to 0 <= purchased 0 → early return, no event.
+        let mut ants = ants_with_crumbs(0.0);
+        let events = buy_ant_producer(
+            &mut ants,
+            BuyAntProducerInput {
+                index: 0,
+                max: true,
+            },
+        );
+        assert_eq!(ants.producers[0].purchased, 0.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_ant_producer_out_of_range_is_noop() {
+        let mut ants = ants_with_crumbs(1e9);
+        let events = buy_ant_producer(
+            &mut ants,
+            BuyAntProducerInput {
+                index: 9,
+                max: false,
+            },
+        );
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/ant_upgrades.rs
+++ b/crates/synergismforkd_logic/src/mechanics/ant_upgrades.rs
@@ -19,8 +19,12 @@
 //! AntELO read additional player state; those are parameterized
 //! through input objects.
 
-use crate::math::calculate_sigmoid_exponential;
+use smallvec::SmallVec;
 use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::math::calculate_sigmoid_exponential;
+use crate::state::AntsState;
 
 // ─── Cost data (function-keyed because 1e37777 > f64::MAX) ────────────────
 
@@ -171,6 +175,84 @@ pub fn get_cost_max_ant_upgrades(input: &AntUpgradeMaxCostInput) -> Decimal {
         input.cost_increase_exponent * (input.max_buyable - 1.0),
     )) * input.base_cost;
     max_cost - spent
+}
+
+// ─── Manual buy ───────────────────────────────────────────────────────────
+
+/// Inputs to [`buy_ant_upgrade`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyAntUpgradeInput {
+    /// Ant-upgrade index (`0..16`, AntSpeed..Mortuus2). Out-of-range is a
+    /// no-op.
+    pub index: u8,
+    /// `true` = buy-max (shift-click): buy as many levels as the crumb budget
+    /// affords; `false` = a single level.
+    pub max: bool,
+}
+
+/// Buy level(s) of ant upgrade `index` with galactic crumbs — a port of the
+/// legacy `buyAntUpgrade`. All cost data is logic-side (`ant_upgrade_base_cost`,
+/// `ant_upgrade_cost_increase_exponent`, and the cost solvers), so the buy
+/// self-computes from the index and state. Spends `ants.crumbs`; emits
+/// [`CoreEvent::AntUpgradePurchased`].
+#[must_use]
+pub fn buy_ant_upgrade(
+    ants: &mut AntsState,
+    input: BuyAntUpgradeInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    let idx = input.index as usize;
+    if idx >= ants.upgrades.len() {
+        return events;
+    }
+    let base_cost = ant_upgrade_base_cost(input.index);
+    let exponent = ant_upgrade_cost_increase_exponent(input.index);
+    let before = ants.upgrades[idx];
+
+    if input.max {
+        let buy_to = get_max_purchasable_ant_upgrades(&AntUpgradeMaxPurchasableInput {
+            base_cost,
+            cost_increase_exponent: exponent,
+            current_level: before,
+            budget: ants.crumbs,
+        });
+        if buy_to <= before {
+            return events;
+        }
+        let cost = get_cost_max_ant_upgrades(&AntUpgradeMaxCostInput {
+            base_cost,
+            cost_increase_exponent: exponent,
+            current_level: before,
+            max_buyable: buy_to,
+        });
+        if ants.crumbs >= cost {
+            ants.crumbs -= cost;
+            ants.upgrades[idx] = buy_to;
+            events.push(CoreEvent::AntUpgradePurchased {
+                index: input.index.into(),
+                before,
+                after: buy_to,
+                spent: cost,
+            });
+        }
+    } else {
+        let cost = get_cost_next_ant_upgrade(&AntUpgradeCostInput {
+            base_cost,
+            cost_increase_exponent: exponent,
+            current_level: before,
+        });
+        if ants.crumbs >= cost {
+            ants.crumbs -= cost;
+            ants.upgrades[idx] += 1.0;
+            events.push(CoreEvent::AntUpgradePurchased {
+                index: input.index.into(),
+                before,
+                after: ants.upgrades[idx],
+                spent: cost,
+            });
+        }
+    }
+    events
 }
 
 // ─── Pure effect functions (per upgrade) ──────────────────────────────────
@@ -588,5 +670,76 @@ mod tests {
         let result = wow_cubes_ant_upgrade_effect(1e6);
         // 2 - 0.999^1e6 ≈ 2 - 0 = 2 (within f64 tolerance)
         assert!((result - 2.0).abs() < 1e-9);
+    }
+
+    // ─── Manual buy ───────────────────────────────────────────────────────
+
+    fn ants_with_crumbs(crumbs: f64) -> AntsState {
+        AntsState {
+            crumbs: Decimal::from_finite(crumbs),
+            ..AntsState::default()
+        }
+    }
+
+    #[test]
+    fn buy_ant_upgrade_single_spends_crumbs() {
+        // AntSpeed (0): base_cost 100 → the first level costs 100 crumbs.
+        let mut ants = ants_with_crumbs(1000.0);
+        let events = buy_ant_upgrade(
+            &mut ants,
+            BuyAntUpgradeInput {
+                index: 0,
+                max: false,
+            },
+        );
+        assert_eq!(ants.upgrades[0], 1.0);
+        assert!((ants.crumbs.to_number() - 900.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::AntUpgradePurchased { index: 0, .. }]
+        ));
+    }
+
+    #[test]
+    fn buy_ant_upgrade_unaffordable_is_noop() {
+        let mut ants = ants_with_crumbs(50.0);
+        let events = buy_ant_upgrade(
+            &mut ants,
+            BuyAntUpgradeInput {
+                index: 0,
+                max: false,
+            },
+        );
+        assert_eq!(ants.upgrades[0], 0.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_ant_upgrade_max_buys_multiple() {
+        // AntSpeed: base 100, exp 1. Budget 1e6 → level 5 (cost 100 * 1e4 = 1e6).
+        let mut ants = ants_with_crumbs(1e6);
+        let events = buy_ant_upgrade(
+            &mut ants,
+            BuyAntUpgradeInput {
+                index: 0,
+                max: true,
+            },
+        );
+        assert_eq!(ants.upgrades[0], 5.0);
+        assert!(ants.crumbs.to_number().abs() < 1e-3);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_ant_upgrade_out_of_range_is_noop() {
+        let mut ants = ants_with_crumbs(1e9);
+        let events = buy_ant_upgrade(
+            &mut ants,
+            BuyAntUpgradeInput {
+                index: 16,
+                max: false,
+            },
+        );
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/blueberry_upgrades.rs
+++ b/crates/synergismforkd_logic/src/mechanics/blueberry_upgrades.rs
@@ -12,6 +12,12 @@
 //! player-derived value as an extra parameter; the UI data-table
 //! closure forwards.
 
+use smallvec::SmallVec;
+
+use crate::events::CoreEvent;
+use crate::state::ambrosia::AMBROSIA_UPGRADES_LEN;
+use crate::state::AmbrosiaState;
+
 // ─── Shape helpers ────────────────────────────────────────────────────────
 
 #[inline]
@@ -248,6 +254,146 @@ pub fn ambrosia_free_red_luck_upgrades_cost_formula(level: u32, base_cost: f64) 
 #[must_use]
 pub fn ambrosia_free_quark_upgrades_cost_formula(level: u32, base_cost: f64) -> f64 {
     cubic_difference(level, base_cost)
+}
+
+// ─── Cost dispatch + manual buy ───────────────────────────────────────────
+
+/// Per-index `costFormula` dispatch table. Slot `i` is the cost formula for
+/// ambrosia upgrade `i` — the array order IS the `AMBROSIA_*` index
+/// convention (legacy `ambrosiaUpgrades` key order), so positions here must
+/// stay in lockstep with `state::ambrosia`.
+const AMBROSIA_COST_FORMULAS: [fn(u32, f64) -> f64; AMBROSIA_UPGRADES_LEN] = [
+    ambrosia_tutorial_cost_formula,                  // 0  tutorial
+    ambrosia_quarks_1_cost_formula,                  // 1  quarks1
+    ambrosia_cubes_1_cost_formula,                   // 2  cubes1
+    ambrosia_luck_1_cost_formula,                    // 3  luck1
+    ambrosia_quark_cube_1_cost_formula,              // 4  quarkCube1
+    ambrosia_luck_cube_1_cost_formula,               // 5  luckCube1
+    ambrosia_cube_quark_1_cost_formula,              // 6  cubeQuark1
+    ambrosia_luck_quark_1_cost_formula,              // 7  luckQuark1
+    ambrosia_cube_luck_1_cost_formula,               // 8  cubeLuck1
+    ambrosia_quark_luck_1_cost_formula,              // 9  quarkLuck1
+    ambrosia_quarks_2_cost_formula,                  // 10 quarks2
+    ambrosia_cubes_2_cost_formula,                   // 11 cubes2
+    ambrosia_luck_2_cost_formula,                    // 12 luck2
+    ambrosia_quarks_3_cost_formula,                  // 13 quarks3
+    ambrosia_cubes_3_cost_formula,                   // 14 cubes3
+    ambrosia_luck_3_cost_formula,                    // 15 luck3
+    ambrosia_luck_4_cost_formula,                    // 16 luck4
+    ambrosia_patreon_cost_formula,                   // 17 patreon
+    ambrosia_obtainium_1_cost_formula,               // 18 obtainium1
+    ambrosia_offering_1_cost_formula,                // 19 offering1
+    ambrosia_hyperflux_cost_formula,                 // 20 hyperflux
+    ambrosia_base_offering_1_cost_formula,           // 21 baseOffering1
+    ambrosia_base_obtainium_1_cost_formula,          // 22 baseObtainium1
+    ambrosia_base_offering_2_cost_formula,           // 23 baseOffering2
+    ambrosia_base_obtainium_2_cost_formula,          // 24 baseObtainium2
+    ambrosia_sing_reduction_1_cost_formula,          // 25 singReduction1
+    ambrosia_infinite_shop_upgrades_1_cost_formula,  // 26 infiniteShopUpgrades1
+    ambrosia_infinite_shop_upgrades_2_cost_formula,  // 27 infiniteShopUpgrades2
+    ambrosia_sing_reduction_2_cost_formula,          // 28 singReduction2
+    ambrosia_talisman_bonus_rune_level_cost_formula, // 29 talismanBonusRuneLevel
+    ambrosia_rune_oom_bonus_cost_formula,            // 30 runeOOMBonus
+    ambrosia_brick_of_lead_cost_formula,             // 31 brickOfLead
+    ambrosia_free_luck_upgrades_cost_formula,        // 32 freeLuckUpgrades
+    ambrosia_free_generation_upgrades_cost_formula,  // 33 freeGenerationUpgrades
+    ambrosia_free_red_luck_upgrades_cost_formula,    // 34 freeRedLuckUpgrades
+    ambrosia_free_quark_upgrades_cost_formula,       // 35 freeQuarkUpgrades
+];
+
+/// Cost of the next level of ambrosia upgrade `index`, via the upgrade's own
+/// `costFormula(level, costPerLevel)`. The UI tier owns the `costPerLevel`
+/// data table; the formula and the index→formula binding live here. `index`
+/// out of range returns `0.0`.
+#[must_use]
+pub fn ambrosia_upgrade_cost(index: usize, level: u32, cost_per_level: f64) -> f64 {
+    AMBROSIA_COST_FORMULAS
+        .get(index)
+        .map_or(0.0, |formula| formula(level, cost_per_level))
+}
+
+/// Inputs to [`buy_ambrosia_upgrade`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyAmbrosiaUpgradeInput {
+    /// Ambrosia-upgrade index (`0..36`, via the `AMBROSIA_*` constants).
+    /// Out-of-range is a no-op.
+    pub index: usize,
+    /// `ambrosiaUpgrades[key].costPerLevel` — per-upgrade base cost (UI-tier
+    /// data-table value). Fed to the index-dispatched cost formula.
+    pub cost_per_level: f64,
+    /// `ambrosiaUpgrades[key].maxLevel` — the purchase cap (UI-tier). The
+    /// `maxLevel <= 0` sentinel means unlimited; otherwise the buy stops once
+    /// `level == max_level`.
+    pub max_level: f64,
+    /// `ambrosiaUpgrades[key].blueberryCost` — blueberry slots the upgrade
+    /// occupies (UI-tier). Paid once, when the upgrade leaves level 0.
+    pub blueberry_cost: f64,
+    /// `calculateBlueberryInventory()` — total blueberries available (the
+    /// reducer is UI-tier / unported, like `ambrosia_luck_3_effect`'s
+    /// `blueberry_inventory`). Gates the first-level slot payment together
+    /// with the already-spent count in state.
+    pub blueberry_inventory: f64,
+}
+
+/// Buy one level of ambrosia upgrade `index` with ambrosia — the single-level
+/// step of the legacy `buyAmbrosiaUpgradeLevel` loop. The cost is computed
+/// logic-side via [`ambrosia_upgrade_cost`]; the caller supplies the static
+/// `cost_per_level` / `max_level` / `blueberry_cost` data-table values and the
+/// `blueberry_inventory` total (UI-tier). Spends `ambrosia.ambrosia`; the
+/// first level out of level 0 also debits `blueberry_cost` to
+/// `ambrosia.spent_blueberries`. Emits [`CoreEvent::AmbrosiaUpgradePurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - **prerequisites**: `checkAmbrosiaUpgradePrerequisites` walks the UI data
+///   table, so — like the octeract/GQ unlock gates — the caller checks them
+///   before dispatching; this buy is ungated on prerequisites;
+/// - **buy-max**: the legacy loops `maxPurchasable` levels (a shift-click /
+///   buy-amount prompt); this buys a single level (the buy-amount-1 case);
+/// - `ambrosiaInvested` / `blueberriesInvested` respec tracking have no
+///   logic-state fields (like the GQ buy's `goldenQuarksInvested`), so they
+///   are not accumulated.
+#[must_use]
+pub fn buy_ambrosia_upgrade(
+    ambrosia: &mut AmbrosiaState,
+    input: BuyAmbrosiaUpgradeInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if input.index >= ambrosia.upgrades.len() {
+        return events;
+    }
+    let before = ambrosia.upgrades[input.index].level;
+
+    // Legacy gate: bounded upgrades stop at `maxLevel`; `maxLevel <= 0` is the
+    // unlimited sentinel.
+    let not_maxed = input.max_level <= 0.0 || before < input.max_level;
+    if !not_maxed {
+        return events;
+    }
+
+    let cost = ambrosia_upgrade_cost(input.index, before as u32, input.cost_per_level);
+    if ambrosia.ambrosia < cost {
+        return events;
+    }
+
+    // The blueberry-slot cost is paid once, when the upgrade leaves level 0.
+    // Gated by the blueberries still free (inventory minus already-spent).
+    if before == 0.0 {
+        let available = input.blueberry_inventory - ambrosia.spent_blueberries;
+        if available < input.blueberry_cost {
+            return events;
+        }
+        ambrosia.spent_blueberries += input.blueberry_cost;
+    }
+
+    ambrosia.ambrosia -= cost;
+    ambrosia.upgrades[input.index].level += 1.0;
+    events.push(CoreEvent::AmbrosiaUpgradePurchased {
+        index: input.index as u32,
+        before,
+        after: ambrosia.upgrades[input.index].level,
+        spent: cost,
+    });
+    events
 }
 
 // ─── Multi-key effect dispatchers ─────────────────────────────────────────
@@ -673,5 +819,158 @@ mod tests {
         let result = ambrosia_luck_quark_1_effect(1.0, 100_000.0);
         // 1 + 0.0001 * 10000 = 2
         assert!((result - 2.0).abs() < 1e-12);
+    }
+
+    // ─── Cost dispatch + buy ──────────────────────────────────────────────
+
+    #[test]
+    fn ambrosia_upgrade_cost_dispatches_by_index() {
+        // Slot 0 = tutorial (quadratic diff), base 1: level 0 → 1, level 1 → 3.
+        assert_eq!(ambrosia_upgrade_cost(0, 0, 1.0), 1.0);
+        assert_eq!(ambrosia_upgrade_cost(0, 1, 1.0), 3.0);
+        // Slot 1 = quarks1 (cubic diff), base 1: level 1 → (2^3 - 1^3) = 7.
+        assert_eq!(ambrosia_upgrade_cost(1, 1, 1.0), 7.0);
+        // Out of range → 0.
+        assert_eq!(ambrosia_upgrade_cost(AMBROSIA_UPGRADES_LEN, 0, 1.0), 0.0);
+    }
+
+    fn amb_state(level: f64, ambrosia: f64) -> AmbrosiaState {
+        let mut s = AmbrosiaState {
+            ambrosia,
+            ..AmbrosiaState::default()
+        };
+        s.upgrades[0].level = level;
+        s
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_levels_up_and_spends() {
+        // tutorial at level 0, costPerLevel 1 → cost 1; blueberryCost 0.
+        let mut ambrosia = amb_state(0.0, 10.0);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 0.0,
+                blueberry_inventory: 0.0,
+            },
+        );
+        assert_eq!(ambrosia.upgrades[0].level, 1.0);
+        assert!((ambrosia.ambrosia - 9.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::AmbrosiaUpgradePurchased { index: 0, .. }]
+        ));
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_unaffordable_is_noop() {
+        let mut ambrosia = amb_state(0.0, 0.5);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 0.0,
+                blueberry_inventory: 0.0,
+            },
+        );
+        assert_eq!(ambrosia.upgrades[0].level, 0.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_maxed_is_noop() {
+        let mut ambrosia = amb_state(10.0, 1e9);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 0.0,
+                blueberry_inventory: 0.0,
+            },
+        );
+        assert_eq!(ambrosia.upgrades[0].level, 10.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_first_level_pays_blueberry_slot() {
+        // Leaving level 0 with blueberryCost 2 and 3 free blueberries: pays 2.
+        let mut ambrosia = amb_state(0.0, 10.0);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 2.0,
+                blueberry_inventory: 3.0,
+            },
+        );
+        assert_eq!(ambrosia.upgrades[0].level, 1.0);
+        assert!((ambrosia.spent_blueberries - 2.0).abs() < 1e-9);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_blocked_when_no_free_blueberries() {
+        // blueberryCost 2 but only 1 free blueberry: no purchase, no spend.
+        let mut ambrosia = amb_state(0.0, 10.0);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 2.0,
+                blueberry_inventory: 1.0,
+            },
+        );
+        assert_eq!(ambrosia.upgrades[0].level, 0.0);
+        assert_eq!(ambrosia.spent_blueberries, 0.0);
+        assert!((ambrosia.ambrosia - 10.0).abs() < 1e-9);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_above_level_0_skips_blueberry_slot() {
+        // Already past level 0: the slot cost is not re-paid even with no free
+        // blueberries. cost = quadratic_difference(5, 1) = 36 - 25 = 11.
+        let mut ambrosia = amb_state(5.0, 100.0);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 99.0,
+                blueberry_inventory: 0.0,
+            },
+        );
+        assert_eq!(ambrosia.upgrades[0].level, 6.0);
+        assert_eq!(ambrosia.spent_blueberries, 0.0);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_ambrosia_upgrade_out_of_range_is_noop() {
+        let mut ambrosia = amb_state(0.0, 1e9);
+        let events = buy_ambrosia_upgrade(
+            &mut ambrosia,
+            BuyAmbrosiaUpgradeInput {
+                index: AMBROSIA_UPGRADES_LEN,
+                cost_per_level: 1.0,
+                max_level: 10.0,
+                blueberry_cost: 0.0,
+                blueberry_inventory: 0.0,
+            },
+        );
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/hepteract_values.rs
+++ b/crates/synergismforkd_logic/src/mechanics/hepteract_values.rs
@@ -13,6 +13,18 @@
 //! - [`hepteract_final_cap`]:
 //!   `hepteract_cap * (limitedAscensions Exalt 3 reward active ? 2 :
 //!   1)` — the post-Exalt cap actually used by the UI.
+//!
+//! Beyond the value/cap helpers, this module owns the two manual
+//! actions — [`buy_hepteract_craft`] (multi-resource craft toward the
+//! cap) and [`buy_hepteract_expand`] (spend a full bar to double the
+//! cap). The per-craft conversion constants stay UI-tier; the caller
+//! passes them in [`HepteractConversions`].
+
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::{CubeBalancesState, HepteractCraft, HepteractsState};
 
 /// Inputs to [`hepteract_effective`].
 #[derive(Debug, Clone, Copy)]
@@ -71,6 +83,237 @@ pub fn hepteract_final_cap(
 ) -> f64 {
     let special_multiplier = if exalt_3_hepteract_cap { 2.0 } else { 1.0 };
     hepteract_cap(base_cap, times_cap_extended) * special_multiplier
+}
+
+// ─── Manual buy: craft + expand ───────────────────────────────────────────
+
+/// Selects which of the eight hepteract crafts a buy targets. Discriminants
+/// match the [`CoreEvent`] `index` and the `HepteractsState` field order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HepteractKind {
+    /// `chronos` craft.
+    Chronos = 0,
+    /// `hyperrealism` craft.
+    Hyperrealism = 1,
+    /// `quark` craft.
+    Quark = 2,
+    /// `challenge` craft.
+    Challenge = 3,
+    /// `abyss` craft.
+    Abyss = 4,
+    /// `accelerator` craft.
+    Accelerator = 5,
+    /// `acceleratorBoost` craft.
+    AcceleratorBoost = 6,
+    /// `multiplier` craft.
+    Multiplier = 7,
+}
+
+fn craft_mut(hepteracts: &mut HepteractsState, kind: HepteractKind) -> &mut HepteractCraft {
+    match kind {
+        HepteractKind::Chronos => &mut hepteracts.chronos,
+        HepteractKind::Hyperrealism => &mut hepteracts.hyperrealism,
+        HepteractKind::Quark => &mut hepteracts.quark,
+        HepteractKind::Challenge => &mut hepteracts.challenge,
+        HepteractKind::Abyss => &mut hepteracts.abyss,
+        HepteractKind::Accelerator => &mut hepteracts.accelerator,
+        HepteractKind::AcceleratorBoost => &mut hepteracts.accelerator_boost,
+        HepteractKind::Multiplier => &mut hepteracts.multiplier,
+    }
+}
+
+/// Floored craft units a Decimal resource affords at `per_unit_cost`. A
+/// `<= 0` cost means the craft doesn't consume the resource, so it imposes no
+/// limit (`+∞`).
+fn resource_craft_limit(available: Decimal, per_unit_cost: f64) -> f64 {
+    if per_unit_cost <= 0.0 {
+        f64::INFINITY
+    } else {
+        (available.to_number() / per_unit_cost).floor()
+    }
+}
+
+/// Subtract `amount` from a Decimal resource, clamped at zero. Skips the work
+/// (and the `Decimal` allocation) when nothing is owed.
+fn spend_decimal(resource: &mut Decimal, amount: f64) {
+    if amount > 0.0 {
+        *resource = (*resource - Decimal::from_finite(amount)).max(Decimal::zero());
+    }
+}
+
+/// Per-craft conversion constants (the legacy `HEPTERACT_CONVERSION` +
+/// `OTHER_CONVERSIONS`), supplied by the caller (UI-tier data table). A `0`
+/// rate means the craft does not consume that resource. Every rate except
+/// `worlds` is additionally scaled by the craft-cost multiplier.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HepteractConversions {
+    /// `HEPTERACT_CONVERSION` — wow-abyssals per craft unit.
+    pub hepteract: f64,
+    /// `OTHER_CONVERSIONS.obtainium`.
+    pub obtainium: f64,
+    /// `OTHER_CONVERSIONS.offerings`.
+    pub offerings: f64,
+    /// `OTHER_CONVERSIONS.worlds` — the one resource spent without the
+    /// craft-cost multiplier.
+    pub worlds: f64,
+    /// `OTHER_CONVERSIONS.wowCubes`.
+    pub wow_cubes: f64,
+    /// `OTHER_CONVERSIONS.wowTesseracts`.
+    pub wow_tesseracts: f64,
+    /// `OTHER_CONVERSIONS.wowHypercubes`.
+    pub wow_hypercubes: f64,
+    /// `OTHER_CONVERSIONS.wowPlatonicCubes`.
+    pub wow_platonic_cubes: f64,
+}
+
+/// Inputs to [`buy_hepteract_craft`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyHepteractCraftInput {
+    /// Which craft to top up.
+    pub kind: HepteractKind,
+    /// Per-craft conversion rates (UI-tier data table).
+    pub conversions: HepteractConversions,
+    /// `calculateSingularityDebuff('Hepteract Costs')` — multiplies every cost
+    /// except `worlds`. Caller-provided (UI-tier); `1.0` at low singularity.
+    pub craft_cost_multi: f64,
+    /// `getSingularityChallengeEffect('limitedAscensions', 'hepteractCap')`
+    /// (Exalt 3) — doubles the craft ceiling when active. `false` outside
+    /// Exalt 3.
+    pub exalt_3_cap: bool,
+    /// Units the player asked to craft (the legacy prompt). Ignored when `max`
+    /// is set.
+    pub requested_amount: f64,
+    /// `true` = craft-max: fill toward the cap with everything affordable.
+    pub max: bool,
+}
+
+/// Craft toward a hepteract's cap by spending wow-abyssals plus the craft's
+/// `OTHER_CONVERSIONS` resources — a port of the legacy `craftHepteracts`
+/// core. The craftable amount is the floor-min over every spendable resource
+/// (`getCraftableHepteractAmount`) capped by the remaining bar room; `max`
+/// fills it, otherwise `requested_amount` bounds it. Emits
+/// [`CoreEvent::HepteractCrafted`].
+///
+/// Faithful-at-current-state deferrals: the unlock check (`UNLOCKED()`) and
+/// the integer/positive validation of the requested amount are UI-tier, so
+/// the caller gates on them; the per-craft conversion table and the
+/// singularity-debuff multiplier are caller-provided.
+#[must_use]
+pub fn buy_hepteract_craft(
+    hepteracts: &mut HepteractsState,
+    cube_balances: &mut CubeBalancesState,
+    obtainium: &mut Decimal,
+    offerings: &mut Decimal,
+    worlds: &mut Decimal,
+    input: BuyHepteractCraftInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    let c = input.conversions;
+    let multi = input.craft_cost_multi;
+
+    let craft = craft_mut(hepteracts, input.kind);
+    let final_cap = craft.cap * if input.exalt_3_cap { 2.0 } else { 1.0 };
+    let room = final_cap - craft.bal;
+    if room <= 0.0 {
+        return events;
+    }
+
+    // getCraftableHepteractAmount: the floor-min over each spendable resource,
+    // plus the remaining cap room (unfloored, per legacy).
+    let craftable = room
+        .min((cube_balances.wow_abyssals / (c.hepteract * multi)).floor())
+        .min(resource_craft_limit(*obtainium, c.obtainium * multi))
+        .min(resource_craft_limit(*offerings, c.offerings * multi))
+        .min(resource_craft_limit(*worlds, c.worlds)) // worlds: no cost multiplier
+        .min(resource_craft_limit(cube_balances.wow_cubes, c.wow_cubes * multi))
+        .min(resource_craft_limit(
+            cube_balances.wow_tesseracts,
+            c.wow_tesseracts * multi,
+        ))
+        .min(resource_craft_limit(
+            cube_balances.wow_hypercubes,
+            c.wow_hypercubes * multi,
+        ))
+        .min(resource_craft_limit(
+            cube_balances.wow_platonic_cubes,
+            c.wow_platonic_cubes * multi,
+        ));
+
+    let requested = if input.max {
+        craftable
+    } else {
+        input.requested_amount
+    };
+    let amount = craftable.min(requested);
+    if amount <= 0.0 {
+        return events;
+    }
+
+    let before = craft.bal;
+    craft.bal = final_cap.min(craft.bal + amount);
+
+    // Spend. wow-abyssals and the Decimal `OTHER_CONVERSIONS` use the cost
+    // multiplier; `worlds` is the one exception (no multiplier).
+    cube_balances.wow_abyssals =
+        (cube_balances.wow_abyssals - amount * c.hepteract * multi).max(0.0);
+    spend_decimal(obtainium, amount * c.obtainium * multi);
+    spend_decimal(offerings, amount * c.offerings * multi);
+    spend_decimal(worlds, amount * c.worlds);
+    spend_decimal(&mut cube_balances.wow_cubes, amount * c.wow_cubes * multi);
+    spend_decimal(
+        &mut cube_balances.wow_tesseracts,
+        amount * c.wow_tesseracts * multi,
+    );
+    spend_decimal(
+        &mut cube_balances.wow_hypercubes,
+        amount * c.wow_hypercubes * multi,
+    );
+    spend_decimal(
+        &mut cube_balances.wow_platonic_cubes,
+        amount * c.wow_platonic_cubes * multi,
+    );
+
+    events.push(CoreEvent::HepteractCrafted {
+        index: input.kind as u32,
+        before,
+        after: craft.bal,
+        amount,
+    });
+    events
+}
+
+/// Inputs to [`buy_hepteract_expand`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyHepteractExpandInput {
+    /// Which craft's cap to double.
+    pub kind: HepteractKind,
+}
+
+/// Double a hepteract craft's cap by spending one full (non-Exalt) bar — a
+/// port of the legacy `expandHepteracts`. Requires the bar to be full to
+/// `cap`; spends `cap` of the balance and doubles `cap` (the legacy
+/// `TIMES_CAP_EXTENDED += 1`, since `cap == BASE_CAP * 2^TIMES_CAP_EXTENDED`).
+/// Emits [`CoreEvent::HepteractCapExpanded`]. The unlock check is UI-tier
+/// (caller-gated).
+#[must_use]
+pub fn buy_hepteract_expand(
+    hepteracts: &mut HepteractsState,
+    input: BuyHepteractExpandInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    let craft = craft_mut(hepteracts, input.kind);
+    if craft.cap <= 0.0 || craft.bal < craft.cap {
+        return events;
+    }
+    craft.bal = (craft.bal - craft.cap).max(0.0);
+    craft.cap *= 2.0;
+    events.push(CoreEvent::HepteractCapExpanded {
+        index: input.kind as u32,
+        bal_after: craft.bal,
+        cap_after: craft.cap,
+    });
+    events
 }
 
 #[cfg(test)]
@@ -137,5 +380,197 @@ mod tests {
         // 1000 * 2^3 = 8000; with exalt → 16000
         assert_eq!(without, 8_000.0);
         assert_eq!(with_exalt, 16_000.0);
+    }
+
+    // ─── Manual buy: craft + expand ───────────────────────────────────────
+
+    fn hepteracts_with_chronos(bal: f64, cap: f64) -> HepteractsState {
+        let mut h = HepteractsState::default();
+        h.chronos.bal = bal;
+        h.chronos.cap = cap;
+        h
+    }
+
+    fn abyssals(amount: f64) -> CubeBalancesState {
+        CubeBalancesState {
+            wow_abyssals: amount,
+            ..CubeBalancesState::default()
+        }
+    }
+
+    fn craft_input(
+        conversions: HepteractConversions,
+        requested: f64,
+        max: bool,
+    ) -> BuyHepteractCraftInput {
+        BuyHepteractCraftInput {
+            kind: HepteractKind::Chronos,
+            conversions,
+            craft_cost_multi: 1.0,
+            exalt_3_cap: false,
+            requested_amount: requested,
+            max,
+        }
+    }
+
+    #[test]
+    fn buy_hepteract_craft_crafts_and_spends() {
+        // cap 100, 50 abyssals, 1 abyssal/unit: requested 10 → craft 10.
+        let mut h = hepteracts_with_chronos(0.0, 100.0);
+        let mut cb = abyssals(50.0);
+        let (mut ob, mut of, mut wo) = (Decimal::zero(), Decimal::zero(), Decimal::zero());
+        let conv = HepteractConversions {
+            hepteract: 1.0,
+            ..HepteractConversions::default()
+        };
+        let events = buy_hepteract_craft(
+            &mut h,
+            &mut cb,
+            &mut ob,
+            &mut of,
+            &mut wo,
+            craft_input(conv, 10.0, false),
+        );
+        assert_eq!(h.chronos.bal, 10.0);
+        assert!((cb.wow_abyssals - 40.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::HepteractCrafted { index: 0, amount, .. }] if (amount - 10.0).abs() < 1e-9
+        ));
+    }
+
+    #[test]
+    fn buy_hepteract_craft_max_fills_to_affordable() {
+        // max with only 30 abyssals (1/unit) → craft 30, spend all.
+        let mut h = hepteracts_with_chronos(0.0, 100.0);
+        let mut cb = abyssals(30.0);
+        let (mut ob, mut of, mut wo) = (Decimal::zero(), Decimal::zero(), Decimal::zero());
+        let conv = HepteractConversions {
+            hepteract: 1.0,
+            ..HepteractConversions::default()
+        };
+        let events = buy_hepteract_craft(
+            &mut h,
+            &mut cb,
+            &mut ob,
+            &mut of,
+            &mut wo,
+            craft_input(conv, 0.0, true),
+        );
+        assert_eq!(h.chronos.bal, 30.0);
+        assert_eq!(cb.wow_abyssals, 0.0);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_hepteract_craft_capped_at_room() {
+        // bal 95 of cap 100: only 5 of room left even though 50 abyssals afford more.
+        let mut h = hepteracts_with_chronos(95.0, 100.0);
+        let mut cb = abyssals(50.0);
+        let (mut ob, mut of, mut wo) = (Decimal::zero(), Decimal::zero(), Decimal::zero());
+        let conv = HepteractConversions {
+            hepteract: 1.0,
+            ..HepteractConversions::default()
+        };
+        let events = buy_hepteract_craft(
+            &mut h,
+            &mut cb,
+            &mut ob,
+            &mut of,
+            &mut wo,
+            craft_input(conv, 20.0, false),
+        );
+        assert_eq!(h.chronos.bal, 100.0);
+        assert!((cb.wow_abyssals - 45.0).abs() < 1e-9);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_hepteract_craft_multi_resource_min_binds() {
+        // hepteract 1/unit (100 abyssals → 100) + obtainium 2/unit (10 → 5):
+        // the obtainium limit binds, so 5 craft.
+        let mut h = hepteracts_with_chronos(0.0, 100.0);
+        let mut cb = abyssals(100.0);
+        let (mut ob, mut of, mut wo) =
+            (Decimal::from_finite(10.0), Decimal::zero(), Decimal::zero());
+        let conv = HepteractConversions {
+            hepteract: 1.0,
+            obtainium: 2.0,
+            ..HepteractConversions::default()
+        };
+        let events = buy_hepteract_craft(
+            &mut h,
+            &mut cb,
+            &mut ob,
+            &mut of,
+            &mut wo,
+            craft_input(conv, 10.0, false),
+        );
+        assert_eq!(h.chronos.bal, 5.0);
+        assert!((cb.wow_abyssals - 95.0).abs() < 1e-9);
+        assert_eq!(ob.to_number(), 0.0);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_hepteract_craft_at_cap_is_noop() {
+        let mut h = hepteracts_with_chronos(100.0, 100.0);
+        let mut cb = abyssals(50.0);
+        let (mut ob, mut of, mut wo) = (Decimal::zero(), Decimal::zero(), Decimal::zero());
+        let conv = HepteractConversions {
+            hepteract: 1.0,
+            ..HepteractConversions::default()
+        };
+        let events = buy_hepteract_craft(
+            &mut h,
+            &mut cb,
+            &mut ob,
+            &mut of,
+            &mut wo,
+            craft_input(conv, 10.0, false),
+        );
+        assert_eq!(h.chronos.bal, 100.0);
+        assert_eq!(cb.wow_abyssals, 50.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_hepteract_expand_doubles_cap() {
+        let mut h = hepteracts_with_chronos(100.0, 100.0);
+        let events = buy_hepteract_expand(
+            &mut h,
+            BuyHepteractExpandInput {
+                kind: HepteractKind::Chronos,
+            },
+        );
+        assert_eq!(h.chronos.bal, 0.0);
+        assert_eq!(h.chronos.cap, 200.0);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_hepteract_expand_not_full_is_noop() {
+        let mut h = hepteracts_with_chronos(50.0, 100.0);
+        let events = buy_hepteract_expand(
+            &mut h,
+            BuyHepteractExpandInput {
+                kind: HepteractKind::Chronos,
+            },
+        );
+        assert_eq!(h.chronos.cap, 100.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_hepteract_expand_locked_is_noop() {
+        // Default (locked) craft: cap 0 → no expansion.
+        let mut h = HepteractsState::default();
+        let events = buy_hepteract_expand(
+            &mut h,
+            BuyHepteractExpandInput {
+                kind: HepteractKind::Chronos,
+            },
+        );
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/octeracts.rs
+++ b/crates/synergismforkd_logic/src/mechanics/octeracts.rs
@@ -8,6 +8,18 @@
 //!
 //! Five effects read mutable state outside the logic tier — those
 //! take the extra value as a parameter.
+//!
+//! Beyond the formulas, this module owns the per-index cost dispatch
+//! table ([`octeract_upgrade_cost`]) and the manual buy
+//! ([`buy_octeract_upgrade`]) — the UI tier supplies only the static
+//! `costPerLevel` / `maxLevel` data-table values.
+
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::octeract_upgrades::OCTERACT_UPGRADES_LEN;
+use crate::state::OcteractUpgradesState;
 
 // Cost-lookup table for octeractBlueberries — fixed sequence of
 // costs per level. Mirrors the legacy `octeractBlueberryCostArr`.
@@ -352,6 +364,133 @@ pub fn octeract_talisman_level_cap_3_cost_formula(level: f64, base_cost: f64) ->
 #[must_use]
 pub fn octeract_talisman_level_cap_4_cost_formula(level: f64, base_cost: f64) -> f64 {
     base_cost * 10.0_f64.powf(level)
+}
+
+// ─── Cost dispatch + manual buy ───────────────────────────────────────────
+
+/// Per-index `costFormula` dispatch table. Slot `i` is the cost formula for
+/// octeract upgrade `i` — the array order IS the `OCTERACT_*` index
+/// convention (legacy `octeractUpgrades` key order), so the positions here
+/// must stay in lockstep with `state::octeract_upgrades`.
+const OCTERACT_COST_FORMULAS: [fn(f64, f64) -> f64; OCTERACT_UPGRADES_LEN] = [
+    octeract_starter_cost_formula,                    // 0  octeractStarter
+    octeract_gain_cost_formula,                       // 1  octeractGain
+    octeract_gain_2_cost_formula,                     // 2  octeractGain2
+    octeract_quark_gain_cost_formula,                 // 3  octeractQuarkGain
+    octeract_quark_gain_2_cost_formula,               // 4  octeractQuarkGain2
+    octeract_corruption_cost_formula,                 // 5  octeractCorruption
+    octeract_gq_cost_reduce_cost_formula,             // 6  octeractGQCostReduce
+    octeract_export_quarks_cost_formula,              // 7  octeractExportQuarks
+    octeract_improved_daily_cost_formula,             // 8  octeractImprovedDaily
+    octeract_improved_daily_2_cost_formula,           // 9  octeractImprovedDaily2
+    octeract_improved_daily_3_cost_formula,           // 10 octeractImprovedDaily3
+    octeract_improved_quark_hept_cost_formula,        // 11 octeractImprovedQuarkHept
+    octeract_improved_global_speed_cost_formula,      // 12 octeractImprovedGlobalSpeed
+    octeract_improved_ascension_speed_cost_formula,   // 13 octeractImprovedAscensionSpeed
+    octeract_improved_ascension_speed_2_cost_formula, // 14 octeractImprovedAscensionSpeed2
+    octeract_improved_free_cost_formula,              // 15 octeractImprovedFree
+    octeract_improved_free_2_cost_formula,            // 16 octeractImprovedFree2
+    octeract_improved_free_3_cost_formula,            // 17 octeractImprovedFree3
+    octeract_improved_free_4_cost_formula,            // 18 octeractImprovedFree4
+    octeract_sing_upgrade_cap_cost_formula,           // 19 octeractSingUpgradeCap
+    octeract_offerings_1_cost_formula,                // 20 octeractOfferings1
+    octeract_obtainium_1_cost_formula,                // 21 octeractObtainium1
+    octeract_ascensions_cost_formula,                 // 22 octeractAscensions
+    octeract_ascensions_2_cost_formula,               // 23 octeractAscensions2
+    octeract_ascensions_octeract_gain_cost_formula,   // 24 octeractAscensionsOcteractGain
+    octeract_fast_forward_cost_formula,               // 25 octeractFastForward
+    octeract_auto_potion_speed_cost_formula,          // 26 octeractAutoPotionSpeed
+    octeract_auto_potion_efficiency_cost_formula,     // 27 octeractAutoPotionEfficiency
+    octeract_one_mind_improver_cost_formula,          // 28 octeractOneMindImprover
+    octeract_ambrosia_luck_cost_formula,              // 29 octeractAmbrosiaLuck
+    octeract_ambrosia_luck_2_cost_formula,            // 30 octeractAmbrosiaLuck2
+    octeract_ambrosia_luck_3_cost_formula,            // 31 octeractAmbrosiaLuck3
+    octeract_ambrosia_luck_4_cost_formula,            // 32 octeractAmbrosiaLuck4
+    octeract_ambrosia_generation_cost_formula,        // 33 octeractAmbrosiaGeneration
+    octeract_ambrosia_generation_2_cost_formula,      // 34 octeractAmbrosiaGeneration2
+    octeract_ambrosia_generation_3_cost_formula,      // 35 octeractAmbrosiaGeneration3
+    octeract_ambrosia_generation_4_cost_formula,      // 36 octeractAmbrosiaGeneration4
+    octeract_bonus_tokens_1_cost_formula,             // 37 octeractBonusTokens1
+    octeract_bonus_tokens_2_cost_formula,             // 38 octeractBonusTokens2
+    octeract_bonus_tokens_3_cost_formula,             // 39 octeractBonusTokens3
+    octeract_bonus_tokens_4_cost_formula,             // 40 octeractBonusTokens4
+    octeract_blueberries_cost_formula,                // 41 octeractBlueberries
+    octeract_infinite_shop_upgrades_cost_formula,     // 42 octeractInfiniteShopUpgrades
+    octeract_talisman_level_cap_1_cost_formula,       // 43 octeractTalismanLevelCap1
+    octeract_talisman_level_cap_2_cost_formula,       // 44 octeractTalismanLevelCap2
+    octeract_talisman_level_cap_3_cost_formula,       // 45 octeractTalismanLevelCap3
+    octeract_talisman_level_cap_4_cost_formula,       // 46 octeractTalismanLevelCap4
+];
+
+/// Cost of the next level of octeract upgrade `index`, via the upgrade's own
+/// `costFormula(level, costPerLevel)`. The UI tier owns the `costPerLevel`
+/// data table; the formula and the index→formula binding live here. `index`
+/// out of range returns `0.0`.
+#[must_use]
+pub fn octeract_upgrade_cost(index: usize, level: f64, cost_per_level: f64) -> f64 {
+    OCTERACT_COST_FORMULAS
+        .get(index)
+        .map_or(0.0, |formula| formula(level, cost_per_level))
+}
+
+/// Inputs to [`buy_octeract_upgrade`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyOcteractUpgradeInput {
+    /// Octeract-upgrade index (`0..47`, via the `OCTERACT_*` constants).
+    /// Out-of-range is a no-op.
+    pub index: usize,
+    /// `octeractUpgrades[key].costPerLevel` — the per-upgrade base cost
+    /// (UI-tier data-table value). Fed to the index-dispatched cost formula.
+    pub cost_per_level: f64,
+    /// `octeractUpgrades[key].maxLevel` — the purchase cap (UI-tier). The
+    /// `maxLevel <= 0` sentinel means unlimited; otherwise the buy stops once
+    /// `level == max_level`.
+    pub max_level: f64,
+}
+
+/// Buy one level of octeract upgrade `index` with octeracts — the
+/// single-level step of the legacy `buyOcteractUpgradeLevel` loop (the
+/// `costFormula` → spend → `level += 1` body, buy-amount 1). The cost is
+/// computed logic-side via [`octeract_upgrade_cost`]; only the static
+/// `cost_per_level` / `max_level` data-table values are caller-provided
+/// (UI-tier). Emits [`CoreEvent::OcteractUpgradePurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - **buy-max**: the legacy loops `maxPurchasable` levels (a shift-click /
+///   buy-amount prompt); this buys a single level (the buy-amount-1 case);
+/// - `octeractsInvested` respec tracking has no logic-state field (like the
+///   GQ buy's `goldenQuarksInvested`), so it is not accumulated.
+#[must_use]
+pub fn buy_octeract_upgrade(
+    upgrades: &mut OcteractUpgradesState,
+    wow_octeracts: &mut Decimal,
+    input: BuyOcteractUpgradeInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if input.index >= upgrades.upgrades.len() {
+        return events;
+    }
+    let before = upgrades.upgrades[input.index].level;
+
+    // Legacy gate: bounded upgrades stop at `maxLevel`; `maxLevel <= 0` is the
+    // unlimited sentinel.
+    let not_maxed = input.max_level <= 0.0 || before < input.max_level;
+    if !not_maxed {
+        return events;
+    }
+
+    let cost = octeract_upgrade_cost(input.index, before, input.cost_per_level);
+    if wow_octeracts.to_number() >= cost {
+        *wow_octeracts -= Decimal::from_finite(cost);
+        upgrades.upgrades[input.index].level += 1.0;
+        events.push(CoreEvent::OcteractUpgradePurchased {
+            index: input.index as u32,
+            before,
+            after: upgrades.upgrades[input.index].level,
+            spent: cost,
+        });
+    }
+    events
 }
 
 // ─── Per-upgrade effect functions ─────────────────────────────────────────
@@ -806,5 +945,118 @@ mod tests {
         // → 1 + (1/10000) * 2 * 111 * 2 = 1 + 0.0444 = 1.0444
         let result = octeract_quark_gain_2_effect(111.0, 222.0, 10.0);
         assert!((result - 1.044_4).abs() < 1e-9);
+    }
+
+    // ─── Cost dispatch + buy ──────────────────────────────────────────────
+
+    #[test]
+    fn octeract_upgrade_cost_dispatches_by_index() {
+        // Slot 0 = octeractStarter: base × (level + 1) = 10 × 4 = 40.
+        assert_eq!(octeract_upgrade_cost(0, 3.0, 10.0), 40.0);
+        // Last slot = octeractTalismanLevelCap4: base × 10^level = 5 × 100 = 500.
+        assert_eq!(
+            octeract_upgrade_cost(OCTERACT_UPGRADES_LEN - 1, 2.0, 5.0),
+            500.0
+        );
+        // Out of range → 0.
+        assert_eq!(octeract_upgrade_cost(OCTERACT_UPGRADES_LEN, 1.0, 1.0), 0.0);
+    }
+
+    fn oct_state(starter_level: f64) -> OcteractUpgradesState {
+        let mut s = OcteractUpgradesState::default();
+        s.upgrades[0].level = starter_level;
+        s
+    }
+
+    #[test]
+    fn buy_octeract_upgrade_levels_up_and_spends() {
+        // octeractStarter at level 0, costPerLevel 100 → cost 100 × (0+1) = 100.
+        let mut upgrades = oct_state(0.0);
+        let mut oct = Decimal::from_finite(250.0);
+        let events = buy_octeract_upgrade(
+            &mut upgrades,
+            &mut oct,
+            BuyOcteractUpgradeInput {
+                index: 0,
+                cost_per_level: 100.0,
+                max_level: 10.0,
+            },
+        );
+        assert_eq!(upgrades.upgrades[0].level, 1.0);
+        assert!((oct.to_number() - 150.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::OcteractUpgradePurchased { index: 0, .. }]
+        ));
+    }
+
+    #[test]
+    fn buy_octeract_upgrade_unaffordable_is_noop() {
+        let mut upgrades = oct_state(0.0);
+        let mut oct = Decimal::from_finite(50.0);
+        let events = buy_octeract_upgrade(
+            &mut upgrades,
+            &mut oct,
+            BuyOcteractUpgradeInput {
+                index: 0,
+                cost_per_level: 100.0,
+                max_level: 10.0,
+            },
+        );
+        assert_eq!(upgrades.upgrades[0].level, 0.0);
+        assert!((oct.to_number() - 50.0).abs() < 1e-9);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_octeract_upgrade_maxed_is_noop() {
+        let mut upgrades = oct_state(10.0);
+        let mut oct = Decimal::from_finite(1e30);
+        let events = buy_octeract_upgrade(
+            &mut upgrades,
+            &mut oct,
+            BuyOcteractUpgradeInput {
+                index: 0,
+                cost_per_level: 100.0,
+                max_level: 10.0,
+            },
+        );
+        assert_eq!(upgrades.upgrades[0].level, 10.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_octeract_upgrade_unlimited_ignores_cap() {
+        // maxLevel <= 0 is the unlimited sentinel: buys past any level.
+        // octeractStarter at level 999, costPerLevel 1 → cost 1 × 1000 = 1000.
+        let mut upgrades = oct_state(999.0);
+        let mut oct = Decimal::from_finite(1e30);
+        let events = buy_octeract_upgrade(
+            &mut upgrades,
+            &mut oct,
+            BuyOcteractUpgradeInput {
+                index: 0,
+                cost_per_level: 1.0,
+                max_level: 0.0,
+            },
+        );
+        assert_eq!(upgrades.upgrades[0].level, 1000.0);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_octeract_upgrade_out_of_range_is_noop() {
+        let mut upgrades = oct_state(0.0);
+        let mut oct = Decimal::from_finite(1e30);
+        let events = buy_octeract_upgrade(
+            &mut upgrades,
+            &mut oct,
+            BuyOcteractUpgradeInput {
+                index: OCTERACT_UPGRADES_LEN,
+                cost_per_level: 100.0,
+                max_level: 10.0,
+            },
+        );
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/rune_levels.rs
+++ b/crates/synergismforkd_logic/src/mechanics/rune_levels.rs
@@ -9,7 +9,11 @@
 //! this module owns the closed-form EXP↔level inversion plus the
 //! "given a budget, how many levels can I buy" planner.
 
+use smallvec::SmallVec;
 use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::RunesState;
 
 /// EXP required to **reach** a target rune level, starting from 0 EXP.
 /// Formula: `cost_coefficient * (10^(level / levels_per_oom) - 1)`.
@@ -185,9 +189,123 @@ pub fn max_rune_level_purchase(input: MaxRuneLevelPurchaseInput) -> MaxRuneLevel
     }
 }
 
+// ─── Manual buy ───────────────────────────────────────────────────────────
+
+/// Inputs to [`buy_rune_levels`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyRuneLevelsInput {
+    /// Rune index (`0..7`, via the `RUNE_*` constants). Out-of-range is a
+    /// no-op.
+    pub index: usize,
+    /// `rune.costCoefficient` (UI-tier rune data table).
+    pub cost_coefficient: Decimal,
+    /// `getLevelsPerOOM(rune)` = `rune.levelsPerOOM + rune.levelsPerOOMIncrease()`
+    /// — the combined slope, pre-evaluated by the caller (UI-tier).
+    pub levels_per_oom: f64,
+    /// `getRuneEXPPerOffering(rune)` = `universalRuneEXPMult(level)` — the
+    /// per-offering EXP rate, pre-evaluated by the caller.
+    pub rune_exp_per_offering: Decimal,
+    /// Target levels to add this purchase — the `offeringbuyamount` toggle
+    /// (1/10/100/…) or [`max_rune_level_purchase`]`.levels` for buy-max (a
+    /// UI-tier decision). The `budget` caps how many actually land.
+    pub levels_to_add: f64,
+    /// Offerings the caller authorizes spending (the legacy `budget`; for a
+    /// plain manual click this is the whole offerings balance — keep it
+    /// `<= offerings`, the legacy quirk is to bank free EXP otherwise).
+    pub budget: Decimal,
+}
+
+/// Buy rune levels for rune `index` by spending offerings — a port of the
+/// legacy `sacrificeOfferings` core (`levelRune` + `updateLevelsFromEXP`).
+/// Adds EXP toward `level + levels_to_add`; if `budget` can't reach that
+/// target it banks partial EXP, and the level is re-derived from EXP (so a
+/// 10-level request on a 3-level budget lands 3 levels). Spends from
+/// `offerings`; emits [`CoreEvent::RuneLevelsPurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - **unlock**: `rune.isUnlocked()` reads achievements / researches
+///   (UI-tier), so — like the octeract / GQ / blueberry gates — the caller
+///   checks it; this buy is ungated on unlock;
+/// - the buy-amount toggle and the buy-max planner
+///   ([`max_rune_level_purchase`], already ported) live caller-side and feed
+///   `levels_to_add`;
+/// - rune EXP is held as `f64` in state (`RunesState::rune_exp`), so it is
+///   widened to `Decimal` for the math and narrowed back on store.
+#[must_use]
+pub fn buy_rune_levels(
+    runes: &mut RunesState,
+    offerings: &mut Decimal,
+    input: BuyRuneLevelsInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if input.index >= runes.rune_levels.len()
+        || input.budget <= Decimal::zero()
+        || input.levels_to_add < 1.0
+    {
+        return events;
+    }
+
+    let before = runes.rune_levels[input.index];
+    let current_exp = Decimal::from_finite(runes.rune_exp[input.index]);
+    let target_level = before + input.levels_to_add;
+
+    // levelRune: spend toward `target_level`, banking partial EXP when the
+    // budget falls short of the full jump.
+    let exp_left = rune_exp_left_to_level(
+        input.cost_coefficient,
+        target_level,
+        input.levels_per_oom,
+        current_exp,
+    );
+    let offerings_required = (exp_left / input.rune_exp_per_offering)
+        .ceil()
+        .max(Decimal::one());
+
+    let (new_exp, budget_used) = if offerings_required > input.budget {
+        (
+            current_exp + input.budget * input.rune_exp_per_offering,
+            input.budget,
+        )
+    } else {
+        (
+            rune_exp_to_level(input.cost_coefficient, target_level, input.levels_per_oom),
+            offerings_required,
+        )
+    };
+    runes.rune_exp[input.index] = new_exp.to_number();
+    *offerings -= budget_used;
+
+    // updateLevelsFromEXP: re-derive the integer level, with the legacy
+    // off-by-one fix-up when EXP sits exactly on a level boundary.
+    let levels = rune_level_from_exp(new_exp, input.cost_coefficient, input.levels_per_oom);
+    let exp_left_next = rune_exp_left_to_level(
+        input.cost_coefficient,
+        levels + 1.0,
+        input.levels_per_oom,
+        new_exp,
+    );
+    runes.rune_levels[input.index] = if exp_left_next == Decimal::zero() {
+        levels + 1.0
+    } else {
+        levels
+    };
+
+    // Legacy clamp: never let offerings go negative.
+    *offerings = (*offerings).max(Decimal::zero());
+
+    events.push(CoreEvent::RuneLevelsPurchased {
+        index: input.index as u32,
+        before,
+        after: runes.rune_levels[input.index],
+        spent: budget_used,
+    });
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::{RUNE_COUNT, RUNE_SPEED};
 
     #[test]
     fn rune_exp_to_level_zero_at_zero() {
@@ -312,5 +430,75 @@ mod tests {
         let result = max_rune_level_purchase(input);
         assert_eq!(result.levels, 1.0);
         assert!(result.exp_required > Decimal::one());
+    }
+
+    // ─── Manual buy ───────────────────────────────────────────────────────
+
+    fn speed_buy_input(levels_to_add: f64, budget: f64) -> BuyRuneLevelsInput {
+        BuyRuneLevelsInput {
+            index: RUNE_SPEED,
+            cost_coefficient: Decimal::from_finite(100.0),
+            levels_per_oom: 5.0,
+            rune_exp_per_offering: Decimal::from_finite(10.0),
+            levels_to_add,
+            budget: Decimal::from_finite(budget),
+        }
+    }
+
+    #[test]
+    fn buy_rune_levels_adds_levels_and_spends() {
+        // coeff 100, lpo 5, perOffering 10: reaching level 5 needs 900 EXP =
+        // 90 offerings; budget 1000 affords it in full.
+        let mut runes = RunesState::default();
+        let mut offerings = Decimal::from_finite(1000.0);
+        let events = buy_rune_levels(&mut runes, &mut offerings, speed_buy_input(5.0, 1000.0));
+        assert_eq!(runes.rune_levels[RUNE_SPEED], 5.0);
+        assert!((runes.rune_exp[RUNE_SPEED] - 900.0).abs() < 1e-6);
+        assert!((offerings.to_number() - 910.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::RuneLevelsPurchased { index: 0, .. }]
+        ));
+    }
+
+    #[test]
+    fn buy_rune_levels_partial_when_budget_short() {
+        // Budget 30 (< 90 needed for level 5): banks 300 EXP → lands level 3,
+        // spends the whole 30.
+        let mut runes = RunesState::default();
+        let mut offerings = Decimal::from_finite(30.0);
+        let events = buy_rune_levels(&mut runes, &mut offerings, speed_buy_input(5.0, 30.0));
+        assert_eq!(runes.rune_levels[RUNE_SPEED], 3.0);
+        assert!((runes.rune_exp[RUNE_SPEED] - 300.0).abs() < 1e-6);
+        assert_eq!(offerings.to_number(), 0.0);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_rune_levels_out_of_range_is_noop() {
+        let mut runes = RunesState::default();
+        let mut offerings = Decimal::from_finite(1000.0);
+        let mut input = speed_buy_input(5.0, 1000.0);
+        input.index = RUNE_COUNT;
+        let events = buy_rune_levels(&mut runes, &mut offerings, input);
+        assert!(events.is_empty());
+        assert_eq!(offerings.to_number(), 1000.0);
+    }
+
+    #[test]
+    fn buy_rune_levels_zero_budget_is_noop() {
+        let mut runes = RunesState::default();
+        let mut offerings = Decimal::from_finite(1000.0);
+        let events = buy_rune_levels(&mut runes, &mut offerings, speed_buy_input(5.0, 0.0));
+        assert!(events.is_empty());
+        assert_eq!(runes.rune_levels[RUNE_SPEED], 0.0);
+    }
+
+    #[test]
+    fn buy_rune_levels_below_one_level_is_noop() {
+        let mut runes = RunesState::default();
+        let mut offerings = Decimal::from_finite(1000.0);
+        let events = buy_rune_levels(&mut runes, &mut offerings, speed_buy_input(0.0, 1000.0));
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/talisman_levels.rs
+++ b/crates/synergismforkd_logic/src/mechanics/talisman_levels.rs
@@ -8,9 +8,12 @@
 //! rarity)` → display rarity, the levels-until-next-rarity counter,
 //! and the per-level affordability check.
 
+use smallvec::SmallVec;
 use synergismforkd_bignum::Decimal;
 
 use super::talisman_costs::TalismanCraftCosts;
+use crate::events::CoreEvent;
+use crate::state::TalismansState;
 
 // ─── Rarity value table ────────────────────────────────────────────────────
 
@@ -163,6 +166,91 @@ pub fn affordable_talisman_level(input: &AffordableTalismanLevelInput) -> bool {
         return false;
     }
     true
+}
+
+// ─── Manual buy ────────────────────────────────────────────────────────────
+
+/// Inputs to [`buy_talisman_level`].
+#[derive(Debug, Clone, Copy)]
+pub struct BuyTalismanLevelInput {
+    /// Talisman index (`0..7`, via the `TALISMAN_*` constants). Out-of-range
+    /// is a no-op.
+    pub index: usize,
+    /// Per-item cost for the next level — the caller evaluates the talisman's
+    /// cost progression ([`regular_cost_progression`] /
+    /// [`exponential_cost_progression`]) for the current level. The per-talisman
+    /// `baseMult` / `ratio` / which-progression are UI-tier data.
+    ///
+    /// [`regular_cost_progression`]: super::talisman_costs::regular_cost_progression
+    /// [`exponential_cost_progression`]: super::talisman_costs::exponential_cost_progression
+    pub costs: TalismanCraftCosts,
+    /// `getTalismanLevelCap` = `maxLevel + levelCapIncrease()` — the purchase
+    /// cap (UI-tier). The buy stops at `level == level_cap`.
+    pub level_cap: f64,
+}
+
+/// Buy one talisman level for talisman `index` by spending talisman shards and
+/// the six fragment tiers — a port of the legacy `buyTalismanLevel`. The cost
+/// map is caller-provided (evaluated from the ported cost progression for the
+/// current level); affordability uses [`affordable_talisman_level`]. Emits
+/// [`CoreEvent::TalismanLevelPurchased`].
+///
+/// Faithful-at-current-state deferrals:
+/// - **unlock** (`isUnlocked()`) is UI-tier, so the caller gates on it; this
+///   buy is ungated on unlock;
+/// - the rarity recompute (`setTalismanRarity`) reads UI-tier `isUnlocked`
+///   (rarity is `0` while locked, the reachable state today), so it is left to
+///   the UI — `talisman_rarity` is not updated here;
+/// - `fragmentsInvested` respec tracking has no logic-state field, so it is
+///   not accumulated;
+/// - the resource pools are `f64` in state, so the `Decimal` costs are widened
+///   for the affordability check and narrowed on the spend.
+#[must_use]
+pub fn buy_talisman_level(
+    talismans: &mut TalismansState,
+    input: BuyTalismanLevelInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let mut events = SmallVec::new();
+    if input.index >= talismans.talisman_levels.len() {
+        return events;
+    }
+    let before = talismans.talisman_levels[input.index];
+    if before >= input.level_cap {
+        return events;
+    }
+
+    let budget = TalismanCraftCosts {
+        shard: Decimal::from_finite(talismans.talisman_shards),
+        common_fragment: Decimal::from_finite(talismans.common_fragments),
+        uncommon_fragment: Decimal::from_finite(talismans.uncommon_fragments),
+        rare_fragment: Decimal::from_finite(talismans.rare_fragments),
+        epic_fragment: Decimal::from_finite(talismans.epic_fragments),
+        legendary_fragment: Decimal::from_finite(talismans.legendary_fragments),
+        mythical_fragment: Decimal::from_finite(talismans.mythical_fragments),
+    };
+    if !affordable_talisman_level(&AffordableTalismanLevelInput {
+        costs: input.costs,
+        budget,
+        buffer_mult: 1.0,
+    }) {
+        return events;
+    }
+
+    talismans.talisman_shards -= input.costs.shard.to_number();
+    talismans.common_fragments -= input.costs.common_fragment.to_number();
+    talismans.uncommon_fragments -= input.costs.uncommon_fragment.to_number();
+    talismans.rare_fragments -= input.costs.rare_fragment.to_number();
+    talismans.epic_fragments -= input.costs.epic_fragment.to_number();
+    talismans.legendary_fragments -= input.costs.legendary_fragment.to_number();
+    talismans.mythical_fragments -= input.costs.mythical_fragment.to_number();
+    talismans.talisman_levels[input.index] += 1.0;
+
+    events.push(CoreEvent::TalismanLevelPurchased {
+        index: input.index as u32,
+        before,
+        after: talismans.talisman_levels[input.index],
+    });
+    events
 }
 
 // ─── Sum of rarities ───────────────────────────────────────────────────────
@@ -327,5 +415,113 @@ mod tests {
     fn sum_of_talisman_rarities_is_simple_sum() {
         let rarities = [1_u8, 3, 5, 7, 10];
         assert_eq!(sum_of_talisman_rarities(&rarities), 26.0);
+    }
+
+    // ─── Manual buy ───────────────────────────────────────────────────────
+
+    /// A cost map of `shard` shards + `common` common-fragments, the rest 0.
+    fn cost_map(shard: f64, common: f64) -> TalismanCraftCosts {
+        TalismanCraftCosts {
+            shard: Decimal::from_finite(shard),
+            common_fragment: Decimal::from_finite(common),
+            uncommon_fragment: Decimal::zero(),
+            rare_fragment: Decimal::zero(),
+            epic_fragment: Decimal::zero(),
+            legendary_fragment: Decimal::zero(),
+            mythical_fragment: Decimal::zero(),
+        }
+    }
+
+    fn talismans_with(shards: f64, common: f64) -> TalismansState {
+        TalismansState {
+            talisman_shards: shards,
+            common_fragments: common,
+            ..TalismansState::default()
+        }
+    }
+
+    #[test]
+    fn buy_talisman_level_spends_and_levels() {
+        // Talisman 0 (Exemption) at level 0, next level costs 10 shards.
+        let mut t = talismans_with(100.0, 0.0);
+        let events = buy_talisman_level(
+            &mut t,
+            BuyTalismanLevelInput {
+                index: 0,
+                costs: cost_map(10.0, 0.0),
+                level_cap: 100.0,
+            },
+        );
+        assert_eq!(t.talisman_levels[0], 1.0);
+        assert!((t.talisman_shards - 90.0).abs() < 1e-9);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::TalismanLevelPurchased { index: 0, .. }]
+        ));
+    }
+
+    #[test]
+    fn buy_talisman_level_unaffordable_is_noop() {
+        let mut t = talismans_with(5.0, 0.0);
+        let events = buy_talisman_level(
+            &mut t,
+            BuyTalismanLevelInput {
+                index: 0,
+                costs: cost_map(10.0, 0.0),
+                level_cap: 100.0,
+            },
+        );
+        assert_eq!(t.talisman_levels[0], 0.0);
+        assert_eq!(t.talisman_shards, 5.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_talisman_level_multi_fragment_spends_all() {
+        // 10 shards + 20 common fragments; budget covers both.
+        let mut t = talismans_with(100.0, 50.0);
+        let events = buy_talisman_level(
+            &mut t,
+            BuyTalismanLevelInput {
+                index: 0,
+                costs: cost_map(10.0, 20.0),
+                level_cap: 100.0,
+            },
+        );
+        assert_eq!(t.talisman_levels[0], 1.0);
+        assert!((t.talisman_shards - 90.0).abs() < 1e-9);
+        assert!((t.common_fragments - 30.0).abs() < 1e-9);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buy_talisman_level_maxed_is_noop() {
+        let mut t = talismans_with(1e9, 0.0);
+        t.talisman_levels[0] = 100.0;
+        let events = buy_talisman_level(
+            &mut t,
+            BuyTalismanLevelInput {
+                index: 0,
+                costs: cost_map(10.0, 0.0),
+                level_cap: 100.0,
+            },
+        );
+        assert_eq!(t.talisman_levels[0], 100.0);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn buy_talisman_level_out_of_range_is_noop() {
+        let mut t = talismans_with(1e9, 0.0);
+        let out_of_range = t.talisman_levels.len();
+        let events = buy_talisman_level(
+            &mut t,
+            BuyTalismanLevelInput {
+                index: out_of_range,
+                costs: cost_map(10.0, 0.0),
+                level_cap: 100.0,
+            },
+        );
+        assert!(events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -59,6 +59,7 @@ use crate::mechanics::researches::{buy_research, BuyResearchInput};
 use crate::mechanics::resource_gain::{resource_gain, ResourceGainPre};
 use crate::mechanics::rune_levels::{buy_rune_levels, BuyRuneLevelsInput};
 use crate::mechanics::shop_costs::{buy_shop, BuyShopInput};
+use crate::mechanics::talisman_levels::{buy_talisman_level, BuyTalismanLevelInput};
 use crate::mechanics::tesseract_buildings::{buy_tesseract_building, BuyTesseractBuildingInput};
 use crate::mechanics::update_all_multiplier::{
     update_all_multiplier, UpdateAllMultiplierPre, UpdateAllMultiplierResult,
@@ -294,6 +295,8 @@ pub enum BuyRequest {
     HepteractCraft(BuyHepteractCraftInput),
     /// Routes to [`buy_hepteract_expand`].
     HepteractExpand(BuyHepteractExpandInput),
+    /// Routes to [`buy_talisman_level`].
+    TalismanLevel(BuyTalismanLevelInput),
     /// Routes to [`buy_shop`].
     Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
@@ -4194,6 +4197,7 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
             *inp,
         ),
         BuyRequest::HepteractExpand(inp) => buy_hepteract_expand(&mut state.hepteracts, *inp),
+        BuyRequest::TalismanLevel(inp) => buy_talisman_level(&mut state.talismans, *inp),
         BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
@@ -5386,6 +5390,51 @@ mod tests {
         // Spent one cap (100) and doubled it: bal 0, cap 200.
         assert_eq!(state.hepteracts.chronos.bal, 0.0);
         assert_eq!(state.hepteracts.chronos.cap, 200.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_talisman_level_action() {
+        use crate::mechanics::talisman_costs::TalismanCraftCosts;
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.talismans.talisman_shards = 100.0;
+
+        let costs = TalismanCraftCosts {
+            shard: Decimal::from_finite(10.0),
+            common_fragment: Decimal::zero(),
+            uncommon_fragment: Decimal::zero(),
+            rare_fragment: Decimal::zero(),
+            epic_fragment: Decimal::zero(),
+            legendary_fragment: Decimal::zero(),
+            mythical_fragment: Decimal::zero(),
+        };
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::TalismanLevel(
+                BuyTalismanLevelInput {
+                    index: 0,
+                    costs,
+                    level_cap: 100.0,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::TalismanLevelPurchased { .. })),
+            "expected TalismanLevelPurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.talismans.talisman_levels[0], 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -37,6 +37,8 @@ use synergismforkd_bignum::Decimal;
 use crate::events::{CoreEvent, ProducerType};
 use crate::mechanics::accelerators::{buy_accelerator, BuyAcceleratorInput};
 use crate::mechanics::achievement_rewards;
+use crate::mechanics::ant_producers::{buy_ant_producer, BuyAntProducerInput};
+use crate::mechanics::ant_upgrades::{buy_ant_upgrade, BuyAntUpgradeInput};
 use crate::mechanics::blueberry_upgrades::{buy_ambrosia_upgrade, BuyAmbrosiaUpgradeInput};
 use crate::mechanics::challenge_15_rewards;
 use crate::mechanics::crystal_upgrades::{buy_crystal_upgrades, BuyCrystalUpgradesInput};
@@ -281,6 +283,10 @@ pub enum BuyRequest {
     AmbrosiaUpgrade(BuyAmbrosiaUpgradeInput),
     /// Routes to [`buy_rune_levels`].
     RuneLevels(BuyRuneLevelsInput),
+    /// Routes to [`buy_ant_producer`].
+    AntProducer(BuyAntProducerInput),
+    /// Routes to [`buy_ant_upgrade`].
+    AntUpgrade(BuyAntUpgradeInput),
     /// Routes to [`buy_shop`].
     Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
@@ -4170,6 +4176,8 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
         BuyRequest::RuneLevels(inp) => {
             buy_rune_levels(&mut state.runes, &mut state.automation.offerings, *inp)
         }
+        BuyRequest::AntProducer(inp) => buy_ant_producer(&mut state.ants, *inp),
+        BuyRequest::AntUpgrade(inp) => buy_ant_upgrade(&mut state.ants, *inp),
         BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
@@ -5234,6 +5242,56 @@ mod tests {
             output.events
         );
         assert_eq!(state.runes.rune_levels[0], 5.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_ant_actions() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.ants.crumbs = Decimal::from_finite(1000.0);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::AntProducer(
+                BuyAntProducerInput {
+                    index: 0,
+                    max: false,
+                },
+            )));
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::AntUpgrade(
+                BuyAntUpgradeInput {
+                    index: 0,
+                    max: false,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::AntProducersPurchased { .. })),
+            "expected AntProducersPurchased in events, got {:?}",
+            output.events
+        );
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::AntUpgradePurchased { .. })),
+            "expected AntUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.ants.producers[0].purchased, 1.0);
+        assert_eq!(state.ants.upgrades[0], 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -37,6 +37,7 @@ use synergismforkd_bignum::Decimal;
 use crate::events::{CoreEvent, ProducerType};
 use crate::mechanics::accelerators::{buy_accelerator, BuyAcceleratorInput};
 use crate::mechanics::achievement_rewards;
+use crate::mechanics::blueberry_upgrades::{buy_ambrosia_upgrade, BuyAmbrosiaUpgradeInput};
 use crate::mechanics::challenge_15_rewards;
 use crate::mechanics::crystal_upgrades::{buy_crystal_upgrades, BuyCrystalUpgradesInput};
 use crate::mechanics::cube_upgrades::{buy_cube_upgrade, BuyCubeUpgradeInput};
@@ -275,6 +276,8 @@ pub enum BuyRequest {
     GoldenQuarkUpgrade(BuyGQUpgradeInput),
     /// Routes to [`buy_octeract_upgrade`].
     OcteractUpgrade(BuyOcteractUpgradeInput),
+    /// Routes to [`buy_ambrosia_upgrade`].
+    AmbrosiaUpgrade(BuyAmbrosiaUpgradeInput),
     /// Routes to [`buy_shop`].
     Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
@@ -4160,6 +4163,7 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
             &mut state.cube_balances.wow_octeracts,
             *inp,
         ),
+        BuyRequest::AmbrosiaUpgrade(inp) => buy_ambrosia_upgrade(&mut state.ambrosia, *inp),
         BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
@@ -5153,6 +5157,40 @@ mod tests {
             output.events
         );
         assert_eq!(state.octeract_upgrades.upgrades[0].level, 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_ambrosia_upgrade_action() {
+        let mut state = GameState::default();
+        state.ambrosia.ambrosia = 10.0;
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::AmbrosiaUpgrade(
+                BuyAmbrosiaUpgradeInput {
+                    index: 0,
+                    cost_per_level: 1.0,
+                    max_level: 10.0,
+                    blueberry_cost: 0.0,
+                    blueberry_inventory: 0.0,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::AmbrosiaUpgradePurchased { .. })),
+            "expected AmbrosiaUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.ambrosia.upgrades[0].level, 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -52,6 +52,7 @@ use crate::mechanics::platonic_upgrade_costs::{buy_platonic_upgrade, BuyPlatonic
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
 use crate::mechanics::researches::{buy_research, BuyResearchInput};
 use crate::mechanics::resource_gain::{resource_gain, ResourceGainPre};
+use crate::mechanics::rune_levels::{buy_rune_levels, BuyRuneLevelsInput};
 use crate::mechanics::shop_costs::{buy_shop, BuyShopInput};
 use crate::mechanics::tesseract_buildings::{buy_tesseract_building, BuyTesseractBuildingInput};
 use crate::mechanics::update_all_multiplier::{
@@ -278,6 +279,8 @@ pub enum BuyRequest {
     OcteractUpgrade(BuyOcteractUpgradeInput),
     /// Routes to [`buy_ambrosia_upgrade`].
     AmbrosiaUpgrade(BuyAmbrosiaUpgradeInput),
+    /// Routes to [`buy_rune_levels`].
+    RuneLevels(BuyRuneLevelsInput),
     /// Routes to [`buy_shop`].
     Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
@@ -4164,6 +4167,9 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
             *inp,
         ),
         BuyRequest::AmbrosiaUpgrade(inp) => buy_ambrosia_upgrade(&mut state.ambrosia, *inp),
+        BuyRequest::RuneLevels(inp) => {
+            buy_rune_levels(&mut state.runes, &mut state.automation.offerings, *inp)
+        }
         BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
@@ -5191,6 +5197,43 @@ mod tests {
             output.events
         );
         assert_eq!(state.ambrosia.upgrades[0].level, 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_rune_levels_action() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.automation.offerings = Decimal::from_finite(1000.0);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::RuneLevels(
+                BuyRuneLevelsInput {
+                    index: 0,
+                    cost_coefficient: Decimal::from_finite(100.0),
+                    levels_per_oom: 5.0,
+                    rune_exp_per_offering: Decimal::from_finite(10.0),
+                    levels_to_add: 5.0,
+                    budget: Decimal::from_finite(1000.0),
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::RuneLevelsPurchased { .. })),
+            "expected RuneLevelsPurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.runes.rune_levels[0], 5.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -47,6 +47,9 @@ use crate::mechanics::global_multipliers::{
     compute_global_multipliers, GlobalMultipliersPreEvaluated, GlobalMultipliersResult,
 };
 use crate::mechanics::gq_upgrade_cost::{buy_gq_upgrade, BuyGQUpgradeInput};
+use crate::mechanics::hepteract_values::{
+    buy_hepteract_craft, buy_hepteract_expand, BuyHepteractCraftInput, BuyHepteractExpandInput,
+};
 use crate::mechanics::multipliers::{buy_multiplier, BuyMultiplierInput};
 use crate::mechanics::octeracts::{buy_octeract_upgrade, BuyOcteractUpgradeInput};
 use crate::mechanics::particle_buildings::{buy_particle_building, BuyParticleBuildingInput};
@@ -287,6 +290,10 @@ pub enum BuyRequest {
     AntProducer(BuyAntProducerInput),
     /// Routes to [`buy_ant_upgrade`].
     AntUpgrade(BuyAntUpgradeInput),
+    /// Routes to [`buy_hepteract_craft`].
+    HepteractCraft(BuyHepteractCraftInput),
+    /// Routes to [`buy_hepteract_expand`].
+    HepteractExpand(BuyHepteractExpandInput),
     /// Routes to [`buy_shop`].
     Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
@@ -4178,6 +4185,15 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
         }
         BuyRequest::AntProducer(inp) => buy_ant_producer(&mut state.ants, *inp),
         BuyRequest::AntUpgrade(inp) => buy_ant_upgrade(&mut state.ants, *inp),
+        BuyRequest::HepteractCraft(inp) => buy_hepteract_craft(
+            &mut state.hepteracts,
+            &mut state.cube_balances,
+            &mut state.researches.obtainium,
+            &mut state.automation.offerings,
+            &mut state.quarks.worlds,
+            *inp,
+        ),
+        BuyRequest::HepteractExpand(inp) => buy_hepteract_expand(&mut state.hepteracts, *inp),
         BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
@@ -5292,6 +5308,84 @@ mod tests {
         );
         assert_eq!(state.ants.producers[0].purchased, 1.0);
         assert_eq!(state.ants.upgrades[0], 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_hepteract_craft_action() {
+        use crate::mechanics::hepteract_values::{HepteractConversions, HepteractKind};
+
+        let mut state = GameState::default();
+        state.hepteracts.chronos.cap = 100.0;
+        state.cube_balances.wow_abyssals = 50.0;
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::HepteractCraft(
+                BuyHepteractCraftInput {
+                    kind: HepteractKind::Chronos,
+                    conversions: HepteractConversions {
+                        hepteract: 1.0,
+                        ..HepteractConversions::default()
+                    },
+                    craft_cost_multi: 1.0,
+                    exalt_3_cap: false,
+                    requested_amount: 10.0,
+                    max: false,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::HepteractCrafted { .. })),
+            "expected HepteractCrafted in events, got {:?}",
+            output.events
+        );
+        // 10 units crafted at cost 1 abyssal each: bal 0 → 10, abyssals 50 → 40.
+        assert_eq!(state.hepteracts.chronos.bal, 10.0);
+        assert!((state.cube_balances.wow_abyssals - 40.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_hepteract_expand_action() {
+        use crate::mechanics::hepteract_values::{BuyHepteractExpandInput, HepteractKind};
+
+        let mut state = GameState::default();
+        state.hepteracts.chronos.cap = 100.0;
+        state.hepteracts.chronos.bal = 100.0; // full bar — expandable
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::HepteractExpand(
+                BuyHepteractExpandInput {
+                    kind: HepteractKind::Chronos,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::HepteractCapExpanded { .. })),
+            "expected HepteractCapExpanded in events, got {:?}",
+            output.events
+        );
+        // Spent one cap (100) and doubled it: bal 0, cap 200.
+        assert_eq!(state.hepteracts.chronos.bal, 0.0);
+        assert_eq!(state.hepteracts.chronos.cap, 200.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -45,6 +45,7 @@ use crate::mechanics::global_multipliers::{
 };
 use crate::mechanics::gq_upgrade_cost::{buy_gq_upgrade, BuyGQUpgradeInput};
 use crate::mechanics::multipliers::{buy_multiplier, BuyMultiplierInput};
+use crate::mechanics::octeracts::{buy_octeract_upgrade, BuyOcteractUpgradeInput};
 use crate::mechanics::particle_buildings::{buy_particle_building, BuyParticleBuildingInput};
 use crate::mechanics::platonic_upgrade_costs::{buy_platonic_upgrade, BuyPlatonicUpgradeInput};
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
@@ -272,6 +273,8 @@ pub enum BuyRequest {
     Research(BuyResearchInput),
     /// Routes to [`buy_gq_upgrade`].
     GoldenQuarkUpgrade(BuyGQUpgradeInput),
+    /// Routes to [`buy_octeract_upgrade`].
+    OcteractUpgrade(BuyOcteractUpgradeInput),
     /// Routes to [`buy_shop`].
     Shop(BuyShopInput),
     /// Routes to [`buy_multiplier`].
@@ -4152,6 +4155,11 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
         BuyRequest::Upgrade(inp) => buy_upgrades(&mut state.upgrades, *inp),
         BuyRequest::Research(inp) => buy_research(&mut state.researches, *inp),
         BuyRequest::GoldenQuarkUpgrade(inp) => buy_gq_upgrade(&mut state.golden_quarks, *inp),
+        BuyRequest::OcteractUpgrade(inp) => buy_octeract_upgrade(
+            &mut state.octeract_upgrades,
+            &mut state.cube_balances.wow_octeracts,
+            *inp,
+        ),
         BuyRequest::Shop(inp) => buy_shop(&mut state.shop, &mut state.quarks.worlds, *inp),
         BuyRequest::Multiplier(inp) => {
             buy_multiplier(&mut state.multiplier, &mut state.upgrades.coins, *inp)
@@ -5111,6 +5119,40 @@ mod tests {
             output.events
         );
         assert_eq!(state.golden_quarks.upgrades[0].level, 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_buy_octeract_upgrade_action() {
+        use synergismforkd_bignum::Decimal;
+
+        let mut state = GameState::default();
+        state.cube_balances.wow_octeracts = Decimal::from_finite(500.0);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::OcteractUpgrade(
+                BuyOcteractUpgradeInput {
+                    index: 0,
+                    cost_per_level: 100.0,
+                    max_level: 10.0,
+                },
+            )));
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::OcteractUpgradePurchased { .. })),
+            "expected OcteractUpgradePurchased in events, got {:?}",
+            output.events
+        );
+        assert_eq!(state.octeract_upgrades.upgrades[0].level, 1.0);
     }
 
     #[test]


### PR DESCRIPTION
Completes the player-action **buy surface** — ports every remaining manual buy family on top of the five that landed in #250 (research / cube / GQ / platonic / shop) and the classic upgrades/producers.

Each family follows the established buy recipe (a `BuyRequest` variant + a `dispatch_buy` arm + a `buy_*` mechanic next to its cost solver + an action `CoreEvent`), is ungated on unlock (caller/UI gates) with affordability + maxed gates in the mechanic, and adds **no new state fields**.

| Commit | Family | Notes |
|---|---|---|
| `ccc190e7` | octeract | per-upgrade cost via a 47-entry index→formula dispatch table; spends `wow_octeracts` |
| `f24b167b` | blueberry / ambrosia | 36-entry table + the blueberry-slot cost (paid leaving level 0) + caller-gated prereqs |
| `7f391d37` | runes | EXP/offerings model — banks partial EXP, re-derives level (composes the ported rune-EXP helpers) |
| `3871fb11` | ants | multi-sub-buy (producers + upgrades), both crumb-spent; first family with faithful buy-max |
| `2997426e` | hepteracts | crafting: an 8-currency craft toward the cap + a cap-doubling expand |
| `5c6e6bc1` | talismans | level via shards + 6 fragment tiers (inert at reachable state, but faithful) |

Cost computation stays logic-side throughout (the shop/platonic precedent): callers supply only static data-table values (per-upgrade cost params, conversion tables, the singularity-debuff multiplier). The hepteract expand needed no `times_cap_extended` field — the live expanded cap is already stored, so expand just doubles `cap`.

logic tests 1085 → 1133 (+48: per-family unit tests + a tack-level dispatch test each). All four gates green on every commit: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, and the `wasm32-unknown-unknown` `ui_web` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)