### PR TITLE
feat(logic): extinction_divisor table + research[192]·trueAntLevel(Mortuus) cube term

### DIFF
--- a/crates/synergismforkd_logic/src/mechanics/corruptions.rs
+++ b/crates/synergismforkd_logic/src/mechanics/corruptions.rs
@@ -127,6 +127,28 @@ pub fn illiteracy_power_at_level(level: u32) -> f64 {
     ILLITERACY_POWER.get(level as usize).copied().unwrap_or(0.0)
 }
 
+/// `G.extinctionDivisor` lookup table — ant-upgrade true-level divisor
+/// indexed by `player.corruptions.used.extinction` corruption level.
+/// 17 entries (`0..=16`); levels past `16` fall back to `0.0`.
+/// Verbatim port of the constant in
+/// `legacy/original/src/Variables.ts:191`.
+///
+/// Used by [`calculate_true_ant_level`](crate::mechanics::ant_upgrade_levels::calculate_true_ant_level)
+/// via the `corruption_extinction_divisor` input field.
+pub const EXTINCTION_DIVISOR: [f64; 17] = [
+    1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+];
+
+/// `G.extinctionDivisor[level]` with a safe out-of-range fallback to
+/// `0.0`.
+#[must_use]
+pub fn extinction_divisor_at_level(level: u32) -> f64 {
+    EXTINCTION_DIVISOR
+        .get(level as usize)
+        .copied()
+        .unwrap_or(0.0)
+}
+
 /// `G.deflationMultiplier` lookup table — prestige-power scaler indexed by
 /// `player.corruptions.used.deflation` corruption level. 17 entries
 /// (`0..=16`); the tail is `0`. Verbatim port of the constant in
@@ -446,6 +468,18 @@ mod tests {
         assert_eq!(illiteracy_power_at_level(16), 0.04);
         // Past the last entry — saturates to 0.
         assert_eq!(illiteracy_power_at_level(100), 0.0);
+    }
+
+    #[test]
+    fn extinction_divisor_table_matches_legacy() {
+        // Legacy `G.extinctionDivisor` from `Variables.ts:191`.
+        assert_eq!(extinction_divisor_at_level(0), 1.0); // no corruption → no penalty
+        assert_eq!(extinction_divisor_at_level(1), 1.25);
+        assert_eq!(extinction_divisor_at_level(4), 3.0);
+        assert_eq!(extinction_divisor_at_level(5), 4.0);
+        assert_eq!(extinction_divisor_at_level(16), 15.0);
+        // Past the last entry — falls back to 0.
+        assert_eq!(extinction_divisor_at_level(100), 0.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -2140,14 +2140,58 @@ fn compute_cube_multiplier(
     // AscensionScore band.
     let ascension_score_line = (effective_score / 3000.0).powf(1.0 / 4.1);
 
-    // Researches: the `research[192]·calculateTrueAntLevel(Mortuus)` factor is
-    // deferred (corruptionEffects('extinction') unported) → that factor is 1.
+    // Researches: now wires the `research[192]·calculateTrueAntLevel(Mortuus)`
+    // factor. Mortuus (index 11) is exemptFromCorruption=true, so the extinction
+    // divisor is 1 regardless of corruption level — the factor can be computed
+    // without extinction effect. Formula from Statistics.ts allWowCubeStats:
+    //   `(1 + (1/500) * research[192] * trueAntLevel(Mortuus))`
+    const ANT_UPGRADE_MORTUUS: usize = 11;
+    let mortuus_true_level = {
+        use crate::mechanics::ant_upgrade_levels::{
+            calculate_true_ant_level, compute_free_ant_upgrade_levels, CalculateTrueAntLevelInput,
+            ComputeFreeAntUpgradeLevelsInput,
+        };
+        let cc = &state.challenges.challenge_completions;
+        let c11_active = state.challenges.current_ascension_challenge == 11;
+        // `challenge15Rewards.bonusAntLevel` — baseValue 1, requirement 5e5.
+        // Unported as a standalone helper; neutral 1.0 (baseValue) at default.
+        let bonus_ant_level_value = 1.0_f64;
+        let free_levels = compute_free_ant_upgrade_levels(&ComputeFreeAntUpgradeLevelsInput {
+            c9_reincarnation_ecc: crate::mechanics::challenges::calc_ecc(
+                crate::mechanics::challenges::ChallengeType::Reincarnation,
+                cc[9],
+            ),
+            constant_upgrade_6: state.campaigns.constant_upgrades[6],
+            c11_ascension_ecc: crate::mechanics::challenges::calc_ecc(
+                crate::mechanics::challenges::ChallengeType::Ascension,
+                cc[11],
+            ),
+            research_97: research[97],
+            research_98: research[98],
+            research_102: research[102],
+            research_132: research[132],
+            research_200: research[200],
+            free_ant_upgrades_achievement_reward: 0.0, // getAchievementReward('freeAntUpgrades') unported → neutral 0
+            challenge_15_bonus_ant_level_value: bonus_ant_level_value,
+            c11_active,
+            c8_completions: cc[8],
+            c9_completions: cc[9],
+        });
+        calculate_true_ant_level(&CalculateTrueAntLevelInput {
+            current_level: state.ants.upgrades[ANT_UPGRADE_MORTUUS],
+            free_levels,
+            exempt_from_corruption: true, // Mortuus exemptFromCorruption = true
+            corruption_extinction_divisor: 1.0, // moot for exempt upgrades
+            c11_active,
+        })
+    };
     let researches = (1.0 + research[119] / 1000.0)
         * (1.0 + research[120] / 200.0)
         * (1.0 + research[137] / 100.0)
         * (1.0 + 0.9 * research[152] / 100.0)
         * (1.0 + 0.8 * research[167] / 100.0)
         * (1.0 + 0.7 * research[182] / 100.0)
+        * (1.0 + (1.0 / 500.0) * research[192] * mortuus_true_level) // 8x17
         * (1.0 + 0.6 * research[197] / 100.0);
 
     // ConstantUpgrade10: 1 + 0.01·log4(ascendShards+1)·min(1, constantUpgrades[10]).
@@ -6923,5 +6967,48 @@ mod tests {
         s2.tesseract_buildings.ascend_building_1.owned = 500.0;
         let pre2 = compute_global_multipliers_pre(&s2);
         assert_eq!(pre2.ascend_building_dr_value, 500.0);
+    }
+
+    #[test]
+    fn compute_cube_multiplier_research_192_mortuus_wires_through() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        // With research[192] = 0 (default) the term is (1 + 0) = 1 — no change.
+        let mut state = GameState::default();
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut out_default = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut out_default);
+
+        // Activate research[192] + give Mortuus some levels → the factor rises.
+        // With research[192]=100 and Mortuus level=50 (exempt → divisor=1,
+        // free_levels=0 → trueAnt = 50 + min(50,0) = 50):
+        //   factor = 1 + (1/500) * 100 * 50 = 1 + 10 = 11
+        // This doesn't test the final cube mult directly (it needs an ascension),
+        // but we verify the helper path compiles and the mortuus true level
+        // formula is correct for the exempt case.
+        let mut s = GameState::default();
+        s.ants.upgrades[11] = 50.0; // Mortuus level 50
+        s.researches.researches[192] = 100.0;
+        // At default challenge15_exponent = 0 and all free-level sources = 0:
+        // free_levels = 0, trueAnt = 50 + min(50, 0) = 50.
+        // Factor = 1 + (1/500) * 100 * 50 = 11.0.
+        {
+            use crate::mechanics::ant_upgrade_levels::{
+                calculate_true_ant_level, CalculateTrueAntLevelInput,
+            };
+            let true_level = calculate_true_ant_level(&CalculateTrueAntLevelInput {
+                current_level: 50.0,
+                free_levels: 0.0,
+                exempt_from_corruption: true,
+                corruption_extinction_divisor: 1.0,
+                c11_active: false,
+            });
+            assert_eq!(true_level, 50.0); // 50 + min(50, 0)=0 → 50+0=50
+            let factor = 1.0 + (1.0 / 500.0) * 100.0 * true_level;
+            assert!((factor - 11.0).abs() < 1e-9); // 1 + (1/500)*100*50 = 1+10 = 11
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two things that were jointly blocking each other:

### 1. `extinction_divisor_at_level` — `G.extinctionDivisor` (Variables.ts:191)

17-entry lookup table for the ant-upgrade true-level divisor, indexed by `corruption.used.extinction` level. Follows the same pattern as `illiteracy_power_at_level`, `recession_power_at_level`, etc. already in `corruptions.rs`.

```
[1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]
```

Consumed by `calculate_true_ant_level()` via the `corruption_extinction_divisor` input field.

### 2. `research[192] * trueAntLevel(Mortuus)` cube sub-term

Removes the last neutral-default placeholder in `compute_cube_multiplier`'s Researches line. The formula from Statistics.ts `allWowCubeStats`:

```
(1 + (1/500) * research[192] * calculateTrueAntLevel(AntUpgrades.Mortuus))
```

**Key insight:** Mortuus (`exemptFromCorruption = true`) means the extinction divisor is always 1 — so this term could be wired without needing actual extinction state reads.

All inputs sourced from `GameState`: `ants.upgrades[11]`, `researches[192]`, `challenge_completions[8/9/11]`, `constant_upgrades[6]`, `researches[97/98/102/132/200]`, `current_ascension_challenge`.

Neutral defaults (faithful at current state):
- `getAchievementReward('freeAntUpgrades')` → `0` (two achievement sources, aggregator unported)
- `challenge15Rewards.bonusAntLevel` → `1.0` (baseValue; requires exponent ≥ 5e5)

### Tests
- Extinction table: boundary values (0→1.0, 1→1.25, 4→3.0, 16→15.0, OOB→0.0)
- Mortuus exempt path: correct true-level + factor formula verified in isolation

### Gates
- cargo test --workspace → **1168 passed** (was 1166, +2 new)
- cargo clippy … -D warnings → clean
- cargo fmt --all --check → clean
- cargo build … wasm32 → clean