### PR TITLE
feat(logic): C15 accrual, achievement tail (P3.1 3b), rune-blessing wiring, daily-reset seam

### DIFF
--- a/crates/synergismforkd_logic/src/lib.rs
+++ b/crates/synergismforkd_logic/src/lib.rs
@@ -48,7 +48,7 @@ pub use currency::{Coins, Multiplier, PrestigePoints, ReincarnationPoints, Trans
 
 // ─── Tick orchestrator ───────────────────────────────────────────────────
 
-pub use tick::{tack, AutomationPre, BuyRequest, PlayerAction, TackInput, TickOutput};
+pub use tick::{daily_reset, tack, AutomationPre, BuyRequest, PlayerAction, TackInput, TickOutput};
 
 // ─── Per-tick aggregator entry points ────────────────────────────────────
 

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -574,6 +574,82 @@ pub fn challenge_achievement_check(
     award_threshold_group(ach, challenge_completions[challenge], table)
 }
 
+/// Per-completion context for the ungrouped per-challenge achievements (the
+/// `awardUngroupedAchievement` calls in `challengeAchievementCheck`). All fields
+/// are existing state reads; coins are carried as `log10(coins + 1)` because the
+/// thresholds (`1e1000`, `1e99999`, `1e120000`) far exceed `f64`.
+#[derive(Debug, Clone, Copy)]
+pub struct ChallengeUngroupedContext {
+    /// `log10(player.coinsThisTranscension + 1)`.
+    pub coins_this_transcension_log10: f64,
+    /// `player.currentChallenge.transcension`.
+    pub current_transcension_challenge: u32,
+    /// `sumContents(player.upgrades.slice(101, 106))` — generator upgrades
+    /// (101..=105) owned (`0` = none bought this run).
+    pub generator_upgrades_owned: u32,
+    /// `player.acceleratorBought`.
+    pub accelerator_bought: f64,
+    /// `player.acceleratorBoostBought`.
+    pub accelerator_boost_bought: f64,
+    /// `player.corruptions.used.extinction` level.
+    pub extinction_level: f64,
+}
+
+/// `challengeAchievementCheck`'s ungrouped per-challenge achievements, awarded
+/// alongside the `challengeN` group: `chal{1,2,3}NoGen` (reach the coin
+/// threshold in that transcension challenge with no generator upgrades),
+/// `diamondSearch` (challenge 5: `1e120000` coins, no accelerators/boosts), and
+/// `extraChallenging` (challenge 11: `c10 > 50 && extinction >= 5 && c11 >= 20`).
+/// `sadisticAch` (challenge 15) is awarded from the c15 path instead. Each
+/// `(index, pointValue)` and unlock condition is taken verbatim from the legacy
+/// `achievements` array. Returns the count newly awarded.
+pub fn challenge_ungrouped_achievement_check(
+    ach: &mut AchievementsState,
+    challenge: usize,
+    challenge_completions: &[f64],
+    ctx: &ChallengeUngroupedContext,
+) -> usize {
+    let tc = ctx.current_transcension_challenge as usize;
+    let no_generators = ctx.generator_upgrades_owned == 0;
+    match challenge {
+        1 => usize::from(award_achievement(
+            ach,
+            75,
+            tc == 1 && ctx.coins_this_transcension_log10 >= 1_000.0 && no_generators,
+            25.0,
+        )),
+        2 => usize::from(award_achievement(
+            ach,
+            76,
+            tc == 2 && ctx.coins_this_transcension_log10 >= 1_000.0 && no_generators,
+            25.0,
+        )),
+        3 => usize::from(award_achievement(
+            ach,
+            77,
+            tc == 3 && ctx.coins_this_transcension_log10 >= 99_999.0 && no_generators,
+            50.0,
+        )),
+        5 => usize::from(award_achievement(
+            ach,
+            63,
+            ctx.coins_this_transcension_log10 >= 120_000.0
+                && ctx.accelerator_bought == 0.0
+                && ctx.accelerator_boost_bought == 0.0,
+            35.0,
+        )),
+        11 => usize::from(award_achievement(
+            ach,
+            247,
+            challenge_completions[10] > 50.0
+                && ctx.extinction_level >= 5.0
+                && challenge_completions[11] >= 20.0,
+            50.0,
+        )),
+        _ => 0,
+    }
+}
+
 /// `sacCount` achievement group — `antSacrificeCount >= threshold`. Awarded
 /// after every ant sacrifice (legacy `awardAchievementGroup('sacCount')` inside
 /// `resetPlayerAntSacrificeCounts`).
@@ -951,6 +1027,86 @@ mod tests {
         challenge_achievement_check(&mut ach, 15, &completions);
         challenge_achievement_check(&mut ach, 0, &completions);
         assert_eq!(ach.achievement_points, 0.0);
+    }
+
+    #[test]
+    fn challenge_ungrouped_chal_no_gen_needs_no_generators_and_coins() {
+        let completions = [0.0_f64; 16];
+        let ctx = ChallengeUngroupedContext {
+            coins_this_transcension_log10: 1_500.0, // >= 1e1000
+            current_transcension_challenge: 1,
+            generator_upgrades_owned: 0,
+            accelerator_bought: 0.0,
+            accelerator_boost_bought: 0.0,
+            extinction_level: 0.0,
+        };
+        let mut ach = AchievementsState::default();
+        challenge_ungrouped_achievement_check(&mut ach, 1, &completions, &ctx);
+        assert_eq!(ach.achievements[75], 1); // chal1NoGen, pv 25
+        assert_eq!(ach.achievement_points, 25.0);
+
+        // Owning even one generator upgrade suppresses it.
+        let mut ach2 = AchievementsState::default();
+        let ctx2 = ChallengeUngroupedContext {
+            generator_upgrades_owned: 1,
+            ..ctx
+        };
+        challenge_ungrouped_achievement_check(&mut ach2, 1, &completions, &ctx2);
+        assert_eq!(ach2.achievements[75], 0);
+    }
+
+    #[test]
+    fn challenge_ungrouped_diamond_search_needs_coins_and_no_accelerators() {
+        let completions = [0.0_f64; 16];
+        let ctx = ChallengeUngroupedContext {
+            coins_this_transcension_log10: 120_000.0, // >= 1e120000
+            current_transcension_challenge: 5,
+            generator_upgrades_owned: 0,
+            accelerator_bought: 0.0,
+            accelerator_boost_bought: 0.0,
+            extinction_level: 0.0,
+        };
+        let mut ach = AchievementsState::default();
+        challenge_ungrouped_achievement_check(&mut ach, 5, &completions, &ctx);
+        assert_eq!(ach.achievements[63], 1); // diamondSearch, pv 35
+        assert_eq!(ach.achievement_points, 35.0);
+
+        // Any accelerator bought suppresses it.
+        let mut ach2 = AchievementsState::default();
+        let ctx2 = ChallengeUngroupedContext {
+            accelerator_bought: 1.0,
+            ..ctx
+        };
+        challenge_ungrouped_achievement_check(&mut ach2, 5, &completions, &ctx2);
+        assert_eq!(ach2.achievements[63], 0);
+    }
+
+    #[test]
+    fn challenge_ungrouped_extra_challenging_needs_all_three_conditions() {
+        let mut completions = [0.0_f64; 16];
+        completions[10] = 51.0; // c10 > 50
+        completions[11] = 20.0; // c11 >= 20
+        let ctx = ChallengeUngroupedContext {
+            coins_this_transcension_log10: 0.0,
+            current_transcension_challenge: 0,
+            generator_upgrades_owned: 0,
+            accelerator_bought: 0.0,
+            accelerator_boost_bought: 0.0,
+            extinction_level: 5.0, // extinction >= 5
+        };
+        let mut ach = AchievementsState::default();
+        challenge_ungrouped_achievement_check(&mut ach, 11, &completions, &ctx);
+        assert_eq!(ach.achievements[247], 1); // extraChallenging, pv 50
+        assert_eq!(ach.achievement_points, 50.0);
+
+        // extinction < 5 suppresses it.
+        let mut ach2 = AchievementsState::default();
+        let ctx2 = ChallengeUngroupedContext {
+            extinction_level: 4.0,
+            ..ctx
+        };
+        challenge_ungrouped_achievement_check(&mut ach2, 11, &completions, &ctx2);
+        assert_eq!(ach2.achievements[247], 0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -36,11 +36,19 @@
 //!   that into a count, and each call site credits it via
 //!   `credit_achievement_quarks`.
 //!
+//! ## Implemented since slice 1 (continued)
+//!
+//! - The ungrouped no-reset achievements (indices 57–62, 64–70) — awarded by
+//!   [`reset_achievement_check`] from the per-run "didn't buy X" flags
+//!   ([`ResetNoBuyFlags`]). Those flags are already plumbed false-on-buy /
+//!   true-on-reset across the multiplier/accelerator/upgrade slices, so a flag
+//!   still `true` at the (pre-reset) check means the run avoided that purchase.
+//!
 //! ## Still deferred (faithful: those bits stay `0`)
 //!
-//! - The ungrouped no-accelerator / no-mult / no-upgrade reset achievements
-//!   (indices 57–74) — they need the timing-sensitive `*no*` flags + a
-//!   name→index map; they land with the ungrouped tail.
+//! - The per-challenge ungrouped extras (`chalNNoGen`, `diamondSearch` #63,
+//!   `extraChallenging` #247, `sadisticAch` #252) — the ungrouped tail of
+//!   `challengeAchievementCheck`.
 //!
 //! Points accumulate **incrementally** here (`achievement_points +=
 //! pointValue`), mirroring `awardAchievement`. The full-recompute path
@@ -429,27 +437,111 @@ pub fn building_achievement_check(ach: &mut AchievementsState, coin_owned: &[f64
         + award_threshold_group(ach, coin_owned[4], FIFTH_OWNED_COIN)
 }
 
-/// `resetAchievementCheck(reset)` — slice-1 subset: the per-tier point-gain
-/// group, awarded from the just-computed `gain` (`G.{tier}PointGain`). Must
-/// run **before** the reset proper (the legacy trigger calls it ahead of
-/// `reset()`), so the offering/obtainium awards inside the reset see the
-/// updated `achievement_points`.
+/// Per-run "didn't buy X this run" flags read by the ungrouped no-reset
+/// achievements (the `awardUngroupedAchievement` calls in the legacy
+/// `resetAchievementCheck`). Each starts `true`, is cleared on the matching
+/// purchase, and restored on the matching reset — so a flag still `true` at the
+/// check (which runs *before* the reset body) means the run reached this reset
+/// without that purchase. The caller fills the current tier's tier-prefixed
+/// flags; cross-tier fields stay `false` (each tier branch reads only its own).
+/// Synergism naming: "diamond" = the prestige currency, "mythos" = the
+/// transcend currency.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResetNoBuyFlags {
+    /// `{tier}nomultiplier`.
+    pub no_multiplier: bool,
+    /// `{tier}noaccelerator`.
+    pub no_accelerator: bool,
+    /// `{tier}nocoinupgrades`.
+    pub no_coin_upgrades: bool,
+    /// `{tier}nocoinorprestigeupgrades` — "no coin or diamond upgrade"
+    /// (transcend #66, reincarnate #68).
+    pub no_coin_or_prestige_upgrades: bool,
+    /// `reincarnatenocoinprestigeortranscendupgrades` — "no coin/diamond/mythos
+    /// upgrade" (#69).
+    pub no_coin_prestige_or_transcend_upgrades: bool,
+    /// `reincarnatenocoinprestigetranscendorgeneratorupgrades` — the "minimum
+    /// upgrades" achievement (#70).
+    pub no_coin_prestige_transcend_or_generator_upgrades: bool,
+}
+
+/// The ungrouped no-reset achievements awarded by `resetAchievementCheck`'s
+/// `awardUngroupedAchievement` calls, gated on the per-run [`ResetNoBuyFlags`].
+/// Each `(index, pointValue)` is taken verbatim from the legacy `achievements`
+/// array, where the unlock condition is exactly the matching flag. Returns the
+/// count newly awarded.
+fn award_no_buy_achievements(
+    ach: &mut AchievementsState,
+    tier: AutoResetTier,
+    f: &ResetNoBuyFlags,
+) -> usize {
+    match tier {
+        AutoResetTier::Prestige => {
+            usize::from(award_achievement(ach, 57, f.no_multiplier, 5.0))
+                + usize::from(award_achievement(ach, 60, f.no_accelerator, 20.0))
+                + usize::from(award_achievement(ach, 64, f.no_coin_upgrades, 5.0))
+        }
+        AutoResetTier::Transcension => {
+            usize::from(award_achievement(ach, 58, f.no_multiplier, 10.0))
+                + usize::from(award_achievement(ach, 61, f.no_accelerator, 25.0))
+                + usize::from(award_achievement(ach, 65, f.no_coin_upgrades, 10.0))
+                + usize::from(award_achievement(
+                    ach,
+                    66,
+                    f.no_coin_or_prestige_upgrades,
+                    15.0,
+                ))
+        }
+        AutoResetTier::Reincarnation => {
+            usize::from(award_achievement(ach, 59, f.no_multiplier, 15.0))
+                + usize::from(award_achievement(ach, 62, f.no_accelerator, 30.0))
+                + usize::from(award_achievement(ach, 67, f.no_coin_upgrades, 15.0))
+                + usize::from(award_achievement(
+                    ach,
+                    68,
+                    f.no_coin_or_prestige_upgrades,
+                    20.0,
+                ))
+                + usize::from(award_achievement(
+                    ach,
+                    69,
+                    f.no_coin_prestige_or_transcend_upgrades,
+                    30.0,
+                ))
+                + usize::from(award_achievement(
+                    ach,
+                    70,
+                    f.no_coin_prestige_transcend_or_generator_upgrades,
+                    40.0,
+                ))
+        }
+        AutoResetTier::Ascension => 0,
+    }
+}
+
+/// `resetAchievementCheck(reset)` — the ungrouped no-reset achievements (gated
+/// on [`ResetNoBuyFlags`]) plus the per-tier point-gain group (from the
+/// just-computed `gain`, `G.{tier}PointGain`). Must run **before** the reset
+/// proper (the legacy trigger calls it ahead of `reset()`), so the
+/// offering/obtainium awards inside the reset see the updated
+/// `achievement_points`.
 ///
-/// `Ascension` awards no point-gain group (faithful to
-/// `resetAchievementCheck('ascension')`). The ungrouped no-* reset
-/// achievements are deferred (see module docs).
+/// `Ascension` awards nothing (faithful to `resetAchievementCheck('ascension')`).
 pub fn reset_achievement_check(
     ach: &mut AchievementsState,
     tier: AutoResetTier,
     gain: Decimal,
+    no_buy: &ResetNoBuyFlags,
 ) -> usize {
+    let mut awarded = award_no_buy_achievements(ach, tier, no_buy);
     let table = match tier {
         AutoResetTier::Prestige => PRESTIGE_POINT_GAIN,
         AutoResetTier::Transcension => TRANSCEND_POINT_GAIN,
         AutoResetTier::Reincarnation => REINCARNATION_POINT_GAIN,
-        AutoResetTier::Ascension => return 0,
+        AutoResetTier::Ascension => return awarded,
     };
-    award_log10_group(ach, gain, table)
+    awarded += award_log10_group(ach, gain, table);
+    awarded
 }
 
 /// `challengeAchievementCheck(i)` — award the `challengeI` group from the
@@ -685,7 +777,12 @@ mod tests {
         let mut ach = AchievementsState::default();
         // gain 1e6 → log10 6 → rows at thresholds 0 and 6 (indices 36,37;
         // pv 5+10 = 15). Threshold-100 row (index 38) stays unmet.
-        reset_achievement_check(&mut ach, AutoResetTier::Prestige, Decimal::from_finite(1e6));
+        reset_achievement_check(
+            &mut ach,
+            AutoResetTier::Prestige,
+            Decimal::from_finite(1e6),
+            &ResetNoBuyFlags::default(),
+        );
         assert_eq!(ach.achievements[36], 1);
         assert_eq!(ach.achievements[37], 1);
         assert_eq!(ach.achievements[38], 0);
@@ -695,7 +792,12 @@ mod tests {
     #[test]
     fn reset_check_zero_gain_awards_nothing() {
         let mut ach = AchievementsState::default();
-        reset_achievement_check(&mut ach, AutoResetTier::Prestige, Decimal::zero());
+        reset_achievement_check(
+            &mut ach,
+            AutoResetTier::Prestige,
+            Decimal::zero(),
+            &ResetNoBuyFlags::default(),
+        );
         assert_eq!(ach.achievement_points, 0.0);
         assert_eq!(ach.achievements[36], 0);
     }
@@ -707,6 +809,7 @@ mod tests {
             &mut ach,
             AutoResetTier::Ascension,
             Decimal::from_finite(1e9),
+            &ResetNoBuyFlags::default(),
         );
         assert_eq!(ach.achievement_points, 0.0);
     }
@@ -720,11 +823,95 @@ mod tests {
             &mut ach,
             AutoResetTier::Reincarnation,
             Decimal::from_finite(1e5),
+            &ResetNoBuyFlags::default(),
         );
         assert_eq!(ach.achievements[50], 1);
         assert_eq!(ach.achievements[51], 1);
         assert_eq!(ach.achievements[52], 0);
         assert_eq!(ach.achievement_points, 15.0);
+    }
+
+    #[test]
+    fn reset_check_awards_prestige_no_buy_achievements() {
+        let mut ach = AchievementsState::default();
+        // All three prestige no-buy flags still set, zero gain → only the
+        // ungrouped no-reset achievements fire (57 noMult, 60 noAccel, 64 noCoinUpg).
+        let flags = ResetNoBuyFlags {
+            no_multiplier: true,
+            no_accelerator: true,
+            no_coin_upgrades: true,
+            ..ResetNoBuyFlags::default()
+        };
+        let awarded =
+            reset_achievement_check(&mut ach, AutoResetTier::Prestige, Decimal::zero(), &flags);
+        assert_eq!(ach.achievements[57], 1);
+        assert_eq!(ach.achievements[60], 1);
+        assert_eq!(ach.achievements[64], 1);
+        assert_eq!(ach.achievement_points, 30.0); // 5 + 20 + 5
+        assert_eq!(awarded, 3);
+    }
+
+    #[test]
+    fn reset_check_no_buy_flag_false_suppresses_its_achievement() {
+        let mut ach = AchievementsState::default();
+        // Bought a multiplier this run → flag cleared → #57 not awarded; the
+        // other two prestige no-buy achievements still fire.
+        let flags = ResetNoBuyFlags {
+            no_multiplier: false,
+            no_accelerator: true,
+            no_coin_upgrades: true,
+            ..ResetNoBuyFlags::default()
+        };
+        reset_achievement_check(&mut ach, AutoResetTier::Prestige, Decimal::zero(), &flags);
+        assert_eq!(ach.achievements[57], 0);
+        assert_eq!(ach.achievements[60], 1);
+        assert_eq!(ach.achievements[64], 1);
+        assert_eq!(ach.achievement_points, 25.0); // 20 + 5
+    }
+
+    #[test]
+    fn reset_check_awards_all_reincarnation_no_buy_achievements() {
+        let mut ach = AchievementsState::default();
+        let flags = ResetNoBuyFlags {
+            no_multiplier: true,
+            no_accelerator: true,
+            no_coin_upgrades: true,
+            no_coin_or_prestige_upgrades: true,
+            no_coin_prestige_or_transcend_upgrades: true,
+            no_coin_prestige_transcend_or_generator_upgrades: true,
+        };
+        reset_achievement_check(
+            &mut ach,
+            AutoResetTier::Reincarnation,
+            Decimal::zero(),
+            &flags,
+        );
+        // 59,62,67,68,69,70 → pv 15 + 30 + 15 + 20 + 30 + 40 = 150.
+        for idx in [59, 62, 67, 68, 69, 70] {
+            assert_eq!(ach.achievements[idx], 1, "achievement {idx} should be set");
+        }
+        assert_eq!(ach.achievement_points, 150.0);
+    }
+
+    #[test]
+    fn reset_check_no_buy_and_point_gain_combine_in_one_call() {
+        // resetAchievementCheck awards both the ungrouped no-buy achievements
+        // and the point-gain group in a single call.
+        let mut ach = AchievementsState::default();
+        let flags = ResetNoBuyFlags {
+            no_multiplier: true,
+            no_accelerator: true,
+            no_coin_upgrades: true,
+            ..ResetNoBuyFlags::default()
+        };
+        reset_achievement_check(
+            &mut ach,
+            AutoResetTier::Prestige,
+            Decimal::from_finite(1e6),
+            &flags,
+        );
+        // no-buy 57,60,64 (30) + point-gain 36 (>=1) & 37 (>=1e6) (15) = 45.
+        assert_eq!(ach.achievement_points, 45.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
@@ -244,6 +244,17 @@ pub fn hepteracts_unlocked(exponent: f64) -> f64 {
     }
 }
 
+/// `challenge15Rewards.achievementUnlock.value` — `1` once `exponent >= 666666`,
+/// else `0`. Gates the `sadisticAch` achievement (#252).
+#[must_use]
+pub fn achievement_unlock(exponent: f64) -> f64 {
+    if exponent >= 666_666.0 {
+        1.0
+    } else {
+        0.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -377,5 +388,8 @@ mod tests {
         assert_eq!(hepteracts_unlocked(0.0), 0.0);
         assert_eq!(hepteracts_unlocked(9.9e14), 0.0);
         assert_eq!(hepteracts_unlocked(1e15), 1.0);
+        assert_eq!(achievement_unlock(0.0), 0.0);
+        assert_eq!(achievement_unlock(666_665.0), 0.0);
+        assert_eq!(achievement_unlock(666_666.0), 1.0);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -34,9 +34,9 @@ use crate::state::GameState;
 /// `calculateAntSacrificeMultiplier` (Calculate.ts:382) — the product of the
 /// `antSacrificeRewardStats` StatLine times `calculateAntSacrificeCubeBlessing`.
 ///
-/// Neutral-defaulted lines (faithful — identity at the current state):
-/// `RuneBlessing` (prism rune-blessing `antSacrificeMult` — the rune-blessing
-/// layer is unported; identity `1` at blessing level 0) and `Event` (UI-tier
+/// The `RuneBlessing` line reads the prism rune-blessing `antSacrificeMult`
+/// (`prism_rune_blessing_effects` over the shared `rune_blessing_power`; identity
+/// at blessing level 0). The only neutral-defaulted line is `Event` (UI-tier
 /// event calendar → `1`). The trailing `calculateAntSacrificeCubeBlessing` reads
 /// the live blessing cascade (`ant_sacrifice_cube_blessing`) now that `open()`
 /// (P3.2) makes the cube-blessing levels accrue. (`compute_obtainium_gain`'s
@@ -46,6 +46,8 @@ pub(super) fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
     use crate::mechanics::ant_upgrades::ant_sacrifice_ant_upgrade_effect;
     use crate::mechanics::calculate::product_f64;
     use crate::mechanics::challenges::{calc_ecc, ChallengeType};
+    use crate::mechanics::rune_blessing_effects::prism_rune_blessing_effects;
+    use crate::state::RUNE_PRISM;
 
     // Ant upgrade slot: AntSacrifice (index 10).
     const ANT_UPGRADE_ANT_SACRIFICE: usize = 10;
@@ -62,7 +64,10 @@ pub(super) fn compute_ant_sacrifice_multiplier(state: &GameState) -> Decimal {
             .ant_sacrifice_multiplier,
         1.0 + researches[103] / 20.0,
         1.0 + researches[104] / 20.0,
-        1.0, // RuneBlessing — prism rune-blessing antSacrificeMult (unported → 1)
+        // RuneBlessing — prism rune-blessing antSacrificeMult, wired through the
+        // shared blessing power (rune_blessing_power); identity at level 0.
+        prism_rune_blessing_effects(super::rune_blessing_power(state, RUNE_PRISM))
+            .ant_sacrifice_mult,
         1.0 + (1.0 / 50.0)
             * calc_ecc(
                 ChallengeType::Reincarnation,
@@ -627,6 +632,20 @@ mod tests {
         state.cube_blessings.ant_sacrifice = 5_000.0;
         assert!(ant_sacrifice_cube_blessing(&state).to_number() > 1.0);
         assert!(compute_ant_sacrifice_multiplier(&state).to_number() > base);
+    }
+
+    #[test]
+    fn ant_sacrifice_multiplier_picks_up_prism_blessing() {
+        use crate::state::RUNE_PRISM;
+        let mut state = GameState::default();
+        // Default: prism blessing power = 0 → antSacrificeMult factor = 1.
+        let base = compute_ant_sacrifice_multiplier(&state).to_number();
+        // blessing power = blessing_level · rune_level · otherMult (1 at default):
+        // 1000 · 1000 = 1e6 → factor = 1 + 1e6/1e6 = 2 → the multiplier doubles.
+        state.runes.rune_blessing_levels[RUNE_PRISM] = 1000.0;
+        state.runes.rune_levels[RUNE_PRISM] = 1000.0;
+        let boosted = compute_ant_sacrifice_multiplier(&state).to_number();
+        assert!((boosted / base - 2.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -6354,6 +6354,7 @@ mod tests {
             &mut state.achievements,
             crate::events::AutoResetTier::Prestige,
             Decimal::from_finite(1e6),
+            &crate::mechanics::achievement_awards::ResetNoBuyFlags::default(),
         );
         assert_eq!(state.achievements.achievement_points, 15.0);
 
@@ -8010,6 +8011,12 @@ mod tests {
         // c1 transcension challenge, enough coins to complete.
         state.challenges.current_transcension_challenge = 1;
         state.coin_counters.coins_this_transcension = Decimal::from_finite(1e11);
+        // Clear the transcension no-buy flags so the completion-triggered reset
+        // doesn't add their quarks (isolating the highest-challenge reward).
+        state.multiplier.transcend_no_multiplier = false;
+        state.accelerator.transcend_no_accelerator = false;
+        state.upgrades.transcend_no_coin_upgrades = false;
+        state.upgrades.transcend_no_coin_or_prestige_upgrades = false;
         // ascension_count == 0 → gate passes.
         assert_eq!(state.reset_counters.ascension_count, 0.0);
         // quark_bonus = 0 → multiplier = 1; base = 1 + floor(1 * 0.1) = 1 + 0 = 1.
@@ -8043,6 +8050,12 @@ mod tests {
         let mut state = GameState::default();
         state.challenges.current_transcension_challenge = 1;
         state.coin_counters.coins_this_transcension = Decimal::from_finite(1e11);
+        // Clear the transcension no-buy flags so the completion-triggered reset
+        // doesn't add their quarks (isolating the gated highest-challenge reward).
+        state.multiplier.transcend_no_multiplier = false;
+        state.accelerator.transcend_no_accelerator = false;
+        state.upgrades.transcend_no_coin_upgrades = false;
+        state.upgrades.transcend_no_coin_or_prestige_upgrades = false;
         // ascension_count > 0 → gate blocks quark award.
         state.reset_counters.ascension_count = 1.0;
         let gains = ResetCurrencyResult {

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -5112,15 +5112,17 @@ fn phase_challenge_completion(
     output: &mut TickOutput,
 ) {
     use crate::mechanics::challenges::{
-        challenge_requirement, get_max_challenges, ChallengeRequirementInput,
-        GetMaxChallengesInput, CHALLENGE_BASE_REQUIREMENTS,
+        challenge_15_score_multiplier, challenge_requirement, get_max_challenges,
+        Challenge15ScoreMultiplierInput, ChallengeRequirementInput, GetMaxChallengesInput,
+        CHALLENGE_BASE_REQUIREMENTS,
     };
     use crate::mechanics::shop_upgrades::{
         challenge_extension_effect, instant_challenge_2_effect, instant_challenge_effect,
         InstantChallengeKey, InstantChallengeValue,
     };
     use crate::state::shop::{
-        SHOP_CHALLENGE_EXTENSION, SHOP_INSTANT_CHALLENGE, SHOP_INSTANT_CHALLENGE_2,
+        SHOP_CHALLENGE_15_AUTO, SHOP_CHALLENGE_EXTENSION, SHOP_INSTANT_CHALLENGE,
+        SHOP_INSTANT_CHALLENGE_2,
     };
 
     const PLATONIC_UPGRADE_8: usize = 8;
@@ -5299,6 +5301,41 @@ fn phase_challenge_completion(
                 gains,
                 output,
             );
+        }
+    }
+
+    // ── Ascension challenge 15: exponent accrual.
+    // c15 does NOT increment `challengecompletions`; instead `challenge15Exponent`
+    // grows from coins, and the (already-ported) `challenge_15_rewards::*` cascade
+    // reads that exponent live. Synergism.ts:4514-4525 ("Challenge 15 autoupdate")
+    // and the `a === 15` branch of `resetCheck` (3760-3784) share the same body.
+    // The only tick-reachable trigger is the `challenge15Auto` shop upgrade — the
+    // manual / leaving-the-challenge update is UI-tier (deferred). `c15RewardUpdate()`
+    // is a no-op for us (rewards are read live), and the
+    // `challenge15Exponent >= 1e15 → unlocks.hepteracts` side-effect is already
+    // covered: the hepteract-gain gate reads
+    // `challenge_15_rewards::hepteracts_unlocked(exponent)` directly (calculate.rs).
+    if qa == 15 && state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] > 0.0 {
+        // challenge15ScoreMultiplier(): campaign · challenge-hepteract · OMEGA.
+        let c15_sm = challenge_15_score_multiplier(&Challenge15ScoreMultiplierInput {
+            // Campaign subsystem unported → neutral (mirrors the `campaign_*` legs
+            // elsewhere in the tick, e.g. `campaign_ascension_score_mult`).
+            c15_bonus: 1.0,
+            // `hepteractEffective('challenge')` — challenge craft LIMIT 1000, DR 1/6,
+            // DR_INCREASE 0 (Hepteracts.ts:190-192).
+            challenge_hepteract_effective: hepteract_effective_bal(
+                state.hepteracts.challenge.bal,
+                1.0 / 6.0,
+            ),
+            platonic_upgrade_15: state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_15],
+        });
+        // Grow only once coins clear the next threshold `10^(exponent / c15SM)`.
+        let threshold = Decimal::from_finite(10.0).pow(Decimal::from_finite(
+            state.challenges.challenge15_exponent / c15_sm,
+        ));
+        if state.upgrades.coins >= threshold {
+            state.challenges.challenge15_exponent =
+                (state.upgrades.coins + Decimal::one()).log10().to_number() * c15_sm;
         }
     }
 }
@@ -7650,6 +7687,108 @@ mod tests {
         assert_eq!(state.challenges.challenge_completions[11], 0.0);
         assert_eq!(state.challenges.current_ascension_challenge, 11); // still in
         assert!(!state.reset_counters.tesseracts_unlocked);
+    }
+
+    #[test]
+    fn phase_challenge_completion_c15_quiescent_without_auto() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        use crate::state::shop::SHOP_CHALLENGE_15_AUTO;
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 15;
+        state.upgrades.coins = Decimal::from_finite(1e6);
+        // challenge15Auto NOT unlocked → the tick autoupdate must not fire
+        // (the manual update path is UI-tier).
+        assert_eq!(state.shop.upgrades[SHOP_CHALLENGE_15_AUTO], 0.0);
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        assert_eq!(state.challenges.challenge15_exponent, 0.0);
+    }
+
+    #[test]
+    fn phase_challenge_completion_c15_accrues_with_auto() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        use crate::state::shop::SHOP_CHALLENGE_15_AUTO;
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 15;
+        state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] = 1.0; // challenge15Auto unlocked
+        state.upgrades.coins = Decimal::from_finite(1e6);
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        // c15SM = 1 at default legs (campaign 1, no challenge hept, platonic[15]=0),
+        // so exponent = log10(1e6 + 1) * 1 ≈ 6.0.
+        assert!((state.challenges.challenge15_exponent - 6.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn phase_challenge_completion_c15_threshold_gates_growth() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        use crate::state::shop::SHOP_CHALLENGE_15_AUTO;
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 15;
+        state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] = 1.0;
+        // Already-high exponent → next threshold is 10^(100/1) = 1e100.
+        state.challenges.challenge15_exponent = 100.0;
+        state.upgrades.coins = Decimal::from_finite(1e6);
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        // Coins (1e6) < threshold (1e100) → exponent unchanged.
+        assert_eq!(state.challenges.challenge15_exponent, 100.0);
+    }
+
+    #[test]
+    fn phase_challenge_completion_c15_exponent_lights_reward_cascade() {
+        use crate::mechanics::challenge_15_rewards;
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        use crate::state::shop::SHOP_CHALLENGE_15_AUTO;
+        // The whole point of the accrual: a frozen-0 exponent leaves every
+        // c15 reward at identity; a grown exponent lights the cascade.
+        assert_eq!(challenge_15_rewards::coin_exponent(0.0), 1.0);
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 15;
+        state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] = 1.0;
+        // coins = 1e4000 → exponent ≈ 4000, past coin_exponent's 3000 requirement.
+        state.upgrades.coins = Decimal::from_finite(10.0).pow(Decimal::from_finite(4000.0));
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        assert!(state.challenges.challenge15_exponent > 3000.0);
+        assert!(challenge_15_rewards::coin_exponent(state.challenges.challenge15_exponent) > 1.0);
+    }
+
+    #[test]
+    fn tack_accrues_challenge_15_exponent_end_to_end() {
+        // The orchestrator runs the c15 accrual during a normal tick (closes the
+        // "is the new phase actually wired into tack" blind spot).
+        use crate::state::shop::SHOP_CHALLENGE_15_AUTO;
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 15;
+        state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] = 1.0;
+        state.upgrades.coins = Decimal::from_finite(1e6);
+        let input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        let _ = tack(&mut state, &input);
+        assert!(state.challenges.challenge15_exponent > 0.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -418,6 +418,37 @@ pub enum ResetRequest {
     AscensionChallenge,
 }
 
+/// `forcedDailyReset` (Calculate.ts:1638) — the once-per-real-day bookkeeping
+/// reset. A **host seam**: the logic crate has no clock, so a host (web/desktop)
+/// calls this when its `dailyResetCheck` detects a new calendar day. Zeroes the
+/// per-day cube-opening counters and the reborn-ELO daily leaderboard; the
+/// latter (`resetPlayerRebornELODaily`) also clears `quarks_gained_from_ants`,
+/// so the next day's ant-sacrifice quark award restarts from a clean delta. The
+/// all-time `highest_reborn_elo_ever` leaderboard is intentionally left intact.
+///
+/// The `rewards = true` overflux branch (`overfluxPowder += overfluxOrbs *
+/// calculatePowderConversion()`; `overfluxOrbs = challenge15Rewards.freeOrbs`)
+/// is **not** ported: `calculatePowderConversion`'s full formula and the c15
+/// `freeOrbs` reward are unported. The counter reset is the portion that maps to
+/// ported state — and `forcedDailyReset` deliberately awards no powder / expires
+/// no orbs on the manual (`rewards = false`) path regardless.
+pub fn daily_reset(state: &mut GameState) {
+    let cubes = &mut state.cube_balances;
+    cubes.cube_quark_daily = 0.0;
+    cubes.tesseract_quark_daily = 0.0;
+    cubes.hypercube_quark_daily = 0.0;
+    cubes.platonic_cube_quark_daily = 0.0;
+    cubes.cube_opened_daily = 0.0;
+    cubes.tesseract_opened_daily = 0.0;
+    cubes.hypercube_opened_daily = 0.0;
+    cubes.platonic_cube_opened_daily = 0.0;
+
+    // resetPlayerRebornELODaily(): empty the daily leaderboard + zero the running
+    // ant-quark total (defaultHighestRebornELODaily = [], defaultQuarksGainedFromAnts = 0).
+    state.ants.highest_reborn_elo_daily.clear();
+    state.ants.quarks_gained_from_ants = 0.0;
+}
+
 /// Result of [`tack`]. The accumulated event stream is the only output
 /// the UI tier reads from a tick today; derived stats and dirty flags
 /// land here once Phase 2 acquires a `state.g_cache` slice to read from.
@@ -7848,6 +7879,48 @@ mod tests {
         phase_challenge_completion(&mut state, &gains, &mut output);
         assert!(state.challenges.challenge15_exponent >= 666_666.0);
         assert_eq!(state.achievements.achievements[252], 1);
+    }
+
+    #[test]
+    fn daily_reset_zeroes_daily_counters_and_preserves_all_time() {
+        use crate::state::ants::RebornELOEntry;
+        let mut state = GameState::default();
+        // A day of play populates the daily counters, the daily leaderboard, and
+        // the running ant-quark total — plus the all-time leaderboard.
+        state.cube_balances.cube_opened_daily = 12.0;
+        state.cube_balances.cube_quark_daily = 34.0;
+        state.cube_balances.tesseract_opened_daily = 5.0;
+        state.cube_balances.tesseract_quark_daily = 6.0;
+        state.cube_balances.hypercube_opened_daily = 7.0;
+        state.cube_balances.hypercube_quark_daily = 8.0;
+        state.cube_balances.platonic_cube_opened_daily = 9.0;
+        state.cube_balances.platonic_cube_quark_daily = 10.0;
+        state.ants.quarks_gained_from_ants = 500.0;
+        state.ants.highest_reborn_elo_daily.push(RebornELOEntry {
+            elo: 1000.0,
+            sacrifice_id: 1,
+        });
+        state.ants.highest_reborn_elo_ever.push(RebornELOEntry {
+            elo: 1000.0,
+            sacrifice_id: 1,
+        });
+
+        daily_reset(&mut state);
+
+        // All 8 per-day cube counters cleared.
+        assert_eq!(state.cube_balances.cube_opened_daily, 0.0);
+        assert_eq!(state.cube_balances.cube_quark_daily, 0.0);
+        assert_eq!(state.cube_balances.tesseract_opened_daily, 0.0);
+        assert_eq!(state.cube_balances.tesseract_quark_daily, 0.0);
+        assert_eq!(state.cube_balances.hypercube_opened_daily, 0.0);
+        assert_eq!(state.cube_balances.hypercube_quark_daily, 0.0);
+        assert_eq!(state.cube_balances.platonic_cube_opened_daily, 0.0);
+        assert_eq!(state.cube_balances.platonic_cube_quark_daily, 0.0);
+        // Daily reborn-ELO leaderboard + running ant-quark total reset...
+        assert!(state.ants.highest_reborn_elo_daily.is_empty());
+        assert_eq!(state.ants.quarks_gained_from_ants, 0.0);
+        // ...but the all-time leaderboard survives.
+        assert_eq!(state.ants.highest_reborn_elo_ever.len(), 1);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -5338,6 +5338,21 @@ fn phase_challenge_completion(
                 (state.upgrades.coins + Decimal::one()).log10().to_number() * c15_sm;
         }
     }
+
+    // sadisticAch (#252): `challengeAchievementCheck(15)` awards it once the c15
+    // `achievementUnlock` reward (exponent >= 666666) is active. Idempotent and
+    // independent of challenge15Auto (the exponent may already be high). pv 50.
+    if qa == 15
+        && challenge_15_rewards::achievement_unlock(state.challenges.challenge15_exponent) == 1.0
+    {
+        let awarded = crate::mechanics::achievement_awards::award_ungrouped_achievement(
+            &mut state.achievements,
+            252,
+            50.0,
+            true,
+        );
+        credit_achievement_quarks(state, awarded);
+    }
 }
 
 /// Award + exit + reset for one in-progress challenge that has met its goal
@@ -5365,13 +5380,35 @@ fn complete_active_challenge(
         counter += 1.0;
     }
     state.challenges.challenge_completions[q_idx] = comp;
-    // challengeAchievementCheck(q) — award the challengeN group from the
-    // updated completion count (the legacy resetCheck calls it after the
-    // completion increments).
+    // challengeAchievementCheck(q) — award the challengeN group plus the
+    // ungrouped per-challenge extras (chalNNoGen / diamondSearch / extraChallenging)
+    // from the updated completion count (the legacy resetCheck calls it after the
+    // completion increments). The extras' context is captured before the mutable
+    // achievements borrow; `current_transcension_challenge` is still set here (the
+    // challenge exits further below).
+    let extras_ctx = crate::mechanics::achievement_awards::ChallengeUngroupedContext {
+        coins_this_transcension_log10: (state.coin_counters.coins_this_transcension
+            + Decimal::one())
+        .log10()
+        .to_number(),
+        current_transcension_challenge: state.challenges.current_transcension_challenge,
+        generator_upgrades_owned: state.upgrades.upgrades[101..=105]
+            .iter()
+            .map(|&u| u32::from(u))
+            .sum(),
+        accelerator_bought: state.accelerator.accelerator_bought,
+        accelerator_boost_bought: state.accelerator.accelerator_boost_bought,
+        extinction_level: f64::from(state.corruptions.used.levels[crate::state::EXTINCTION_INDEX]),
+    };
     let awarded = crate::mechanics::achievement_awards::challenge_achievement_check(
         &mut state.achievements,
         q_idx,
         &state.challenges.challenge_completions,
+    ) + crate::mechanics::achievement_awards::challenge_ungrouped_achievement_check(
+        &mut state.achievements,
+        q_idx,
+        &state.challenges.challenge_completions,
+        &extras_ctx,
     );
     credit_achievement_quarks(state, awarded);
     while state.challenges.challenge_completions[q_idx]
@@ -7790,6 +7827,27 @@ mod tests {
         };
         let _ = tack(&mut state, &input);
         assert!(state.challenges.challenge15_exponent > 0.0);
+    }
+
+    #[test]
+    fn c15_awards_sadistic_achievement_once_exponent_unlocks_it() {
+        use crate::mechanics::reset_currency::ResetCurrencyResult;
+        use crate::state::shop::SHOP_CHALLENGE_15_AUTO;
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 15;
+        state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] = 1.0;
+        // coins = 1e700000 → accrued exponent ≈ 700000, past the c15
+        // achievementUnlock requirement (666666) → sadisticAch (#252) awarded.
+        state.upgrades.coins = Decimal::from_finite(10.0).pow(Decimal::from_finite(700_000.0));
+        let gains = ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        phase_challenge_completion(&mut state, &gains, &mut output);
+        assert!(state.challenges.challenge15_exponent >= 666_666.0);
+        assert_eq!(state.achievements.achievements[252], 1);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -701,14 +701,23 @@ fn hepteract_effective_bal(raw_amount: f64, dr_exponent: f64) -> f64 {
 
 /// `firstFiveEffectiveRuneLevelMult` (Statistics.ts `firstFiveRuneEffectivenessStats`):
 /// the product applied to the first five runes' level. The eight research
-/// factors, `ConstantUpgrade9`, and `Research4x9` are live; the `Challenge15`
-/// rune bonus, the `MidasTribute` cube-blessing chain, and the `AchievementBonus`
-/// quark-gain reward are neutral-defaulted to `1.0` (unported / blessing chain
-/// deferred / achievements unported, H5). Identity at the default state.
-/// TS-anchored against the verbatim Statistics.ts expressions.
+/// factors, `ConstantUpgrade9`, `Research4x9`, and the `MidasTribute`
+/// cube-blessing cascade are live; only the `Challenge15` rune bonus stays
+/// neutral-defaulted to `1.0` (its `challenge_15_rewards` reader is unported).
+/// (A spurious `quarkGain` factor was dropped here — `getAchievementReward('quarkGain')`
+/// is an `allQuarkStats` term, not part of `firstFiveRuneEffectivenessStats`.)
+/// Identity at the default state. TS-anchored against the verbatim Statistics.ts.
 fn first_five_effective_rune_level_mult(state: &GameState) -> f64 {
     use crate::mechanics::calculate::product_f64;
     use crate::mechanics::challenges::{calc_ecc, ChallengeType};
+    use crate::mechanics::cube_blessings::calculate_rune_effectiveness_cube_blessing;
+    use crate::mechanics::hypercube_blessings::calculate_rune_effectiveness_hypercube_blessing;
+    use crate::mechanics::platonic_blessings::calculate_hypercube_blessing_multiplier_platonic_blessing;
+    use crate::mechanics::tesseract_blessings::calculate_rune_effectiveness_tesseract_blessing;
+
+    // `player.cubeUpgrades[44]` — the rune-effectiveness cube-blessing DR increase.
+    const CUBE_UPGRADE_RUNE_EFFECTIVENESS_BLESSING: usize = 44;
+
     let research = &state.researches.researches;
     let cc = &state.challenges.challenge_completions;
     // ConstantUpgrade9: 1 + 0.01·log4(talismanShards+1)·min(1, constantUpgrades[9]).
@@ -716,6 +725,26 @@ fn first_five_effective_rune_level_mult(state: &GameState) -> f64 {
         + 0.01
             * ((state.talismans.talisman_shards + 1.0).ln() / 4.0_f64.ln())
             * state.campaigns.constant_upgrades[9].min(1.0);
+
+    // MidasTribute = calculateRuneEffectivenessCubeBlessing(): the cube-blessing
+    // cascade (platonic → hypercube → tesseract → cube), now live since open()
+    // (P3.2) makes the blessing levels accrue. Identity at level 0.
+    let platonic_amplifier =
+        calculate_hypercube_blessing_multiplier_platonic_blessing(&state.platonic_blessings);
+    let hypercube_blessing = calculate_rune_effectiveness_hypercube_blessing(
+        &state.hypercube_blessings,
+        platonic_amplifier,
+    );
+    let tesseract_blessing = calculate_rune_effectiveness_tesseract_blessing(
+        &state.tesseract_blessings,
+        hypercube_blessing,
+    );
+    let midas_tribute = calculate_rune_effectiveness_cube_blessing(
+        &state.cube_blessings,
+        tesseract_blessing,
+        state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_RUNE_EFFECTIVENESS_BLESSING],
+    );
+
     product_f64(&[
         1.0 + research[4] / 10.0 * (1.0 + calc_ecc(ChallengeType::Ascension, cc[14])),
         1.0 + research[21] / 100.0,
@@ -726,10 +755,9 @@ fn first_five_effective_rune_level_mult(state: &GameState) -> f64 {
         1.0 + (research[176] / 200.0 * 2.0) / 5.0,
         1.0 + (research[191] / 200.0) / 5.0,
         const_upgrade_9,
-        1.0, // Challenge15 runeBonus -> neutral (unported)
-        1.0, // MidasTribute cube blessing -> neutral (blessing chain deferred)
-        1.0 + research[84] / 200.0,
-        1.0, // AchievementBonus quarkGain -> neutral (achievements unported, H5)
+        1.0,           // Challenge15 runeBonus -> neutral (challenge_15_rewards reader unported)
+        midas_tribute, // MidasTribute = rune-effectiveness cube-blessing cascade
+        1.0 + research[84] / 200.0, // Research4x9 (runeEffectivenessStatsSI)
     ])
 }
 
@@ -7921,6 +7949,19 @@ mod tests {
         assert_eq!(state.ants.quarks_gained_from_ants, 0.0);
         // ...but the all-time leaderboard survives.
         assert_eq!(state.ants.highest_reborn_elo_ever.len(), 1);
+    }
+
+    #[test]
+    fn first_five_rune_mult_picks_up_midas_tribute_cube_blessing() {
+        let mut state = GameState::default();
+        // No blessings opened → every factor is identity → the mult is 1.
+        assert_eq!(first_five_effective_rune_level_mult(&state), 1.0);
+        // Accruing the talisman-bonus blessing tier (as opening cubes would) lifts
+        // the MidasTribute cascade above 1, so the rune-effectiveness mult rises.
+        state.cube_blessings.talisman_bonus = 500.0;
+        state.tesseract_blessings.talisman_bonus = 5_000.0;
+        state.hypercube_blessings.talisman_bonus = 5_000.0;
+        assert!(first_five_effective_rune_level_mult(&state) > 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -121,10 +121,17 @@ pub(crate) fn perform_prestige_reset(
     // resetAchievementCheck('prestige') runs before reset() in the legacy
     // trigger, so the offering award inside the base reset sees the updated
     // achievement_points.
+    let no_buy = crate::mechanics::achievement_awards::ResetNoBuyFlags {
+        no_multiplier: state.multiplier.prestige_no_multiplier,
+        no_accelerator: state.accelerator.prestige_no_accelerator,
+        no_coin_upgrades: state.upgrades.prestige_no_coin_upgrades,
+        ..Default::default()
+    };
     let awarded = crate::mechanics::achievement_awards::reset_achievement_check(
         &mut state.achievements,
         AutoResetTier::Prestige,
         prestige_point_gain,
+        &no_buy,
     );
     super::credit_achievement_quarks(state, awarded);
     apply_base_reset(state, prestige_point_gain);
@@ -208,10 +215,18 @@ pub(crate) fn perform_transcension_reset(
     state: &mut GameState,
     gains: &ResetCurrencyResult,
 ) -> SmallVec<[CoreEvent; 2]> {
+    let no_buy = crate::mechanics::achievement_awards::ResetNoBuyFlags {
+        no_multiplier: state.multiplier.transcend_no_multiplier,
+        no_accelerator: state.accelerator.transcend_no_accelerator,
+        no_coin_upgrades: state.upgrades.transcend_no_coin_upgrades,
+        no_coin_or_prestige_upgrades: state.upgrades.transcend_no_coin_or_prestige_upgrades,
+        ..Default::default()
+    };
     let awarded = crate::mechanics::achievement_awards::reset_achievement_check(
         &mut state.achievements,
         AutoResetTier::Transcension,
         gains.transcend_point_gain,
+        &no_buy,
     );
     super::credit_achievement_quarks(state, awarded);
     apply_base_reset(state, gains.prestige_point_gain);
@@ -299,10 +314,23 @@ pub(crate) fn perform_reincarnation_reset(
 ) -> SmallVec<[CoreEvent; 2]> {
     // resetAchievementCheck('reincarnation') runs first, so the obtainium and
     // offering awards below read the updated achievement_points.
+    let no_buy = crate::mechanics::achievement_awards::ResetNoBuyFlags {
+        no_multiplier: state.multiplier.reincarnate_no_multiplier,
+        no_accelerator: state.accelerator.reincarnate_no_accelerator,
+        no_coin_upgrades: state.upgrades.reincarnate_no_coin_upgrades,
+        no_coin_or_prestige_upgrades: state.upgrades.reincarnate_no_coin_or_prestige_upgrades,
+        no_coin_prestige_or_transcend_upgrades: state
+            .upgrades
+            .reincarnate_no_coin_prestige_or_transcend_upgrades,
+        no_coin_prestige_transcend_or_generator_upgrades: state
+            .upgrades
+            .reincarnate_no_coin_prestige_transcend_or_generator_upgrades,
+    };
     let awarded = crate::mechanics::achievement_awards::reset_achievement_check(
         &mut state.achievements,
         AutoResetTier::Reincarnation,
         gains.reincarnation_point_gain,
+        &no_buy,
     );
     super::credit_achievement_quarks(state, awarded);
     // `reincarnationCheck` is the *pre-reset* shard total — capture it
@@ -1086,6 +1114,18 @@ mod tests {
         // the 1e30 row (index 52) stays unmet.
         let mut state = GameState::default();
         state.reset_counters.transcend_shards = Decimal::from_finite(1e305);
+        // Clear the reincarnation no-buy flags so only reincarnationPointGain
+        // awards here (the no-buy achievements have their own tests).
+        state.multiplier.reincarnate_no_multiplier = false;
+        state.accelerator.reincarnate_no_accelerator = false;
+        state.upgrades.reincarnate_no_coin_upgrades = false;
+        state.upgrades.reincarnate_no_coin_or_prestige_upgrades = false;
+        state
+            .upgrades
+            .reincarnate_no_coin_prestige_or_transcend_upgrades = false;
+        state
+            .upgrades
+            .reincarnate_no_coin_prestige_transcend_or_generator_upgrades = false;
         perform_reincarnation_reset(&mut state, &gains(0.0, 0.0, 1e6));
         assert_eq!(state.achievements.achievements[50], 1);
         assert_eq!(state.achievements.achievements[51], 1);
@@ -1096,6 +1136,12 @@ mod tests {
     #[test]
     fn prestige_reset_awards_point_gain_achievements() {
         let mut state = GameState::default();
+        // Clear the prestige no-buy flags (as if purchases were made this run)
+        // so only prestigePointGain awards here — the no-buy achievements have
+        // their own tests.
+        state.multiplier.prestige_no_multiplier = false;
+        state.accelerator.prestige_no_accelerator = false;
+        state.upgrades.prestige_no_coin_upgrades = false;
         // gain 1e6 → log10 6 → prestigePointGain rows at thresholds 0 and 6
         // (indices 36,37; pv 5+10 = 15).
         perform_prestige_reset(&mut state, Decimal::from_finite(1e6));


### PR DESCRIPTION
Closes several TS→Rust port frontier subsystems. Six self-contained,
gate-green commits; **zero new state fields** across all of them.

## What's in it

**Challenge subsystem — finished (C15)**
- `ff7683e9` — **C15 exponent accrual.** `phase_challenge_completion` now grows
  `challenge15_exponent = log10(coins+1)·c15SM` when `coins ≥ 10^(exp/c15SM)`,
  gated on the `challenge15Auto` shop upgrade. This lights the entire
  already-ported `challenge_15_rewards::*` cascade (~15 read sites), which was
  frozen at identity (audit H-gap). `c15RewardUpdate()` is a no-op for us
  (rewards read live); the `exp≥1e15→unlocks.hepteracts` side-effect is already
  covered by the exponent-derived hepteract-gain gate.
  *(Note: the PR-#262 handoff listed c11–15 entry/completion as the "primary"
  task, but `git log` showed it had already shipped in `b02bedaf`; C15 accrual
  was the genuine remaining gap.)*

**Achievement tail (P3.1 slice 3b) — closed**
- `6573f22d` — **No-reset achievements** (idx 57–62, 64–70): "reset without
  buying a multiplier/accelerator/coin upgrade" + the diamond/mythos/generator
  variants, folded into `reset_achievement_check` via `ResetNoBuyFlags`. The
  per-run flags were already plumbed (cleared on buy, restored on reset).
- `0104c0c3` — **Per-challenge extras**: `chal{1,2,3}NoGen`, `diamondSearch`,
  `extraChallenging`, and `sadisticAch` (via the new
  `challenge_15_rewards::achievement_unlock`).

  Only the full-table recompute (`compute_achievement_points`, needs the
  509-entry value table) remains — deferred to save-load.

**Rune-blessing wiring (audit H4, blessing side) — complete**
- `1a6a9817` — **Prism rune-blessing** `antSacrificeMult` wired into the
  ant-sacrifice multiplier (was hardcoded `1.0`), through the shared
  `rune_blessing_power`.
- `1d49b300` — **MidasTribute** rune-effectiveness cube-blessing cascade wired
  into `first_five_effective_rune_level_mult`; also dropped a spurious
  `quarkGain` factor there (it belongs to a different stat array — a
  behavior-preserving `×1.0` removal).

**Host seam**
- `74e7a1a1` — **`daily_reset(state)`** (exported from the crate root): zeroes
  the 8 cube daily counters + the reborn-ELO daily leaderboard + the running
  ant-quark total, leaving the all-time leaderboard intact. A host calls it on
  a new calendar day (the logic crate has no clock).

## Faithfully deferred / blocked
- **thrift** rune-blessing — blocked on the unported `boostAccelerator` buy
  (`get_accelerator_boost_cost` has no production caller).
- **boostAccelerator buy** — scoped; bigger than a standard buy (default path is
  a per-boost prestige reset, couples to tick-layer orchestration) — left for a
  dedicated PR.
- Challenge15 `runeBonus` reader, the quark-multiplier `quarkGain` reader, rune
  **spirits** (P2.2b) — unported / off-limits.

## Latent observations (logged, NOT touched — for a future audit)
- `first_five_effective_rune_level_mult` appears to conflate
  `firstFiveRuneEffectivenessStats` with `runeEffectivenessStatsSI` (it includes
  `research[84]`, the SI-only stat).

## Testing
All gates green: `cargo test --workspace` (1259 logic tests, 0 failures) ·
`clippy --all-targets -D warnings` · `fmt --check` · `wasm32` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
