### PR TITLE
feat(logic): ant-sacrifice + reborn-ELO activation (P3.3)

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -540,6 +540,18 @@ pub enum CoreEvent {
     ///
     /// Emitted by `checkAntSacrificeReady` (tick-side, not yet ported).
     AntSacrificeTriggered,
+    /// An ant sacrifice was *executed* this tick — immortal ELO, offerings,
+    /// obtainium, and talisman fragments have been credited and the ants reset
+    /// to crumbs. The effect counterpart to [`Self::AntSacrificeTriggered`]
+    /// (the intent). Emitted by `perform_ant_sacrifice`.
+    AntSacrificePerformed {
+        /// Offerings credited by the sacrifice.
+        offerings_gained: Decimal,
+        /// Obtainium credited (`0` when inside ascension challenge 14).
+        obtainium_gained: Decimal,
+        /// Immortal-ELO gained — the high-water-mark delta.
+        immortal_elo_gained: f64,
+    },
     /// The auto-rune-sacrifice timer crossed `autoSacrificeInterval`
     /// and offerings > 0. Pure intent signal — the UI dispatcher runs
     /// the blessing/spirit/talisman/per-rune-or-all purchase fan-out.

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -621,6 +621,29 @@ pub enum CoreEvent {
         /// Quarks to credit (already multiplied by the quark bonus).
         quarks: f64,
     },
+    /// Cubes of a tier were opened — blessings have been distributed into the
+    /// matching `*_blessings` slice and any quark gift credited. Emitted by the
+    /// cube-open mechanic. The cascade's free re-opens of lower tiers emit
+    /// their own `CubesOpened` events.
+    CubesOpened {
+        /// Which cube tier was opened.
+        tier: CubeTier,
+        /// Number of cubes consumed from the balance.
+        spent: f64,
+    },
+}
+
+/// Which cube-tier currency a [`CoreEvent::CubesOpened`] / open action targets.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CubeTier {
+    /// Wow! Cubes.
+    Cubes,
+    /// Wow! Tesseracts.
+    Tesseracts,
+    /// Wow! Hypercubes.
+    Hypercubes,
+    /// Platonic Cubes.
+    Platonic,
 }
 
 #[cfg(test)]

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -460,6 +460,83 @@ pub fn challenge_achievement_check(
     award_threshold_group(ach, challenge_completions[challenge], table);
 }
 
+/// `sacCount` achievement group — `antSacrificeCount >= threshold`. Awarded
+/// after every ant sacrifice (legacy `awardAchievementGroup('sacCount')` inside
+/// `resetPlayerAntSacrificeCounts`).
+const SAC_COUNT: &[ThresholdRow] = &[
+    (481, 1.0, 3.0),
+    (482, 10.0, 6.0),
+    (483, 50.0, 9.0),
+    (484, 250.0, 12.0),
+    (485, 1_250.0, 15.0),
+    (486, 5_000.0, 17.0),
+    (487, 20_000.0, 19.0),
+    (488, 80_000.0, 21.0),
+    (489, 250_000.0, 23.0),
+    (490, 1_000_000.0, 25.0),
+    (491, 3_000_000.0, 40.0),
+    (492, 10_000_000.0, 45.0),
+    (493, 100_000_000.0, 55.0),
+];
+
+/// `awardAchievementGroup('sacCount')` — the ant-sacrifice-count milestones.
+pub fn sac_count_achievement_check(ach: &mut AchievementsState, ant_sacrifice_count: f64) {
+    award_threshold_group(ach, ant_sacrifice_count, SAC_COUNT);
+}
+
+/// `sacMult` achievement group — the compound condition
+/// `immortalELO >= elo_req && producers[tier].purchased > 0`; the late #347/#348
+/// are immortal-ELO-only (`tier = None`), so [`award_threshold_group`] can't
+/// express them. Rows: `(index, elo_req, producer_tier, point_value)`.
+const SAC_MULT: &[(usize, f64, Option<usize>, f64)] = &[
+    (176, 50.0, Some(1), 5.0),
+    (177, 200.0, Some(2), 10.0),
+    (178, 500.0, Some(3), 15.0),
+    (179, 1_000.0, Some(4), 20.0),
+    (180, 2_500.0, Some(5), 25.0),
+    (181, 20_000.0, Some(6), 30.0),
+    (182, 100_000.0, Some(7), 35.0),
+    (347, 400_000.0, None, 40.0),
+    (348, 1_500_000.0, None, 45.0),
+    (349, 5_000_000.0, Some(8), 50.0),
+];
+
+/// `awardAchievementGroup('sacMult')` — awarded after a sacrifice, *before* the
+/// ants reset (so the producers are still owned). `producer_owned[t]` is
+/// `producers[t].purchased > 0` for tier `t` (Workers=0 .. HolySpirit=8).
+pub fn sac_mult_achievement_check(
+    ach: &mut AchievementsState,
+    immortal_elo: f64,
+    producer_owned: &[bool; 9],
+) {
+    for &(index, elo_req, tier, point_value) in SAC_MULT {
+        let owned = tier.is_none_or(|t| producer_owned[t]);
+        award_achievement(ach, index, immortal_elo >= elo_req && owned, point_value);
+    }
+}
+
+/// The two ungrouped mythical-fragment achievements checked after a sacrifice:
+/// `seeingRed` (#239, `mythicalFragments >= 1e25`) and `seeingRedNoBlue` (#248,
+/// `mythicalFragments >= 1e11` inside ascension challenge 14), each worth 50
+/// points. Mirrors the trailing `awardUngroupedAchievement` calls in
+/// `sacrificeAnts` (`awardUngroupedAchievement(name)` →
+/// `awardAchievement(achievementID)`).
+pub fn ant_sacrifice_fragment_achievement_check(
+    ach: &mut AchievementsState,
+    mythical_fragments: f64,
+    in_ascension_challenge_14: bool,
+) {
+    const SEEING_RED: usize = 239;
+    const SEEING_RED_NO_BLUE: usize = 248;
+    award_achievement(ach, SEEING_RED, mythical_fragments >= 1e25, 50.0);
+    award_achievement(
+        ach,
+        SEEING_RED_NO_BLUE,
+        mythical_fragments >= 1e11 && in_ascension_challenge_14,
+        50.0,
+    );
+}
+
 /// Apply one progressive-achievement update — a port of `updateProgressiveCache`
 /// and `updateProgressiveAP`. Bumps the cached value via `Math.max(cached,
 /// live_value)`, recomputes its awarded points via `points_of(cached_value)`,
@@ -641,5 +718,45 @@ mod tests {
         assert_eq!(ach.progressive[4].cached_value, 7.0);
         assert_eq!(ach.progressive[4].cached_points, 42.0);
         assert_eq!(ach.achievement_points, 42.0);
+    }
+
+    #[test]
+    fn sac_count_group_awards_met_thresholds() {
+        let mut ach = AchievementsState::default();
+        sac_count_achievement_check(&mut ach, 60.0);
+        // >=1 (#481,3), >=10 (#482,6), >=50 (#483,9) met; >=250 (#484) not.
+        assert_ne!(ach.achievements[481], 0);
+        assert_ne!(ach.achievements[483], 0);
+        assert_eq!(ach.achievements[484], 0);
+        assert_eq!(ach.achievement_points, 18.0); // 3 + 6 + 9
+    }
+
+    #[test]
+    fn sac_mult_group_requires_both_elo_and_producer() {
+        let mut ach = AchievementsState::default();
+        // High ELO but no producers owned → the producer-gated tiers stay locked,
+        // while the immortal-ELO-only tiers (#347 @400k, #348 @1.5M) can fire.
+        sac_mult_achievement_check(&mut ach, 1_000_000.0, &[false; 9]);
+        assert_eq!(ach.achievements[176], 0); // needs Breeders
+        assert_ne!(ach.achievements[347], 0); // ELO-only, 1M >= 400k
+        assert_eq!(ach.achievements[348], 0); // 1M < 1.5M
+
+        let mut owned = [false; 9];
+        owned[1] = true; // Breeders
+        sac_mult_achievement_check(&mut ach, 1_000_000.0, &owned);
+        assert_ne!(ach.achievements[176], 0);
+    }
+
+    #[test]
+    fn seeing_red_awards_above_fragment_thresholds() {
+        let mut ach = AchievementsState::default();
+        ant_sacrifice_fragment_achievement_check(&mut ach, 1e25, false);
+        assert_ne!(ach.achievements[239], 0); // seeingRed (>= 1e25)
+        assert_eq!(ach.achievements[248], 0); // seeingRedNoBlue needs c14
+
+        let mut c14 = AchievementsState::default();
+        ant_sacrifice_fragment_achievement_check(&mut c14, 1e11, true);
+        assert_ne!(c14.achievements[248], 0); // >= 1e11 inside ascension c14
+        assert_eq!(c14.achievements[239], 0); // 1e11 < 1e25
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -25,15 +25,22 @@
 //! brace-matched parse, not hand-counted) to avoid index-transcription
 //! drift.
 //!
-//! ## Deferred (faithful: those bits stay `0`, as before)
+//! ## Implemented since slice 1
 //!
-//! - The ungrouped no-accelerator / no-mult / no-upgrade reset
-//!   achievements (indices 57–74) — they need the timing-sensitive
-//!   `*no*` flags + a name→index map; they land with the ungrouped tail.
-//! - `challengeAchievementCheck` (the 14 challenge groups) — slice 2.
-//! - Progressive achievements (the `Math.max` cache system) — slice 3.
-//! - The quark reward on award (`player.worlds.add(getAchievementQuarks())`)
-//!   — a separable currency effect; see [`super::achievement_points`].
+//! - `challengeAchievementCheck` (the 14 challenge groups) — slice 2;
+//!   progressive achievements (the `Math.max` cache) — slice 3a; the
+//!   `sacMult` / `sacCount` and ungrouped (`seeingRed`, `oneCubeOfMany`)
+//!   sacrifice & cube achievements.
+//! - The per-achievement quark reward (`player.worlds.add(getAchievementQuarks())`):
+//!   `award_achievement` returns whether it newly awarded, the check helpers sum
+//!   that into a count, and each call site credits it via
+//!   `credit_achievement_quarks`.
+//!
+//! ## Still deferred (faithful: those bits stay `0`)
+//!
+//! - The ungrouped no-accelerator / no-mult / no-upgrade reset achievements
+//!   (indices 57–74) — they need the timing-sensitive `*no*` flags + a
+//!   name→index map; they land with the ungrouped tail.
 //!
 //! Points accumulate **incrementally** here (`achievement_points +=
 //! pointValue`), mirroring `awardAchievement`. The full-recompute path
@@ -381,34 +388,45 @@ fn award_achievement(
 }
 
 /// Award every row in a building group whose owned threshold `value` meets.
-fn award_threshold_group(ach: &mut AchievementsState, value: f64, table: &[ThresholdRow]) {
+/// Returns the count of achievements newly awarded (for the per-achievement
+/// quark reward).
+fn award_threshold_group(ach: &mut AchievementsState, value: f64, table: &[ThresholdRow]) -> usize {
+    let mut awarded = 0;
     for &(index, threshold, point_value) in table {
-        award_achievement(ach, index, value >= threshold, point_value);
+        if award_achievement(ach, index, value >= threshold, point_value) {
+            awarded += 1;
+        }
     }
+    awarded
 }
 
 /// Award every row in a point-gain group whose `10^threshold` the `gain`
 /// meets, compared in log10 space. A non-positive gain (a zero-gain reset)
-/// awards nothing — every row requires `gain >= 1`.
-fn award_log10_group(ach: &mut AchievementsState, gain: Decimal, table: &[Log10Row]) {
+/// awards nothing — every row requires `gain >= 1`. Returns the count newly
+/// awarded.
+fn award_log10_group(ach: &mut AchievementsState, gain: Decimal, table: &[Log10Row]) -> usize {
     if gain <= Decimal::zero() {
-        return;
+        return 0;
     }
     let log10 = gain.log10().to_number();
+    let mut awarded = 0;
     for &(index, threshold, point_value) in table {
-        award_achievement(ach, index, log10 >= threshold, point_value);
+        if award_achievement(ach, index, log10 >= threshold, point_value) {
+            awarded += 1;
+        }
     }
+    awarded
 }
 
 /// `buildingAchievementCheck()` — award the five `*OwnedCoin` groups from the
 /// owned coin-producer counts (`coin_owned[0..5]` = first..fifth owned coin).
 /// Called after a coin-producer buy.
-pub fn building_achievement_check(ach: &mut AchievementsState, coin_owned: &[f64; 5]) {
-    award_threshold_group(ach, coin_owned[0], FIRST_OWNED_COIN);
-    award_threshold_group(ach, coin_owned[1], SECOND_OWNED_COIN);
-    award_threshold_group(ach, coin_owned[2], THIRD_OWNED_COIN);
-    award_threshold_group(ach, coin_owned[3], FOURTH_OWNED_COIN);
-    award_threshold_group(ach, coin_owned[4], FIFTH_OWNED_COIN);
+pub fn building_achievement_check(ach: &mut AchievementsState, coin_owned: &[f64; 5]) -> usize {
+    award_threshold_group(ach, coin_owned[0], FIRST_OWNED_COIN)
+        + award_threshold_group(ach, coin_owned[1], SECOND_OWNED_COIN)
+        + award_threshold_group(ach, coin_owned[2], THIRD_OWNED_COIN)
+        + award_threshold_group(ach, coin_owned[3], FOURTH_OWNED_COIN)
+        + award_threshold_group(ach, coin_owned[4], FIFTH_OWNED_COIN)
 }
 
 /// `resetAchievementCheck(reset)` — slice-1 subset: the per-tier point-gain
@@ -420,14 +438,18 @@ pub fn building_achievement_check(ach: &mut AchievementsState, coin_owned: &[f64
 /// `Ascension` awards no point-gain group (faithful to
 /// `resetAchievementCheck('ascension')`). The ungrouped no-* reset
 /// achievements are deferred (see module docs).
-pub fn reset_achievement_check(ach: &mut AchievementsState, tier: AutoResetTier, gain: Decimal) {
+pub fn reset_achievement_check(
+    ach: &mut AchievementsState,
+    tier: AutoResetTier,
+    gain: Decimal,
+) -> usize {
     let table = match tier {
         AutoResetTier::Prestige => PRESTIGE_POINT_GAIN,
         AutoResetTier::Transcension => TRANSCEND_POINT_GAIN,
         AutoResetTier::Reincarnation => REINCARNATION_POINT_GAIN,
-        AutoResetTier::Ascension => return,
+        AutoResetTier::Ascension => return 0,
     };
-    award_log10_group(ach, gain, table);
+    award_log10_group(ach, gain, table)
 }
 
 /// `challengeAchievementCheck(i)` — award the `challengeI` group from the
@@ -439,7 +461,7 @@ pub fn challenge_achievement_check(
     ach: &mut AchievementsState,
     challenge: usize,
     challenge_completions: &[f64],
-) {
+) -> usize {
     let table: &[ThresholdRow] = match challenge {
         1 => CHALLENGE_1,
         2 => CHALLENGE_2,
@@ -455,9 +477,9 @@ pub fn challenge_achievement_check(
         12 => CHALLENGE_12,
         13 => CHALLENGE_13,
         14 => CHALLENGE_14,
-        _ => return,
+        _ => return 0,
     };
-    award_threshold_group(ach, challenge_completions[challenge], table);
+    award_threshold_group(ach, challenge_completions[challenge], table)
 }
 
 /// `sacCount` achievement group — `antSacrificeCount >= threshold`. Awarded
@@ -480,8 +502,8 @@ const SAC_COUNT: &[ThresholdRow] = &[
 ];
 
 /// `awardAchievementGroup('sacCount')` — the ant-sacrifice-count milestones.
-pub fn sac_count_achievement_check(ach: &mut AchievementsState, ant_sacrifice_count: f64) {
-    award_threshold_group(ach, ant_sacrifice_count, SAC_COUNT);
+pub fn sac_count_achievement_check(ach: &mut AchievementsState, ant_sacrifice_count: f64) -> usize {
+    award_threshold_group(ach, ant_sacrifice_count, SAC_COUNT)
 }
 
 /// `sacMult` achievement group — the compound condition
@@ -508,11 +530,15 @@ pub fn sac_mult_achievement_check(
     ach: &mut AchievementsState,
     immortal_elo: f64,
     producer_owned: &[bool; 9],
-) {
+) -> usize {
+    let mut awarded = 0;
     for &(index, elo_req, tier, point_value) in SAC_MULT {
         let owned = tier.is_none_or(|t| producer_owned[t]);
-        award_achievement(ach, index, immortal_elo >= elo_req && owned, point_value);
+        if award_achievement(ach, index, immortal_elo >= elo_req && owned, point_value) {
+            awarded += 1;
+        }
     }
+    awarded
 }
 
 /// The two ungrouped mythical-fragment achievements checked after a sacrifice:
@@ -525,16 +551,20 @@ pub fn ant_sacrifice_fragment_achievement_check(
     ach: &mut AchievementsState,
     mythical_fragments: f64,
     in_ascension_challenge_14: bool,
-) {
+) -> usize {
     const SEEING_RED: usize = 239;
     const SEEING_RED_NO_BLUE: usize = 248;
-    award_achievement(ach, SEEING_RED, mythical_fragments >= 1e25, 50.0);
-    award_achievement(
+    usize::from(award_achievement(
+        ach,
+        SEEING_RED,
+        mythical_fragments >= 1e25,
+        50.0,
+    )) + usize::from(award_achievement(
         ach,
         SEEING_RED_NO_BLUE,
         mythical_fragments >= 1e11 && in_ascension_challenge_14,
         50.0,
-    );
+    ))
 }
 
 /// Award a single ungrouped achievement by index when `unlocked` and not
@@ -547,8 +577,40 @@ pub fn award_ungrouped_achievement(
     index: usize,
     point_value: f64,
     unlocked: bool,
+) -> usize {
+    usize::from(award_achievement(ach, index, unlocked, point_value))
+}
+
+/// `getAchievementQuarks()` — quarks granted per achievement award:
+/// `floor(5 × applyBonus(1))`, where `applyBonus(1) = 1 + quark_bonus / 100`
+/// (the cached quark multiplier), soft-capped at `100^0.6 × m^0.4` once it
+/// exceeds 100.
+#[must_use]
+pub fn get_achievement_quarks(quark_bonus: f64) -> f64 {
+    let mut multiplier = 1.0 + quark_bonus / 100.0;
+    if multiplier > 100.0 {
+        multiplier = 100.0_f64.powf(0.6) * multiplier.powf(0.4);
+    }
+    (5.0 * multiplier).floor()
+}
+
+/// Credit the per-achievement quark reward (legacy `awardAchievement`'s
+/// `player.worlds.add(getAchievementQuarks(), false, true)`): `count`
+/// newly-awarded achievements each grant `get_achievement_quarks(quark_bonus)`,
+/// credited to `worlds` + `quarks_this_singularity`. No `QuarksAwarded` event —
+/// the achievement awards already signal the gain to the UI.
+pub fn credit_achievement_quarks(
+    worlds: &mut Decimal,
+    quarks_this_singularity: &mut f64,
+    quark_bonus: f64,
+    count: usize,
 ) {
-    award_achievement(ach, index, unlocked, point_value);
+    if count == 0 {
+        return;
+    }
+    let total = get_achievement_quarks(quark_bonus) * count as f64;
+    *worlds += Decimal::from_finite(total);
+    *quarks_this_singularity += total;
 }
 
 /// Apply one progressive-achievement update — a port of `updateProgressiveCache`
@@ -772,5 +834,29 @@ mod tests {
         ant_sacrifice_fragment_achievement_check(&mut c14, 1e11, true);
         assert_ne!(c14.achievements[248], 0); // >= 1e11 inside ascension c14
         assert_eq!(c14.achievements[239], 0); // 1e11 < 1e25
+    }
+
+    #[test]
+    fn achievement_quarks_default_is_five_with_soft_cap() {
+        // quark_bonus 0 → multiplier 1 → floor(5 × 1) = 5.
+        assert_eq!(get_achievement_quarks(0.0), 5.0);
+        // multiplier exactly 100 (bonus 9900) → no cap → floor(5 × 100) = 500.
+        assert_eq!(get_achievement_quarks(9900.0), 500.0);
+        // multiplier 200 (> 100) → soft cap 100^0.6 × 200^0.4.
+        let expected = (5.0 * (100.0_f64.powf(0.6) * 200.0_f64.powf(0.4))).floor();
+        assert_eq!(get_achievement_quarks(19_900.0), expected);
+    }
+
+    #[test]
+    fn credit_achievement_quarks_scales_with_count() {
+        let mut worlds = Decimal::zero();
+        let mut quarks_this_singularity = 0.0;
+        // 3 achievements × 5 quarks each at the default bonus.
+        credit_achievement_quarks(&mut worlds, &mut quarks_this_singularity, 0.0, 3);
+        assert_eq!(worlds.to_number(), 15.0);
+        assert_eq!(quarks_this_singularity, 15.0);
+        // count 0 is a no-op.
+        credit_achievement_quarks(&mut worlds, &mut quarks_this_singularity, 0.0, 0);
+        assert_eq!(worlds.to_number(), 15.0);
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -537,6 +537,20 @@ pub fn ant_sacrifice_fragment_achievement_check(
     );
 }
 
+/// Award a single ungrouped achievement by index when `unlocked` and not
+/// already owned — the generic `awardUngroupedAchievement` →
+/// `awardAchievement(index)` path. `point_value` is that achievement's
+/// `pointValue`. (e.g. `oneCubeOfMany` #246, awarded on opening a single cube
+/// at high accelerator blessing.)
+pub fn award_ungrouped_achievement(
+    ach: &mut AchievementsState,
+    index: usize,
+    point_value: f64,
+    unlocked: bool,
+) {
+    award_achievement(ach, index, unlocked, point_value);
+}
+
 /// Apply one progressive-achievement update — a port of `updateProgressiveCache`
 /// and `updateProgressiveAP`. Bumps the cached value via `Math.max(cached,
 /// live_value)`, recomputes its awarded points via `points_of(cached_value)`,

--- a/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
@@ -121,6 +121,11 @@ const PARTICLE_GAIN_INDEX: usize = 50;
 /// bool reward (`Boolean(player.achievements[173])`), not an aggregator.
 const ANT_SACRIFICE_UNLOCK_INDEX: usize = 173;
 
+/// Legacy index of the lone `sacrificeMult` achievement (#137): challenge 9
+/// completed ≥ 5 times, group `challenge9`, reward `() => 1.25`. The first
+/// (single earned-flag) product line in `antSacrificeRewardStats`.
+const SACRIFICE_MULT_INDEX: usize = 137;
+
 /// Legacy index of the lone `antELOAdditiveMultiplier` achievement (#484):
 /// `() => 0.01`.
 const ANT_ELO_ADDITIVE_MULTIPLIER_INDEX: usize = 484;
@@ -317,6 +322,18 @@ pub fn crystal_multiplier(input: &AchievementRewardInput) -> f64 {
 #[must_use]
 pub fn ant_sacrifice_unlocked(achievements: &[u8; ACHIEVEMENTS_LEN]) -> bool {
     earned(achievements, ANT_SACRIFICE_UNLOCK_INDEX)
+}
+
+/// `getAchievementReward('sacrificeMult')` — `1.25` once achievement #137
+/// (challenge 9 completed ≥ 5 times) is earned, else `1`. The first line of the
+/// `antSacrificeRewardStats` ant-sacrifice multiplier.
+#[must_use]
+pub fn sacrifice_mult(achievements: &[u8; ACHIEVEMENTS_LEN]) -> f64 {
+    if earned(achievements, SACRIFICE_MULT_INDEX) {
+        1.25
+    } else {
+        1.0
+    }
 }
 
 /// `getAchievementReward('ascensionRewardScaling')` — `true` once achievement

--- a/crates/synergismforkd_logic/src/mechanics/cube_opening.rs
+++ b/crates/synergismforkd_logic/src/mechanics/cube_opening.rs
@@ -157,7 +157,14 @@ pub(crate) fn open_cubes(
 
     // oneCubeOfMany — opening exactly one cube at >= 2e11 accelerator blessing.
     if value == 1.0 && state.cube_blessings.accelerator >= 2e11 {
-        award_ungrouped_achievement(&mut state.achievements, ONE_CUBE_OF_MANY, 50.0, true);
+        let awarded =
+            award_ungrouped_achievement(&mut state.achievements, ONE_CUBE_OF_MANY, 50.0, true);
+        crate::mechanics::achievement_awards::credit_achievement_quarks(
+            &mut state.quarks.worlds,
+            &mut state.golden_quarks.quarks_this_singularity,
+            state.quarks.quark_bonus,
+            awarded,
+        );
     }
 
     if !free {

--- a/crates/synergismforkd_logic/src/mechanics/cube_opening.rs
+++ b/crates/synergismforkd_logic/src/mechanics/cube_opening.rs
@@ -1,0 +1,548 @@
+//! Cube opening — distribute Wow! Cube / Tesseract / Hypercube / Platonic
+//! "blessings" by opening the matching cube currency.
+//!
+//! Port of the legacy `CubeExperimental.ts` `open()` methods. Opening `n`
+//! cubes splits into a **deterministic bulk** grant (`weight × floor(n / base)`
+//! per blessing, where the weights sum to the modulo `base`, so a full set
+//! yields exactly the expected counts) and a **stochastic remainder** (`n %
+//! base` per-cube rolls against the blessing pdf bands).
+//!
+//! The RNG draws from [`RngPurpose::CubeOpen`]. Like the rest of the port's
+//! randomness, this stream is a deterministic `Xoshiro256PlusPlus` rather than
+//! the legacy unseeded `Math.random()`, so opens are reproducible but **not**
+//! TS-bit-equal; tests assert the deterministic bulk exactly and the stochastic
+//! remainder by total/range.
+//!
+//! Three tiers cascade: opening tesseracts grants free cube opens
+//! (`researches[153]`), hypercubes grant free tesseract opens
+//! (`researches[183]`). The platonic→hypercube cascade needs the unported
+//! `platonicToHypercubes` achievement reward and is inert (neutral 0) until it
+//! lands. The platonic `scoreBonus` blessing is written-but-never-read in the
+//! legacy schema, so this port computes its distribution share (for faithful
+//! remainder accounting) and discards it (see [`PlatonicBlessings::add_from_eight`]).
+
+use rand::Rng;
+use smallvec::SmallVec;
+use synergismforkd_bignum::Decimal;
+
+use crate::events::{CoreEvent, CubeTier};
+use crate::math::rng::next_f64;
+use crate::state::rng::RngPurpose;
+use crate::state::GameState;
+
+// ─── Distribution tables ──────────────────────────────────────────────────────
+
+/// Per-blessing weights for cube / tesseract / hypercube opening, in the
+/// canonical `cubeBlessings` key order. Sum to 20 — the bulk modulo base.
+const CUBE_WEIGHTS: [f64; 10] = [4.0, 4.0, 2.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0, 1.0];
+
+/// Upper bound of each cube-blessing pdf band over `(0, 100]`. A per-cube roll
+/// `num = 100·rand()` grants `+1` to the first blessing whose band it does not
+/// exceed (`num <= band`), so each blessing's probability is `weight / 20`.
+const CUBE_BANDS: [f64; 10] = [20.0, 40.0, 50.0, 60.0, 70.0, 80.0, 85.0, 90.0, 95.0, 100.0];
+
+/// Platonic-blessing weights, 8 logical slots (incl. the dead `scoreBonus` at
+/// index 6) in the legacy `platonicBlessings` key order. Sum to 40000.
+const PLATONIC_WEIGHTS: [f64; 8] = [13200.0, 13200.0, 13200.0, 396.0, 1.0, 1.0, 1.0, 1.0];
+
+/// Upper bound of each platonic pdf band over `(0, 100]` for the final per-unit
+/// roll.
+const PLATONIC_BANDS: [f64; 8] = [33.0, 66.0, 99.0, 99.99, 99.9925, 99.995, 99.9975, 100.0];
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+/// Resolve the cube count to consume: `max` opens the whole balance, `free`
+/// opens exactly `value` without spending, otherwise `min(balance, value)`.
+fn resolve_to_spend(balance: f64, value: f64, max: bool, free: bool) -> f64 {
+    if max {
+        balance
+    } else if free {
+        value
+    } else {
+        balance.min(value)
+    }
+}
+
+/// `calculateCubeQuarkMultiplier()` assembled from `&GameState`. The
+/// `autoWarpCheck` / `dailyPowderResetUses` warp bonus is an unported
+/// auto-feature → neutral (`auto_warp_check = false`).
+fn cube_quark_multiplier(state: &GameState) -> f64 {
+    use crate::mechanics::overflux_bonuses::{
+        calculate_cube_quark_multiplier, CalculateCubeQuarkMultiplierInput,
+    };
+    use crate::mechanics::shop_upgrades::cube_to_quark_all_effect;
+    use crate::state::shop::SHOP_CUBE_TO_QUARK_ALL;
+
+    calculate_cube_quark_multiplier(&CalculateCubeQuarkMultiplierInput {
+        overflux_orbs: state.hepteracts.overflux_orbs,
+        highest_singularity_count: state.singularity.highest_singularity_count,
+        cube_to_quark_all_mult: cube_to_quark_all_effect(
+            state.shop.upgrades[SHOP_CUBE_TO_QUARK_ALL],
+        ),
+        auto_warp_check: false,
+        daily_powder_reset_uses: 0.0,
+    })
+}
+
+/// `checkQuarkGain(base, mult, cubesOpenedDaily)` — quarks earned from the
+/// cumulative cubes opened today: `floor(applyBonus(log10(cubes) · base · mult ·
+/// cubeMult))`, where `applyBonus(x) = x · (1 + quark_bonus / 100)`.
+fn check_quark_gain(
+    base: f64,
+    mult: f64,
+    cube_mult: f64,
+    quark_bonus: f64,
+    cubes_opened: f64,
+) -> f64 {
+    if cubes_opened < 1.0 {
+        return 0.0;
+    }
+    let multiplier = mult * cube_mult;
+    ((1.0 + quark_bonus / 100.0) * (cubes_opened.log10() * base * multiplier)).floor()
+}
+
+/// The shared 20-bucket cube/tesseract/hypercube distribution: deterministic
+/// `weight × div20` bulk, then `modulo` stochastic per-cube pdf rolls. Returns
+/// the per-blessing increments in canonical order.
+fn distribute_cube_blessings(div20: f64, modulo: f64, rng: &mut impl Rng) -> [f64; 10] {
+    let mut acc = [0.0_f64; 10];
+    for (slot, &weight) in acc.iter_mut().zip(CUBE_WEIGHTS.iter()) {
+        *slot = weight * div20;
+    }
+    for _ in 0..(modulo as u64) {
+        let num = 100.0 * next_f64(rng);
+        let idx = CUBE_BANDS.iter().position(|&band| num <= band).unwrap_or(9);
+        acc[idx] += 1.0;
+    }
+    acc
+}
+
+/// Credit the incremental quark gift from opening (`worlds.add(actual, false,
+/// true)`): the delta over the running daily total. Pushes [`CoreEvent::QuarksAwarded`].
+fn credit_open_quarks(
+    state: &mut GameState,
+    gain: f64,
+    daily_awarded: f64,
+    events: &mut SmallVec<[CoreEvent; 2]>,
+) -> f64 {
+    let actual = (gain - daily_awarded).max(0.0);
+    if actual > 0.0 {
+        state.quarks.worlds += Decimal::from_finite(actual);
+        state.golden_quarks.quarks_this_singularity += actual;
+        events.push(CoreEvent::QuarksAwarded { quarks: actual });
+    }
+    actual
+}
+
+// ─── Per-tier open ────────────────────────────────────────────────────────────
+
+/// `WowCubes.open` — the most involved tier: research multipliers, the
+/// `taxmanLastStand` divisor, the `cubeUpgrades[13/23/33]` modulo boosts, the
+/// `1e300` tribute cap, and the `oneCubeOfMany` achievement.
+pub(crate) fn open_cubes(
+    state: &mut GameState,
+    value: f64,
+    max: bool,
+    free: bool,
+) -> SmallVec<[CoreEvent; 2]> {
+    use crate::mechanics::achievement_awards::award_ungrouped_achievement;
+    use crate::mechanics::shop_upgrades::cube_to_quark_effect;
+    use crate::state::shop::SHOP_CUBE_TO_QUARK;
+    const ONE_CUBE_OF_MANY: usize = 246;
+
+    let mut events: SmallVec<[CoreEvent; 2]> = SmallVec::new();
+    let balance = state.cube_balances.wow_cubes.to_number();
+    let mut to_spend = resolve_to_spend(balance, value, max, free);
+    let spent = to_spend;
+
+    // oneCubeOfMany — opening exactly one cube at >= 2e11 accelerator blessing.
+    if value == 1.0 && state.cube_blessings.accelerator >= 2e11 {
+        award_ungrouped_achievement(&mut state.achievements, ONE_CUBE_OF_MANY, 50.0, true);
+    }
+
+    if !free {
+        state.cube_balances.wow_cubes = Decimal::from_finite((balance - to_spend).max(0.0));
+    }
+    state.cube_balances.cube_opened_daily += to_spend;
+
+    let cube_mult = cube_quark_multiplier(state);
+    let shop_mult = cube_to_quark_effect(state.shop.upgrades[SHOP_CUBE_TO_QUARK]);
+    let gain = check_quark_gain(
+        5.0,
+        shop_mult,
+        cube_mult,
+        state.quarks.quark_bonus,
+        state.cube_balances.cube_opened_daily,
+    );
+    let actual = credit_open_quarks(
+        state,
+        gain,
+        state.cube_balances.cube_quark_daily,
+        &mut events,
+    );
+    state.cube_balances.cube_quark_daily += actual;
+
+    // `sumContents(cubeBlessings) >= 1e300` → no more tributes awarded.
+    let sum_of_tributes = state.cube_blessings.sum();
+    if sum_of_tributes >= 1e300 {
+        events.push(CoreEvent::CubesOpened {
+            tier: CubeTier::Cubes,
+            spent,
+        });
+        return events;
+    }
+
+    // Cubes-only research multipliers (researches 138 / 168 / 198), then floor.
+    let r138 = state.researches.researches[138];
+    let r168 = state.researches.researches[168];
+    let r198 = state.researches.researches[198];
+    to_spend *= 1.0 + r138 / 1000.0;
+    to_spend *= 1.0 + 0.8 * r168 / 1000.0;
+    to_spend *= 1.0 + 0.6 * r198 / 1000.0;
+    to_spend = to_spend.floor();
+    to_spend = to_spend.min(1e300 - sum_of_tributes);
+
+    // Exalt-8 taxmanLastStand divisor at >= 5 completions.
+    if state.singularity.taxman_last_stand.enabled
+        && state.singularity.taxman_last_stand.completions >= 5.0
+    {
+        to_spend /= (1.0 + (1.0 + sum_of_tributes + to_spend).ln()).powi(3);
+    }
+
+    // div/modulo split + the cubeUpgrade[13/23/33] modulo boosts, then re-fold.
+    let mut modulo = to_spend % 20.0;
+    let mut div20 = (to_spend / 20.0).floor();
+    let cu13 = state.cube_upgrade_levels.cube_upgrades[13];
+    let cu23 = state.cube_upgrade_levels.cube_upgrades[23];
+    let cu33 = state.cube_upgrade_levels.cube_upgrades[33];
+    if div20 > 0.0 && cu13 == 1.0 {
+        modulo += div20;
+    }
+    if div20 > 0.0 && cu23 == 1.0 {
+        modulo += div20;
+    }
+    if div20 > 0.0 && cu33 == 1.0 {
+        modulo += div20;
+    }
+    div20 += (modulo / 20.0).floor();
+    modulo %= 20.0;
+
+    let acc = distribute_cube_blessings(div20, modulo, state.rng.draw(RngPurpose::CubeOpen));
+    state.cube_blessings.add_in_order(&acc);
+
+    events.push(CoreEvent::CubesOpened {
+        tier: CubeTier::Cubes,
+        spent,
+    });
+    events
+}
+
+/// `WowTesseracts.open` — the plain 20-bucket distribution + the cube cascade
+/// (`researches[153]` free cube opens).
+pub(crate) fn open_tesseracts(
+    state: &mut GameState,
+    value: f64,
+    max: bool,
+    free: bool,
+) -> SmallVec<[CoreEvent; 2]> {
+    use crate::mechanics::shop_upgrades::tesseract_to_quark_effect;
+    use crate::state::shop::SHOP_TESSERACT_TO_QUARK;
+
+    let mut events: SmallVec<[CoreEvent; 2]> = SmallVec::new();
+    let balance = state.cube_balances.wow_tesseracts.to_number();
+    let to_spend = resolve_to_spend(balance, value, max, free);
+
+    if !free {
+        state.cube_balances.wow_tesseracts = Decimal::from_finite((balance - to_spend).max(0.0));
+    }
+    state.cube_balances.tesseract_opened_daily += to_spend;
+
+    let cube_mult = cube_quark_multiplier(state);
+    let shop_mult = tesseract_to_quark_effect(state.shop.upgrades[SHOP_TESSERACT_TO_QUARK]);
+    let gain = check_quark_gain(
+        7.0,
+        shop_mult,
+        cube_mult,
+        state.quarks.quark_bonus,
+        state.cube_balances.tesseract_opened_daily,
+    );
+    let actual = credit_open_quarks(
+        state,
+        gain,
+        state.cube_balances.tesseract_quark_daily,
+        &mut events,
+    );
+    state.cube_balances.tesseract_quark_daily += actual;
+
+    let modulo = to_spend % 20.0;
+    let div20 = (to_spend / 20.0).floor();
+    let acc = distribute_cube_blessings(div20, modulo, state.rng.draw(RngPurpose::CubeOpen));
+    state.tesseract_blessings.add_in_order(&acc);
+    events.push(CoreEvent::CubesOpened {
+        tier: CubeTier::Tesseracts,
+        spent: to_spend,
+    });
+
+    // Cascade: research 6x33 grants free cube opens.
+    let extra = (12.0 * to_spend * state.researches.researches[153]).floor();
+    if extra > 0.0 {
+        events.extend(open_cubes(state, extra, false, true));
+    }
+    events
+}
+
+/// `WowHypercubes.open` — 20-bucket distribution + the tesseract cascade
+/// (`researches[183]` free tesseract opens).
+pub(crate) fn open_hypercubes(
+    state: &mut GameState,
+    value: f64,
+    max: bool,
+    free: bool,
+) -> SmallVec<[CoreEvent; 2]> {
+    use crate::mechanics::shop_upgrades::hypercube_to_quark_effect;
+    use crate::state::shop::SHOP_HYPERCUBE_TO_QUARK;
+
+    let mut events: SmallVec<[CoreEvent; 2]> = SmallVec::new();
+    let balance = state.cube_balances.wow_hypercubes.to_number();
+    let to_spend = resolve_to_spend(balance, value, max, free);
+
+    if !free {
+        state.cube_balances.wow_hypercubes = Decimal::from_finite((balance - to_spend).max(0.0));
+    }
+    state.cube_balances.hypercube_opened_daily += to_spend;
+
+    let cube_mult = cube_quark_multiplier(state);
+    let shop_mult = hypercube_to_quark_effect(state.shop.upgrades[SHOP_HYPERCUBE_TO_QUARK]);
+    let gain = check_quark_gain(
+        10.0,
+        shop_mult,
+        cube_mult,
+        state.quarks.quark_bonus,
+        state.cube_balances.hypercube_opened_daily,
+    );
+    let actual = credit_open_quarks(
+        state,
+        gain,
+        state.cube_balances.hypercube_quark_daily,
+        &mut events,
+    );
+    state.cube_balances.hypercube_quark_daily += actual;
+
+    let modulo = to_spend % 20.0;
+    let div20 = (to_spend / 20.0).floor();
+    let acc = distribute_cube_blessings(div20, modulo, state.rng.draw(RngPurpose::CubeOpen));
+    state.hypercube_blessings.add_in_order(&acc);
+    events.push(CoreEvent::CubesOpened {
+        tier: CubeTier::Hypercubes,
+        spent: to_spend,
+    });
+
+    // Cascade: research 8x33 grants free tesseract opens.
+    let extra = (100.0 * to_spend * state.researches.researches[183]).floor();
+    if extra > 0.0 {
+        events.extend(open_tesseracts(state, extra, false, true));
+    }
+    events
+}
+
+/// `WowPlatonicCubes.open` — the bespoke 40000-bucket distribution: bulk grant
+/// (with the `cubeUpgrades[64]` weight-1 doubling), the "RNGesus" rare-drop
+/// loop, proportional common drops, then a final per-unit pdf roll. The
+/// platonic→hypercube cascade (`platonicToHypercubes` achievement reward) is
+/// unported → inert.
+pub(crate) fn open_platonic(
+    state: &mut GameState,
+    value: f64,
+    max: bool,
+    free: bool,
+) -> SmallVec<[CoreEvent; 2]> {
+    let mut events: SmallVec<[CoreEvent; 2]> = SmallVec::new();
+    let balance = state.cube_balances.wow_platonic_cubes.to_number();
+    let to_spend = resolve_to_spend(balance, value, max, free);
+
+    if !free {
+        state.cube_balances.wow_platonic_cubes =
+            Decimal::from_finite((balance - to_spend).max(0.0));
+    }
+    state.cube_balances.platonic_cube_opened_daily += to_spend;
+
+    // Base 15, fixed mult 1.5 (no platonic-to-quark shop upgrade).
+    let cube_mult = cube_quark_multiplier(state);
+    let gain = check_quark_gain(
+        15.0,
+        1.5,
+        cube_mult,
+        state.quarks.quark_bonus,
+        state.cube_balances.platonic_cube_opened_daily,
+    );
+    let actual = credit_open_quarks(
+        state,
+        gain,
+        state.cube_balances.platonic_cube_quark_daily,
+        &mut events,
+    );
+    state.cube_balances.platonic_cube_quark_daily += actual;
+
+    let div40000 = (to_spend / 40_000.0).floor();
+    let mut modulo = to_spend % 40_000.0;
+
+    // Bulk grant; the four weight-1 rare slots double under cubeUpgrades[64].
+    let double_rares = state.cube_upgrade_levels.cube_upgrades[64] > 0.0;
+    let mut acc = [0.0_f64; 8];
+    for (slot, &weight) in acc.iter_mut().zip(PLATONIC_WEIGHTS.iter()) {
+        *slot = weight * div40000;
+        if weight == 1.0 && double_rares {
+            *slot += div40000;
+        }
+    }
+
+    // "RNGesus" rare-drop loop over the four weight-1 slots (indices 4..8).
+    for slot in acc[4..8].iter_mut() {
+        let num = next_f64(state.rng.draw(RngPurpose::CubeOpen));
+        if modulo / 40_000.0 >= num && modulo != 0.0 {
+            *slot += 1.0;
+            modulo -= 1.0;
+        }
+    }
+
+    // Proportional common drops over the four common slots (indices 0..4), each
+    // computed against the same post-RNGesus remainder.
+    let common = [
+        (33.0 * modulo / 100.0).floor(),
+        (33.0 * modulo / 100.0).floor(),
+        (33.0 * modulo / 100.0).floor(),
+        (396.0 * modulo / 40_000.0).floor(),
+    ];
+    for (slot, &gained) in acc[..4].iter_mut().zip(common.iter()) {
+        *slot += gained;
+        modulo -= gained;
+    }
+
+    // Final per-unit pdf roll on the leftover.
+    for _ in 0..(modulo as u64) {
+        let num = 100.0 * next_f64(state.rng.draw(RngPurpose::CubeOpen));
+        let idx = PLATONIC_BANDS
+            .iter()
+            .position(|&band| num <= band)
+            .unwrap_or(7);
+        acc[idx] += 1.0;
+    }
+
+    state.platonic_blessings.add_from_eight(&acc);
+    events.push(CoreEvent::CubesOpened {
+        tier: CubeTier::Platonic,
+        spent: to_spend,
+    });
+    events
+}
+
+/// Open `value` cubes of `tier` (or the whole balance when `max`). The
+/// player-initiated entry point — never `free`; the free re-opens are internal
+/// to the tier cascades.
+pub(crate) fn open(
+    state: &mut GameState,
+    tier: CubeTier,
+    value: f64,
+    max: bool,
+) -> SmallVec<[CoreEvent; 2]> {
+    match tier {
+        CubeTier::Cubes => open_cubes(state, value, max, false),
+        CubeTier::Tesseracts => open_tesseracts(state, value, max, false),
+        CubeTier::Hypercubes => open_hypercubes(state, value, max, false),
+        CubeTier::Platonic => open_platonic(state, value, max, false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_cubes_bulk_is_deterministic_at_a_full_set() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_cubes = Decimal::from_finite(100.0);
+        // 20 cubes → div20 = 1, modulo = 0 → exactly the weights, RNG-free.
+        open_cubes(&mut state, 20.0, false, false);
+        let b = &state.cube_blessings;
+        assert_eq!(b.accelerator, 4.0);
+        assert_eq!(b.multiplier, 4.0);
+        assert_eq!(b.offering, 2.0);
+        assert_eq!(b.ant_sacrifice, 1.0);
+        assert_eq!(b.global_speed, 1.0);
+        // Currency spent.
+        assert_eq!(state.cube_balances.wow_cubes.to_number(), 80.0);
+    }
+
+    #[test]
+    fn open_cubes_remainder_grants_exactly_modulo_blessings() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_cubes = Decimal::from_finite(50.0);
+        // 5 cubes → div20 = 0, modulo = 5 → 5 RNG +1s total (which blessings
+        // depends on the seed, but the total is exact).
+        open_cubes(&mut state, 5.0, false, false);
+        assert_eq!(state.cube_blessings.sum(), 5.0);
+    }
+
+    #[test]
+    fn open_most_spends_whole_balance() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_cubes = Decimal::from_finite(123.0);
+        open_cubes(&mut state, 0.0, true, false);
+        assert_eq!(state.cube_balances.wow_cubes.to_number(), 0.0);
+        // 123 cubes → 6 full sets (div20=6) + 3 remainder = 6*20 + 3 = 123 blessings.
+        assert_eq!(state.cube_blessings.sum(), 123.0);
+    }
+
+    #[test]
+    fn tesseract_open_cascades_into_cube_blessings() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_tesseracts = Decimal::from_finite(100.0);
+        state.researches.researches[153] = 1.0; // enables the free cube cascade
+
+        open_tesseracts(&mut state, 20.0, false, false);
+
+        // Tesseract's own full set.
+        assert_eq!(state.tesseract_blessings.accelerator, 4.0);
+        // Cascade: floor(12 * 20 * 1) = 240 free cube opens → div20 = 12 → 48.
+        assert_eq!(state.cube_blessings.accelerator, 48.0);
+    }
+
+    #[test]
+    fn platonic_open_bulk_is_deterministic_at_a_full_set() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_platonic_cubes = Decimal::from_finite(40_000.0);
+        // 40000 → div40000 = 1, modulo = 0 → exactly the weights, RNG-free.
+        open_platonic(&mut state, 40_000.0, false, false);
+        let p = &state.platonic_blessings;
+        assert_eq!(p.cubes, 13_200.0);
+        assert_eq!(p.platonics, 396.0);
+        assert_eq!(p.hypercube_bonus, 1.0);
+        assert_eq!(p.taxes, 1.0);
+        assert_eq!(p.global_speed, 1.0); // the scoreBonus slot is discarded
+        assert_eq!(state.cube_balances.wow_platonic_cubes.to_number(), 0.0);
+    }
+
+    #[test]
+    fn one_cube_of_many_awards_at_high_accelerator_blessing() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_cubes = Decimal::from_finite(10.0);
+        state.cube_blessings.accelerator = 2e11;
+        open_cubes(&mut state, 1.0, false, false);
+        assert_ne!(state.achievements.achievements[246], 0); // oneCubeOfMany
+    }
+
+    #[test]
+    fn opening_awards_quarks_with_overflux_orbs() {
+        let mut state = GameState::default();
+        state.cube_balances.wow_cubes = Decimal::from_finite(1e6);
+        state.hepteracts.overflux_orbs = 1e6; // drives the cube-quark multiplier
+
+        let events = open_cubes(&mut state, 1e6, false, false);
+
+        assert!(state.quarks.worlds.to_number() > 0.0);
+        assert!(state.cube_balances.cube_quark_daily > 0.0);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::QuarksAwarded { .. })));
+    }
+}

--- a/crates/synergismforkd_logic/src/mechanics/mod.rs
+++ b/crates/synergismforkd_logic/src/mechanics/mod.rs
@@ -28,6 +28,7 @@ pub mod corruptions;
 pub mod crystal_and_building_power;
 pub mod crystal_upgrades;
 pub mod cube_blessings;
+pub mod cube_opening;
 pub mod cube_upgrades;
 pub mod event_buffs;
 pub mod exalt_penalties;

--- a/crates/synergismforkd_logic/src/state/blessings.rs
+++ b/crates/synergismforkd_logic/src/state/blessings.rs
@@ -63,3 +63,57 @@ pub struct PlatonicBlessings {
     /// Global-speed blessing count.
     pub global_speed: f64,
 }
+
+impl BlessingValues {
+    /// Add a cube-open distribution in the legacy `cubeBlessings` key order
+    /// (accelerator, multiplier, offering, runeExp, obtainium, antSpeed,
+    /// antSacrifice, antELO, talismanBonus, globalSpeed) — the same order the
+    /// open-distribution weight/pdf tables use.
+    pub(crate) fn add_in_order(&mut self, increments: &[f64; 10]) {
+        self.accelerator += increments[0];
+        self.multiplier += increments[1];
+        self.offering += increments[2];
+        self.rune_exp += increments[3];
+        self.obtainium += increments[4];
+        self.ant_speed += increments[5];
+        self.ant_sacrifice += increments[6];
+        self.ant_elo += increments[7];
+        self.talisman_bonus += increments[8];
+        self.global_speed += increments[9];
+    }
+
+    /// Sum of all ten blessing counts — the legacy `sumContents(cubeBlessings)`
+    /// used for the `1e300` tribute cap on cube opening.
+    pub(crate) fn sum(&self) -> f64 {
+        self.accelerator
+            + self.multiplier
+            + self.offering
+            + self.rune_exp
+            + self.obtainium
+            + self.ant_speed
+            + self.ant_sacrifice
+            + self.ant_elo
+            + self.talisman_bonus
+            + self.global_speed
+    }
+}
+
+impl PlatonicBlessings {
+    /// Add an 8-slot platonic-open distribution in the legacy `platonicBlessings`
+    /// key order (cubes, tesseracts, hypercubes, platonics, hypercubeBonus,
+    /// taxes, **scoreBonus**, globalSpeed). The `scoreBonus` slot (index 6) is
+    /// dropped: the legacy schema stores it but no effect reads it (the
+    /// ascension-score reader reads `globalSpeed`), so this port omits the field
+    /// — its distribution share is still computed (for faithful remainder
+    /// accounting) and then discarded here.
+    pub(crate) fn add_from_eight(&mut self, increments: &[f64; 8]) {
+        self.cubes += increments[0];
+        self.tesseracts += increments[1];
+        self.hypercubes += increments[2];
+        self.platonics += increments[3];
+        self.hypercube_bonus += increments[4];
+        self.taxes += increments[5];
+        // increments[6] = scoreBonus — discarded (write-only dead field).
+        self.global_speed += increments[7];
+    }
+}

--- a/crates/synergismforkd_logic/src/state/cube_balances.rs
+++ b/crates/synergismforkd_logic/src/state/cube_balances.rs
@@ -42,6 +42,26 @@ pub struct CubeBalancesState {
     pub platonic_cubes_this_ascension: Decimal,
     /// `hepteracts_this_ascension` — see [`Self::cubes_this_ascension`].
     pub hepteracts_this_ascension: Decimal,
+    // ── Daily cube-opening counters (quark-from-opening bookkeeping) ──────
+    // Reset on a new real-life day (the daily reset is a UI/time-tier
+    // concern, not yet ported); `open()` accumulates the cubes opened and
+    // the quarks already awarded today, so each open awards only the delta.
+    /// `player.cubeOpenedDaily` — cubes opened today.
+    pub cube_opened_daily: f64,
+    /// `player.cubeQuarkDaily` — quarks already awarded from cube opens today.
+    pub cube_quark_daily: f64,
+    /// `player.tesseractOpenedDaily`.
+    pub tesseract_opened_daily: f64,
+    /// `player.tesseractQuarkDaily`.
+    pub tesseract_quark_daily: f64,
+    /// `player.hypercubeOpenedDaily`.
+    pub hypercube_opened_daily: f64,
+    /// `player.hypercubeQuarkDaily`.
+    pub hypercube_quark_daily: f64,
+    /// `player.platonicCubeOpenedDaily`.
+    pub platonic_cube_opened_daily: f64,
+    /// `player.platonicCubeQuarkDaily`.
+    pub platonic_cube_quark_daily: f64,
 }
 
 impl Default for CubeBalancesState {
@@ -60,6 +80,14 @@ impl Default for CubeBalancesState {
             hypercubes_this_ascension: Decimal::zero(),
             platonic_cubes_this_ascension: Decimal::zero(),
             hepteracts_this_ascension: Decimal::zero(),
+            cube_opened_daily: 0.0,
+            cube_quark_daily: 0.0,
+            tesseract_opened_daily: 0.0,
+            tesseract_quark_daily: 0.0,
+            hypercube_opened_daily: 0.0,
+            hypercube_quark_daily: 0.0,
+            platonic_cube_opened_daily: 0.0,
+            platonic_cube_quark_daily: 0.0,
         }
     }
 }

--- a/crates/synergismforkd_logic/src/state/rng.rs
+++ b/crates/synergismforkd_logic/src/state/rng.rs
@@ -33,11 +33,16 @@ pub enum RngPurpose {
     Ambrosia = 1,
     /// Red-ambrosia loot rolls. Legacy `Seed.RedAmbrosia = 2`.
     RedAmbrosia = 2,
+    /// Cube-opening blessing-distribution rolls (Wow! Cubes / Tesseracts /
+    /// Hypercubes / Platonic Cubes share one stream). Legacy used the
+    /// unseeded global `Math.random()`; this port keeps a deterministic
+    /// per-purpose stream, so opens are reproducible but not TS-bit-equal.
+    CubeOpen = 3,
 }
 
 impl RngPurpose {
     /// Count of `RngPurpose` variants. Update when adding a variant.
-    pub const COUNT: usize = 3;
+    pub const COUNT: usize = 4;
 }
 
 /// One `Xoshiro256PlusPlus` per [`RngPurpose`]. Fixed-arity array keyed by the

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -36,12 +36,12 @@ use crate::state::GameState;
 ///
 /// Neutral-defaulted lines (faithful — identity at the current state):
 /// `RuneBlessing` (prism rune-blessing `antSacrificeMult` — the rune-blessing
-/// layer is unported; identity `1` at blessing level 0), `Event` (UI-tier event
-/// calendar → `1`), and the trailing `calculateAntSacrificeCubeBlessing` (cube
-/// blessing levels are frozen at `0` until `open()` lands — P3.2 — where it
-/// evaluates to `1`; the same factor is neutral-defaulted in
-/// `compute_obtainium_gain`'s ant-sacrifice source).
-fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
+/// layer is unported; identity `1` at blessing level 0) and `Event` (UI-tier
+/// event calendar → `1`). The trailing `calculateAntSacrificeCubeBlessing` reads
+/// the live blessing cascade (`ant_sacrifice_cube_blessing`) now that `open()`
+/// (P3.2) makes the cube-blessing levels accrue. (`compute_obtainium_gain`'s
+/// ant-sacrifice obtainium source still neutral-defaults — see its docs.)
+pub(super) fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
     use crate::mechanics::achievement_rewards::sacrifice_mult;
     use crate::mechanics::ant_upgrades::ant_sacrifice_ant_upgrade_effect;
     use crate::mechanics::calculate::product_f64;
@@ -76,8 +76,9 @@ fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
         1.0, // Event — UI-tier event calendar → 1 + 0
     ]);
 
-    // × calculateAntSacrificeCubeBlessing() — `1` while blessing levels frozen.
-    Decimal::from_finite(stats)
+    // × calculateAntSacrificeCubeBlessing() — the live ant-sacrifice blessing
+    // cascade (now that `open()` makes the cube-blessing levels accrue).
+    Decimal::from_finite(stats) * ant_sacrifice_cube_blessing(state)
 }
 
 /// `rebornELOCreationSpeedMult` (RebornELO/lib/calculate.ts) — the product of
@@ -86,9 +87,10 @@ fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
 ///
 /// Neutral-defaulted lines (faithful — identity at the current state):
 /// `MortuusTalisman` (talisman effect-level wiring is unported — P2.3 blocked;
-/// `MORTUUS_INSCRIPT_VALUES[0] = 1`), `CubeBlessing`
-/// (`calculateAntELOCubeBlessing` — frozen blessing levels → `1`, P3.2), and
-/// `Exalt6` (singularity layer paused → `1`).
+/// `MORTUUS_INSCRIPT_VALUES[0] = 1`) and `Exalt6` (singularity layer paused →
+/// `1`). The `CubeBlessing` line (`calculateAntELOCubeBlessing`) reads the live
+/// blessing cascade via `ant_elo_cube_blessing` now that `open()` (P3.2) makes
+/// the levels accrue.
 fn compute_reborn_elo_creation_speed_mult(state: &GameState) -> f64 {
     use crate::mechanics::ant_reborn_elo::{
         reborn_elo_stage_modifiers, RebornELOStageModifiersInput,
@@ -130,10 +132,56 @@ fn compute_reborn_elo_creation_speed_mult(state: &GameState) -> f64 {
         if owned(HOLY_SPIRIT) { 3.0 } else { 1.0 },
         stage_mods.reborn_speed_mult,
         1.0, // MortuusTalisman — talisman effect level unported (P2.3) → 1
-        1.0, // CubeBlessing — calculateAntELOCubeBlessing, frozen blessings → 1
+        ant_elo_cube_blessing(state), // CubeBlessing — calculateAntELOCubeBlessing
         1.0 + state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_12] / 10.0,
         1.0, // Exalt6 — singularity layer paused → 1
     ])
+}
+
+// ─── Live cube-blessing cascades (platonic → hypercube → tesseract → cube) ────
+
+/// `calculateAntSacrificeCubeBlessing()` — the ant-sacrifice cube-blessing
+/// cascade. Evaluates to `1` until cubes are opened (all blessing levels `0`);
+/// P3.2's `open()` makes the levels accrue, so this reads the live state.
+fn ant_sacrifice_cube_blessing(state: &GameState) -> Decimal {
+    use crate::mechanics::cube_blessings::calculate_ant_sacrifice_cube_blessing;
+    use crate::mechanics::hypercube_blessings::calculate_ant_sacrifice_hypercube_blessing;
+    use crate::mechanics::platonic_blessings::calculate_hypercube_blessing_multiplier_platonic_blessing;
+    use crate::mechanics::tesseract_blessings::calculate_ant_sacrifice_tesseract_blessing;
+
+    // `player.cubeUpgrades[15]` — the ant-sacrifice cube-blessing DR increase.
+    const CUBE_UPGRADE_ANT_SACRIFICE_BLESSING: usize = 15;
+
+    let platonic =
+        calculate_hypercube_blessing_multiplier_platonic_blessing(&state.platonic_blessings);
+    let hypercube =
+        calculate_ant_sacrifice_hypercube_blessing(&state.hypercube_blessings, platonic);
+    let tesseract =
+        calculate_ant_sacrifice_tesseract_blessing(&state.tesseract_blessings, hypercube);
+    calculate_ant_sacrifice_cube_blessing(
+        &state.cube_blessings,
+        tesseract,
+        state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_ANT_SACRIFICE_BLESSING],
+    )
+}
+
+/// `calculateAntELOCubeBlessing()` — the ant-ELO cube-blessing cascade (its
+/// hypercube layer takes no platonic amplifier). `1` until cubes are opened.
+fn ant_elo_cube_blessing(state: &GameState) -> f64 {
+    use crate::mechanics::cube_blessings::calculate_ant_elo_cube_blessing;
+    use crate::mechanics::hypercube_blessings::calculate_ant_elo_hypercube_blessing;
+    use crate::mechanics::tesseract_blessings::calculate_ant_elo_tesseract_blessing;
+
+    // `player.cubeUpgrades[25]` — the ant-ELO cube-blessing exponent increase.
+    const CUBE_UPGRADE_ANT_ELO_BLESSING: usize = 25;
+
+    let hypercube = calculate_ant_elo_hypercube_blessing(&state.hypercube_blessings);
+    let tesseract = calculate_ant_elo_tesseract_blessing(&state.tesseract_blessings, hypercube);
+    calculate_ant_elo_cube_blessing(
+        &state.cube_blessings,
+        tesseract,
+        state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_ANT_ELO_BLESSING],
+    )
 }
 
 // ─── The sacrifice ────────────────────────────────────────────────────────────
@@ -556,6 +604,28 @@ mod tests {
         assert_eq!(state.achievements.achievement_points, 8.0);
         // The producer was consumed by the post-sacrifice reset.
         assert_eq!(state.ants.producers[1].purchased, 0.0);
+    }
+
+    #[test]
+    fn ant_sacrifice_multiplier_picks_up_live_cube_blessings() {
+        let mut state = GameState::default();
+        // No blessings opened → the cube-blessing factor is identity.
+        assert_eq!(ant_sacrifice_cube_blessing(&state).to_number(), 1.0);
+        let base = compute_ant_sacrifice_multiplier(&state).to_number();
+
+        // Raising the ant-sacrifice cube blessing (as opening cubes would) lifts
+        // both the cascade factor and the assembled multiplier above the base.
+        state.cube_blessings.ant_sacrifice = 5_000.0;
+        assert!(ant_sacrifice_cube_blessing(&state).to_number() > 1.0);
+        assert!(compute_ant_sacrifice_multiplier(&state).to_number() > base);
+    }
+
+    #[test]
+    fn reborn_elo_rate_picks_up_live_ant_elo_cube_blessing() {
+        let mut state = GameState::default();
+        assert_eq!(ant_elo_cube_blessing(&state), 1.0); // identity at level 0
+        state.cube_blessings.ant_elo = 1e6;
+        assert!(ant_elo_cube_blessing(&state) > 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -155,6 +155,7 @@ pub(super) fn perform_ant_sacrifice(
     state: &mut GameState,
     reincarnation_point_gain: Decimal,
 ) -> SmallVec<[CoreEvent; 2]> {
+    use crate::mechanics::achievement_awards;
     use crate::mechanics::ant_reborn_elo::{
         reborn_elo_stage_modifiers, RebornELOStageModifiersInput,
     };
@@ -278,10 +279,27 @@ pub(super) fn perform_ant_sacrifice(
         t.legendary_fragments += talisman_rewards[5];
         t.mythical_fragments += talisman_rewards[6];
     }
-    // TODO(P3.1): awardAchievementGroup('sacMult') + the seeingRed /
-    // seeingRedNoBlue ungrouped mythical-fragment achievements.
+    // awardAchievementGroup('sacMult') — reads the updated immortal ELO and the
+    // still-owned producers, before the reset clears them.
+    let immortal_elo = state.ants.immortal_elo;
+    let producer_owned: [bool; 9] =
+        std::array::from_fn(|i| state.ants.producers[i].purchased > 0.0);
+    achievement_awards::sac_mult_achievement_check(
+        &mut state.achievements,
+        immortal_elo,
+        &producer_owned,
+    );
 
     reset_ants_for_sacrifice(state);
+
+    // Trailing ungrouped seeingRed / seeingRedNoBlue checks (post-reset in
+    // `sacrificeAnts`; the reset does not touch the mythical-fragment balance).
+    let mythical_fragments = state.talismans.mythical_fragments;
+    achievement_awards::ant_sacrifice_fragment_achievement_check(
+        &mut state.achievements,
+        mythical_fragments,
+        in_challenge_14,
+    );
 
     smallvec![CoreEvent::AntSacrificePerformed {
         offerings_gained,
@@ -334,6 +352,13 @@ fn reset_ants_for_sacrifice(state: &mut GameState) {
     // `antSacrificeCountMultiplier` achievement reward is unported (→ ×1).
     state.ants.current_sacrifice_id += 1;
     state.ants.ant_sacrifice_count += 1.0 + state.researches.researches[RESEARCH_SAC_COUNT];
+
+    // awardAchievementGroup('sacCount') — on the updated sacrifice count.
+    let sacrifice_count = state.ants.ant_sacrifice_count;
+    crate::mechanics::achievement_awards::sac_count_achievement_check(
+        &mut state.achievements,
+        sacrifice_count,
+    );
 
     // Timers reset.
     state.ants.ant_sacrifice_timer = 0.0;
@@ -503,12 +528,34 @@ mod tests {
         assert_eq!(state.ants.crumbs_this_sacrifice.to_number(), 1.0);
         assert_eq!(state.ants.reborn_elo, 0.0);
         assert_eq!(state.ants.ant_sacrifice_count, 1.0);
+        // sacCount >= 1 achievement (#481, 3 points) fires on the first sacrifice.
+        assert_eq!(state.achievements.achievement_points, 3.0);
+        assert_ne!(state.achievements.achievements[481], 0);
         assert_eq!(state.ants.current_sacrifice_id, 1);
         assert_eq!(state.ants.ant_sacrifice_timer, 0.0);
         assert!(matches!(
             events.as_slice(),
             [CoreEvent::AntSacrificePerformed { .. }]
         ));
+    }
+
+    #[test]
+    fn sacrifice_awards_sac_mult_when_elo_and_producer_met() {
+        let mut state = GameState::default();
+        state.ants.ant_sacrifice_timer = 10.0;
+        // Pre-existing immortal ELO + an owned Breeders producer unlocks the
+        // first sacMult tier (#176: immortalELO >= 50 && Breeders owned).
+        state.ants.immortal_elo = 1_000.0;
+        state.ants.producers[1].purchased = 5.0; // Breeders
+
+        let _ = perform_ant_sacrifice(&mut state, Decimal::zero());
+
+        // sacMult #176 (5 pts) + sacCount #481 (3 pts) = 8.
+        assert_ne!(state.achievements.achievements[176], 0, "sacMult tier 1");
+        assert_ne!(state.achievements.achievements[481], 0, "sacCount >= 1");
+        assert_eq!(state.achievements.achievement_points, 8.0);
+        // The producer was consumed by the post-sacrifice reset.
+        assert_eq!(state.ants.producers[1].purchased, 0.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -13,15 +13,14 @@
 //! and applies the results, the way `tick::reset` consumes the reset
 //! calculators (and reaches the private `super::compute_*` resource helpers).
 //!
-//! Two pieces are deliberately deferred:
+//! One piece is deliberately omitted:
 //!
-//! - **Quark award.** `activateELO`'s closing `availableQuarksFromELO()` →
-//!   `player.worlds.applyBonus(...)` award needs the worlds quark-bonus system
-//!   (porting slice 3b). Omitted here; the reborn-ELO leaderboard it reads is
-//!   fully maintained, so wiring it later is purely additive.
 //! - **Lotus shortcut.** The `getLotusTimeExpiresAt()` branch that snaps
 //!   `rebornELO = immortalELO` reads wall-clock time, forbidden in the logic
-//!   crate. Omitted — the gradual activation path is always taken.
+//!   crate. Omitted — the gradual activation path is always taken. (The quark
+//!   award — `activateELO`'s closing `worlds.add(availableQuarksFromELO())` — is
+//!   wired below; the `autoWarpCheck` / `dailyPowderResetUses` warp factor is an
+//!   unported auto-feature and neutral-defaults to 1.)
 
 use smallvec::{smallvec, SmallVec};
 use synergismforkd_bignum::Decimal;
@@ -350,7 +349,7 @@ fn reset_ants_for_sacrifice(state: &mut GameState) {
 /// Called each live tick from `phase_automation` (gated on `immortal_elo > 0`).
 /// The Lotus wall-clock shortcut and the trailing quark award are omitted (see
 /// the module header).
-pub(super) fn activate_elo(state: &mut GameState, dt: f64) {
+pub(super) fn activate_elo(state: &mut GameState, dt: f64) -> SmallVec<[CoreEvent; 1]> {
     use crate::mechanics::ant_reborn_elo::{
         calculate_available_reborn_elo, calculate_reborn_elo_thresholds,
         calculate_to_next_reborn_elo_threshold, AvailableRebornELOInput,
@@ -379,9 +378,55 @@ pub(super) fn activate_elo(state: &mut GameState, dt: f64) {
         state.ants.reborn_elo = state.ants.reborn_elo.min(state.ants.immortal_elo);
     }
     update_ant_leaderboards(state);
-    // TODO(P3.1 slice 3b): availableQuarksFromELO() → player.worlds.applyBonus()
-    // quark award. Needs the worlds quark-bonus system; the leaderboards it
-    // reads are maintained above, so this is purely additive.
+
+    // Quark award — `activateELO`'s closing `worlds.add(availableQuarksFromELO(),
+    // false, true)` (useBonus false: the quark multiplier is already applied
+    // inside `available_quarks_from_elo`; `addToQuarksThisSingularity` true).
+    let quarks = available_quarks_from_elo(state);
+    let mut events: SmallVec<[CoreEvent; 1]> = SmallVec::new();
+    if quarks > 0.0 {
+        state.quarks.worlds += Decimal::from_finite(quarks);
+        state.golden_quarks.quarks_this_singularity += quarks;
+        state.ants.quarks_gained_from_ants += quarks;
+        events.push(CoreEvent::QuarksAwarded { quarks });
+    }
+    events
+}
+
+/// `availableQuarksFromELO` (QuarkCorner/lib/calculate-quarks.ts) — the
+/// incremental quark gift from the reborn-ELO leaderboards. The daily
+/// leaderboard's stages set the base quark count + per-stage multiplier; the
+/// all-time leaderboard scales it (`quarks_from_elo_mult`); `applyBonus` (the
+/// cached quark multiplier) multiplies; and the running
+/// `quarks_gained_from_ants` total is subtracted so each tick only awards the
+/// delta. The `autoWarpCheck ? 1 + dailyPowderResetUses : 1` factor
+/// neutral-defaults to 1 (auto-warp is an unported auto-feature).
+fn available_quarks_from_elo(state: &GameState) -> f64 {
+    use crate::mechanics::ant_reborn_elo::{
+        base_quarks_from_reborn_elo_stages, calculate_leaderboard_value,
+        calculate_reborn_elo_thresholds, quarks_from_elo_mult,
+    };
+
+    let daily: Vec<f64> = state
+        .ants
+        .highest_reborn_elo_daily
+        .iter()
+        .map(|e| e.elo)
+        .collect();
+    let num_stages = calculate_reborn_elo_thresholds(calculate_leaderboard_value(&daily));
+    let bq = base_quarks_from_reborn_elo_stages(num_stages);
+
+    let ever: Vec<f64> = state
+        .ants
+        .highest_reborn_elo_ever
+        .iter()
+        .map(|e| e.elo)
+        .collect();
+    let ant_quark_mult = quarks_from_elo_mult(calculate_leaderboard_value(&ever)) * bq.stage_mult;
+
+    // applyBonus(baseQuarks): the cached quark multiplier (a percent → ×).
+    let applied = bq.base_quarks * (1.0 + state.quarks.quark_bonus / 100.0);
+    (applied * ant_quark_mult - state.ants.quarks_gained_from_ants).max(0.0)
 }
 
 /// `updateAntLeaderboards` (QuarkCorner/lib/leaderboard-update.ts) — record the
@@ -516,6 +561,30 @@ mod tests {
         assert_eq!(state.ants.reborn_elo, 500.0);
         // The leaderboard still records the (maxed) reborn ELO.
         assert_eq!(state.ants.highest_reborn_elo_ever[0].elo, 500.0);
+    }
+
+    #[test]
+    fn activate_elo_awards_quarks_from_the_leaderboard() {
+        let mut state = GameState::default();
+        state.ants.immortal_elo = 200_000.0;
+
+        let events = activate_elo(&mut state, 1e9);
+
+        assert!(
+            state.quarks.worlds.to_number() > 0.0,
+            "the reborn-ELO leaderboard should award quarks"
+        );
+        assert!(state.ants.quarks_gained_from_ants > 0.0);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::QuarksAwarded { .. })));
+
+        // The running `quarks_gained_from_ants` total dedups: re-activating at
+        // the same leaderboard (dt 0 → no further climb) awards ~nothing more.
+        let before = state.quarks.worlds.to_number();
+        let _ = activate_elo(&mut state, 0.0);
+        let delta = state.quarks.worlds.to_number() - before;
+        assert!(delta < 1.0, "second activation re-awarded {delta} quarks");
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -1,0 +1,617 @@
+//! Ant-sacrifice orchestration — the effect side of the mechanic.
+//!
+//! Ports the legacy `sacrificeAnts()`
+//! (Features/Ants/AntSacrifice/sacrifice.ts) and the per-tick `activateELO()`
+//! (Rewards/ELO/RebornELO/lib/create-reborn.ts), which together restore the
+//! offering / obtainium / talisman economy, raise the `immortalELO` high-water
+//! mark, and populate the reborn-ELO leaderboards that drive the slice-3a
+//! achievement progressive.
+//!
+//! The pure reward math lives in `mechanics::ant_sacrifice_reward_calc`,
+//! `mechanics::ant_sacrifice_rewards`, and `mechanics::ant_reborn_elo`; this
+//! module is the `&mut GameState` orchestrator that reduces the live StatLines
+//! and applies the results, the way `tick::reset` consumes the reset
+//! calculators (and reaches the private `super::compute_*` resource helpers).
+//!
+//! Two pieces are deliberately deferred:
+//!
+//! - **Quark award.** `activateELO`'s closing `availableQuarksFromELO()` →
+//!   `player.worlds.applyBonus(...)` award needs the worlds quark-bonus system
+//!   (porting slice 3b). Omitted here; the reborn-ELO leaderboard it reads is
+//!   fully maintained, so wiring it later is purely additive.
+//! - **Lotus shortcut.** The `getLotusTimeExpiresAt()` branch that snaps
+//!   `rebornELO = immortalELO` reads wall-clock time, forbidden in the logic
+//!   crate. Omitted — the gradual activation path is always taken.
+
+use smallvec::{smallvec, SmallVec};
+use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::state::ants::{PlayerAntProducer, RebornELOEntry};
+use crate::state::GameState;
+
+// ─── Reward StatLine reducers (live, `&GameState`) ────────────────────────────
+
+/// `calculateAntSacrificeMultiplier` (Calculate.ts:382) — the product of the
+/// `antSacrificeRewardStats` StatLine times `calculateAntSacrificeCubeBlessing`.
+///
+/// Neutral-defaulted lines (faithful — identity at the current state):
+/// `RuneBlessing` (prism rune-blessing `antSacrificeMult` — the rune-blessing
+/// layer is unported; identity `1` at blessing level 0), `Event` (UI-tier event
+/// calendar → `1`), and the trailing `calculateAntSacrificeCubeBlessing` (cube
+/// blessing levels are frozen at `0` until `open()` lands — P3.2 — where it
+/// evaluates to `1`; the same factor is neutral-defaulted in
+/// `compute_obtainium_gain`'s ant-sacrifice source).
+fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
+    use crate::mechanics::achievement_rewards::sacrifice_mult;
+    use crate::mechanics::ant_upgrades::ant_sacrifice_ant_upgrade_effect;
+    use crate::mechanics::calculate::product_f64;
+    use crate::mechanics::challenges::{calc_ecc, ChallengeType};
+
+    // Ant upgrade slot: AntSacrifice (index 10).
+    const ANT_UPGRADE_ANT_SACRIFICE: usize = 10;
+    // `player.upgrades[40]` — accelerator-boost upgrade.
+    const ACCELERATOR_BOOST_UPGRADE: usize = 40;
+
+    let ach = &state.achievements.achievements;
+    let researches = &state.researches.researches;
+    let upgrades = &state.upgrades.upgrades;
+
+    let stats = product_f64(&[
+        sacrifice_mult(ach),
+        ant_sacrifice_ant_upgrade_effect(super::true_ant_level(state, ANT_UPGRADE_ANT_SACRIFICE))
+            .ant_sacrifice_multiplier,
+        1.0 + researches[103] / 20.0,
+        1.0 + researches[104] / 20.0,
+        1.0, // RuneBlessing — prism rune-blessing antSacrificeMult (unported → 1)
+        1.0 + (1.0 / 50.0)
+            * calc_ecc(
+                ChallengeType::Reincarnation,
+                state.challenges.challenge_completions[10],
+            ),
+        1.0 + (1.0 / 50.0) * researches[122],
+        1.0 + (3.0 / 100.0) * researches[133],
+        1.0 + (2.0 / 100.0) * researches[163],
+        1.0 + (1.0 / 100.0) * researches[193],
+        1.0 + (1.0 / 4.0) * f64::from(upgrades[ACCELERATOR_BOOST_UPGRADE]),
+        1.0, // Event — UI-tier event calendar → 1 + 0
+    ]);
+
+    // × calculateAntSacrificeCubeBlessing() — `1` while blessing levels frozen.
+    Decimal::from_finite(stats)
+}
+
+/// `rebornELOCreationSpeedMult` (RebornELO/lib/calculate.ts) — the product of
+/// `rebornELOCreationSpeedMultStats`. Sets how fast `immortalELO` bleeds into
+/// `rebornELO` per second in [`activate_elo`].
+///
+/// Neutral-defaulted lines (faithful — identity at the current state):
+/// `MortuusTalisman` (talisman effect-level wiring is unported — P2.3 blocked;
+/// `MORTUUS_INSCRIPT_VALUES[0] = 1`), `CubeBlessing`
+/// (`calculateAntELOCubeBlessing` — frozen blessing levels → `1`, P3.2), and
+/// `Exalt6` (singularity layer paused → `1`).
+fn compute_reborn_elo_creation_speed_mult(state: &GameState) -> f64 {
+    use crate::mechanics::ant_reborn_elo::{
+        reborn_elo_stage_modifiers, RebornELOStageModifiersInput,
+    };
+    use crate::mechanics::calculate::product_f64;
+
+    // Ant producer slots: Queens .. HolySpirit.
+    const QUEENS: usize = 4;
+    const LORD_ROYALS: usize = 5;
+    const ALMIGHTIES: usize = 6;
+    const DISCIPLES: usize = 7;
+    const HOLY_SPIRIT: usize = 8;
+    // `player.upgrades[124]` — Coin upgrade 2x4.
+    const COIN_UPGRADE_24: usize = 124;
+    // `player.platonicUpgrades[12]`.
+    const PLATONIC_UPGRADE_12: usize = 12;
+
+    let researches = &state.researches.researches;
+    let upgrades = &state.upgrades.upgrades;
+    let producers = &state.ants.producers;
+    let owned = |i: usize| producers[i].purchased > 0.0;
+
+    let stage_mods = reborn_elo_stage_modifiers(&RebornELOStageModifiersInput {
+        reborn_elo: state.ants.reborn_elo,
+        sing_count: state.singularity.singularity_count,
+    });
+
+    product_f64(&[
+        0.01, // Base
+        super::compute_effective_ant_elo(state),
+        1.0 + 0.1 * f64::from(upgrades[COIN_UPGRADE_24]),
+        1.0 + researches[110] / 50.0,
+        1.0 + researches[120] / 250.0,
+        1.0 + researches[148] / 50.0,
+        if owned(QUEENS) { 1.15 } else { 1.0 },
+        if owned(LORD_ROYALS) { 1.25 } else { 1.0 },
+        if owned(ALMIGHTIES) { 1.4 } else { 1.0 },
+        if owned(DISCIPLES) { 2.0 } else { 1.0 },
+        if owned(HOLY_SPIRIT) { 3.0 } else { 1.0 },
+        stage_mods.reborn_speed_mult,
+        1.0, // MortuusTalisman — talisman effect level unported (P2.3) → 1
+        1.0, // CubeBlessing — calculateAntELOCubeBlessing, frozen blessings → 1
+        1.0 + state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_12] / 10.0,
+        1.0, // Exalt6 — singularity layer paused → 1
+    ])
+}
+
+// ─── The sacrifice ────────────────────────────────────────────────────────────
+
+/// Execute an ant sacrifice — the effect side of `AntSacrificeTriggered`.
+///
+/// Ports `sacrificeAnts()`: credits the immortal-ELO high-water gain,
+/// offerings, obtainium (unless inside ascension challenge 14), and the seven
+/// talisman craft items (gated on challenge-9 completions), then resets the
+/// ants to crumbs. All rewards are computed from the pre-sacrifice state (as
+/// `antSacrificeRewards()` does) before any mutation is applied. Returns the
+/// [`CoreEvent::AntSacrificePerformed`] effect event.
+///
+/// The `sacMult` / `sacCount` achievement-group awards, the
+/// `antSacrificeToReincarnation` reincarnation bump, and the `seeingRed`
+/// mythical-fragment achievements are deferred to the achievement-awarding
+/// workstream (P3.1) — see the inline TODOs.
+pub(super) fn perform_ant_sacrifice(
+    state: &mut GameState,
+    reincarnation_point_gain: Decimal,
+) -> SmallVec<[CoreEvent; 2]> {
+    use crate::mechanics::ant_reborn_elo::{
+        reborn_elo_stage_modifiers, RebornELOStageModifiersInput,
+    };
+    use crate::mechanics::ant_sacrifice_reward_calc::{
+        calculate_ant_sacrifice_obtainium, calculate_ant_sacrifice_offering,
+        calculate_immortal_elo_gain, AntSacrificeObtainiumInput, AntSacrificeOfferingInput,
+        CalculateImmortalELOGainInput,
+    };
+    use crate::mechanics::ant_sacrifice_rewards::{
+        calculate_ant_sacrifice_talisman_item, AntSacrificeTalismanItemInput, TalismanCraftItem,
+    };
+    use crate::mechanics::calculate::{calculate_offerings, CalculateOfferingsInput};
+
+    // Ascension challenge 14 suppresses the obtainium credit (the reward is
+    // still computed; only the credit to the balance is skipped).
+    const ASCENSION_CHALLENGE_14: u32 = 14;
+
+    // ── Compute all rewards from the pre-sacrifice state ─────────────────────
+    let effective_elo = super::compute_effective_ant_elo(state);
+    let ant_sac_mult = compute_ant_sacrifice_multiplier(state);
+    let time_multiplier =
+        super::offering_obtainium_time_multiplier(state, state.ants.ant_sacrifice_timer, true);
+    let stage_mods = reborn_elo_stage_modifiers(&RebornELOStageModifiersInput {
+        reborn_elo: state.ants.reborn_elo,
+        sing_count: state.singularity.singularity_count,
+    });
+    let taxman_enabled = state.singularity.taxman_last_stand.enabled;
+    let taxman_completions = state.singularity.taxman_last_stand.completions;
+
+    let immortal_elo_gained = calculate_immortal_elo_gain(&CalculateImmortalELOGainInput {
+        effective_elo,
+        immortal_elo: state.ants.immortal_elo,
+    });
+
+    // offering_mult / obtainium_mult = calculateOfferings(false) /
+    // calculateObtainium(false): the standard awards with the time multiplier
+    // off (the ant-sacrifice time multiplier is applied separately below).
+    let base_offerings = super::compute_base_offerings(state);
+    let offering_mult = calculate_offerings(&CalculateOfferingsInput {
+        base_offerings,
+        time_multiplier: 1.0,
+        offering_mult: super::compute_offering_mult(state, base_offerings),
+        taxman_last_stand_enabled: taxman_enabled,
+        taxman_last_stand_completions: taxman_completions,
+        current_offerings: state.automation.offerings,
+    });
+    let offerings_gained = calculate_ant_sacrifice_offering(&AntSacrificeOfferingInput {
+        ant_sac_mult,
+        stage_mult: stage_mods.ant_sacrifice_offering_mult,
+        time_multiplier,
+        offering_mult,
+        current_offerings: state.automation.offerings,
+        taxman_last_stand_enabled: taxman_enabled,
+        taxman_last_stand_completions: taxman_completions,
+    });
+
+    let obtainium_mult = super::compute_obtainium(
+        state,
+        super::compute_base_obtainium(state),
+        reincarnation_point_gain,
+        1.0,
+    );
+    let obtainium_reward = calculate_ant_sacrifice_obtainium(&AntSacrificeObtainiumInput {
+        ant_sac_mult,
+        stage_mult: stage_mods.ant_sacrifice_obtainium_mult,
+        time_multiplier,
+        obtainium_mult,
+        current_obtainium: state.researches.obtainium,
+        taxman_last_stand_enabled: taxman_enabled,
+        taxman_last_stand_completions: taxman_completions,
+    });
+    let in_challenge_14 = state.challenges.current_ascension_challenge == ASCENSION_CHALLENGE_14;
+    let obtainium_gained = if in_challenge_14 {
+        Decimal::zero()
+    } else {
+        obtainium_reward
+    };
+
+    // Talisman craft items — gated on challenge-9 completions. Quantities are
+    // `Decimal`; the talisman fragment/shard balances are `f64` in this slice,
+    // so the credits round through `to_number()`.
+    let talisman_gated = state.challenges.challenge_completions[9] > 0.0;
+    let talisman_rewards: [f64; 7] = if talisman_gated {
+        let reward_mult = ant_sac_mult * Decimal::from_finite(time_multiplier);
+        let stage_mult = stage_mods.ant_sacrifice_talisman_fragment_mult;
+        let qty = |item: TalismanCraftItem| {
+            calculate_ant_sacrifice_talisman_item(&AntSacrificeTalismanItemInput {
+                item,
+                elo: effective_elo,
+                reward_mult,
+                stage_mult,
+            })
+            .to_number()
+        };
+        [
+            qty(TalismanCraftItem::Shard),
+            qty(TalismanCraftItem::CommonFragment),
+            qty(TalismanCraftItem::UncommonFragment),
+            qty(TalismanCraftItem::RareFragment),
+            qty(TalismanCraftItem::EpicFragment),
+            qty(TalismanCraftItem::LegendaryFragment),
+            qty(TalismanCraftItem::MythicalFragment),
+        ]
+    } else {
+        [0.0; 7]
+    };
+
+    // ── Apply mutations ──────────────────────────────────────────────────────
+    state.ants.immortal_elo += immortal_elo_gained;
+    state.automation.offerings += offerings_gained;
+    if !in_challenge_14 {
+        state.researches.obtainium += obtainium_reward;
+    }
+    if talisman_gated {
+        let t = &mut state.talismans;
+        t.talisman_shards += talisman_rewards[0];
+        t.common_fragments += talisman_rewards[1];
+        t.uncommon_fragments += talisman_rewards[2];
+        t.rare_fragments += talisman_rewards[3];
+        t.epic_fragments += talisman_rewards[4];
+        t.legendary_fragments += talisman_rewards[5];
+        t.mythical_fragments += talisman_rewards[6];
+    }
+    // TODO(P3.1): awardAchievementGroup('sacMult') + the seeingRed /
+    // seeingRedNoBlue ungrouped mythical-fragment achievements.
+
+    reset_ants_for_sacrifice(state);
+
+    smallvec![CoreEvent::AntSacrificePerformed {
+        offerings_gained,
+        obtainium_gained,
+        immortal_elo_gained,
+    }]
+}
+
+/// `resetAnts(AntSacrificeTiers.sacrifice)` — the post-sacrifice reset (tier 0).
+///
+/// Resets crumbs, producers, masteries, the sacrifice-tier ant upgrades, and
+/// `rebornELO` to their defaults; bumps the sacrifice id and count. `immortalELO`
+/// is **not** reset at the sacrifice tier (it only clears at ascension), and the
+/// reborn-ELO leaderboards persist (they clear at singularity / save-reset).
+///
+/// The `highestSingularityCount >= 10/15/20` crumb / producer / upgrade regrants
+/// and the `sacCount` group award + `antSacrificeToReincarnation` bump are
+/// omitted — the singularity layer is paused and the group awards belong to the
+/// achievement-awarding workstream. All are inert at every non-singularity state.
+fn reset_ants_for_sacrifice(state: &mut GameState) {
+    // Ant upgrades whose `minimumResetTier` is `sacrifice` (0) — reset on every
+    // sacrifice. Salvage(7) / Mortuus(11) / Mortuus2(13) / AscensionScore(14)
+    // persist (higher reset tiers) and are intentionally absent.
+    const SACRIFICE_TIER_UPGRADES: &[usize] = &[0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 12];
+    // `player.researches[116]` — 5x16, +1 sacrifice count per level.
+    const RESEARCH_SAC_COUNT: usize = 116;
+
+    // Crumbs → defaults (`defaultCrumbs` / `defaultCrumbsThisSacrifice` = 1).
+    state.ants.crumbs = Decimal::one();
+    state.ants.crumbs_this_sacrifice = Decimal::one();
+
+    // Producers → empty; masteries → mastery 0 (highest_mastery preserved).
+    for producer in &mut state.ants.producers {
+        *producer = PlayerAntProducer::default();
+    }
+    for mastery in &mut state.ants.masteries {
+        mastery.mastery = 0;
+    }
+
+    // Sacrifice-tier ant upgrades → 0.
+    for &i in SACRIFICE_TIER_UPGRADES {
+        state.ants.upgrades[i] = 0.0;
+    }
+
+    // rebornELO → 0; `activate_elo` re-accrues it from immortalELO each tick.
+    state.ants.reborn_elo = 0.0;
+
+    // Sacrifice bookkeeping. `currentSacrificeId` always increments (permanent
+    // leaderboard tagging). `antSacrificeCount += 1 + researches[116]` — the
+    // `antSacrificeCountMultiplier` achievement reward is unported (→ ×1).
+    state.ants.current_sacrifice_id += 1;
+    state.ants.ant_sacrifice_count += 1.0 + state.researches.researches[RESEARCH_SAC_COUNT];
+
+    // Timers reset.
+    state.ants.ant_sacrifice_timer = 0.0;
+    state.ants.ant_sacrifice_timer_real = 0.0;
+}
+
+// ─── Reborn-ELO activation + leaderboard ──────────────────────────────────────
+
+/// `activateELO(dt)` (RebornELO/lib/create-reborn.ts) — bleed available
+/// `immortalELO` into `rebornELO` at the creation-speed rate, then refresh the
+/// reborn-ELO leaderboards.
+///
+/// Called each live tick from `phase_automation` (gated on `immortal_elo > 0`).
+/// The Lotus wall-clock shortcut and the trailing quark award are omitted (see
+/// the module header).
+pub(super) fn activate_elo(state: &mut GameState, dt: f64) {
+    use crate::mechanics::ant_reborn_elo::{
+        calculate_available_reborn_elo, calculate_reborn_elo_thresholds,
+        calculate_to_next_reborn_elo_threshold, AvailableRebornELOInput,
+    };
+
+    let to_activate = calculate_available_reborn_elo(&AvailableRebornELOInput {
+        immortal_elo: state.ants.immortal_elo,
+        reborn_elo: state.ants.reborn_elo,
+    });
+    if to_activate > 0.0 {
+        let limit = state.ants.immortal_elo - state.ants.reborn_elo;
+        let gain = limit.min(dt * compute_reborn_elo_creation_speed_mult(state));
+        let mut stages = calculate_reborn_elo_thresholds(state.ants.reborn_elo);
+        let mut elo_to_next =
+            calculate_to_next_reborn_elo_threshold(state.ants.reborn_elo, Some(stages));
+        let mut budget = gain;
+        while budget >= elo_to_next {
+            state.ants.reborn_elo += elo_to_next;
+            budget -= elo_to_next;
+            budget /= 1.02; // each threshold makes further ELO harder to gain
+            stages += 1.0;
+            elo_to_next =
+                calculate_to_next_reborn_elo_threshold(state.ants.reborn_elo, Some(stages));
+        }
+        state.ants.reborn_elo += budget;
+        state.ants.reborn_elo = state.ants.reborn_elo.min(state.ants.immortal_elo);
+    }
+    update_ant_leaderboards(state);
+    // TODO(P3.1 slice 3b): availableQuarksFromELO() → player.worlds.applyBonus()
+    // quark award. Needs the worlds quark-bonus system; the leaderboards it
+    // reads are maintained above, so this is purely additive.
+}
+
+/// `updateAntLeaderboards` (QuarkCorner/lib/leaderboard-update.ts) — record the
+/// current `rebornELO` (tagged by `currentSacrificeId`) into the daily and
+/// all-time top-5 reborn-ELO leaderboards.
+fn update_ant_leaderboards(state: &mut GameState) {
+    let elo = state.ants.reborn_elo;
+    let sacrifice_id = state.ants.current_sacrifice_id;
+    update_single_leaderboard(&mut state.ants.highest_reborn_elo_daily, elo, sacrifice_id);
+    update_single_leaderboard(&mut state.ants.highest_reborn_elo_ever, elo, sacrifice_id);
+}
+
+/// Insert/refresh one leaderboard: keep the top `LEADERBOARD_WEIGHTS.len()` (5)
+/// entries sorted by ELO descending, deduping by `sacrifice_id` so a climbing
+/// sacrifice updates its own entry in place. Verbatim port of
+/// `updateSingleLeaderboard`.
+fn update_single_leaderboard(
+    leaderboard: &mut SmallVec<[RebornELOEntry; 5]>,
+    elo: f64,
+    sacrifice_id: u32,
+) {
+    use crate::mechanics::ant_reborn_elo::LEADERBOARD_WEIGHTS;
+    let cap = LEADERBOARD_WEIGHTS.len();
+
+    // Full and below the floor → nothing to do.
+    if leaderboard.len() == cap {
+        if let Some(last) = leaderboard.last() {
+            if elo < last.elo {
+                return;
+            }
+        }
+    }
+
+    if let Some(idx) = leaderboard
+        .iter()
+        .position(|e| e.sacrifice_id == sacrifice_id)
+    {
+        leaderboard[idx].elo = elo;
+        if idx > 0 && leaderboard[idx].elo > leaderboard[idx - 1].elo {
+            leaderboard.sort_by(|a, b| b.elo.total_cmp(&a.elo));
+        }
+    } else {
+        leaderboard.push(RebornELOEntry { elo, sacrifice_id });
+        leaderboard.sort_by(|a, b| b.elo.total_cmp(&a.elo));
+    }
+
+    if leaderboard.len() > cap {
+        leaderboard.truncate(cap);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mechanics::ant_reborn_elo::calculate_leaderboard_value;
+
+    #[test]
+    fn sacrifice_credits_immortal_elo_offerings_and_resets_ants() {
+        let mut state = GameState::default();
+        // A non-zero sacrifice timer gives a non-zero time multiplier (the
+        // threshold penalty is `(timer / 10)^2`, zero at timer 0).
+        state.ants.ant_sacrifice_timer = 10.0;
+        state.ants.crumbs = Decimal::from_finite(1e50);
+        state.ants.crumbs_this_sacrifice = Decimal::from_finite(1e50);
+
+        let events = perform_ant_sacrifice(&mut state, Decimal::zero());
+
+        // Effective ELO at the default state is 1 (the `ants` level reward),
+        // immortal ELO was 0 → gain 1.
+        assert_eq!(state.ants.immortal_elo, 1.0);
+        assert!(state.automation.offerings.to_number() > 0.0);
+        // Ants reset to crumbs; bookkeeping advanced.
+        assert_eq!(state.ants.crumbs.to_number(), 1.0);
+        assert_eq!(state.ants.crumbs_this_sacrifice.to_number(), 1.0);
+        assert_eq!(state.ants.reborn_elo, 0.0);
+        assert_eq!(state.ants.ant_sacrifice_count, 1.0);
+        assert_eq!(state.ants.current_sacrifice_id, 1);
+        assert_eq!(state.ants.ant_sacrifice_timer, 0.0);
+        assert!(matches!(
+            events.as_slice(),
+            [CoreEvent::AntSacrificePerformed { .. }]
+        ));
+    }
+
+    #[test]
+    fn ascension_challenge_14_suppresses_obtainium_credit() {
+        let mut state = GameState::default();
+        state.ants.ant_sacrifice_timer = 10.0;
+        state.challenges.current_ascension_challenge = 14;
+        let before = state.researches.obtainium;
+
+        let events = perform_ant_sacrifice(&mut state, Decimal::zero());
+
+        assert_eq!(state.researches.obtainium, before);
+        let CoreEvent::AntSacrificePerformed {
+            obtainium_gained, ..
+        } = events[0]
+        else {
+            panic!("expected AntSacrificePerformed");
+        };
+        assert_eq!(obtainium_gained.to_number(), 0.0);
+    }
+
+    #[test]
+    fn activate_elo_climbs_reborn_elo_and_populates_leaderboard() {
+        let mut state = GameState::default();
+        state.ants.immortal_elo = 1_000.0;
+        assert!(state.ants.highest_reborn_elo_ever.is_empty());
+
+        // A large dt lets the gradual activation reach the immortal-ELO cap.
+        activate_elo(&mut state, 1e9);
+
+        assert!(state.ants.reborn_elo > 0.0);
+        assert!(state.ants.reborn_elo <= 1_000.0);
+        assert!(!state.ants.highest_reborn_elo_ever.is_empty());
+        let elos: Vec<f64> = state
+            .ants
+            .highest_reborn_elo_ever
+            .iter()
+            .map(|e| e.elo)
+            .collect();
+        // This is the value that unsticks the slice-3a reborn-ELO progressive.
+        assert!(calculate_leaderboard_value(&elos) > 0.0);
+    }
+
+    #[test]
+    fn activate_elo_noop_when_reborn_already_maxed() {
+        let mut state = GameState::default();
+        state.ants.immortal_elo = 500.0;
+        state.ants.reborn_elo = 500.0; // already fully activated → no bleed
+        activate_elo(&mut state, 1e9);
+        assert_eq!(state.ants.reborn_elo, 500.0);
+        // The leaderboard still records the (maxed) reborn ELO.
+        assert_eq!(state.ants.highest_reborn_elo_ever[0].elo, 500.0);
+    }
+
+    #[test]
+    fn leaderboard_dedups_by_sacrifice_id_and_caps_at_five() {
+        let mut lb: SmallVec<[RebornELOEntry; 5]> = SmallVec::new();
+        update_single_leaderboard(&mut lb, 100.0, 1);
+        update_single_leaderboard(&mut lb, 200.0, 2);
+        // Same sacrifice id climbing → updates in place, no new row.
+        update_single_leaderboard(&mut lb, 150.0, 1);
+        assert_eq!(lb.len(), 2);
+        assert_eq!(lb[0].elo, 200.0); // sacrifice 2
+        assert_eq!(lb[1].elo, 150.0); // sacrifice 1, updated
+
+        // Eight distinct sacrifices total → capped at the top 5.
+        for id in 3..=8 {
+            update_single_leaderboard(&mut lb, f64::from(id) * 10.0, id);
+        }
+        assert_eq!(lb.len(), 5);
+        // Sorted descending: the two big early entries survive on top.
+        assert_eq!(lb[0].elo, 200.0);
+        assert_eq!(lb[1].elo, 150.0);
+    }
+
+    #[test]
+    fn leaderboard_below_floor_when_full_is_dropped() {
+        let mut lb: SmallVec<[RebornELOEntry; 5]> = SmallVec::new();
+        for id in 1..=5 {
+            update_single_leaderboard(&mut lb, f64::from(id) * 100.0, id);
+        }
+        assert_eq!(lb.len(), 5);
+        let floor = lb.last().unwrap().elo;
+        // A new sacrifice below the current floor is rejected.
+        update_single_leaderboard(&mut lb, floor - 1.0, 99);
+        assert_eq!(lb.len(), 5);
+        assert!(lb.iter().all(|e| e.sacrifice_id != 99));
+    }
+
+    // ── End-to-end wiring through `tack` (the orchestration blind spot) ──────
+
+    #[test]
+    fn tack_consumes_ant_sacrifice_trigger_and_executes_the_sacrifice() {
+        use crate::tick::{tack, TackInput};
+
+        let mut state = GameState::default();
+        // Unlock ant sacrifice (achievement #173) and prime the auto-sacrifice
+        // gate: enough crumbs, past the cooldown, auto-sacrifice enabled.
+        state.achievements.achievements[173] = 1;
+        state.ants.crumbs_this_sacrifice = Decimal::from_finite(1e40);
+        state.ants.ant_sacrifice_timer_real = 0.1;
+        state.ants.toggles.auto_sacrifice_enabled = true;
+
+        let input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        let output = tack(&mut state, &input);
+
+        // The emitted `AntSacrificeTriggered` intent is consumed and the
+        // sacrifice executes — proving the consume-wiring (the dropped-event
+        // class of bug) actually fires end to end.
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::AntSacrificePerformed { .. })),
+            "AntSacrificeTriggered should be consumed into an executed sacrifice"
+        );
+        assert!(state.ants.immortal_elo > 0.0);
+        assert!(state.ants.ant_sacrifice_count >= 1.0);
+        assert_eq!(state.ants.crumbs.to_number(), 1.0); // ants reset to crumbs
+    }
+
+    #[test]
+    fn tack_reborn_elo_activation_lights_the_progressive() {
+        use crate::tick::{tack, TackInput};
+
+        let mut state = GameState::default();
+        // Simulate a post-sacrifice state with a large activated reborn ELO.
+        state.ants.immortal_elo = 200_000.0;
+        state.ants.reborn_elo = 150_000.0;
+        assert_eq!(state.achievements.achievement_points, 0.0);
+
+        let input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        // Tick 1: `phase_automation`'s activation records the reborn ELO onto the
+        // leaderboard (read by the *next* tick's `phase_global_state`).
+        tack(&mut state, &input);
+        assert!(!state.ants.highest_reborn_elo_ever.is_empty());
+        // Tick 2: the slot-3 reborn-ELO progressive picks up the leaderboard.
+        tack(&mut state, &input);
+
+        assert!(
+            state.achievements.achievement_points > 0.0,
+            "the populated reborn-ELO leaderboard should light the slice-3a progressive"
+        );
+    }
+}

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -338,22 +338,24 @@ pub(super) fn perform_ant_sacrifice(
     let immortal_elo = state.ants.immortal_elo;
     let producer_owned: [bool; 9] =
         std::array::from_fn(|i| state.ants.producers[i].purchased > 0.0);
-    achievement_awards::sac_mult_achievement_check(
+    let awarded = achievement_awards::sac_mult_achievement_check(
         &mut state.achievements,
         immortal_elo,
         &producer_owned,
     );
+    super::credit_achievement_quarks(state, awarded);
 
     reset_ants_for_sacrifice(state);
 
     // Trailing ungrouped seeingRed / seeingRedNoBlue checks (post-reset in
     // `sacrificeAnts`; the reset does not touch the mythical-fragment balance).
     let mythical_fragments = state.talismans.mythical_fragments;
-    achievement_awards::ant_sacrifice_fragment_achievement_check(
+    let awarded = achievement_awards::ant_sacrifice_fragment_achievement_check(
         &mut state.achievements,
         mythical_fragments,
         in_challenge_14,
     );
+    super::credit_achievement_quarks(state, awarded);
 
     smallvec![CoreEvent::AntSacrificePerformed {
         offerings_gained,
@@ -409,10 +411,11 @@ fn reset_ants_for_sacrifice(state: &mut GameState) {
 
     // awardAchievementGroup('sacCount') — on the updated sacrifice count.
     let sacrifice_count = state.ants.ant_sacrifice_count;
-    crate::mechanics::achievement_awards::sac_count_achievement_check(
+    let awarded = crate::mechanics::achievement_awards::sac_count_achievement_check(
         &mut state.achievements,
         sacrifice_count,
     );
+    super::credit_achievement_quarks(state, awarded);
 
     // Timers reset.
     state.ants.ant_sacrifice_timer = 0.0;

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -85,17 +85,20 @@ pub(super) fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
 /// `rebornELOCreationSpeedMultStats`. Sets how fast `immortalELO` bleeds into
 /// `rebornELO` per second in [`activate_elo`].
 ///
-/// Neutral-defaulted lines (faithful — identity at the current state):
-/// `MortuusTalisman` (talisman effect-level wiring is unported — P2.3 blocked;
-/// `MORTUUS_INSCRIPT_VALUES[0] = 1`) and `Exalt6` (singularity layer paused →
-/// `1`). The `CubeBlessing` line (`calculateAntELOCubeBlessing`) reads the live
-/// blessing cascade via `ant_elo_cube_blessing` now that `open()` (P3.2) makes
-/// the levels accrue.
+/// Neutral-defaulted lines (faithful — identity at the current state): only
+/// `Exalt6` (singularity layer paused → `1`). The `MortuusTalisman` line reads
+/// `mortuus_talisman_effects(talismanRarity[mortuus]).ant_bonus`
+/// (`MORTUUS_INSCRIPT_VALUES[rarity]`, identity at rarity 0) and the
+/// `CubeBlessing` line (`calculateAntELOCubeBlessing`) reads the live blessing
+/// cascade via `ant_elo_cube_blessing` — both wired now that the underlying
+/// state can accrue (talisman rarity / `open()` blessings).
 fn compute_reborn_elo_creation_speed_mult(state: &GameState) -> f64 {
     use crate::mechanics::ant_reborn_elo::{
         reborn_elo_stage_modifiers, RebornELOStageModifiersInput,
     };
     use crate::mechanics::calculate::product_f64;
+    use crate::mechanics::talisman_effects::mortuus_talisman_effects;
+    use crate::state::talismans::TALISMAN_MORTUUS;
 
     // Ant producer slots: Queens .. HolySpirit.
     const QUEENS: usize = 4;
@@ -131,7 +134,10 @@ fn compute_reborn_elo_creation_speed_mult(state: &GameState) -> f64 {
         if owned(DISCIPLES) { 2.0 } else { 1.0 },
         if owned(HOLY_SPIRIT) { 3.0 } else { 1.0 },
         stage_mods.reborn_speed_mult,
-        1.0, // MortuusTalisman — talisman effect level unported (P2.3) → 1
+        // MortuusTalisman — getTalismanEffects('mortuus').antBonus =
+        // MORTUUS_INSCRIPT_VALUES[talismanRarity[mortuus]] (1 at rarity 0).
+        mortuus_talisman_effects(state.talismans.talisman_rarity[TALISMAN_MORTUUS] as i32)
+            .ant_bonus,
         ant_elo_cube_blessing(state), // CubeBlessing — calculateAntELOCubeBlessing
         1.0 + state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_12] / 10.0,
         1.0, // Exalt6 — singularity layer paused → 1
@@ -626,6 +632,15 @@ mod tests {
         assert_eq!(ant_elo_cube_blessing(&state), 1.0); // identity at level 0
         state.cube_blessings.ant_elo = 1e6;
         assert!(ant_elo_cube_blessing(&state) > 1.0);
+    }
+
+    #[test]
+    fn reborn_elo_rate_picks_up_mortuus_talisman_rarity() {
+        let mut state = GameState::default();
+        let base = compute_reborn_elo_creation_speed_mult(&state);
+        // Mortuus rarity 5 → MORTUUS_INSCRIPT_VALUES[5] = 1.3× the rate.
+        state.talismans.talisman_rarity[5] = 5.0;
+        assert!(compute_reborn_elo_creation_speed_mult(&state) > base);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -5331,11 +5331,12 @@ fn complete_active_challenge(
     // challengeAchievementCheck(q) — award the challengeN group from the
     // updated completion count (the legacy resetCheck calls it after the
     // completion increments).
-    crate::mechanics::achievement_awards::challenge_achievement_check(
+    let awarded = crate::mechanics::achievement_awards::challenge_achievement_check(
         &mut state.achievements,
         q_idx,
         &state.challenges.challenge_completions,
     );
+    credit_achievement_quarks(state, awarded);
     while state.challenges.challenge_completions[q_idx]
         > state.challenges.highest_challenge_completions[q_idx]
     {
@@ -6052,14 +6053,27 @@ fn inside_singularity_challenge(s: &crate::state::SingularityState) -> bool {
 // ─── Dispatch helpers ────────────────────────────────────────────────────
 
 /// `buildingAchievementCheck()` — run after a coin-producer buy to award the
+/// Credit the per-achievement quark reward for `count` newly-awarded
+/// achievements (legacy `awardAchievement`'s `player.worlds.add`). Threads the
+/// `GameState` quark slices into the slice-based reward helper.
+pub(crate) fn credit_achievement_quarks(state: &mut GameState, count: usize) {
+    crate::mechanics::achievement_awards::credit_achievement_quarks(
+        &mut state.quarks.worlds,
+        &mut state.golden_quarks.quarks_this_singularity,
+        state.quarks.quark_bonus,
+        count,
+    );
+}
+
 /// `*OwnedCoin` achievement groups from the current owned counts (the legacy
 /// `buyBuilding` calls it on every building purchase).
 fn check_coin_building_achievements(state: &mut GameState) {
     let coin_owned: [f64; 5] = std::array::from_fn(|i| state.coin_producers.tiers[i].owned);
-    crate::mechanics::achievement_awards::building_achievement_check(
+    let awarded = crate::mechanics::achievement_awards::building_achievement_check(
         &mut state.achievements,
         &coin_owned,
     );
+    credit_achievement_quarks(state, awarded);
 }
 
 fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent; 4]> {
@@ -7878,8 +7892,10 @@ mod tests {
         assert!(
             matches!(quark_events[0], CoreEvent::QuarksAwarded { quarks } if (*quarks - 1.0).abs() < 1e-9)
         );
-        assert!((state.quarks.worlds.to_number() - 1.0).abs() < 1e-9);
-        assert!((state.golden_quarks.quarks_this_singularity - 1.0).abs() < 1e-9);
+        // worlds = 1 (highest-challenge reward) + 5 (the challenge-1 achievement
+        // award now grants getAchievementQuarks() = 5 at the default quark bonus).
+        assert!((state.quarks.worlds.to_number() - 6.0).abs() < 1e-9);
+        assert!((state.golden_quarks.quarks_this_singularity - 6.0).abs() < 1e-9);
     }
 
     #[test]
@@ -7901,7 +7917,9 @@ mod tests {
             .events
             .iter()
             .any(|e| matches!(e, CoreEvent::QuarksAwarded { .. })));
-        assert_eq!(state.quarks.worlds.to_number(), 0.0);
+        // The highest-challenge reward is gated off (no QuarksAwarded event), but
+        // the challenge-1 achievement still grants its 5 quarks (ungated).
+        assert_eq!(state.quarks.worlds.to_number(), 5.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -5590,7 +5590,7 @@ fn phase_automation(
         // outcome-identical to the legacy unconditional push (see
         // `ant_sacrifice::activate_elo`).
         if state.ants.immortal_elo > 0.0 {
-            ant_sacrifice::activate_elo(state, dt);
+            output.events.extend(ant_sacrifice::activate_elo(state, dt));
         }
 
         // ── Head: simple counters (no events) ────────────────────────────

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -34,7 +34,7 @@ use smallvec::{smallvec, SmallVec};
 
 use synergismforkd_bignum::Decimal;
 
-use crate::events::{CoreEvent, ProducerType};
+use crate::events::{CoreEvent, CubeTier, ProducerType};
 use crate::mechanics::accelerators::{buy_accelerator, BuyAcceleratorInput};
 use crate::mechanics::achievement_rewards;
 use crate::mechanics::ant_producers::{buy_ant_producer, BuyAntProducerInput};
@@ -297,6 +297,17 @@ pub enum PlayerAction {
     EnterChallenge {
         /// Challenge index (`0..=15`; `0` exits the transcension slot).
         challenge: u32,
+    },
+    /// Open cubes of a tier (legacy `WowCubes.open` etc.): distribute blessings
+    /// into the matching `*_blessings` slice and credit any quark gift. `value`
+    /// is the count to open; `max` opens the whole balance (ignoring `value`).
+    OpenCubes {
+        /// Which cube tier to open.
+        tier: CubeTier,
+        /// Number of cubes to open (ignored when `max`).
+        value: f64,
+        /// Open the entire balance.
+        max: bool,
     },
 }
 
@@ -4978,6 +4989,11 @@ fn phase_player_input(
                 output
                     .events
                     .extend(enter_challenge(state, *challenge, reset_gains));
+            }
+            PlayerAction::OpenCubes { tier, value, max } => {
+                output.events.extend(crate::mechanics::cube_opening::open(
+                    state, *tier, *value, *max,
+                ));
             }
         }
     }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -69,6 +69,7 @@ use crate::mechanics::upgrades::{buy_upgrades, BuyUpgradeInput};
 use crate::state::{GameState, RngPurpose};
 
 mod ant_generation;
+mod ant_sacrifice;
 mod auto_research;
 mod auto_reset;
 mod automatic_tools;
@@ -4033,31 +4034,25 @@ fn compute_available_reborn_elo(state: &GameState) -> f64 {
     })
 }
 
-/// Ant-sacrifice `immortalELO` gain (legacy `antSacrificeRewards().immortalELO`),
-/// self-derived from `&GameState`. `max(0, calculateEffectiveAntELO −
-/// immortalELO)`, where `calculateEffectiveAntELO = ⌊Σ antELOStats ×
-/// Σ additiveAntELOMultStats⌋` — the base-ELO sum (15 lines) times the
-/// additive-multiplier sum (10 lines, base 1), both StatLine reductions.
-/// Drives the `ImmortalELOGain` auto-sacrifice mode.
+/// `calculateEffectiveAntELO` (Statistics-backed) — self-derived from
+/// `&GameState`. `⌊Σ antELOStats × Σ additiveAntELOMultStats⌋`: the base-ELO
+/// sum (15 lines) times the additive-multiplier sum (10 lines, base 1), both
+/// StatLine reductions. Feeds [`compute_immortal_elo_gain`], the per-sacrifice
+/// talisman-item thresholds, and the reborn-ELO creation-speed `EffectiveELO`
+/// line.
 ///
 /// Self-derives to `1` at the default state — the `ants` level reward's
-/// `defaultValue` (1) is the sole non-zero base line, × mult 1, floored — vs
-/// the old `AutomationPre` default `0`. Harmless: the ant-sacrifice middle that
-/// reads it is gated by `ant_sacrifice_unlocked` (false at default), so it is
-/// never consumed there, and `1` is in fact the faithful legacy value. The
+/// `defaultValue` (1) is the sole non-zero base line, × mult 1, floored. The
 /// `SingularityDebuff` line neutral-defaults to its Ant-ELO no-penalty value
 /// `0` (additive context; `calculate_singularity_debuff` is banner-flagged
 /// DO NOT extend / paused).
-fn compute_immortal_elo_gain(state: &GameState) -> f64 {
+fn compute_effective_ant_elo(state: &GameState) -> f64 {
     use crate::mechanics::achievement_levels::achievement_level_from_points;
     use crate::mechanics::achievement_rewards::{
         ant_elo_additive, ant_elo_additive_multiplier, ant_speed_2_upgrade_improver,
     };
     use crate::mechanics::ant_reborn_elo::{
         calculate_singularity_perk_elo, singularity_elo_bonus_mult, SingularityPerkELOInput,
-    };
-    use crate::mechanics::ant_sacrifice_reward_calc::{
-        calculate_immortal_elo_gain, CalculateImmortalELOGainInput,
     };
     use crate::mechanics::ant_upgrades::{
         ant_elo_ant_upgrade_effect, ant_sacrifice_ant_upgrade_effect, AntELOAntUpgradeInput,
@@ -4163,10 +4158,23 @@ fn compute_immortal_elo_gain(state: &GameState) -> f64 {
         singularity_elo_bonus_mult(sing_count),
     ]);
 
-    let effective_elo = (base_ant_elo * elo_mult).floor();
+    (base_ant_elo * elo_mult).floor()
+}
+
+/// Ant-sacrifice `immortalELO` gain (legacy `antSacrificeRewards().immortalELO`):
+/// `max(0, calculateEffectiveAntELO − immortalELO)`. Drives the
+/// `ImmortalELOGain` auto-sacrifice mode. Self-derives to `1` at the default
+/// state (effective ELO `1`, immortal ELO `0`); harmless because the
+/// ant-sacrifice middle that reads it is gated by `ant_sacrifice_unlocked`
+/// (false at default), so it is never consumed there, and `1` is the faithful
+/// legacy value.
+fn compute_immortal_elo_gain(state: &GameState) -> f64 {
+    use crate::mechanics::ant_sacrifice_reward_calc::{
+        calculate_immortal_elo_gain, CalculateImmortalELOGainInput,
+    };
     calculate_immortal_elo_gain(&CalculateImmortalELOGainInput {
-        effective_elo,
-        immortal_elo,
+        effective_elo: compute_effective_ant_elo(state),
+        immortal_elo: state.ants.immortal_elo,
     })
 }
 
@@ -5574,6 +5582,17 @@ fn phase_automation(
         state.ants.crumbs_this_sacrifice = ant.crumbs_this_sacrifice;
         state.ants.crumbs_ever_made = ant.crumbs_ever_made;
 
+        // Reborn-ELO activation — the legacy `generateAntsAndCrumbs` tail calls
+        // `activateELO(dt)` each live tick. Gated on `immortal_elo > 0` to keep
+        // the default-state sim unshifted: the only default effect would be an
+        // inert `{elo: 0}` leaderboard push, and any all-zero entry contributes
+        // `weight × 0 = 0` to `calculate_leaderboard_value`, so suppressing it is
+        // outcome-identical to the legacy unconditional push (see
+        // `ant_sacrifice::activate_elo`).
+        if state.ants.immortal_elo > 0.0 {
+            ant_sacrifice::activate_elo(state, dt);
+        }
+
         // ── Head: simple counters (no events) ────────────────────────────
         state.reset_counters.prestige_counter = timers::advance_reset_counter(
             state.reset_counters.prestige_counter,
@@ -5805,7 +5824,21 @@ fn phase_automation(
                     reborn_elo: state.ants.reborn_elo,
                 },
             );
+
+            // Consume the `AntSacrificeTriggered` intent → run the sacrifice
+            // effect, mirroring the `AutoResetTriggered` → `perform_reset` loop
+            // in this phase's tail. Intent first, then the effect event.
+            let mut performed: SmallVec<[CoreEvent; 2]> = SmallVec::new();
+            for event in &events {
+                if matches!(event, CoreEvent::AntSacrificeTriggered) {
+                    performed.extend(ant_sacrifice::perform_ant_sacrifice(
+                        state,
+                        pre.reincarnation_point_gain,
+                    ));
+                }
+            }
             output.events.extend(events);
+            output.events.extend(performed);
         }
 
         // 3. Obtainium — research[61] == 1 credits gain; else (vestigial)

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -3591,10 +3591,9 @@ fn compute_offerings(state: &GameState) -> Decimal {
 /// The resource multiplier (`calculateObtainium(false)`) and base obtainium
 /// flow through [`compute_obtainium`] / [`compute_base_obtainium`]. The
 /// ant-sacrifice obtainium source (a `max()` alternative gated by
-/// `cubeUpgrades[47] > 0`) is neutral-defaulted to `0`: it needs
-/// `calculateAntSacrificeMultiplier()` — the unported `antSacrificeRewardStats`
-/// StatLine + ant-sacrifice cube blessing — and is inert at the current state
-/// (`cubeUpgrades[47] == 0`). The reset-time divisor uses
+/// `cubeUpgrades[47] > 0`) is now wired to `calculateAntSacrificeObtainium` via
+/// the ported `ant_sacrifice::compute_ant_sacrifice_multiplier`; it stays inert
+/// at the current state (`cubeUpgrades[47] == 0`). The reset-time divisor uses
 /// `campaignTimeThresholdReduction = 0` (campaign subsystem unported).
 fn compute_obtainium_gain(
     state: &GameState,
@@ -3614,6 +3613,38 @@ fn compute_obtainium_gain(
         campaign_time_threshold_reduction: 0.0, // campaign subsystem unported → 0
     });
 
+    // Ant-sacrifice obtainium alternative source (gated by cubeUpgrades[47]):
+    // `calculateAntSacrificeObtainium(antSacrificeObtainiumStageMult, useTime=false)`.
+    // Inert until the cube upgrade is bought; the obtainium multiplier reuses the
+    // already-computed `calculateObtainium(false)` (`resource_mult`).
+    let ant_sacrifice_obtainium = if cube[47] > 0.0 {
+        use crate::mechanics::ant_reborn_elo::{
+            reborn_elo_stage_modifiers, RebornELOStageModifiersInput,
+        };
+        use crate::mechanics::ant_sacrifice_reward_calc::{
+            calculate_ant_sacrifice_obtainium, AntSacrificeObtainiumInput,
+        };
+        let stage_mods = reborn_elo_stage_modifiers(&RebornELOStageModifiersInput {
+            reborn_elo: state.ants.reborn_elo,
+            sing_count: state.singularity.singularity_count,
+        });
+        calculate_ant_sacrifice_obtainium(&AntSacrificeObtainiumInput {
+            ant_sac_mult: ant_sacrifice::compute_ant_sacrifice_multiplier(state),
+            stage_mult: stage_mods.ant_sacrifice_obtainium_mult,
+            time_multiplier: offering_obtainium_time_multiplier(
+                state,
+                state.ants.ant_sacrifice_timer,
+                false,
+            ),
+            obtainium_mult: resource_mult,
+            current_obtainium: state.researches.obtainium,
+            taxman_last_stand_enabled: state.singularity.taxman_last_stand.enabled,
+            taxman_last_stand_completions: state.singularity.taxman_last_stand.completions,
+        })
+    } else {
+        Decimal::zero()
+    };
+
     calculate_research_automatic_obtainium(&ResearchAutomaticObtainiumInput {
         delta_time: dt,
         ascension_challenge: state.challenges.current_ascension_challenge,
@@ -3626,7 +3657,7 @@ fn compute_obtainium_gain(
         reset_time_divisor,
         reincarnation_counter: state.reset_counters.reincarnation_counter,
         base_obtainium,
-        ant_sacrifice_obtainium: Decimal::zero(),
+        ant_sacrifice_obtainium,
         ant_sacrifice_timer: state.ants.ant_sacrifice_timer,
     })
 }
@@ -6705,6 +6736,31 @@ mod tests {
         state.researches.researches[108] = 4.0; // effective ELO 101
         state.ants.immortal_elo = 50.0;
         assert_eq!(compute_immortal_elo_gain(&state), 51.0);
+    }
+
+    #[test]
+    fn auto_obtainium_ant_sacrifice_source_engages_with_cube_upgrade_47() {
+        let mut state = GameState::default();
+        // Activate the auto-research-obtainium multiplier gate (0.8·cubeUpgrades[3]).
+        state.cube_upgrade_levels.cube_upgrades[3] = 1.0;
+        // Make the ant-sacrifice obtainium source large: a big multiplier line,
+        // a live ant-sacrifice cube blessing, and a non-zero sacrifice timer.
+        state.researches.researches[103] = 1_000.0;
+        state.cube_blessings.ant_sacrifice = 5_000.0;
+        state.ants.ant_sacrifice_timer = 9.0;
+
+        let without = compute_obtainium_gain(&state, 1.0, Decimal::zero());
+        state.cube_upgrade_levels.cube_upgrades[47] = 1.0; // enable the ant branch
+        let with = compute_obtainium_gain(&state, 1.0, Decimal::zero());
+
+        // The ant-sacrifice source is a max() alternative; with it dominating
+        // here, the auto-obtainium rises.
+        assert!(
+            with > without,
+            "ant source should raise auto-obtainium: {} vs {}",
+            with.to_number(),
+            without.to_number()
+        );
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -121,11 +121,12 @@ pub(crate) fn perform_prestige_reset(
     // resetAchievementCheck('prestige') runs before reset() in the legacy
     // trigger, so the offering award inside the base reset sees the updated
     // achievement_points.
-    crate::mechanics::achievement_awards::reset_achievement_check(
+    let awarded = crate::mechanics::achievement_awards::reset_achievement_check(
         &mut state.achievements,
         AutoResetTier::Prestige,
         prestige_point_gain,
     );
+    super::credit_achievement_quarks(state, awarded);
     apply_base_reset(state, prestige_point_gain);
     smallvec![CoreEvent::ResetPerformed {
         tier: AutoResetTier::Prestige,
@@ -207,11 +208,12 @@ pub(crate) fn perform_transcension_reset(
     state: &mut GameState,
     gains: &ResetCurrencyResult,
 ) -> SmallVec<[CoreEvent; 2]> {
-    crate::mechanics::achievement_awards::reset_achievement_check(
+    let awarded = crate::mechanics::achievement_awards::reset_achievement_check(
         &mut state.achievements,
         AutoResetTier::Transcension,
         gains.transcend_point_gain,
     );
+    super::credit_achievement_quarks(state, awarded);
     apply_base_reset(state, gains.prestige_point_gain);
     apply_transcension_layer(state, gains.transcend_point_gain);
     smallvec![CoreEvent::ResetPerformed {
@@ -297,11 +299,12 @@ pub(crate) fn perform_reincarnation_reset(
 ) -> SmallVec<[CoreEvent; 2]> {
     // resetAchievementCheck('reincarnation') runs first, so the obtainium and
     // offering awards below read the updated achievement_points.
-    crate::mechanics::achievement_awards::reset_achievement_check(
+    let awarded = crate::mechanics::achievement_awards::reset_achievement_check(
         &mut state.achievements,
         AutoResetTier::Reincarnation,
         gains.reincarnation_point_gain,
     );
+    super::credit_achievement_quarks(state, awarded);
     // `reincarnationCheck` is the *pre-reset* shard total — capture it
     // before the transcension layer zeroes `transcend_shards`.
     let reincarnation_check = state.reset_counters.transcend_shards

--- a/crates/synergismforkd_testkit/fixtures/parity_aggregators.json
+++ b/crates/synergismforkd_testkit/fixtures/parity_aggregators.json
@@ -256,5 +256,49 @@
       "current_obtainium": "0",
       "value": "0"
     }
+  ],
+  "calculate_ant_sacrifice_offering": [
+    {
+      "ant_sac_mult": "2",
+      "stage_mult": 1.5,
+      "time_multiplier": 3,
+      "offering_mult": "10",
+      "current_offerings": "0",
+      "taxman_last_stand_enabled": false,
+      "taxman_last_stand_completions": 0,
+      "value": "90"
+    },
+    {
+      "ant_sac_mult": "1",
+      "stage_mult": 1,
+      "time_multiplier": 1,
+      "offering_mult": "1e20",
+      "current_offerings": "5",
+      "taxman_last_stand_enabled": true,
+      "taxman_last_stand_completions": 2,
+      "value": "501"
+    }
+  ],
+  "calculate_ant_sacrifice_obtainium": [
+    {
+      "ant_sac_mult": "2",
+      "stage_mult": 1.5,
+      "time_multiplier": 3,
+      "obtainium_mult": "10",
+      "current_obtainium": "0",
+      "taxman_last_stand_enabled": false,
+      "taxman_last_stand_completions": 0,
+      "value": "90"
+    },
+    {
+      "ant_sac_mult": "1",
+      "stage_mult": 1,
+      "time_multiplier": 1,
+      "obtainium_mult": "1e20",
+      "current_obtainium": "7",
+      "taxman_last_stand_enabled": true,
+      "taxman_last_stand_completions": 3,
+      "value": "701"
+    }
   ]
 }

--- a/crates/synergismforkd_testkit/src/parity.rs
+++ b/crates/synergismforkd_testkit/src/parity.rs
@@ -471,6 +471,30 @@ struct ObtainiumCase {
 }
 
 #[derive(Deserialize)]
+struct AntSacrificeOfferingCase {
+    ant_sac_mult: String,
+    stage_mult: f64,
+    time_multiplier: f64,
+    offering_mult: String,
+    current_offerings: String,
+    taxman_last_stand_enabled: bool,
+    taxman_last_stand_completions: f64,
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct AntSacrificeObtainiumCase {
+    ant_sac_mult: String,
+    stage_mult: f64,
+    time_multiplier: f64,
+    obtainium_mult: String,
+    current_obtainium: String,
+    taxman_last_stand_enabled: bool,
+    taxman_last_stand_completions: f64,
+    value: String,
+}
+
+#[derive(Deserialize)]
 struct AggregatorVectors {
     calculate_global_speed_mult: Vec<GlobalSpeedCase>,
     calculate_ascension_speed_mult: Vec<AscensionSpeedCase>,
@@ -480,6 +504,8 @@ struct AggregatorVectors {
     get_reduction_value: Vec<ReductionCase>,
     calculate_offerings: Vec<OfferingsCase>,
     calculate_obtainium: Vec<ObtainiumCase>,
+    calculate_ant_sacrifice_offering: Vec<AntSacrificeOfferingCase>,
+    calculate_ant_sacrifice_obtainium: Vec<AntSacrificeObtainiumCase>,
 }
 
 /// Like [`assert_decimal_parity`] but tolerant of an exact zero (the c14
@@ -496,6 +522,10 @@ fn assert_aggregator_decimal(label: &str, rust: Decimal, ts: Decimal) {
 
 #[test]
 fn calculate_aggregators_match_typescript() {
+    use synergismforkd_logic::mechanics::ant_sacrifice_reward_calc::{
+        calculate_ant_sacrifice_obtainium, calculate_ant_sacrifice_offering,
+        AntSacrificeObtainiumInput, AntSacrificeOfferingInput,
+    };
     use synergismforkd_logic::mechanics::calculate::{
         calculate_actual_ant_speed_mult, calculate_ambrosia_generation_speed,
         calculate_ambrosia_luck, calculate_ascension_speed_mult, calculate_global_speed_mult,
@@ -509,7 +539,9 @@ fn calculate_aggregators_match_typescript() {
     assert!(
         !v.calculate_global_speed_mult.is_empty()
             && !v.calculate_offerings.is_empty()
-            && !v.calculate_obtainium.is_empty(),
+            && !v.calculate_obtainium.is_empty()
+            && !v.calculate_ant_sacrifice_offering.is_empty()
+            && !v.calculate_ant_sacrifice_obtainium.is_empty(),
         "fixture should carry aggregator vectors"
     );
 
@@ -624,6 +656,42 @@ fn calculate_aggregators_match_typescript() {
         let ts = Decimal::from_string(&c.value).expect("ts decimal parses");
         assert_aggregator_decimal(
             &format!("calculate_obtainium(base={})", c.base_obtainium),
+            rust,
+            ts,
+        );
+    }
+    for c in &v.calculate_ant_sacrifice_offering {
+        let rust = calculate_ant_sacrifice_offering(&AntSacrificeOfferingInput {
+            ant_sac_mult: Decimal::from_string(&c.ant_sac_mult).expect("ant_sac_mult parses"),
+            stage_mult: c.stage_mult,
+            time_multiplier: c.time_multiplier,
+            offering_mult: Decimal::from_string(&c.offering_mult).expect("offering_mult parses"),
+            current_offerings: Decimal::from_string(&c.current_offerings)
+                .expect("current_offerings parses"),
+            taxman_last_stand_enabled: c.taxman_last_stand_enabled,
+            taxman_last_stand_completions: c.taxman_last_stand_completions,
+        });
+        let ts = Decimal::from_string(&c.value).expect("ts decimal parses");
+        assert_aggregator_decimal(
+            &format!("calculate_ant_sacrifice_offering(mult={})", c.ant_sac_mult),
+            rust,
+            ts,
+        );
+    }
+    for c in &v.calculate_ant_sacrifice_obtainium {
+        let rust = calculate_ant_sacrifice_obtainium(&AntSacrificeObtainiumInput {
+            ant_sac_mult: Decimal::from_string(&c.ant_sac_mult).expect("ant_sac_mult parses"),
+            stage_mult: c.stage_mult,
+            time_multiplier: c.time_multiplier,
+            obtainium_mult: Decimal::from_string(&c.obtainium_mult).expect("obtainium_mult parses"),
+            current_obtainium: Decimal::from_string(&c.current_obtainium)
+                .expect("current_obtainium parses"),
+            taxman_last_stand_enabled: c.taxman_last_stand_enabled,
+            taxman_last_stand_completions: c.taxman_last_stand_completions,
+        });
+        let ts = Decimal::from_string(&c.value).expect("ts decimal parses");
+        assert_aggregator_decimal(
+            &format!("calculate_ant_sacrifice_obtainium(mult={})", c.ant_sac_mult),
             rust,
             ts,
         );


### PR DESCRIPTION
Ports the **ant-sacrifice** mechanic (P3.3). The mechanic is two separable pieces, both now live in `tick/ant_sacrifice.rs`:

1. **`perform_ant_sacrifice`** (= TS `sacrificeAnts()`) — consumes the previously-*dropped* `CoreEvent::AntSacrificeTriggered`, crediting the immortal-ELO high-water gain → `automation.offerings` → `researches.obtainium` (skipped under ascension challenge 14) → the 7 talisman fragment/shard tiers (gated on challenge-9 completions), then resets the ants to crumbs. Emits the new `AntSacrificePerformed` effect event.
2. **`activate_elo`** (= TS `activateELO`, per-tick) — bleeds available reborn-ELO into `rebornELO` (1.02-per-threshold ramp) and maintains the daily/all-time top-5 reborn-ELO leaderboards. **This is the write that populates `highest_reborn_elo_ever` and unsticks the slice-3a `rebornELO` progressive** (frozen at 0 until now). Porting only the sacrifice would leave `rebornELO` pinned at 0 — a dead progressive and broken `MaxRebornELO` auto-toggles.

### Notes
- `activate_elo` is gated on `immortal_elo > 0` to preserve default-state quiescence — outcome-identical to the legacy unconditional leaderboard push (any all-zero entry contributes `weight × 0 = 0` to `calculate_leaderboard_value`).
- Obtainium gate is `current_ascension_challenge == 14` (the *current* challenge being c14), not an achievement unlock.
- **Deferred (documented TODOs, inert at the current state):** the quark award (slice 3b — needs `worlds.applyBonus`), the `sacMult`/`sacCount` achievement-group awards, the Lotus time-of-day shortcut, and the singularity-perk reset regrants. Cube/rune/mortuus blessing factors neutral-default to identity.

### Tests
- 8 new tests incl. **2 end-to-end through `tack`** (consume-wiring fires + progressive lights), closing the orchestration blind spot.
- `calculate_ant_sacrifice_offering`/`_obtainium` anchored in the parity harness.
- Full gate green: **1239 tests, 0 failures; clippy `-D warnings` clean; fmt applied.**

> 🚧 In progress — more will be added to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)