### PR TITLE
chore(github): point FUNDING at fork owner's Patreon; align feature template with Rust state

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-github: [khafradev, pseudonian]
-patreon: synergism
+patreon: NerdyMaddie

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,7 +29,7 @@ body:
     id: save-impact
     attributes:
       label: Save format impact
-      description: Would this require adding or modifying fields on the `player` object?
+      description: Would this require adding or modifying fields on a `synergismforkd_logic::state` slice (i.e. the saved game state)?
       options:
         - "No — UI / display only"
         - "Yes — new fields needed"


### PR DESCRIPTION
## Summary

Two `.github` metadata fixes surfaced while reviewing repo automation:

- **FUNDING.yml** — retarget from the upstream Synergism authors (`khafradev`, `pseudonian`, `patreon: synergism`) to the fork owner's Patreon (`patreon: NerdyMaddie`).
- **feature_request.yml** — update the "Save format impact" wording from the TS-era `player` object to the Rust `synergismforkd_logic::state` slice, matching `PULL_REQUEST_TEMPLATE.md` and `CLAUDE.md`.

## Save format impact

- [x] No save format impact (metadata / templates only)

## Test plan

No code touched — `.github` config and issue-template YAML only. `pr-title-lint` validates the title; the issue form renders on the next new feature request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)