### PR TITLE
Port the runes-talismans system (spirits, talismans, boostAccelerator)

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -172,6 +172,18 @@ pub enum CoreEvent {
         /// Coins removed from the player's balance.
         spent: Decimal,
     },
+    /// Accelerator boosts were purchased — `after - before` boosts at a
+    /// `prestigePoints` cost of `spent`. In the legacy pre-upgrade path each
+    /// boost also triggers a prestige reset (surfaced as a separate
+    /// [`CoreEvent::ResetPerformed`]).
+    AcceleratorBoostsPurchased {
+        /// Boost count before the purchase ran.
+        before: f64,
+        /// Boost count after the purchase ran.
+        after: f64,
+        /// Prestige points removed from the player's balance.
+        spent: Decimal,
+    },
     /// Multipliers were purchased — same shape as
     /// [`CoreEvent::AcceleratorsPurchased`].
     MultipliersPurchased {

--- a/crates/synergismforkd_logic/src/mechanics/accelerator_boosts.rs
+++ b/crates/synergismforkd_logic/src/mechanics/accelerator_boosts.rs
@@ -13,7 +13,12 @@
 //! the legacy `web_ui/Buy.ts` because it calls `reset('prestige')` inline;
 //! that part migrates with the reset-system overhaul.
 
+use smallvec::SmallVec;
 use synergismforkd_bignum::Decimal;
+
+use crate::events::CoreEvent;
+use crate::math::smallest_inc::smallest_inc;
+use crate::state::AcceleratorState;
 
 const BUYMAX: f64 = 1e15;
 
@@ -74,6 +79,127 @@ pub fn get_accelerator_boost_cost(level: f64, input: GetAcceleratorBoostCostInpu
     cost
 }
 
+/// Input to [`buy_accelerator_boost_bulk`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BuyAcceleratorBoostInput {
+    /// `getRuneBlessingEffect('thrift').accelBoostCostDelay`, captured once per
+    /// buy (the thrift rune blessing pushes back the quadratic-cost threshold).
+    pub accel_boost_cost_delay: f64,
+}
+
+/// Bulk accelerator-boost purchase — the `player.upgrades[46] >= 1` path of the
+/// legacy `boostAccelerator` (`Buy.ts:386-457`). Spends `prestige_points`, with
+/// no per-click cap and no prestige reset (that is the pre-upgrade path, which
+/// stays in [`crate::tick`] because it calls `reset('prestige')`). Mirrors the
+/// structure of [`buy_accelerator`](super::accelerators::buy_accelerator): a
+/// high-end binary search past `BUYMAX`, otherwise a 4× bracket + stepdown
+/// refine + forward walk. Sets the transcend / reincarnate no-accelerator flags
+/// (a boost does **not** clear the prestige flag).
+#[must_use]
+pub fn buy_accelerator_boost_bulk(
+    state: &mut AcceleratorState,
+    prestige_points: &mut Decimal,
+    input: BuyAcceleratorBoostInput,
+) -> SmallVec<[CoreEvent; 4]> {
+    let cost_input = GetAcceleratorBoostCostInput {
+        accel_boost_cost_delay: input.accel_boost_cost_delay,
+    };
+    let mut events: SmallVec<[CoreEvent; 4]> = SmallVec::new();
+    let starting_points = *prestige_points;
+    let buy_start = state.accelerator_boost_bought;
+
+    // High-end binary-search path (buyStart >= 1e15): snap to the largest
+    // affordable count; the diminishing cost makes per-step accounting moot
+    // (no points are subtracted here, matching the legacy source).
+    if buy_start >= BUYMAX {
+        let diminishing_exponent = 1.0_f64 / 8.0;
+        let log10_resource = prestige_points.log10().to_number();
+        let log10_quadrillion_cost = get_accelerator_boost_cost(BUYMAX, cost_input)
+            .log10()
+            .to_number();
+
+        let mut hi = (BUYMAX
+            * (1.0_f64).max((log10_resource / log10_quadrillion_cost).powf(diminishing_exponent)))
+        .floor();
+        let mut lo = BUYMAX;
+        for _ in 0..128 {
+            if hi - lo <= 0.5 {
+                break;
+            }
+            let mid = (lo + (hi - lo) / 2.0).floor();
+            if mid == lo || mid == hi {
+                break;
+            }
+            if *prestige_points < get_accelerator_boost_cost(mid, cost_input) {
+                hi = mid;
+            } else {
+                lo = mid;
+            }
+        }
+        let buyable = lo;
+        state.accelerator_boost_bought = buyable;
+        state.accelerator_boost_cost = get_accelerator_boost_cost(buyable, cost_input);
+        if state.accelerator_boost_bought > buy_start {
+            events.push(CoreEvent::AcceleratorBoostsPurchased {
+                before: buy_start,
+                after: state.accelerator_boost_bought,
+                spent: starting_points - *prestige_points,
+            });
+        }
+        return events;
+    }
+
+    // Normal path: 4× bracket on buyInc, stepdown refine, then forward walk.
+    let buydefault = buy_start + smallest_inc(buy_start);
+    let mut buy_inc = 1.0_f64;
+    let mut cost = get_accelerator_boost_cost(buy_start + buy_inc, cost_input);
+    while *prestige_points >= cost {
+        buy_inc *= 4.0;
+        cost = get_accelerator_boost_cost(buy_start + buy_inc, cost_input);
+    }
+    let mut stepdown = (buy_inc / 8.0).floor();
+    while stepdown >= smallest_inc(buy_inc) {
+        if get_accelerator_boost_cost(buy_start + buy_inc - stepdown, cost_input)
+            <= *prestige_points
+        {
+            stepdown = (stepdown / 2.0).floor();
+        } else {
+            buy_inc -= smallest_inc(buy_inc).max(stepdown);
+        }
+    }
+
+    // Walk forward from ~6 below the bracket, paying `this_cost` (which starts
+    // at the cost of the current level — the legacy first-step undercharge).
+    let mut buy_from = (buy_start + buy_inc - 6.0 - smallest_inc(buy_inc)).max(buydefault);
+    let mut this_cost = get_accelerator_boost_cost(buy_start, cost_input);
+    while buy_from <= buy_start + buy_inc
+        && *prestige_points >= get_accelerator_boost_cost(buy_from, cost_input)
+    {
+        *prestige_points -= this_cost;
+        if buy_from >= BUYMAX {
+            buy_from = BUYMAX;
+        }
+        state.accelerator_boost_bought = buy_from;
+        buy_from += smallest_inc(buy_from);
+        this_cost = get_accelerator_boost_cost(buy_from, cost_input);
+        state.accelerator_boost_cost = this_cost;
+        state.transcend_no_accelerator = false;
+        state.reincarnate_no_accelerator = false;
+        if buy_from >= BUYMAX {
+            break;
+        }
+    }
+
+    if state.accelerator_boost_bought > buy_start {
+        events.push(CoreEvent::AcceleratorBoostsPurchased {
+            before: buy_start,
+            after: state.accelerator_boost_bought,
+            spent: starting_points - *prestige_points,
+        });
+    }
+    events
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +258,37 @@ mod tests {
         let cost_d1 = get_accelerator_boost_cost(1500.0, input(1.0));
         let cost_d2 = get_accelerator_boost_cost(1500.0, input(2.0));
         assert!(cost_d2 < cost_d1);
+    }
+
+    // ─── buy_accelerator_boost_bulk ───────────────────────────────────────
+
+    fn bulk_input() -> BuyAcceleratorBoostInput {
+        BuyAcceleratorBoostInput {
+            accel_boost_cost_delay: 1.0,
+        }
+    }
+
+    #[test]
+    fn bulk_buy_is_noop_when_broke() {
+        let mut state = AcceleratorState::default();
+        let mut points = Decimal::zero();
+        let events = buy_accelerator_boost_bulk(&mut state, &mut points, bulk_input());
+        assert_eq!(state.accelerator_boost_bought, 0.0);
+        assert!(events.is_empty());
+        assert!(state.transcend_no_accelerator); // flag untouched when nothing bought
+    }
+
+    #[test]
+    fn bulk_buy_spends_prestige_points_and_buys() {
+        let mut state = AcceleratorState::default();
+        let mut points = Decimal::from_finite(1e30);
+        let events = buy_accelerator_boost_bulk(&mut state, &mut points, bulk_input());
+        assert!(state.accelerator_boost_bought > 0.0);
+        assert!(points < Decimal::from_finite(1e30)); // spent something
+        assert_eq!(events.len(), 1);
+        // The boost clears the transcend / reincarnate flags (not prestige).
+        assert!(!state.transcend_no_accelerator);
+        assert!(!state.reincarnate_no_accelerator);
+        assert!(state.prestige_no_accelerator);
     }
 }

--- a/crates/synergismforkd_logic/src/mechanics/accelerators.rs
+++ b/crates/synergismforkd_logic/src/mechanics/accelerators.rs
@@ -359,6 +359,7 @@ mod tests {
         AcceleratorState {
             accelerator_bought: 0.0,
             accelerator_boost_bought: 0.0,
+            accelerator_boost_cost: Decimal::from_finite(1e3),
             accelerator_cost: get_cost_accelerator(1.0, baseline()),
             prestige_no_accelerator: true,
             transcend_no_accelerator: true,

--- a/crates/synergismforkd_logic/src/state/accelerator.rs
+++ b/crates/synergismforkd_logic/src/state/accelerator.rs
@@ -29,9 +29,12 @@ pub struct AcceleratorState {
     pub accelerator_bought: f64,
     /// `player.acceleratorBoostBought` — accelerator-boosts purchased.
     /// Feeds `calculate_total_accelerator_boost` (the `bought + free`
-    /// total). Defaults to 0; set by the (not-yet-ported) buy-boost
-    /// action.
+    /// total). Set by [`crate::tick`]'s accelerator-boost buy.
     pub accelerator_boost_bought: f64,
+    /// `player.acceleratorBoostCost` — running `prestigePoints` cost of the
+    /// next accelerator boost. Grown incrementally by the pre-upgrade buy
+    /// path and snapped to the closed form by the bulk path.
+    pub accelerator_boost_cost: Decimal,
     /// Cost of the next accelerator (cached so the UI can render without
     /// recomputing).
     pub accelerator_cost: Decimal,
@@ -51,6 +54,7 @@ impl Default for AcceleratorState {
         Self {
             accelerator_bought: 0.0,
             accelerator_boost_bought: 0.0,
+            accelerator_boost_cost: Decimal::from_finite(1e3),
             accelerator_cost: Decimal::zero(),
             prestige_no_accelerator: true,
             transcend_no_accelerator: true,

--- a/crates/synergismforkd_logic/src/state/mod.rs
+++ b/crates/synergismforkd_logic/src/state/mod.rs
@@ -82,8 +82,10 @@ pub use runes::{
 pub use shop::{ShopBuyMaxMode, ShopState};
 pub use singularity::{SingularityChallengeState, SingularityState};
 pub use talismans::{
-    TalismanRuneAssignment, TalismansState, TALISMAN_CHRONOS, TALISMAN_COUNT, TALISMAN_EXEMPTION,
+    TalismanRuneAssignment, TalismansState, TALISMAN_ACHIEVEMENT, TALISMAN_CHRONOS,
+    TALISMAN_COOKIE_GRANDMA, TALISMAN_COUNT, TALISMAN_EXEMPTION, TALISMAN_HORSE_SHOE,
     TALISMAN_METAPHYSICS, TALISMAN_MIDAS, TALISMAN_MORTUUS, TALISMAN_PLASTIC, TALISMAN_POLYMATH,
+    TALISMAN_WOW_SQUARE,
 };
 pub use tesseract_buildings::{AscendBuildingState, TesseractBuildingsState};
 pub use upgrades::{UpgradesState, UPGRADES_DEFAULT_LEN};

--- a/crates/synergismforkd_logic/src/state/mod.rs
+++ b/crates/synergismforkd_logic/src/state/mod.rs
@@ -75,8 +75,9 @@ pub use researches::{AutoResearchMode, ResearchesState};
 pub use reset_counters::ResetCountersState;
 pub use rng::{RngPurpose, RngState};
 pub use runes::{
-    RunesState, RUNE_ANTIQUITIES, RUNE_COUNT, RUNE_DUPLICATION, RUNE_FINITE_DESCENT, RUNE_PRISM,
-    RUNE_SPEED, RUNE_SUPERIOR_INTELLECT, RUNE_THRIFT,
+    RunesState, RUNE_ANTIQUITIES, RUNE_COUNT, RUNE_DUPLICATION, RUNE_FINITE_DESCENT,
+    RUNE_HORSE_SHOE, RUNE_INFINITE_ASCENT, RUNE_PRISM, RUNE_SPEED, RUNE_SUPERIOR_INTELLECT,
+    RUNE_THRIFT, RUNE_TOP_HAT,
 };
 pub use shop::{ShopBuyMaxMode, ShopState};
 pub use singularity::{SingularityChallengeState, SingularityState};

--- a/crates/synergismforkd_logic/src/state/runes.rs
+++ b/crates/synergismforkd_logic/src/state/runes.rs
@@ -13,10 +13,17 @@ use serde::{Deserialize, Serialize};
 
 use synergismforkd_bignum::Decimal;
 
-/// Number of rune slots. Legacy synergism has 7: speed,
-/// duplication, prism, thrift, superiorIntellect, antiquities,
-/// finiteDescent.
-pub const RUNE_COUNT: usize = 7;
+/// Number of rune slots. The current synergism build has 10 runes;
+/// index `i` is the i-th key of the legacy `runes` object
+/// (`legacy/core_split/packages/web_ui/src/Runes.ts`): speed,
+/// duplication, prism, thrift, superiorIntellect, infiniteAscent,
+/// antiquities, horseShoe, finiteDescent, topHat.
+///
+/// Rune blessings and spirits only exist for the first five runes
+/// (speed..superiorIntellect); the `rune_blessing_levels` /
+/// `rune_spirit_levels` arrays are still sized `RUNE_COUNT` for index
+/// parity, with the trailing slots unused.
+pub const RUNE_COUNT: usize = 10;
 
 /// Index of the Speed rune in [`RunesState::rune_levels`] etc.
 pub const RUNE_SPEED: usize = 0;
@@ -28,17 +35,23 @@ pub const RUNE_PRISM: usize = 2;
 pub const RUNE_THRIFT: usize = 3;
 /// Index of the Superior Intellect rune.
 pub const RUNE_SUPERIOR_INTELLECT: usize = 4;
-/// Index of the Antiquities rune (5th-prestige rune).
-pub const RUNE_ANTIQUITIES: usize = 5;
-/// Index of the Finite Descent rune (6th-prestige rune).
-pub const RUNE_FINITE_DESCENT: usize = 6;
+/// Index of the Infinite Ascent rune.
+pub const RUNE_INFINITE_ASCENT: usize = 5;
+/// Index of the Antiquities rune.
+pub const RUNE_ANTIQUITIES: usize = 6;
+/// Index of the Horse Shoe rune.
+pub const RUNE_HORSE_SHOE: usize = 7;
+/// Index of the Finite Descent rune (ascension-score rune).
+pub const RUNE_FINITE_DESCENT: usize = 8;
+/// Index of the Top Hat rune.
+pub const RUNE_TOP_HAT: usize = 9;
 
 /// Slice of `GameState` for rune levels + XP + blessings + spirits
 /// + the rune-shards spend resource.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RunesState {
-    /// Per-rune level. Indexed `0..=6` to match the legacy rune
-    /// enum order.
+    /// Per-rune level. Indexed `0..=9` to match the legacy rune
+    /// object key order.
     pub rune_levels: [f64; RUNE_COUNT],
     /// Per-rune EXP accumulator. Indices match `rune_levels`.
     pub rune_exp: [f64; RUNE_COUNT],
@@ -72,9 +85,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_has_7_rune_slots() {
+    fn default_has_10_rune_slots() {
         let s = RunesState::default();
-        assert_eq!(s.rune_levels.len(), 7);
-        assert_eq!(s.rune_blessing_levels.len(), 7);
+        assert_eq!(s.rune_levels.len(), 10);
+        assert_eq!(s.rune_blessing_levels.len(), 10);
+    }
+
+    #[test]
+    fn rune_index_convention_sentinels() {
+        // Indices follow the legacy `runes` object key order.
+        assert_eq!(RUNE_SPEED, 0);
+        assert_eq!(RUNE_SUPERIOR_INTELLECT, 4);
+        assert_eq!(RUNE_INFINITE_ASCENT, 5);
+        assert_eq!(RUNE_ANTIQUITIES, 6);
+        assert_eq!(RUNE_FINITE_DESCENT, 8);
+        assert_eq!(RUNE_TOP_HAT, RUNE_COUNT - 1);
     }
 }

--- a/crates/synergismforkd_logic/src/state/talismans.rs
+++ b/crates/synergismforkd_logic/src/state/talismans.rs
@@ -8,13 +8,18 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Number of talismans in the legacy synergism build. Seven named:
-/// Exemption, Chronos, Midas, Metaphysics, Polymath, Mortuus, Plastic.
-/// The order matches the legacy `talismans` const
+/// Number of talismans in the current synergism build. Eleven named:
+/// Exemption, Chronos, Midas, Metaphysics, Polymath, Mortuus, Plastic,
+/// WowSquare, Achievement, CookieGrandma, HorseShoe. The order matches
+/// the legacy `talismans` const
 /// (`legacy/core_split/packages/web_ui/src/Talismans.ts`); index `i` is
-/// the i-th talisman, and the `TALISMAN_*` constants below give the
+/// the i-th key, and the `TALISMAN_*` constants below give the
 /// name → index mapping the UI tier must match.
-pub const TALISMAN_COUNT: usize = 7;
+///
+/// The first eight (Exemption..WowSquare) are ascension-tier; Achievement
+/// is singularity-tier; CookieGrandma and HorseShoe are never-tier (cf.
+/// each talisman's `minimalResetTier`).
+pub const TALISMAN_COUNT: usize = 11;
 
 /// `exemption` — index 0.
 pub const TALISMAN_EXEMPTION: usize = 0;
@@ -30,6 +35,14 @@ pub const TALISMAN_POLYMATH: usize = 4;
 pub const TALISMAN_MORTUUS: usize = 5;
 /// `plastic` — index 6.
 pub const TALISMAN_PLASTIC: usize = 6;
+/// `wowSquare` — index 7.
+pub const TALISMAN_WOW_SQUARE: usize = 7;
+/// `achievement` — index 8.
+pub const TALISMAN_ACHIEVEMENT: usize = 8;
+/// `cookieGrandma` — index 9.
+pub const TALISMAN_COOKIE_GRANDMA: usize = 9;
+/// `horseShoe` — index 10.
+pub const TALISMAN_HORSE_SHOE: usize = 10;
 
 /// Per-talisman fragment-allocation state. Mirrors the legacy
 /// `player.talismanOne..Seven` arrays: a small fixed slot list
@@ -51,7 +64,13 @@ pub struct TalismansState {
     /// `player.talismanRarity[0..=6]` — per-talisman rarity tier.
     pub talisman_rarity: [f64; TALISMAN_COUNT],
     /// Per-talisman rune-allocation slots. Legacy uses 5 slots per
-    /// talisman: `[Boolean, 0..=5]` per slot.
+    /// talisman: `[Boolean, 0..=5]` per slot. **Deprecated dead state**:
+    /// the current talisman→rune-level bonus reads fixed per-talisman
+    /// `talismanBaseCoefficient` data (see [`crate::mechanics::talisman_levels`]),
+    /// not these player-chosen slots. Retained because the legacy
+    /// `player.talismanOne..Seven` arrays remain in the (optional) save
+    /// schema; only the seven classic talismans (`0..=6`) ever had slots,
+    /// so indices `7..=10` stay at their unallocated default.
     pub rune_assignments: [[TalismanRuneAssignment; 5]; TALISMAN_COUNT],
     /// `player.talismanShards` — shard balance.
     pub talisman_shards: f64,
@@ -91,19 +110,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_has_7_talismans_with_5_slots_each() {
+    fn default_has_11_talismans_with_5_slots_each() {
         let s = TalismansState::default();
-        assert_eq!(s.talisman_levels.len(), 7);
+        assert_eq!(s.talisman_levels.len(), 11);
+        assert_eq!(s.talisman_rarity.len(), 11);
         assert_eq!(s.rune_assignments[0].len(), 5);
     }
 
     #[test]
     fn talisman_index_convention_sentinels() {
         // Coverage: the last named slot pins the array length.
-        assert_eq!(TALISMAN_PLASTIC, TALISMAN_COUNT - 1);
+        assert_eq!(TALISMAN_HORSE_SHOE, TALISMAN_COUNT - 1);
         // StatLine anchors (legacy `talismans` const order).
         assert_eq!(TALISMAN_EXEMPTION, 0);
         assert_eq!(TALISMAN_CHRONOS, 1);
         assert_eq!(TALISMAN_POLYMATH, 4);
+        assert_eq!(TALISMAN_PLASTIC, 6);
+        // The four current-era talismans appended after the classic seven.
+        assert_eq!(TALISMAN_WOW_SQUARE, 7);
+        assert_eq!(TALISMAN_ACHIEVEMENT, 8);
+        assert_eq!(TALISMAN_COOKIE_GRANDMA, 9);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -858,6 +858,38 @@ fn rune_blessing_power(state: &GameState, rune: usize) -> f64 {
         * other_blessing_multipliers(state)
 }
 
+/// Shared rune-spirit power multiplier — legacy `otherSpiritMultipliers`
+/// (`Statistics.ts:53-60`). The challenge-15 `spiritBonus` reward and the
+/// corruption difficulty multiplier are unported (neutral 1.0 — the latter is
+/// also 1.0 with no corruptions loaded), so this reduces to the four research
+/// terms. Identity at default (all researches 0, not inside an ascension).
+fn other_spirit_multipliers(state: &GameState) -> f64 {
+    let research = &state.researches.researches;
+    let in_ascension = state.challenges.current_ascension_challenge != 0;
+    (1.0 + 8.0 * research[164] / 100.0)
+        * if research[165] > 0.0 && in_ascension {
+            2.0
+        } else {
+            1.0
+        }
+        * (1.0 + 0.15 * (state.talismans.legendary_fragments + 1.0).log10() * research[189])
+        * (1.0 + 2.0 * research[194] / 100.0)
+}
+
+/// Rune-spirit power (legacy `getRuneSpiritPower` × `spiritMultiplier`,
+/// `RuneSpirits.ts:180-183` / `Statistics.ts:62-68`):
+/// `spirit.level · (rune.level + freeLevels()) · blessing.level ·
+/// otherSpiritMultipliers()`. Mirrors [`rune_blessing_power`] with the extra
+/// spirit-level factor; `freeLevels` is deferred (neutral 0, as there). Spirit
+/// levels exist only for the first five runes. Identity at default (spirit
+/// level 0 → power 0).
+fn rune_spirit_power(state: &GameState, rune: usize) -> f64 {
+    state.runes.rune_spirit_levels[rune]
+        * state.runes.rune_levels[rune]
+        * state.runes.rune_blessing_levels[rune]
+        * other_spirit_multipliers(state)
+}
+
 /// Build the shared achievement-reward input from `&GameState` — the
 /// earned-flag array plus the cross-state values the reward formulas
 /// read (coin-producer owned counts, prestige points).
@@ -1090,14 +1122,18 @@ fn compute_global_multipliers_pre(state: &GameState) -> GlobalMultipliersPreEval
         calculate_building_power_coin_multiplier(building_power, total_coin_owned);
 
     // ─── Crystal coin multiplier (prestige-shards production) ─────────────
-    // `prism_spirit_crystal_caps` needs rune-spirit power (the unported
-    // `spiritMultiplier` chain); prism spirit level is 0 in current play,
-    // so the additive cap contribution is 0.
+    // `crystalCaps = getRuneSpiritEffect('prism').crystalCaps` — an additive
+    // cap bonus driven by the prism rune-spirit power. Identity (0) at default
+    // (prism spirit level 0 → power 0).
     let crystal_upgrade_4_max_exp =
         crystal_upgrade_4_max_exponent(&CrystalUpgrade4MaxExponentInput {
             research_129: state.researches.researches[129],
             common_fragments: Decimal::from_finite(state.talismans.common_fragments),
-            prism_spirit_crystal_caps: 0.0,
+            prism_spirit_crystal_caps:
+                crate::mechanics::rune_spirit_effects::prism_rune_spirit_effects(rune_spirit_power(
+                    state, RUNE_PRISM,
+                ))
+                .crystal_caps,
         });
     let crystal_exponent = calculate_crystal_exponent(&CalculateCrystalExponentInput {
         crystal_upgrade_3_max_exponent: crystal_upgrade_4_max_exp,
@@ -1718,7 +1754,10 @@ fn compute_global_speed_mult_pre(state: &GameState) -> f64 {
         1.0 + 0.006 * researches[181],
         1.0 + 0.003 * researches[196],
         speed_rune_blessing_effects(rune_blessing_power(state, RUNE_SPEED)).global_speed,
-        1.0, // speed spirit: effective spirit power unported → 1.0
+        crate::mechanics::rune_spirit_effects::speed_rune_spirit_effects(rune_spirit_power(
+            state, RUNE_SPEED,
+        ))
+        .global_speed,
         chronos_cube,
         1.0 + cube_upgrades[CUBE_UPGRADE_2X8] / 5.0,
         mortuus_ant_upgrade_effect(true_ant_level(state, ANT_UPGRADE_MORTUUS)).global_speed,
@@ -2594,7 +2633,7 @@ fn compute_cube_multiplier(
         wow_cubes_ant_upgrade_effect(true_ant_level(state, ANT_UPGRADE_WOW_CUBES)),
         (1.0 + cube[1] / 6.0) * (1.0 + cube[11] / 11.0) * (1.0 + 0.4 * cube[30]), // CubeUpgrades
         constant_upgrade_10,
-        duplication_rune_spirit_effects(state.runes.rune_spirit_levels[RUNE_DUPLICATION]).wow_cubes,
+        duplication_rune_spirit_effects(rune_spirit_power(state, RUNE_DUPLICATION)).wow_cubes,
         calculate_cube_multiplier_platonic_blessing(&state.platonic_blessings),
         1.0 + 0.00009 * f64::from(total_corruption_levels) * platonic[1], // Platonic1x1
         antiquities_rune_effects(
@@ -3193,7 +3232,10 @@ fn compute_obtainium(
                 ChallengeType::Ascension,
                 state.challenges.challenge_completions[12],
             ),
-        1.0, // SpiritPower — effective rune-spirit power (spiritMultiplier chain) unported → 1.0
+        crate::mechanics::rune_spirit_effects::superior_intellect_rune_spirit_effects(
+            rune_spirit_power(state, RUNE_SUPERIOR_INTELLECT),
+        )
+        .obtainium,
         // Research6x19 — `1 + 0.03·log4(uncommonFragments + 1)·researches[144]`.
         1.0 + 0.03 * ((uncommon_fragments + 1.0).ln() / 4.0_f64.ln()) * researches[144],
         1.0 + 0.0002 * cube[50], // CubeUpgrade5x10
@@ -3549,13 +3591,18 @@ fn compute_offering_mult(state: &GameState, base_offerings: f64) -> Decimal {
         1.0, // TutorialBonus — campaign subsystem unported → 1.0
         1.0, // CampaignBonus — campaign subsystem unported → 1.0
         1.0 + 0.12 * calc_ecc(ChallengeType::Ascension, cc[12]), // Challenge12
-        1.0, // ThriftSpirit — getRuneSpiritEffect('thrift').offerings; spirit-power chain unported → 1.0
+        // ThriftSpirit — getRuneSpiritEffect('thrift').offerings.
+        crate::mechanics::rune_spirit_effects::thrift_rune_spirit_effects(rune_spirit_power(
+            state,
+            crate::state::RUNE_THRIFT,
+        ))
+        .offerings,
         1.0 + (0.01 / 100.0) * researches[200], // Research8x25
-        1.0 + 0.05 * cube[46], // CubeUpgrade5x6
-        1.0 + (0.02 / 100.0) * cube[50], // CubeUpgrade5x10
-        1.0 + platonic[5], // PlatonicALPHA
-        1.0 + 2.5 * platonic[10], // PlatonicBETA
-        1.0 + 5.0 * platonic[15], // PlatonicOMEGA
+        1.0 + 0.05 * cube[46],                  // CubeUpgrade5x6
+        1.0 + (0.02 / 100.0) * cube[50],        // CubeUpgrade5x10
+        1.0 + platonic[5],                      // PlatonicALPHA
+        1.0 + 2.5 * platonic[10],               // PlatonicBETA
+        1.0 + 5.0 * platonic[15],               // PlatonicOMEGA
         challenge_15_rewards::offering(state.challenges.challenge15_exponent), // Challenge15
         10.0_f64.powf(antiquities_rune_effects(
             state.runes.rune_levels[RUNE_ANTIQUITIES],
@@ -8959,6 +9006,50 @@ mod tests {
         // researches[134] = 10 -> mult 1.69 -> 5 * 1000 * 1.69 = 8450.
         s.researches.researches[134] = 10.0;
         assert!((rune_blessing_power(&s, RUNE_SPEED) - 8450.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rune_spirit_power_folds_spirit_rune_and_blessing() {
+        use crate::state::RUNE_SPEED;
+        // power = spirit.level * rune.level * blessing.level * otherSpiritMultipliers.
+        let mut s = GameState::default();
+        s.runes.rune_spirit_levels[RUNE_SPEED] = 5.0;
+        s.runes.rune_levels[RUNE_SPEED] = 1000.0;
+        s.runes.rune_blessing_levels[RUNE_SPEED] = 10.0;
+        // otherSpiritMultipliers = 1 at default -> 5 * 1000 * 10 * 1 = 50_000.
+        assert!((rune_spirit_power(&s, RUNE_SPEED) - 50_000.0).abs() < 1e-6);
+
+        // researches[164] = 25 -> (1 + 8*25/100) = 3.0 -> 50_000 * 3 = 150_000.
+        s.researches.researches[164] = 25.0;
+        assert!((rune_spirit_power(&s, RUNE_SPEED) - 150_000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn other_spirit_multipliers_identity_at_default() {
+        let s = GameState::default();
+        assert!((other_spirit_multipliers(&s) - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn speed_spirit_engages_global_speed_mult() {
+        use crate::state::RUNE_SPEED;
+        // Hold the rune + blessing levels fixed and toggle only the spirit
+        // level, so the delta isolates the speed-spirit wiring.
+        let mut s = GameState::default();
+        s.runes.rune_levels[RUNE_SPEED] = 1000.0;
+        s.runes.rune_blessing_levels[RUNE_SPEED] = 1000.0;
+        let without_spirit = compute_global_speed_mult_pre(&s);
+        // power = 1000 * 1000 * 1000 = 1e9 -> globalSpeed spirit factor = 2.0.
+        s.runes.rune_spirit_levels[RUNE_SPEED] = 1000.0;
+        let with_spirit = compute_global_speed_mult_pre(&s);
+        // The spirit is a clean multiplicative factor on the pre-DR product;
+        // the concave global-speed DR can only shrink it, so the boost is in
+        // (1, 2].
+        assert!(
+            with_spirit > without_spirit,
+            "speed spirit should raise the global-speed mult"
+        );
+        assert!(with_spirit <= 2.0 * without_spirit + 1e-6);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -371,6 +371,13 @@ pub enum BuyRequest {
     Multiplier(BuyMultiplierInput),
     /// Routes to [`buy_accelerator`].
     Accelerator(BuyAcceleratorInput),
+    /// Buy accelerator boosts (legacy `boostAccelerator`). Takes no payload —
+    /// the path (single-boost-with-prestige-reset vs. bulk) is chosen from
+    /// `upgrades[46]`, the cost-delay comes from the thrift rune blessing, and
+    /// the spend currency is `prestigePoints`. Routes to [`buy_accelerator_boost`],
+    /// which receives the tick's prestige-point gain for the pre-upgrade path's
+    /// inline reset.
+    AcceleratorBoost,
     /// Routes to [`buy_crystal_upgrades`].
     CrystalUpgrade(BuyCrystalUpgradesInput),
     /// Routes to [`buy_cube_upgrade`].
@@ -5271,7 +5278,9 @@ fn phase_player_input(
     for action in &input.player_actions {
         match action {
             PlayerAction::Buy(req) => {
-                output.events.extend(dispatch_buy(state, req));
+                output
+                    .events
+                    .extend(dispatch_buy(state, req, reset_gains.prestige_point_gain));
             }
             PlayerAction::Reset(req) => {
                 output
@@ -6420,7 +6429,83 @@ fn check_coin_building_achievements(state: &mut GameState) {
     credit_achievement_quarks(state, awarded);
 }
 
-fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent; 4]> {
+/// Buy accelerator boosts — the legacy `boostAccelerator` (`Buy.ts:348`). With
+/// `upgrades[46] >= 1` this delegates to the pure bulk solver
+/// ([`buy_accelerator_boost_bulk`](crate::mechanics::accelerator_boosts::buy_accelerator_boost_bulk));
+/// otherwise it is the classic single-boost path that triggers a prestige reset
+/// (hence the `prestige_point_gain` argument and the GameState scope). The
+/// cost-delay is the thrift rune blessing — **this is the thrift-blessing
+/// production wire**. `awardAchievementGroup('acceleratorBoosts')` is unported
+/// → skipped. Identity at default (`prestigePoints` 0 → unaffordable).
+fn buy_accelerator_boost(
+    state: &mut GameState,
+    prestige_point_gain: Decimal,
+) -> SmallVec<[CoreEvent; 4]> {
+    use crate::mechanics::accelerator_boosts::{
+        buy_accelerator_boost_bulk, BuyAcceleratorBoostInput,
+    };
+    use crate::mechanics::rune_blessing_effects::thrift_rune_blessing_effects;
+    use crate::state::RUNE_THRIFT;
+
+    let delay = thrift_rune_blessing_effects(rune_blessing_power(state, RUNE_THRIFT))
+        .accel_boost_cost_delay;
+
+    // Bulk path (`upgrades[46] >= 1`): no reset, spends prestigePoints.
+    if state.upgrades.upgrades[46] >= 1 {
+        return buy_accelerator_boost_bulk(
+            &mut state.accelerator,
+            &mut state.upgrades.prestige_points,
+            BuyAcceleratorBoostInput {
+                accel_boost_cost_delay: delay,
+            },
+        );
+    }
+
+    // Classic path: buy one boost (if affordable), grow the running cost, then
+    // wipe upgrades 21..=40 and trigger a prestige reset (which zeroes the coin
+    // economy and re-awards prestigePoints — immediately discarded).
+    let mut events: SmallVec<[CoreEvent; 4]> = SmallVec::new();
+    if state.upgrades.prestige_points < state.accelerator.accelerator_boost_cost {
+        return events;
+    }
+    let before = state.accelerator.accelerator_boost_bought;
+    let starting_points = state.upgrades.prestige_points;
+    state.accelerator.accelerator_boost_bought += 1.0;
+    let bought = state.accelerator.accelerator_boost_bought;
+    // cost *= 1e10 * 10^bought, then the per-level quadratic kicker past the
+    // 1000 * delay threshold.
+    state.accelerator.accelerator_boost_cost *=
+        Decimal::from_finite(1e10) * Decimal::from_finite(10.0).pow(Decimal::from_finite(bought));
+    if bought > 1000.0 * delay {
+        let kicker = (bought - 1000.0 * delay).powi(2) / delay;
+        state.accelerator.accelerator_boost_cost *=
+            Decimal::from_finite(10.0).pow(Decimal::from_finite(kicker));
+    }
+    state.accelerator.transcend_no_accelerator = false;
+    state.accelerator.reincarnate_no_accelerator = false;
+
+    // `upgrades[46]` is 0 here (u8 `< 1`), so the legacy `< 0.5` reset path
+    // always fires.
+    for slot in 21..=40 {
+        state.upgrades.upgrades[slot] = 0;
+    }
+    let reset_events = reset::perform_prestige_reset(state, prestige_point_gain);
+    state.upgrades.prestige_points = Decimal::zero();
+
+    events.push(CoreEvent::AcceleratorBoostsPurchased {
+        before,
+        after: bought,
+        spent: starting_points - state.upgrades.prestige_points,
+    });
+    events.extend(reset_events);
+    events
+}
+
+fn dispatch_buy(
+    state: &mut GameState,
+    req: &BuyRequest,
+    prestige_point_gain: Decimal,
+) -> SmallVec<[CoreEvent; 4]> {
     // Each arm borrows disjoint `GameState` fields explicitly so the
     // borrow checker can verify the per-slice mutator and the canonical
     // `state.upgrades.*` currency don't alias. (A helper returning
@@ -6458,6 +6543,7 @@ fn dispatch_buy(state: &mut GameState, req: &BuyRequest) -> SmallVec<[CoreEvent;
         BuyRequest::Accelerator(inp) => {
             buy_accelerator(&mut state.accelerator, &mut state.upgrades.coins, *inp)
         }
+        BuyRequest::AcceleratorBoost => buy_accelerator_boost(state, prestige_point_gain),
         BuyRequest::CrystalUpgrade(inp) => buy_crystal_upgrades(&mut state.crystal_upgrades, *inp),
         BuyRequest::CubeUpgrade(inp) => buy_cube_upgrade(
             &mut state.cube_upgrade_levels,
@@ -6638,7 +6724,7 @@ mod tests {
             challengecompletions_4: 0.0,
             challengecompletions_8: 0.0,
         });
-        dispatch_buy(&mut state, &req);
+        dispatch_buy(&mut state, &req, Decimal::zero());
         assert_eq!(state.coin_producers.tiers[0].owned, 100.0);
         assert_eq!(state.achievements.achievements[1], 1);
         assert_eq!(state.achievements.achievements[2], 1);
@@ -9325,6 +9411,106 @@ mod tests {
             (with - without - 15.0).abs() < 1e-9,
             "delta = {}",
             with - without
+        );
+    }
+
+    #[test]
+    fn accelerator_boost_classic_path_buys_one_and_prestige_resets() {
+        let mut s = GameState::default();
+        // upgrades[46] = 0 (default) → classic path; default boost cost = 1e3.
+        s.upgrades.prestige_points = Decimal::from_finite(1e6);
+        s.upgrades.coins = Decimal::from_finite(1e9); // wiped by the prestige reset
+        s.upgrades.upgrades[25] = 1; // in the 21..=40 range the boost clears
+        let events = buy_accelerator_boost(&mut s, Decimal::zero());
+
+        assert_eq!(s.accelerator.accelerator_boost_bought, 1.0); // persists the reset
+        assert_eq!(s.upgrades.prestige_points, Decimal::zero()); // all spent
+                                                                 // The prestige reset ran: coins dropped from 1e9 to the 102-coin base.
+        assert_eq!(s.upgrades.coins, Decimal::from_finite(102.0));
+        assert_eq!(s.upgrades.upgrades[25], 0); // upgrades 21..=40 cleared
+        assert!(!s.accelerator.transcend_no_accelerator);
+        assert!(!s.accelerator.reincarnate_no_accelerator);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            CoreEvent::AcceleratorBoostsPurchased { after, .. } if *after == 1.0
+        )));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::ResetPerformed { .. })));
+    }
+
+    #[test]
+    fn accelerator_boost_bulk_path_spends_prestige_without_reset() {
+        let mut s = GameState::default();
+        s.upgrades.upgrades[46] = 1; // bulk path
+        s.upgrades.prestige_points = Decimal::from_finite(1e30);
+        s.upgrades.coins = Decimal::from_finite(1e9);
+        let events = buy_accelerator_boost(&mut s, Decimal::zero());
+
+        assert!(s.accelerator.accelerator_boost_bought > 0.0);
+        assert!(s.upgrades.prestige_points < Decimal::from_finite(1e30)); // spent some
+        assert_eq!(s.upgrades.coins, Decimal::from_finite(1e9)); // no reset
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::AcceleratorBoostsPurchased { .. })));
+        // The bulk path performs no prestige reset.
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::ResetPerformed { .. })));
+    }
+
+    #[test]
+    fn thrift_blessing_pushes_accelerator_boost_cost_threshold() {
+        use crate::state::RUNE_THRIFT;
+        // Buying boost 1002 fires the quadratic kicker when 1002 > 1000*delay.
+        // Default delay = 1 → kicker fires; a thrift blessing lifting delay to 2
+        // pushes the threshold to 2000 → no kicker → a cheaper next cost. This
+        // is the thrift-rune-blessing production wire.
+        let post_buy_cost = |with_blessing: bool| {
+            let mut s = GameState::default();
+            s.accelerator.accelerator_boost_bought = 1001.0;
+            s.accelerator.accelerator_boost_cost = Decimal::from_finite(1e3);
+            s.upgrades.prestige_points = Decimal::from_finite(1e6); // affords the 1e3 gate
+            if with_blessing {
+                // power = blessing.level * rune.level * 1 = 1e6 → delay = 2.
+                s.runes.rune_blessing_levels[RUNE_THRIFT] = 1e6;
+                s.runes.rune_levels[RUNE_THRIFT] = 1.0;
+            }
+            let _ = buy_accelerator_boost(&mut s, Decimal::zero());
+            s.accelerator.accelerator_boost_cost
+        };
+        let cost_no_blessing = post_buy_cost(false); // delay 1 → kicker fires
+        let cost_with_blessing = post_buy_cost(true); // delay 2 → no kicker
+        assert!(
+            cost_no_blessing > cost_with_blessing,
+            "thrift blessing should lower the post-buy boost cost"
+        );
+    }
+
+    #[test]
+    fn tack_dispatches_accelerator_boost_action() {
+        let mut state = GameState::default();
+        state.upgrades.upgrades[46] = 1; // bulk path (no reset side effects)
+        state.upgrades.prestige_points = Decimal::from_finite(1e30);
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::Buy(BuyRequest::AcceleratorBoost));
+
+        let output = tack(&mut state, &input);
+
+        assert!(state.accelerator.accelerator_boost_bought > 0.0);
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::AcceleratorBoostsPurchased { .. })),
+            "expected AcceleratorBoostsPurchased, got {:?}",
+            output.events
         );
     }
 

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1458,8 +1458,77 @@ fn update_progressive_achievements(state: &mut GameState) {
     update_progressive_slot(ach, 11, 0.0, |_| 0.0); // redAmbrosiaUpgrades — maxLevel UI-tier
 }
 
+/// `talismans[t].isUnlocked()` — the per-talisman unlock predicate
+/// (`Talismans.ts`). Every gate is a pure function of `GameState`, so no
+/// persisted unlock flag is needed. Unported gates default to locked:
+/// chronos/midas/metaphysics/polymath read `getAchievementReward('*Talisman')`
+/// (achievement-reward table unported), `achievement` reads a level milestone
+/// (unported), and `horseShoe` reads the `taxmanLastStand` singularity
+/// challenge (singularity paused) — all neutral `false`. Shared with the
+/// talisman→rune-level bonus.
+fn talisman_is_unlocked(state: &GameState, t: usize) -> bool {
+    use crate::mechanics::ant_upgrades::mortuus_ant_upgrade_effect;
+    use crate::mechanics::shop_upgrades::shop_talisman_effect;
+    use crate::state::shop::SHOP_TALISMAN;
+    use crate::state::{
+        TALISMAN_COOKIE_GRANDMA, TALISMAN_EXEMPTION, TALISMAN_MORTUUS, TALISMAN_PLASTIC,
+        TALISMAN_WOW_SQUARE,
+    };
+    const ANT_UPGRADE_MORTUUS: usize = 11;
+    match t {
+        // unlocks.talismans ← highestchallengecompletions[9] > 0 (Synergism.ts:3136).
+        TALISMAN_EXEMPTION => state.challenges.highest_challenge_completions[9] > 0.0,
+        TALISMAN_MORTUUS => {
+            mortuus_ant_upgrade_effect(true_ant_level(state, ANT_UPGRADE_MORTUUS)).talisman_unlock
+        }
+        // shopTalisman: the PCoin instant-unlock-1 path is unported → false.
+        TALISMAN_PLASTIC => shop_talisman_effect(state.shop.upgrades[SHOP_TALISMAN], false),
+        TALISMAN_WOW_SQUARE => state.reset_counters.ascension_count >= 100.0,
+        TALISMAN_COOKIE_GRANDMA => state.cube_upgrade_levels.cube_upgrades[80] > 0.0,
+        // chronos/midas/metaphysics/polymath/achievement/horseShoe: gate unported → locked.
+        _ => false,
+    }
+}
+
+/// `updateTalismanRarities` (`Talismans.ts:670-676`): recompute every
+/// talisman's display rarity from its level + unlock state. Run first in
+/// [`phase_global_state`] so the rarity-indexed effects (midas blessing, the
+/// exemption/chronos/polymath/mortuus multipliers, and the talisman→rune-level
+/// bonus) read this tick's value. Locked talismans collapse to rarity 0; an
+/// unlocked talisman is at least rarity 1 even at level 0.
+fn recompute_talisman_rarities(state: &mut GameState) {
+    use crate::mechanics::talisman_levels::{compute_talisman_rarity, ComputeTalismanRarityInput};
+    use crate::state::TALISMAN_COUNT;
+    /// Per-talisman raw `maxLevel` (the data-table constant, **not** the cap
+    /// with `levelCapIncrease`). Drives the rarity-tier ratios. From the
+    /// legacy `talismans` data table.
+    const TALISMAN_MAX_LEVELS: [f64; TALISMAN_COUNT] = [
+        180.0, // exemption
+        180.0, // chronos
+        180.0, // midas
+        180.0, // metaphysics
+        180.0, // polymath
+        180.0, // mortuus
+        180.0, // plastic
+        210.0, // wowSquare
+        40.0,  // achievement
+        6.0,   // cookieGrandma
+        12.0,  // horseShoe
+    ];
+    for (t, &max_level) in TALISMAN_MAX_LEVELS.iter().enumerate() {
+        let is_unlocked = talisman_is_unlocked(state, t);
+        state.talismans.talisman_rarity[t] =
+            f64::from(compute_talisman_rarity(&ComputeTalismanRarityInput {
+                is_unlocked,
+                level: state.talismans.talisman_levels[t],
+                max_level,
+            }));
+    }
+}
+
 fn phase_global_state(state: &mut GameState) -> AggregatorOutputs {
     update_progressive_achievements(state);
+    recompute_talisman_rarities(state);
     let total_accelerator_boost = compute_total_accelerator_boost(state);
     let update_all_multiplier_pre =
         compute_update_all_multiplier_pre(state, total_accelerator_boost);
@@ -9050,6 +9119,76 @@ mod tests {
             "speed spirit should raise the global-speed mult"
         );
         assert!(with_spirit <= 2.0 * without_spirit + 1e-6);
+    }
+
+    #[test]
+    fn talisman_unlock_gates_are_pure_state_functions() {
+        use crate::state::shop::SHOP_TALISMAN;
+        use crate::state::{
+            TALISMAN_CHRONOS, TALISMAN_COOKIE_GRANDMA, TALISMAN_COUNT, TALISMAN_EXEMPTION,
+            TALISMAN_MORTUUS, TALISMAN_PLASTIC, TALISMAN_WOW_SQUARE,
+        };
+        let mut s = GameState::default();
+        // Default: every talisman locked.
+        for t in 0..TALISMAN_COUNT {
+            assert!(
+                !talisman_is_unlocked(&s, t),
+                "talisman {t} should start locked"
+            );
+        }
+        // exemption ← reincarnation challenge 9 completed at least once.
+        s.challenges.highest_challenge_completions[9] = 1.0;
+        assert!(talisman_is_unlocked(&s, TALISMAN_EXEMPTION));
+        // mortuus ← Mortuus ant upgrade owned.
+        s.ants.upgrades[11] = 5.0;
+        assert!(talisman_is_unlocked(&s, TALISMAN_MORTUUS));
+        // plastic ← shopTalisman bought.
+        s.shop.upgrades[SHOP_TALISMAN] = 1.0;
+        assert!(talisman_is_unlocked(&s, TALISMAN_PLASTIC));
+        // wowSquare ← 100 ascensions.
+        s.reset_counters.ascension_count = 100.0;
+        assert!(talisman_is_unlocked(&s, TALISMAN_WOW_SQUARE));
+        // cookieGrandma ← cubeUpgrade 80.
+        s.cube_upgrade_levels.cube_upgrades[80] = 1.0;
+        assert!(talisman_is_unlocked(&s, TALISMAN_COOKIE_GRANDMA));
+        // chronos gate (getAchievementReward) is unported → still locked.
+        assert!(!talisman_is_unlocked(&s, TALISMAN_CHRONOS));
+    }
+
+    #[test]
+    fn recompute_talisman_rarities_reflects_level_and_unlock() {
+        use crate::state::{TALISMAN_CHRONOS, TALISMAN_EXEMPTION};
+        let mut s = GameState::default();
+        // Locked → rarity 0 even with a level.
+        s.talismans.talisman_levels[TALISMAN_EXEMPTION] = 90.0;
+        recompute_talisman_rarities(&mut s);
+        assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 0.0);
+
+        // Unlock exemption: level 90 / maxLevel 180 = ratio 0.5 → band 3 → rarity 4.
+        s.challenges.highest_challenge_completions[9] = 1.0;
+        recompute_talisman_rarities(&mut s);
+        assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 4.0);
+
+        // Unlocked at level 0 → rarity 1 (the floor for an unlocked talisman).
+        s.talismans.talisman_levels[TALISMAN_EXEMPTION] = 0.0;
+        recompute_talisman_rarities(&mut s);
+        assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 1.0);
+
+        // chronos stays locked (gate unported) → 0 regardless of level.
+        s.talismans.talisman_levels[TALISMAN_CHRONOS] = 180.0;
+        recompute_talisman_rarities(&mut s);
+        assert_eq!(s.talismans.talisman_rarity[TALISMAN_CHRONOS], 0.0);
+    }
+
+    #[test]
+    fn phase_global_state_brings_talisman_rarity_online() {
+        use crate::state::TALISMAN_EXEMPTION;
+        let mut s = GameState::default();
+        s.challenges.highest_challenge_completions[9] = 1.0; // unlocks exemption
+        assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 0.0);
+        let _ = phase_global_state(&mut s);
+        // The per-tick recompute runs inside phase_global_state.
+        assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -66,7 +66,7 @@ use crate::mechanics::update_all_multiplier::{
 };
 use crate::mechanics::update_all_tick::{update_all_tick, UpdateAllTickPre, UpdateAllTickResult};
 use crate::mechanics::upgrades::{buy_upgrades, BuyUpgradeInput};
-use crate::state::{GameState, RngPurpose};
+use crate::state::{GameState, RngPurpose, RUNE_COUNT, TALISMAN_COUNT};
 
 mod ant_generation;
 mod ant_sacrifice;
@@ -794,7 +794,7 @@ fn rune_free_levels(state: &GameState, rune: usize) -> f64 {
 
     let bonus = match rune {
         RUNE_SPEED => bonus_rune_levels_speed(&BonusRuneLevelsSpeedInput {
-            talisman_bonus: 0.0, // getRuneBonusFromAllTalismans unported
+            talisman_bonus: get_rune_bonus_from_all_talismans(state, RUNE_SPEED),
             upgrade_27: upgrade(27),
             coin_log_1e10_floor: (coin_log10 / 10.0).floor(),
             coin_log_1e50_floor: (coin_log10 / 50.0).floor(),
@@ -802,14 +802,17 @@ fn rune_free_levels(state: &GameState, rune: usize) -> f64 {
             total_owned_coins_first_five,
         }),
         RUNE_DUPLICATION => bonus_rune_levels_duplication(&BonusRuneLevelsDuplicationInput {
-            talisman_bonus: 0.0, // getRuneBonusFromAllTalismans unported
+            talisman_bonus: get_rune_bonus_from_all_talismans(state, RUNE_DUPLICATION),
             upgrade_28: upgrade(28),
             total_owned_coins_first_five,
             upgrade_30: upgrade(30),
             coin_log_1e30_floor: (coin_log10 / 30.0).floor(),
             coin_log_1e300_floor: (coin_log10 / 300.0).floor(),
         }),
-        _ => 0.0, // prism/thrift/SI per-rune bonus aggregators unported
+        // prism/thrift/SI: the full per-rune free-level aggregators (coin/
+        // upgrade terms) are still unported, but the talisman→rune-level bonus
+        // term is now live for them.
+        _ => get_rune_bonus_from_all_talismans(state, rune),
     };
     shared + bonus
 }
@@ -1498,7 +1501,6 @@ fn talisman_is_unlocked(state: &GameState, t: usize) -> bool {
 /// unlocked talisman is at least rarity 1 even at level 0.
 fn recompute_talisman_rarities(state: &mut GameState) {
     use crate::mechanics::talisman_levels::{compute_talisman_rarity, ComputeTalismanRarityInput};
-    use crate::state::TALISMAN_COUNT;
     /// Per-talisman raw `maxLevel` (the data-table constant, **not** the cap
     /// with `levelCapIncrease`). Drives the rarity-tier ratios. From the
     /// legacy `talismans` data table.
@@ -1524,6 +1526,99 @@ fn recompute_talisman_rarities(state: &mut GameState) {
                 max_level,
             }));
     }
+}
+
+/// Per-talisman, per-rune base coefficient (`talismanBaseCoefficient`,
+/// `Talismans.ts`). Rows follow the `TALISMAN_*` order; columns the rune
+/// object-key order (speed, duplication, prism, thrift, superiorIntellect,
+/// infiniteAscent, antiquities, horseShoe, finiteDescent, topHat).
+const TALISMAN_BASE_COEFFICIENT: [[f64; RUNE_COUNT]; TALISMAN_COUNT] = [
+    [0.0, 1.5, 0.75, 0.75, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], // exemption
+    [1.5, 0.0, 0.0, 0.75, 0.75, 0.0, 0.0, 0.0, 0.0, 0.0], // chronos
+    [0.0, 0.75, 0.75, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], // midas
+    [0.6, 0.6, 0.6, 0.6, 0.6, 0.0, 0.0, 0.0, 0.0, 0.0],   // metaphysics
+    [0.75, 0.75, 0.0, 0.0, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0], // polymath
+    [0.6, 0.6, 0.6, 0.6, 0.6, 0.0, 0.0, 0.0, 0.0, 0.0],   // mortuus
+    [0.75, 0.0, 1.5, 0.0, 0.75, 0.005, 0.0, 0.0, 0.0, 0.0], // plastic
+    [0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],   // wowSquare
+    [1.4, 1.4, 1.4, 1.4, 1.4, 0.01, 0.0, 0.0, 0.0, 0.0],  // achievement
+    [1.0, 1.0, 1.0, 1.0, 1.0, 0.01, 0.0, 0.0, 0.0, 0.0],  // cookieGrandma
+    [1.2, 1.2, 1.2, 1.2, 1.2, 0.0, 0.0, 0.01, 0.0, 0.0],  // horseShoe
+];
+
+/// `getRuneBonusFromIndividualTalisman` (`Talismans.ts:764-780`):
+/// `coeff[t][rune] · bonusMult · level · rarityValues[rarity]`, gated on the
+/// talisman's unlock. `bonusMult` is 1 except for metaphysics (× its own
+/// `talismanEffect` × `extraTalismanEffect` — the talisman amplifier) and
+/// mortuus (× the Mortuus2 ant-upgrade `talismanEffectBuff`). Zero for a locked
+/// or level-0 talisman.
+fn rune_bonus_from_individual_talisman(state: &GameState, t: usize, rune: usize) -> f64 {
+    use crate::mechanics::ant_upgrades::mortuus_2_ant_upgrade_effect;
+    use crate::mechanics::talisman_effects::metaphysics_talisman_effects;
+    use crate::mechanics::talisman_levels::rarity_value;
+    use crate::state::{TALISMAN_METAPHYSICS, TALISMAN_MORTUUS};
+    const ANT_UPGRADE_MORTUUS_2: usize = 15;
+
+    if !talisman_is_unlocked(state, t) {
+        return 0.0;
+    }
+    let rarity = state.talismans.talisman_rarity[t] as u8;
+    let mut bonus_mult = 1.0;
+    if t == TALISMAN_METAPHYSICS {
+        let e = metaphysics_talisman_effects(i32::from(rarity));
+        bonus_mult *= e.talisman_effect * e.extra_talisman_effect;
+    }
+    if t == TALISMAN_MORTUUS {
+        bonus_mult *= mortuus_2_ant_upgrade_effect(true_ant_level(state, ANT_UPGRADE_MORTUUS_2))
+            .talisman_effect_buff;
+    }
+    TALISMAN_BASE_COEFFICIENT[t][rune]
+        * bonus_mult
+        * state.talismans.talisman_levels[t]
+        * rarity_value(rarity)
+}
+
+/// `allTalismanRuneBonusStatsSum` (`Statistics.ts:2754-2771`): the special
+/// multiplier on the summed talisman→rune bonus. The achievement `talismanPower`
+/// reward, the challenge-15 `talismanBonus`, and the `taxmanLastStand`
+/// singularity challenge are unported → neutral 0. Identity (1.0) at default.
+fn talisman_rune_bonus_stats_sum(state: &GameState) -> f64 {
+    use crate::mechanics::blueberry_upgrades::ambrosia_talisman_bonus_rune_level_effect;
+    use crate::mechanics::golden_quark_upgrades::{
+        sing_talisman_bonus_runes_1_effect, sing_talisman_bonus_runes_2_effect,
+        sing_talisman_bonus_runes_3_effect, sing_talisman_bonus_runes_4_effect,
+    };
+    use crate::state::ambrosia::AMBROSIA_TALISMAN_BONUS_RUNE_LEVEL;
+    use crate::state::golden_quarks::{
+        GQ_SING_TALISMAN_BONUS_RUNES_1, GQ_SING_TALISMAN_BONUS_RUNES_2,
+        GQ_SING_TALISMAN_BONUS_RUNES_3, GQ_SING_TALISMAN_BONUS_RUNES_4,
+    };
+    let research = &state.researches.researches;
+    let gq = |i: usize| {
+        state.golden_quarks.upgrades[i].level + state.golden_quarks.upgrades[i].free_level
+    };
+    let amb = |i: usize| state.ambrosia.upgrades[i].level + state.ambrosia.upgrades[i].free_level;
+    1.0 + research[106] / 1000.0
+        + research[107] / 1000.0
+        + 2.0 * research[118] / 1000.0
+        + 0.004 * (research[200] / 10_000.0).floor()
+        + 0.006 * (state.cube_upgrade_levels.cube_upgrades[50] / 10_000.0).floor()
+        + sing_talisman_bonus_runes_1_effect(gq(GQ_SING_TALISMAN_BONUS_RUNES_1))
+        + sing_talisman_bonus_runes_2_effect(gq(GQ_SING_TALISMAN_BONUS_RUNES_2))
+        + sing_talisman_bonus_runes_3_effect(gq(GQ_SING_TALISMAN_BONUS_RUNES_3))
+        + sing_talisman_bonus_runes_4_effect(gq(GQ_SING_TALISMAN_BONUS_RUNES_4))
+        + ambrosia_talisman_bonus_rune_level_effect(amb(AMBROSIA_TALISMAN_BONUS_RUNE_LEVEL))
+}
+
+/// `getRuneBonusFromAllTalismans` (`Talismans.ts:782-790`): the talisman→
+/// rune-level bonus, `allTalismanRuneBonusStatsSum · Σ_t individual(t, rune)`,
+/// added to the rune's free levels. Zero at default (no talisman both unlocked
+/// and leveled).
+fn get_rune_bonus_from_all_talismans(state: &GameState, rune: usize) -> f64 {
+    let total: f64 = (0..TALISMAN_COUNT)
+        .map(|t| rune_bonus_from_individual_talisman(state, t, rune))
+        .sum();
+    total * talisman_rune_bonus_stats_sum(state)
 }
 
 fn phase_global_state(state: &mut GameState) -> AggregatorOutputs {
@@ -9189,6 +9284,48 @@ mod tests {
         let _ = phase_global_state(&mut s);
         // The per-tick recompute runs inside phase_global_state.
         assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 1.0);
+    }
+
+    #[test]
+    fn talisman_rune_bonus_scales_with_coefficient_level_and_rarity() {
+        use crate::state::{RUNE_DUPLICATION, RUNE_SPEED, TALISMAN_EXEMPTION};
+        let mut s = GameState::default();
+        s.talismans.talisman_levels[TALISMAN_EXEMPTION] = 10.0;
+        s.talismans.talisman_rarity[TALISMAN_EXEMPTION] = 1.0;
+        // Locked → no bonus.
+        assert_eq!(get_rune_bonus_from_all_talismans(&s, RUNE_DUPLICATION), 0.0);
+
+        s.challenges.highest_challenge_completions[9] = 1.0; // unlock exemption
+                                                             // exemption→duplication coeff 1.5, rarity_value(1)=1, level 10,
+                                                             // statsSum 1.0 at default → 1.5 * 1 * 10 * 1.0 = 15.
+        let dup = get_rune_bonus_from_all_talismans(&s, RUNE_DUPLICATION);
+        assert!((dup - 15.0).abs() < 1e-9, "dup = {dup}");
+        // exemption→speed coeff is 0 → no speed bonus.
+        assert_eq!(get_rune_bonus_from_all_talismans(&s, RUNE_SPEED), 0.0);
+
+        // allTalismanRuneBonusStatsSum scales the total: researches[106] = 1000
+        // adds +1.0 → ×2.
+        s.researches.researches[106] = 1000.0;
+        let dup2 = get_rune_bonus_from_all_talismans(&s, RUNE_DUPLICATION);
+        assert!((dup2 - 30.0).abs() < 1e-9, "dup2 = {dup2}");
+    }
+
+    #[test]
+    fn talisman_bonus_feeds_rune_free_levels() {
+        use crate::state::{RUNE_DUPLICATION, TALISMAN_EXEMPTION};
+        let mut s = GameState::default();
+        s.talismans.talisman_levels[TALISMAN_EXEMPTION] = 10.0;
+        s.talismans.talisman_rarity[TALISMAN_EXEMPTION] = 1.0;
+        let without = rune_free_levels(&s, RUNE_DUPLICATION); // exemption locked
+        s.challenges.highest_challenge_completions[9] = 1.0; // unlock exemption
+        let with = rune_free_levels(&s, RUNE_DUPLICATION);
+        // The talisman adds exactly 1.5 * 1 * 10 * rarity_value(1) = 15 to the
+        // rune's free levels.
+        assert!(
+            (with - without - 15.0).abs() < 1e-9,
+            "delta = {}",
+            with - without
+        );
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -25,7 +25,7 @@ use crate::events::{AutoResetTier, CoreEvent, SweepState};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
 use crate::state::{
     AntsState, GameState, TalismansState, DEFLATION_INDEX, RUNE_DUPLICATION, RUNE_FINITE_DESCENT,
-    RUNE_PRISM, RUNE_SPEED, RUNE_SUPERIOR_INTELLECT, RUNE_THRIFT, TALISMAN_COUNT,
+    RUNE_PRISM, RUNE_SPEED, RUNE_SUPERIOR_INTELLECT, RUNE_THRIFT, TALISMAN_WOW_SQUARE,
 };
 use crate::tick::ResetRequest;
 
@@ -827,18 +827,22 @@ fn reset_ants_ascension(ants: &mut AntsState) {
     ants.ant_sacrifice_timer_real = 0.0;
 }
 
-/// `resetTalismanData('ascension')` (`Talismans.ts:1067-1086`). All seven Rust
-/// talismans are ascension-tier, so each `resetSingleTalisman` runs: level → 0
-/// and a rarity recompute (`setTalismanRarity`). The recompute needs the
-/// UI-tier `isUnlocked()` predicate, which is `false` at reachable state
-/// (talismans have no unlock / level path in the port yet) ⇒ rarity 0 —
-/// faithful here; the unlocked-talisman rarity (`compute_talisman_rarity`
-/// returns 1 at level 0) is deferred. The shard balance and the six fragment
-/// pools zero; the rune-buff assignments (legacy `talismanOne..Seven`) are
-/// **not** touched, matching `resetSingleTalisman`.
+/// `resetTalismanData('ascension')` (`Talismans.ts:1067-1086`): an ascension
+/// reset runs `resetSingleTalisman` (level → 0 + rarity recompute) only for the
+/// ascension-tier talismans (`exemption..wowSquare`, indices `0..=7`). The
+/// singularity-tier talisman (achievement) and the never-tier talismans
+/// (cookieGrandma, horseShoe) outrank an ascension and survive untouched.
+/// The rarity recompute needs the UI-tier `isUnlocked()` predicate, which is
+/// `false` at reachable state ⇒ rarity 0 — faithful here; the unlocked-talisman
+/// rarity (`compute_talisman_rarity` returns 1 at level 0) is deferred. The
+/// shard balance and the six fragment pools always zero (every tier);
+/// the rune-buff assignments (legacy `talismanOne..Seven`) are **not** touched,
+/// matching `resetSingleTalisman`.
 fn reset_talismans_ascension(talismans: &mut TalismansState) {
-    talismans.talisman_levels = [0.0; TALISMAN_COUNT];
-    talismans.talisman_rarity = [0.0; TALISMAN_COUNT];
+    for t in 0..=TALISMAN_WOW_SQUARE {
+        talismans.talisman_levels[t] = 0.0;
+        talismans.talisman_rarity[t] = 0.0;
+    }
     talismans.talisman_shards = 0.0;
     talismans.common_fragments = 0.0;
     talismans.uncommon_fragments = 0.0;
@@ -863,6 +867,7 @@ mod tests {
     use crate::mechanics::reset_currency::ResetCurrencyResult;
     use crate::state::{
         RUNE_ANTIQUITIES, RUNE_COUNT, RUNE_HORSE_SHOE, RUNE_INFINITE_ASCENT, RUNE_TOP_HAT,
+        TALISMAN_ACHIEVEMENT, TALISMAN_COOKIE_GRANDMA, TALISMAN_COUNT, TALISMAN_HORSE_SHOE,
     };
 
     fn gains(prestige: f64, transcend: f64, reincarnation: f64) -> ResetCurrencyResult {
@@ -1549,7 +1554,7 @@ mod tests {
     }
 
     #[test]
-    fn ascension_reset_wipes_talisman_levels_and_fragments() {
+    fn ascension_reset_wipes_ascension_tier_talismans_and_all_fragments() {
         let mut state = GameState::default();
         state.talismans.talisman_levels = [50.0; TALISMAN_COUNT];
         state.talismans.talisman_rarity = [4.0; TALISMAN_COUNT];
@@ -1562,8 +1567,33 @@ mod tests {
 
         perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
 
-        assert_eq!(state.talismans.talisman_levels, [0.0; TALISMAN_COUNT]);
-        assert_eq!(state.talismans.talisman_rarity, [0.0; TALISMAN_COUNT]);
+        // Ascension-tier talismans (0..=7) wipe to level + rarity 0.
+        for t in 0..=TALISMAN_WOW_SQUARE {
+            assert_eq!(
+                state.talismans.talisman_levels[t], 0.0,
+                "talisman {t} level"
+            );
+            assert_eq!(
+                state.talismans.talisman_rarity[t], 0.0,
+                "talisman {t} rarity"
+            );
+        }
+        // achievement (singularity) and cookieGrandma/horseShoe (never) survive.
+        for t in [
+            TALISMAN_ACHIEVEMENT,
+            TALISMAN_COOKIE_GRANDMA,
+            TALISMAN_HORSE_SHOE,
+        ] {
+            assert_eq!(
+                state.talismans.talisman_levels[t], 50.0,
+                "talisman {t} level"
+            );
+            assert_eq!(
+                state.talismans.talisman_rarity[t], 4.0,
+                "talisman {t} rarity"
+            );
+        }
+        // Fragment pools + shards always clear, regardless of tier.
         assert_eq!(state.talismans.talisman_shards, 0.0);
         assert_eq!(state.talismans.common_fragments, 0.0);
         assert_eq!(state.talismans.mythical_fragments, 0.0);

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -24,10 +24,25 @@ use synergismforkd_bignum::Decimal;
 use crate::events::{AutoResetTier, CoreEvent, SweepState};
 use crate::mechanics::reset_currency::ResetCurrencyResult;
 use crate::state::{
-    AntsState, GameState, TalismansState, DEFLATION_INDEX, RUNE_ANTIQUITIES, RUNE_COUNT,
-    TALISMAN_COUNT,
+    AntsState, GameState, TalismansState, DEFLATION_INDEX, RUNE_DUPLICATION, RUNE_FINITE_DESCENT,
+    RUNE_PRISM, RUNE_SPEED, RUNE_SUPERIOR_INTELLECT, RUNE_THRIFT, TALISMAN_COUNT,
 };
 use crate::tick::ResetRequest;
+
+/// Runes an `ascension` reset zeroes and regrants — those whose
+/// `minimalResetTier` is `ascension` (`resetTiers.ascension == 4`). The
+/// singularity-tier runes (infiniteAscent, antiquities, topHat) and the
+/// never-tier rune (horseShoe) outrank an ascension and survive untouched.
+/// Order in the legacy `runes` object: speed, duplication, prism, thrift,
+/// superiorIntellect, then finiteDescent.
+const ASCENSION_TIER_RUNES: [usize; 6] = [
+    RUNE_SPEED,
+    RUNE_DUPLICATION,
+    RUNE_PRISM,
+    RUNE_THRIFT,
+    RUNE_SUPERIOR_INTELLECT,
+    RUNE_FINITE_DESCENT,
+];
 
 /// Per-tier coin-producer base cost the prestige reset restores. Mirrors
 /// `player.{first..fifth}CostCoin` (Reset.ts:428-440).
@@ -677,17 +692,14 @@ fn apply_ascension_layer(state: &mut GameState) -> Decimal {
     state.crystal_upgrades.crystal_upgrades = [0.0; 8]; // Reset.ts:672
 
     // resetRunes('ascension') (Runes.ts:917-932): the ascension-tier runes
-    // reset to level + EXP 0, then regrant level = 3 * cubeUpgrades[26]. That
-    // is every classic rune EXCEPT antiquities, which is singularity-tier
-    // (`resetTiers.ascension=4 < singularity=5`) and so survives. Blessings /
-    // spirits / free-levels are not touched (the legacy loop only zeroes
+    // reset to level + EXP 0, then regrant level = 3 * cubeUpgrades[26]. The
+    // singularity-tier runes (infiniteAscent, antiquities, topHat) and the
+    // never-tier rune (horseShoe) outrank the ascension and survive. Blessings
+    // / spirits / free-levels are not touched (the legacy loop only zeroes
     // level + EXP). The `setRuneLevel` EXP-sync for a regranted level > 0 is
     // deferred — inert while `cubeUpgrades[26] == 0` at default.
     let rune_regrant = 3.0 * state.cube_upgrade_levels.cube_upgrades[26];
-    for rune in 0..RUNE_COUNT {
-        if rune == RUNE_ANTIQUITIES {
-            continue;
-        }
+    for rune in ASCENSION_TIER_RUNES {
         state.runes.rune_levels[rune] = rune_regrant;
         state.runes.rune_exp[rune] = 0.0;
     }
@@ -849,6 +861,9 @@ fn reset_upgrade_slots(state: &mut GameState, slots: std::ops::RangeInclusive<us
 mod tests {
     use super::*;
     use crate::mechanics::reset_currency::ResetCurrencyResult;
+    use crate::state::{
+        RUNE_ANTIQUITIES, RUNE_COUNT, RUNE_HORSE_SHOE, RUNE_INFINITE_ASCENT, RUNE_TOP_HAT,
+    };
 
     fn gains(prestige: f64, transcend: f64, reincarnation: f64) -> ResetCurrencyResult {
         ResetCurrencyResult {
@@ -1418,7 +1433,7 @@ mod tests {
     }
 
     #[test]
-    fn ascension_reset_wipes_ascension_tier_runes_but_keeps_antiquities() {
+    fn ascension_reset_wipes_ascension_tier_runes_but_keeps_higher_tiers() {
         let mut state = GameState::default();
         for i in 0..RUNE_COUNT {
             state.runes.rune_levels[i] = 100.0;
@@ -1428,11 +1443,18 @@ mod tests {
 
         perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
 
+        // infiniteAscent / antiquities / topHat are singularity-tier and
+        // horseShoe is never-tier — all outrank an ascension and survive.
+        let survivors = [
+            RUNE_INFINITE_ASCENT,
+            RUNE_ANTIQUITIES,
+            RUNE_HORSE_SHOE,
+            RUNE_TOP_HAT,
+        ];
         for i in 0..RUNE_COUNT {
-            if i == RUNE_ANTIQUITIES {
-                // Singularity-tier ⇒ survives an ascension.
-                assert_eq!(state.runes.rune_levels[i], 100.0);
-                assert_eq!(state.runes.rune_exp[i], 500.0);
+            if survivors.contains(&i) {
+                assert_eq!(state.runes.rune_levels[i], 100.0, "rune {i} level");
+                assert_eq!(state.runes.rune_exp[i], 500.0, "rune {i} exp");
             } else {
                 assert_eq!(state.runes.rune_levels[i], 0.0, "rune {i} level");
                 assert_eq!(state.runes.rune_exp[i], 0.0, "rune {i} exp");

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -29,7 +29,7 @@ porting notes.
 | [reset-cascade.md](reset-cascade.md) | the prestige → … → singularity reset spine; what each tier grants / resets / unlocks | 🟩 mostly |
 | [core-economy.md](core-economy.md) | coins + the 4 building tiers, multipliers/accelerators, crystals, tax, research, obtainium | 🟨 (H1) |
 | [ascension-cubes.md](ascension-cubes.md) | ascension score hub, the 4 cube tiers, opening + blessings + upgrades, hepteracts/overflux | 🟨 |
-| [runes-talismans.md](runes-talismans.md) | offerings, the 7 runes (+finiteDescent), blessings, spirits, talismans, fragments | 🟨 (talismans) |
+| [runes-talismans.md](runes-talismans.md) | offerings, the 10 runes, blessings, spirits, talismans, fragments | 🟩 (thrift blessing pending boostAccelerator) |
 | [ants.md](ants.md) | ant producers / masteries / upgrades / sacrifice / crumbs / true-level | 🟩 (H2) |
 | [challenges-corruptions.md](challenges-corruptions.md) | challenges 1–15, corruptions, campaign, constants, auto-challenge | 🟩 |
 | [singularity-ambrosia.md](singularity-ambrosia.md) | singularity reset, golden quarks, octeracts, perks; ambrosia / blueberry / red-ambrosia | 🟧 / 🟨 |
@@ -53,7 +53,7 @@ flowchart LR
   resets["Reset cascade"]:::ported
   research["Research / Obtainium"]:::ported
   offerings["Offerings"]:::ported
-  runes["Runes / Talismans"]:::partial
+  runes["Runes / Talismans"]:::ported
   ants["Ants"]:::bug
   challenges["Challenges / Corruptions"]:::ported
   ascension["Ascension / Cubes"]:::partial

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -29,7 +29,7 @@ porting notes.
 | [reset-cascade.md](reset-cascade.md) | the prestige → … → singularity reset spine; what each tier grants / resets / unlocks | 🟩 mostly |
 | [core-economy.md](core-economy.md) | coins + the 4 building tiers, multipliers/accelerators, crystals, tax, research, obtainium | 🟨 (H1) |
 | [ascension-cubes.md](ascension-cubes.md) | ascension score hub, the 4 cube tiers, opening + blessings + upgrades, hepteracts/overflux | 🟨 |
-| [runes-talismans.md](runes-talismans.md) | offerings, the 10 runes, blessings, spirits, talismans, fragments | 🟩 (thrift blessing pending boostAccelerator) |
+| [runes-talismans.md](runes-talismans.md) | offerings, the 10 runes, blessings, spirits, talismans, fragments | 🟩 |
 | [ants.md](ants.md) | ant producers / masteries / upgrades / sacrifice / crumbs / true-level | 🟩 (H2) |
 | [challenges-corruptions.md](challenges-corruptions.md) | challenges 1–15, corruptions, campaign, constants, auto-challenge | 🟩 |
 | [singularity-ambrosia.md](singularity-ambrosia.md) | singularity reset, golden quarks, octeracts, perks; ambrosia / blueberry / red-ambrosia | 🟧 / 🟨 |

--- a/docs/systems/core-economy.md
+++ b/docs/systems/core-economy.md
@@ -80,7 +80,9 @@ flowchart LR
 
 - ⚠ **H1 — crystals desync:** `prestige_shards` is read from `crystal_upgrades.prestige_shards`
   (seeded right) but written to a different slice, so the crystal coin-multiplier is under-credited.
-- **Accelerator boosts** have a ported cost formula but no `BuyRequest::AcceleratorBoost` handler, so
-  purchased boost stays 0 — this also blocks the thrift rune-blessing wire on the runes page.
+- **Accelerator boosts** are ported — `BuyRequest::AcceleratorBoost` runs the classic
+  single-boost+prestige-reset path and the bulk solver, and the thrift rune-blessing
+  `accelBoostCostDelay` now feeds the cost (the runes-page wire). The autobuyer path
+  (`boostAccelerator(true)`) and `awardAchievementGroup('acceleratorBoosts')` are still unported.
 - `updateAll` autobuyers (the monolith's separate 50 ms producer/crystal/cube buy loop) are **absent**,
   so a pure-idle Rust loop won't auto-buy producers yet.

--- a/docs/systems/runes-talismans.md
+++ b/docs/systems/runes-talismans.md
@@ -91,6 +91,9 @@ OOM bonuses; finiteDescent → ascension score.
   the metaphysics amplifier is unreachable until its gate ports; the prism/thrift/SI per-rune coin/upgrade
   free-level aggregators are still unported (only their talisman-bonus term is live). The deprecated
   per-rune `rune_assignments` slots are documented dead state.
-- **Thrift blessing** remains the one carve-out — blocked on the accelerator-boost (`boostAccelerator`)
-  buy (see [core-economy.md](core-economy.md)). Its effect (`accelBoostCostDelay`) is a 1-line wire once
-  that buy lands.
+- **Thrift blessing — ported.** The `boostAccelerator` buy is now ported (`BuyRequest::AcceleratorBoost`:
+  the classic single-boost+prestige-reset path and the bulk solver), and its cost is fed the thrift
+  blessing's `accelBoostCostDelay` (`thrift_rune_blessing_effects(rune_blessing_power(state, RUNE_THRIFT))`)
+  — so the blessing now scales the accelerator-boost cost. This was the node's last carve-out; the whole
+  runes/blessings/spirits/talismans surface is ported. (`awardAchievementGroup('acceleratorBoosts')` is
+  still unported → skipped.)

--- a/docs/systems/runes-talismans.md
+++ b/docs/systems/runes-talismans.md
@@ -17,11 +17,11 @@ flowchart LR
 
   offerGen["Offering generators"]:::ported
   offerings["Offerings"]:::ported
-  runes["Runes ×7 +finiteDescent"]:::ported
+  runes["Runes ×10"]:::ported
   runeBless["Rune blessings"]:::ported
-  runeSpirits["Rune spirits"]:::partial
-  talismans["Talismans ×7"]:::partial
-  fragments["Rarity fragments"]:::partial
+  runeSpirits["Rune spirits"]:::ported
+  talismans["Talismans ×11"]:::ported
+  fragments["Rarity fragments"]:::ported
 
   resets["Resets award ↗ reset-cascade"]:::ext
   antSac["Ant sacrifice ↗ ants"]:::ext
@@ -50,11 +50,12 @@ flowchart LR
 
 ## The roster
 
-Seven indexed runes — **speed, duplication, prism, thrift, superiorIntellect, infiniteAscent,
-antiquities** — plus a special **finiteDescent** (ascension-score). Effects (per `Runes.ts`): speed →
-accelerator power + global speed; duplication → multiplier boosts + tax reduction; prism → production
-+ cost divisor; thrift → cost delay + salvage; superiorIntellect → offerings + obtainium;
-infiniteAscent / antiquities → late-game OOM bonuses; finiteDescent → ascension score.
+Ten indexed runes (the current `Runes.ts` roster) — **speed, duplication, prism, thrift,
+superiorIntellect, infiniteAscent, antiquities, horseShoe, finiteDescent, topHat**. The first five
+carry blessings + spirits; the rest are late-game. Effects: speed → accelerator power + global speed;
+duplication → multiplier boosts + tax reduction; prism → production + cost divisor; thrift → cost
+delay + salvage; superiorIntellect → offerings + obtainium; infiniteAscent / antiquities → late-game
+OOM bonuses; finiteDescent → ascension score.
 
 ## Port status
 
@@ -63,8 +64,8 @@ infiniteAscent / antiquities → late-game OOM bonuses; finiteDescent → ascens
 | Offerings | 🟩 Ported | `mechanics/resource_gain.rs` (awarded on every reset tier) |
 | Runes | 🟩 Ported | `state/runes.rs`, `mechanics/rune_*.rs` — effective-level pipeline now wired (was H3) |
 | Rune blessings | 🟩 Ported | `mechanics/rune_blessing_effects.rs` — fed `rune_blessing_power(…)` (was H4) |
-| Rune spirits | 🟨 Partial | `mechanics/rune_spirit_effects.rs` (several inert at default) |
-| Talismans + fragments | 🟨 Partial | `state/talismans.rs`, `mechanics/talisman_*.rs` |
+| Rune spirits | 🟩 Ported | `mechanics/rune_spirit_effects.rs` — all 5 fed `rune_spirit_power(…)`; inert until spirit levels exist (late-game) |
+| Talismans + fragments | 🟩 Ported | `state/talismans.rs`, `mechanics/talisman_*.rs` — rarity recompute + talisman→rune-level bonus live |
 
 ## Porting notes / open bugs
 
@@ -74,6 +75,22 @@ infiniteAscent / antiquities → late-game OOM bonuses; finiteDescent → ascens
   cut before #265.)
 - **H4 — blessing power: fixed (PR #265).** Blessing effects are now fed `rune_blessing_power(state, …)`
   rather than the raw level, so they scale instead of pinning near 1.0×.
-- **Talismans (still partial):** rarity is never recomputed → stays 0, which zeroes all rarity-indexed
-  effects. Rune assignment still maps the legacy-deprecated schema.
-- **Thrift blessing** is blocked on the accelerator-boost buy (see [core-economy.md](core-economy.md)).
+- **Schema grown to the current roster.** State is now 10 runes / 11 talismans (was 7 / 7), matching
+  `Runes.ts` / `Talismans.ts`. Both reset paths (`reset.rs`) are tier-faithful: an ascension keeps the
+  singularity/never-tier runes (infiniteAscent, antiquities, horseShoe, topHat) and talismans
+  (achievement, cookieGrandma, horseShoe).
+- **Rune spirits — ported.** `rune_spirit_power(state, rune) = spirit.level · rune.level · blessing.level
+  · otherSpiritMultipliers` (the `spiritMultiplier` chain, mirroring `rune_blessing_power`) now feeds all
+  five spirit effects (speed/duplication/prism/thrift/SI). Inert at reachable play (spirit levels need
+  late-game unlocks); challenge-15 `spiritBonus` + corruption difficulty mult are neutral 1.0.
+- **Talismans — ported.** Per-tick `recompute_talisman_rarities` drives `talisman_rarity` from level +
+  unlock, lighting the rarity-indexed effects (was frozen 0); `get_rune_bonus_from_all_talismans` ports
+  the talisman→rune-level bonus (11×10 coefficient table + stat-sum + metaphysics/mortuus amplifiers).
+  Residual neutral-defaults: the chronos/midas/metaphysics/polymath/achievement/horseShoe **unlock gates**
+  read unported subsystems (achievement rewards, level milestones, singularity) → those stay locked, so
+  the metaphysics amplifier is unreachable until its gate ports; the prism/thrift/SI per-rune coin/upgrade
+  free-level aggregators are still unported (only their talisman-bonus term is live). The deprecated
+  per-rune `rune_assignments` slots are documented dead state.
+- **Thrift blessing** remains the one carve-out — blocked on the accelerator-boost (`boostAccelerator`)
+  buy (see [core-economy.md](core-economy.md)). Its effect (`accelBoostCostDelay`) is a 1-line wire once
+  that buy lands.


### PR DESCRIPTION
Wraps up the **runes-talismans** systems-map node end-to-end — rune spirits, talisman rarity + the talisman→rune-level bonus, and the `boostAccelerator` buy that wires the last remaining effect (the thrift rune blessing). The node now has **zero carve-outs**.

## What landed (8 commits)

| Area | Summary |
|---|---|
| **Rune roster 7→10** | Adopt the current `Runes.ts` key order (add infiniteAscent, horseShoe, topHat; antiquities 5→6, finiteDescent 6→8 — all via named consts, no ripples). Ascension rune-reset made tier-faithful (singularity/never-tier runes survive). |
| **Talisman roster 7→11** | Append wowSquare, achievement, cookieGrandma, horseShoe. Ascension talisman-reset made tier-faithful. The deprecated per-rune `rune_assignments` slots documented as dead state. |
| **Rune spirits** | Port `rune_spirit_power` (the `spiritMultiplier` chain, mirroring `rune_blessing_power`); wire all 5 spirit effects (speed/duplication/prism/thrift/SI). |
| **Talisman rarity** | Per-tick `recompute_talisman_rarities` drives `talisman_rarity` from level + unlock — finally lighting the already-wired rarity-indexed effects (midas blessing, exemption tax, chronos/polymath speed, mortuus). Every unlock gate is a pure `GameState` function (no new field). |
| **Talisman→rune bonus** | Port `getRuneBonusFromAllTalismans` (11×10 coefficient table + stat-sum + metaphysics/mortuus amplifiers), feeding the first-five rune free levels. |
| **boostAccelerator** | `BuyRequest::AcceleratorBoost` — classic single-boost+prestige-reset path and the bulk solver. Both feed the cost the thrift blessing's `accelBoostCostDelay` — **the thrift-blessing production wire**. |

## Schema changes

- `RUNE_COUNT` 7→10, `TALISMAN_COUNT` 7→11 (arrays grow via the count bumps — no fresh fields).
- One new `player.*` field: `AcceleratorState.accelerator_boost_cost` (Decimal, default `1e3`, mirrors `player.acceleratorBoostCost`), needed for the classic boost path's running cost.
- The save format is pre-release (`SaveV1 = GameState` verbatim), so this evolves in place — no migration.

## Faithful neutral-defaults (documented, prerequisite-blocked)

- Talisman unlock gates that read unported subsystems stay locked: chronos/midas/metaphysics/polymath (achievement-reward table), achievement (level milestone), horseShoe (singularity challenge) — so the metaphysics amplifier is unreachable until its gate ports.
- The prism/thrift/SI per-rune coin/upgrade free-level aggregators (only their talisman-bonus term is live).
- Rune spirits are inert at reachable play (spirit levels need late-game unlocks) but faithful.
- `awardAchievementGroup('acceleratorBoosts')` and the `boostAccelerator(true)` autobuyer.

## Tests / gates

1274 logic tests (16 new, including tack-level dispatch and an end-to-end through `phase_global_state`). All green: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, and the wasm build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)