### PR TITLE
feat(logic): port highestChallengeRewards + CoreEvent::QuarksAwarded

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -595,10 +595,19 @@ pub enum CoreEvent {
     /// An accompanying `ResetPerformed` carries the reset-out (unless
     /// `instantChallenge` is unlocked).
     ChallengeCompleted {
-        /// Challenge index that completed (`1..=5` transcension).
+        /// Challenge index that completed (`1..=15`).
         challenge: u32,
         /// New `challenge_completions[challenge]` after the award.
         completions: f64,
+    },
+    /// Quarks were awarded from `highestChallengeRewards` (Challenges.ts:435).
+    /// Fires once per new `highest_challenge_completions` rise during
+    /// [`complete_active_challenge`]. The amount is pre-multiplied by the
+    /// cached quark bonus. The receiver credits `player.worlds` and
+    /// `quarks_this_singularity`.
+    QuarksAwarded {
+        /// Quarks to credit (already multiplied by the quark bonus).
+        quarks: f64,
     },
 }
 

--- a/crates/synergismforkd_logic/src/mechanics/challenges.rs
+++ b/crates/synergismforkd_logic/src/mechanics/challenges.rs
@@ -608,6 +608,25 @@ pub fn challenge_15_auto_exponent_check(input: &Challenge15AutoExponentCheckInpu
         && input.ascension_counter_real_real >= 0.1_f64.max(input.auto_ascend_threshold - 5.0)
 }
 
+// ─── highestChallengeRewards ───────────────────────────────────────────────
+
+/// Quark award amount for one new `highest_challenge_completions` step
+/// (`highestChallengeRewards`, Challenges.ts:435).
+///
+/// Called once per completion when `challengecompletions[q]` surpasses
+/// the previous `highestchallengecompletions[q]`. The caller is responsible
+/// for gating on `ascensionCount === 0` and applying the quark multiplier
+/// before crediting `player.worlds` + `quarksThisSingularity`.
+///
+/// Formula: `1 + floor(highest_value * multiplier)` where
+/// `multiplier = 0.1` for challenges 1–5 and `1.0` for challenges ≥ 6
+/// (reincarnation, ascension, and above).
+#[must_use]
+pub fn highest_challenge_rewards(chal_num: u32, highest_value: f64) -> f64 {
+    let multiplier = if chal_num >= 6 { 1.0 } else { 0.1 };
+    1.0 + (highest_value * multiplier).floor()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1156,5 +1175,36 @@ mod tests {
         below.auto_ascend_threshold = 5.0; // max(0.1, 0) = 0.1
         below.ascension_counter_real_real = 0.05;
         assert!(!challenge_15_auto_exponent_check(&below));
+    }
+
+    // ── highest_challenge_rewards ────────────────────────────────────────
+
+    #[test]
+    fn hcr_transcension_multiplier_is_tenth() {
+        // c1-5: multiplier = 0.1; amount = 1 + floor(highestValue * 0.1)
+        // highest=1 → 1 + floor(0.1) = 1 + 0 = 1
+        assert_eq!(highest_challenge_rewards(1, 1.0), 1.0);
+        // highest=10 → 1 + floor(1.0) = 2
+        assert_eq!(highest_challenge_rewards(1, 10.0), 2.0);
+        // highest=15 → 1 + floor(1.5) = 2
+        assert_eq!(highest_challenge_rewards(5, 15.0), 2.0);
+        // highest=20 → 1 + floor(2.0) = 3
+        assert_eq!(highest_challenge_rewards(3, 20.0), 3.0);
+    }
+
+    #[test]
+    fn hcr_reincarnation_multiplier_is_one() {
+        // c6-10: multiplier = 1; amount = 1 + floor(highestValue * 1)
+        // highest=1 → 1 + 1 = 2
+        assert_eq!(highest_challenge_rewards(6, 1.0), 2.0);
+        // highest=5 → 1 + 5 = 6
+        assert_eq!(highest_challenge_rewards(10, 5.0), 6.0);
+    }
+
+    #[test]
+    fn hcr_ascension_challenges_also_use_multiplier_one() {
+        // c11-15: multiplier = 1 (chalNum >= 6)
+        assert_eq!(highest_challenge_rewards(11, 1.0), 2.0);
+        assert_eq!(highest_challenge_rewards(14, 3.0), 4.0);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -4403,12 +4403,13 @@ fn enter_challenge(
 /// if the goal meets `challenge_requirement`, [`complete_active_challenge`]
 /// awards completions, raises `highest`, exits, and resets out.
 ///
+///
 /// c15 is deferred (different requirement shape and exponent path). Faithful
 /// neutral-defaults at this scope: the corruption `hyperchallenge` requirement
 /// inflation, the c15 transcend/reincarnation reductions, the c10 requirement
 /// reduction, and the shop `challengeExtension` reincarnation cap (→
 /// requirements/caps as if those upgrades are absent); `highestChallengeRewards`
-/// (research auto-unlocks) is unported → skipped; the post-completion reset
+/// fires quark awards per new highest rise (ported); the post-completion reset
 /// reuses the tick-start `gains` (the port's standing simplification for all
 /// in-tick resets).
 fn phase_challenge_completion(
@@ -4633,7 +4634,6 @@ fn complete_active_challenge(
         > state.challenges.highest_challenge_completions[q_idx]
     {
         state.challenges.highest_challenge_completions[q_idx] += 1.0;
-        // highestChallengeRewards(challenge, ..) unported → skipped.
         // Ascension-challenge unlock side-effects fired on highest[i] first rise
         // (Synergism.ts:3796-3808 — inside the `resetCheck` ascensionChallenge block).
         match q_idx {
@@ -4642,6 +4642,23 @@ fn complete_active_challenge(
             13 => state.reset_counters.hypercubes_unlocked = true,
             14 => state.reset_counters.platonics_unlocked = true,
             _ => {}
+        }
+        // highestChallengeRewards — award quarks when ascensionCount == 0
+        // (Challenges.ts:435). The quark bonus (cached as a %-age in
+        // state.quarks.quark_bonus) approximates calculateQuarkMultiplier().
+        if state.reset_counters.ascension_count == 0.0 {
+            use crate::mechanics::challenges::highest_challenge_rewards;
+            let base = highest_challenge_rewards(
+                challenge,
+                state.challenges.highest_challenge_completions[q_idx],
+            );
+            let multiplier = 1.0 + state.quarks.quark_bonus / 100.0;
+            let awarded = base * multiplier;
+            state.quarks.worlds += synergismforkd_bignum::Decimal::from_finite(awarded);
+            state.golden_quarks.quarks_this_singularity += awarded;
+            output
+                .events
+                .push(CoreEvent::QuarksAwarded { quarks: awarded });
         }
     }
 
@@ -6690,6 +6707,85 @@ mod tests {
         let mut output = TickOutput::default();
         phase_challenge_completion(&mut state, &gains, &mut output);
         assert!(state.reset_counters.platonics_unlocked);
+    }
+
+    #[test]
+    fn highest_challenge_rewards_fires_quarks_on_new_highest() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        let mut state = GameState::default();
+        // c1 transcension challenge, enough coins to complete.
+        state.challenges.current_transcension_challenge = 1;
+        state.coin_counters.coins_this_transcension = Decimal::from_finite(1e11);
+        // ascension_count == 0 → gate passes.
+        assert_eq!(state.reset_counters.ascension_count, 0.0);
+        // quark_bonus = 0 → multiplier = 1; base = 1 + floor(1 * 0.1) = 1 + 0 = 1.
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        // Quark event fired once for highest[1] rising from 0 → 1.
+        let quark_events: Vec<_> = output
+            .events
+            .iter()
+            .filter(|e| matches!(e, CoreEvent::QuarksAwarded { .. }))
+            .collect();
+        assert_eq!(quark_events.len(), 1);
+        // base = 1 + floor(1 * 0.1) = 1; multiplier = 1.0 → awarded = 1.0.
+        assert!(
+            matches!(quark_events[0], CoreEvent::QuarksAwarded { quarks } if (*quarks - 1.0).abs() < 1e-9)
+        );
+        assert!((state.quarks.worlds.to_number() - 1.0).abs() < 1e-9);
+        assert!((state.golden_quarks.quarks_this_singularity - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn highest_challenge_rewards_skipped_when_ascension_count_nonzero() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        let mut state = GameState::default();
+        state.challenges.current_transcension_challenge = 1;
+        state.coin_counters.coins_this_transcension = Decimal::from_finite(1e11);
+        // ascension_count > 0 → gate blocks quark award.
+        state.reset_counters.ascension_count = 1.0;
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        assert!(!output
+            .events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::QuarksAwarded { .. })));
+        assert_eq!(state.quarks.worlds.to_number(), 0.0);
+    }
+
+    #[test]
+    fn highest_challenge_rewards_reincarnation_multiplier_is_one() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        // c6 reincarnation: multiplier = 1; highest will rise to 1.
+        // base = 1 + floor(1 * 1) = 2; quark_bonus = 0 → awarded = 2.0.
+        let mut state = GameState::default();
+        state.challenges.current_reincarnation_challenge = 6;
+        state.reset_counters.transcend_shards = Decimal::from_finite(1e130);
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        let quark_event = output
+            .events
+            .iter()
+            .find(|e| matches!(e, CoreEvent::QuarksAwarded { .. }));
+        assert!(quark_event.is_some());
+        assert!(
+            matches!(quark_event.unwrap(), CoreEvent::QuarksAwarded { quarks } if (*quarks - 2.0).abs() < 1e-9)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Removes the last `// highestChallengeRewards(..) unported → skipped` placeholder in `complete_active_challenge`.

### What's in this PR

**`highest_challenge_rewards(chal_num, highest_value)`** — verbatim port of `highestChallengeRewards` (Challenges.ts:435):
- c1-5: `multiplier = 0.1`, `amount = 1 + floor(highest × 0.1)`
- c6+: `multiplier = 1.0`, `amount = 1 + floor(highest × 1.0)`

**Wired in `complete_active_challenge`:**
- Called once per new `highest_challenge_completions[q]` rise (the while loop)
- Gated on `ascension_count == 0` (faithful to TS)
- Quark amount pre-multiplied by `1 + quark_bonus/100` (the cached `calculateQuarkMultiplier()` approximation)
- Credits both `state.quarks.worlds` and `state.golden_quarks.quarks_this_singularity`

**`CoreEvent::QuarksAwarded { quarks: f64 }`** — new event variant emitted alongside every award. The UI tier reads this to refresh the quark display and `quarksThisSingularity` counter.

### Tests
6 new tests:
- 3 pure-function in `challenges.rs` (transcension 0.1× multiplier, reincarnation 1× multiplier, ascension 1× multiplier)
- 3 tick integration (fires + awards correct amount at c1, skipped when ascension_count > 0, reincarnation multiplier is 1)

### Gates
- cargo test --workspace → **1172 passed** (was 1166, +6 new)
- cargo clippy … -D warnings → clean
- cargo fmt --all --check → clean
- cargo build … wasm32 → clean