### PR TITLE
Close out the unmigrated logic systems (quark mult, blueberry, unlocks, singularity, autobuyers)

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -505,6 +505,16 @@ pub enum CoreEvent {
         /// reset — the execution is ungated).
         points_gained: Decimal,
     },
+    /// A singularity reset executed (legacy `singularity()`, `Reset.ts:1063`) —
+    /// the meta-layer above ascension: golden quarks were granted and the
+    /// singularity count advanced. Distinct from [`Self::ResetPerformed`], whose
+    /// `points_gained` is a prestige-family currency, not golden quarks.
+    SingularityPerformed {
+        /// Golden quarks granted by this reset (`calculateGoldenQuarks()`).
+        golden_quarks_gained: Decimal,
+        /// The new `singularityCount` after the reset.
+        singularity_count: f64,
+    },
     /// One of the four `automaticTools()` branches fired this tick.
     ///
     /// Emitted by the auto-tool state machine (tick-side, not yet

--- a/crates/synergismforkd_logic/src/mechanics/talisman_costs.rs
+++ b/crates/synergismforkd_logic/src/mechanics/talisman_costs.rs
@@ -128,6 +128,41 @@ pub fn exponential_cost_progression(
     }
 }
 
+/// Per-talisman cost map for the *next* level — dispatches the legacy
+/// `talismans[t].costs(baseMult, level)` data table (Talismans.ts): the regular
+/// (cubic) progression for talismans 0-6 (exemption..plastic), exponential for
+/// 7-10 (wowSquare/achievement/cookieGrandma/horseShoe). Base multipliers + the
+/// exponential ratios are the per-talisman constants. Used by the talisman
+/// autobuyer to evaluate [`buy_talisman_level`](super::talisman_levels::buy_talisman_level)'s
+/// `costs` input. Index via the `TALISMAN_*` constants.
+#[must_use]
+pub fn talisman_costs_for_level(talisman: usize, level: f64) -> TalismanCraftCosts {
+    let base = |m: f64| Decimal::from_finite(m);
+    let base_exp = |e: f64| Decimal::from_mantissa_exponent(1.0, e);
+    match talisman {
+        0 => regular_cost_progression(base(1.0), level),
+        1 => regular_cost_progression(base(10.0), level),
+        2 => regular_cost_progression(base(1e4), level),
+        3 => regular_cost_progression(base(1e8), level),
+        4 => regular_cost_progression(base(1e16), level),
+        5 => regular_cost_progression(base(100.0), level),
+        6 => regular_cost_progression(base(1e5), level),
+        7 => exponential_cost_progression(base(1e5), level, 2.0),
+        8 => exponential_cost_progression(base(1e30), level, 10.0),
+        9 => exponential_cost_progression(base_exp(1000.0), level, 1e8), // baseMult 1e1000
+        10 => exponential_cost_progression(base_exp(1200.0), level, 1e5), // baseMult 1e1200
+        _ => TalismanCraftCosts {
+            shard: Decimal::zero(),
+            common_fragment: Decimal::zero(),
+            uncommon_fragment: Decimal::zero(),
+            rare_fragment: Decimal::zero(),
+            epic_fragment: Decimal::zero(),
+            legendary_fragment: Decimal::zero(),
+            mythical_fragment: Decimal::zero(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/synergismforkd_logic/src/mechanics/talisman_levels.rs
+++ b/crates/synergismforkd_logic/src/mechanics/talisman_levels.rs
@@ -13,7 +13,24 @@ use synergismforkd_bignum::Decimal;
 
 use super::talisman_costs::TalismanCraftCosts;
 use crate::events::CoreEvent;
-use crate::state::TalismansState;
+use crate::state::{TalismansState, TALISMAN_COUNT};
+
+/// Per-talisman base `maxLevel` (legacy `talismans[t].maxLevel`, Talismans.ts),
+/// in `TALISMAN_*` index order. The `getTalismanLevelCap` purchase cap adds
+/// `levelCapIncrease()` on top. Shared by the rarity recompute + the autobuyer.
+pub const TALISMAN_MAX_LEVELS: [f64; TALISMAN_COUNT] = [
+    180.0, // exemption
+    180.0, // chronos
+    180.0, // midas
+    180.0, // metaphysics
+    180.0, // polymath
+    180.0, // mortuus
+    180.0, // plastic
+    210.0, // wowSquare
+    40.0,  // achievement
+    6.0,   // cookieGrandma
+    12.0,  // horseShoe
+];
 
 // ─── Rarity value table ────────────────────────────────────────────────────
 

--- a/crates/synergismforkd_logic/src/state/automation.rs
+++ b/crates/synergismforkd_logic/src/state/automation.rs
@@ -56,6 +56,19 @@ pub enum AutoAscendMode {
     RealAscensionTime,
 }
 
+/// `player.resetToggleModes.ascension` (legacy `AutoAscensionModes`) — the
+/// tesseract-autobuyer mode. `Amount` (the `updateAll` Family-12 path) spends
+/// down to a flat `tesseract_auto_buyer_amount` reserve; `Percentage` is the
+/// on-ascension `autoBuyTesseracts` path (`Reset.ts:825`, not driven here).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AutoAscensionMode {
+    /// `amount = 0` — keep a flat reserve.
+    #[default]
+    Amount,
+    /// `percentage = 1` — keep a percentage reserve.
+    Percentage,
+}
+
 /// `player.shoptoggles` — the five category gates read by the upgrade-tab
 /// autobuyer (`autoUpgrades`). Distinct from the indexed `toggles` array:
 /// these are the shop's "auto-buy this upgrade family" switches.
@@ -192,6 +205,9 @@ pub struct AutomationState {
     /// `player.autoTesseracts` — per-tier tesseract autobuy enables (slot 0
     /// unused; `1..=5` are the five buildings).
     pub auto_tesseracts: [bool; 6],
+    /// `player.resetToggleModes.ascension` — the tesseract-autobuyer mode. Only
+    /// `Amount` is driven by the `updateAll` autobuyer.
+    pub ascension_reset_mode: AutoAscensionMode,
     /// `player.autoFortifyToggle` — talisman level→rarity autobuyer armed.
     pub auto_fortify_toggle: bool,
     /// `player.shoptoggles` — the five upgrade-tab auto-buy category gates.
@@ -244,6 +260,7 @@ impl Default for AutomationState {
             tesseract_auto_buyer_amount: 0.0,
             tesseract_buy_amount: 1.0,
             auto_tesseracts: [false; 6],
+            ascension_reset_mode: AutoAscensionMode::Amount,
             auto_fortify_toggle: false,
             shop_toggles: ShopToggles::default(),
         }

--- a/crates/synergismforkd_logic/src/state/golden_quarks.rs
+++ b/crates/synergismforkd_logic/src/state/golden_quarks.rs
@@ -239,6 +239,10 @@ pub struct GoldenQuarksState {
     /// `player.goldenQuarksTimer` — GQ-export accumulator (seconds);
     /// disabled when `export_gq_per_hour == 0`, else clamped to 168 h.
     pub golden_quarks_timer: f64,
+    /// `player.totalQuarksEver` — lifetime quarks across all singularities.
+    /// Accumulated by the singularity reset (`Reset.ts:1143`,
+    /// `+= quarksThisSingularity`); read by the quark statistics line.
+    pub total_quarks_ever: f64,
     /// Per-upgrade state. Indexed by the `GQ_*` constants (index =
     /// legacy `goldenQuarkUpgrades` key order).
     #[serde(with = "BigArray")]
@@ -839,6 +843,7 @@ impl Default for GoldenQuarksState {
             golden_quarks: Decimal::zero(),
             quarks_this_singularity: 0.0,
             golden_quarks_timer: 0.0,
+            total_quarks_ever: 0.0,
             upgrades,
         }
     }

--- a/crates/synergismforkd_logic/src/state/golden_quarks.rs
+++ b/crates/synergismforkd_logic/src/state/golden_quarks.rs
@@ -245,13 +245,601 @@ pub struct GoldenQuarksState {
     pub upgrades: [GoldenQuarkUpgrade; GOLDEN_QUARK_UPGRADES_LEN],
 }
 
+/// One GQ upgrade's seed metadata (legacy `goldenQuarkUpgrades` data table,
+/// `singularity.ts:308-2210`), applied in [`GoldenQuarksState::default`]. Without
+/// it every `cost_per_level` is `0` — a free-unlimited-level hazard once a buy
+/// runs. Index order matches the `GQ_*` constants.
+struct GqSeed {
+    cost: f64,
+    max: f64,
+    exceed: bool,
+    qol: bool,
+    form: StoredSpecialCostForm,
+}
+
+/// The 80 GQ-upgrade seed rows, in `GQ_*` index order. Verbatim from
+/// `singularity.ts` (`'Default'` cost form → `None`; `-1` max → unlimited).
+const GQ_UPGRADE_SEEDS: [GqSeed; GOLDEN_QUARK_UPGRADES_LEN] = {
+    use StoredSpecialCostForm as F;
+    [
+        GqSeed {
+            cost: 12.0,
+            max: 15.0,
+            exceed: true,
+            qol: true,
+            form: F::None,
+        }, // 0 goldenQuarks1
+        GqSeed {
+            cost: 60.0,
+            max: 75.0,
+            exceed: true,
+            qol: true,
+            form: F::None,
+        }, // 1 goldenQuarks2
+        GqSeed {
+            cost: 1000.0,
+            max: 1000.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 2 goldenQuarks3
+        GqSeed {
+            cost: 10.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 3 starterPack
+        GqSeed {
+            cost: 350.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 4 wowPass
+        GqSeed {
+            cost: 100.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 5 cookies
+        GqSeed {
+            cost: 500.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 6 cookies2
+        GqSeed {
+            cost: 24999.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 7 cookies3
+        GqSeed {
+            cost: 499999.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 8 cookies4
+        GqSeed {
+            cost: 1.66e15,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 9 cookies5
+        GqSeed {
+            cost: 5.0,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 10 ascensions
+        GqSeed {
+            cost: 1000.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 11 corruptionFourteen
+        GqSeed {
+            cost: 40000.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 12 corruptionFifteen
+        GqSeed {
+            cost: 1.0,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 13 singOfferings1
+        GqSeed {
+            cost: 25.0,
+            max: 25.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 14 singOfferings2
+        GqSeed {
+            cost: 500.0,
+            max: 40.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 15 singOfferings3
+        GqSeed {
+            cost: 1.0,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 16 singObtainium1
+        GqSeed {
+            cost: 25.0,
+            max: 25.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 17 singObtainium2
+        GqSeed {
+            cost: 500.0,
+            max: 40.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 18 singObtainium3
+        GqSeed {
+            cost: 1.0,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 19 singCubes1
+        GqSeed {
+            cost: 25.0,
+            max: 25.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 20 singCubes2
+        GqSeed {
+            cost: 500.0,
+            max: 40.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 21 singCubes3
+        GqSeed {
+            cost: 500000.0,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 22 singCitadel
+        GqSeed {
+            cost: 1e14,
+            max: 100.0,
+            exceed: false,
+            qol: false,
+            form: F::Quadratic,
+        }, // 23 singCitadel2
+        GqSeed {
+            cost: 8888.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 24 octeractUnlock
+        GqSeed {
+            cost: 9999.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 25 singOcteractPatreonBonus
+        GqSeed {
+            cost: 1e14,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 26 offeringAutomatic
+        GqSeed {
+            cost: 1.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 27 intermediatePack
+        GqSeed {
+            cost: 200.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 28 advancedPack
+        GqSeed {
+            cost: 800.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 29 expertPack
+        GqSeed {
+            cost: 3200.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 30 masterPack
+        GqSeed {
+            cost: 12800.0,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 31 divinePack
+        GqSeed {
+            cost: 12500.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 32 wowPass2
+        GqSeed {
+            cost: 29999999.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 33 wowPass3 (3e7-1)
+        GqSeed {
+            cost: 999.0,
+            max: 10.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 34 potionBuff
+        GqSeed {
+            cost: 1e8,
+            max: 10.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 35 potionBuff2
+        GqSeed {
+            cost: 1e12,
+            max: 10.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 36 potionBuff3
+        GqSeed {
+            cost: 999.0,
+            max: 4.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 37 singChallengeExtension
+        GqSeed {
+            cost: 29999.0,
+            max: 3.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 38 singChallengeExtension2
+        GqSeed {
+            cost: 749999.0,
+            max: 3.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 39 singChallengeExtension3
+        GqSeed {
+            cost: 1.0,
+            max: 30.0,
+            exceed: true,
+            qol: true,
+            form: F::Exponential2,
+        }, // 40 singQuarkImprover1
+        GqSeed {
+            cost: 14999.0,
+            max: 10.0,
+            exceed: false,
+            qol: true,
+            form: F::Quadratic,
+        }, // 41 singQuarkHepteract
+        GqSeed {
+            cost: 449999.0,
+            max: 10.0,
+            exceed: false,
+            qol: true,
+            form: F::Cubic,
+        }, // 42 singQuarkHepteract2
+        GqSeed {
+            cost: 13370000.0,
+            max: 10.0,
+            exceed: true,
+            qol: true,
+            form: F::Exponential2,
+        }, // 43 singQuarkHepteract3
+        GqSeed {
+            cost: 20000.0,
+            max: -1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 44 singOcteractGain
+        GqSeed {
+            cost: 40000.0,
+            max: 25.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 45 singOcteractGain2
+        GqSeed {
+            cost: 250000.0,
+            max: 50.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 46 singOcteractGain3
+        GqSeed {
+            cost: 750000.0,
+            max: 100.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 47 singOcteractGain4
+        GqSeed {
+            cost: 7777777.0,
+            max: 200.0,
+            exceed: true,
+            qol: false,
+            form: F::None,
+        }, // 48 singOcteractGain5
+        GqSeed {
+            cost: 100000.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 49 platonicTau
+        GqSeed {
+            cost: 2e7,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 50 platonicAlpha
+        GqSeed {
+            cost: 5e9,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 51 platonicDelta
+        GqSeed {
+            cost: 2e11,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 52 platonicPhi
+        GqSeed {
+            cost: 6999999.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 53 singFastForward (7e6-1)
+        GqSeed {
+            cost: 99999999999.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 54 singFastForward2 (1e11-1)
+        GqSeed {
+            cost: 1e10,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 55 singAscensionSpeed
+        GqSeed {
+            cost: 1e12,
+            max: 30.0,
+            exceed: false,
+            qol: false,
+            form: F::Exponential2,
+        }, // 56 singAscensionSpeed2
+        GqSeed {
+            cost: 2.22e26,
+            max: 1.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 57 ultimatePen
+        GqSeed {
+            cost: 1.66e12,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 58 halfMind
+        GqSeed {
+            cost: 1.66e13,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 59 oneMind
+        GqSeed {
+            cost: 66666666666.0,
+            max: 1.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 60 wowPass4
+        GqSeed {
+            cost: 1e16,
+            max: 10.0,
+            exceed: false,
+            qol: true,
+            form: F::Exponential2,
+        }, // 61 blueberries
+        GqSeed {
+            cost: 1e9,
+            max: -1.0,
+            exceed: false,
+            qol: true,
+            form: F::Exponential2,
+        }, // 62 singAmbrosiaLuck
+        GqSeed {
+            cost: 4e5,
+            max: 30.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 63 singAmbrosiaLuck2
+        GqSeed {
+            cost: 2e8,
+            max: 30.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 64 singAmbrosiaLuck3
+        GqSeed {
+            cost: 1e19,
+            max: 50.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 65 singAmbrosiaLuck4
+        GqSeed {
+            cost: 1e9,
+            max: -1.0,
+            exceed: false,
+            qol: true,
+            form: F::Exponential2,
+        }, // 66 singAmbrosiaGeneration
+        GqSeed {
+            cost: 8e5,
+            max: 20.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 67 singAmbrosiaGeneration2
+        GqSeed {
+            cost: 3e8,
+            max: 35.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 68 singAmbrosiaGeneration3
+        GqSeed {
+            cost: 1e19,
+            max: 50.0,
+            exceed: false,
+            qol: true,
+            form: F::None,
+        }, // 69 singAmbrosiaGeneration4
+        GqSeed {
+            cost: 25.0,
+            max: 5.0,
+            exceed: false,
+            qol: false,
+            form: F::Exponential2,
+        }, // 70 singBonusTokens1
+        GqSeed {
+            cost: 10000.0,
+            max: 5.0,
+            exceed: false,
+            qol: false,
+            form: F::Exponential2,
+        }, // 71 singBonusTokens2
+        GqSeed {
+            cost: 1e8,
+            max: 5.0,
+            exceed: false,
+            qol: false,
+            form: F::Exponential2,
+        }, // 72 singBonusTokens3
+        GqSeed {
+            cost: 1e13,
+            max: 30.0,
+            exceed: false,
+            qol: false,
+            form: F::Exponential2,
+        }, // 73 singBonusTokens4
+        GqSeed {
+            cost: 1e18,
+            max: 80.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 74 singInfiniteShopUpgrades
+        GqSeed {
+            cost: 25.0,
+            max: 5.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 75 singTalismanBonusRunes1
+        GqSeed {
+            cost: 10000.0,
+            max: 5.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 76 singTalismanBonusRunes2
+        GqSeed {
+            cost: 1e8,
+            max: 5.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 77 singTalismanBonusRunes3
+        GqSeed {
+            cost: 3e15,
+            max: 10.0,
+            exceed: false,
+            qol: false,
+            form: F::None,
+        }, // 78 singTalismanBonusRunes4
+        GqSeed {
+            cost: 1.0,
+            max: 100.0,
+            exceed: false,
+            qol: true,
+            form: F::Exponential2,
+        }, // 79 favoriteUpgrade
+    ]
+};
+
 impl Default for GoldenQuarksState {
     fn default() -> Self {
+        let mut upgrades = [GoldenQuarkUpgrade::default(); GOLDEN_QUARK_UPGRADES_LEN];
+        for (u, seed) in upgrades.iter_mut().zip(GQ_UPGRADE_SEEDS.iter()) {
+            u.max_level = seed.max;
+            u.can_exceed_cap = seed.exceed;
+            u.quality_of_life = seed.qol;
+            u.special_cost_form = seed.form;
+            u.cost_per_level = seed.cost;
+        }
         Self {
             golden_quarks: Decimal::zero(),
             quarks_this_singularity: 0.0,
             golden_quarks_timer: 0.0,
-            upgrades: [GoldenQuarkUpgrade::default(); GOLDEN_QUARK_UPGRADES_LEN],
+            upgrades,
         }
     }
 }
@@ -283,5 +871,40 @@ mod tests {
         assert_eq!(u.level, 0.0);
         assert!(!u.can_exceed_cap);
         assert!(matches!(u.special_cost_form, StoredSpecialCostForm::None));
+    }
+
+    #[test]
+    fn default_seeds_gq_upgrade_metadata() {
+        // The state default must seed the legacy goldenQuarkUpgrades metadata so
+        // costs/caps are real (the unseeded all-zero default let unlimited free
+        // buys run). Anchor a few against singularity.ts.
+        let s = GoldenQuarksState::default();
+        assert_eq!(s.upgrades[GQ_GOLDEN_QUARKS_1].cost_per_level, 12.0);
+        assert_eq!(s.upgrades[GQ_GOLDEN_QUARKS_1].max_level, 15.0);
+        assert!(s.upgrades[GQ_GOLDEN_QUARKS_1].can_exceed_cap);
+        assert!(s.upgrades[GQ_GOLDEN_QUARKS_1].quality_of_life);
+        assert_eq!(s.upgrades[GQ_ASCENSIONS].max_level, -1.0); // unlimited
+        assert_eq!(s.upgrades[GQ_INTERMEDIATE_PACK].cost_per_level, 1.0);
+        assert!(matches!(
+            s.upgrades[GQ_BLUEBERRIES].special_cost_form,
+            StoredSpecialCostForm::Exponential2
+        ));
+        assert!(matches!(
+            s.upgrades[GQ_SING_CITADEL_2].special_cost_form,
+            StoredSpecialCostForm::Quadratic
+        ));
+    }
+
+    #[test]
+    fn default_seeds_have_no_zero_cost() {
+        // No upgrade may seed a 0 cost_per_level — that is the free-unlimited-buy
+        // hazard the seeding closes (legacy minimum costPerLevel is 1).
+        let s = GoldenQuarksState::default();
+        for (i, u) in s.upgrades.iter().enumerate() {
+            assert!(
+                u.cost_per_level > 0.0,
+                "GQ upgrade {i} seeded a non-positive cost_per_level"
+            );
+        }
     }
 }

--- a/crates/synergismforkd_logic/src/state/reset_counters.rs
+++ b/crates/synergismforkd_logic/src/state/reset_counters.rs
@@ -63,6 +63,39 @@ pub struct ResetCountersState {
     /// `player.unlocks.platonics` — set when `highest[14] > 0`.
     /// Gates platonic-cube content.
     pub platonics_unlocked: bool,
+    /// `player.unlocks.coinone`..`coinfour` — coin-producer visibility gates,
+    /// set when `coins` cross `500 / 1e4 / 1e5 / 4e6` (Synergism.ts:3976-3989).
+    /// Reset to `false` only on singularity (Reset.ts:888).
+    pub coin_one_unlocked: bool,
+    /// See [`Self::coin_one_unlocked`].
+    pub coin_two_unlocked: bool,
+    /// See [`Self::coin_one_unlocked`].
+    pub coin_three_unlocked: bool,
+    /// See [`Self::coin_one_unlocked`].
+    pub coin_four_unlocked: bool,
+    /// `player.unlocks.generation` — generator-tab gate, set when buying
+    /// generator 1 (prestige points `>= 1e12`, Automation.ts:8). Singularity-only
+    /// reset.
+    pub generation_unlocked: bool,
+    /// `player.unlocks.rrow1`..`rrow4` — research-row visibility gates. In this
+    /// TS version they are granted at singularity milestones (Reset.ts:970+) and
+    /// reset on singularity; wired with the singularity layer.
+    pub research_row_1_unlocked: bool,
+    /// See [`Self::research_row_1_unlocked`].
+    pub research_row_2_unlocked: bool,
+    /// See [`Self::research_row_1_unlocked`].
+    pub research_row_3_unlocked: bool,
+    /// See [`Self::research_row_1_unlocked`].
+    pub research_row_4_unlocked: bool,
+    /// `player.unlocks.anthill` — ant feature gate, set on first `highest[8] > 0`
+    /// (Synergism.ts:3692). Singularity-only reset.
+    pub anthill_unlocked: bool,
+    /// `player.unlocks.talismans` — talisman feature gate, set on first
+    /// `highest[9] > 0` (Synergism.ts:3695). Singularity-only reset.
+    pub talismans_unlocked: bool,
+    /// `player.unlocks.blessings` — cube-blessing gate, set on first
+    /// `highest[9] > 0` (Synergism.ts:3696). Singularity-only reset.
+    pub blessings_unlocked: bool,
 }
 
 impl Default for ResetCountersState {
@@ -90,6 +123,18 @@ impl Default for ResetCountersState {
             spirits_unlocked: false,
             hypercubes_unlocked: false,
             platonics_unlocked: false,
+            coin_one_unlocked: false,
+            coin_two_unlocked: false,
+            coin_three_unlocked: false,
+            coin_four_unlocked: false,
+            generation_unlocked: false,
+            research_row_1_unlocked: false,
+            research_row_2_unlocked: false,
+            research_row_3_unlocked: false,
+            research_row_4_unlocked: false,
+            anthill_unlocked: false,
+            talismans_unlocked: false,
+            blessings_unlocked: false,
         }
     }
 }

--- a/crates/synergismforkd_logic/src/tick/auto_buy.rs
+++ b/crates/synergismforkd_logic/src/tick/auto_buy.rs
@@ -13,11 +13,12 @@
 //! per-tier unlock upgrades are unowned at default, the whole driver is inert
 //! on a fresh save.
 //!
-//! **Deferred families** (each needs an unported prerequisite, all dormant at
-//! default): the **ant-upgrade** autobuyer (its 16 per-upgrade `autobuy()`
-//! conditions are distinct unported achievement rewards / level milestones).
-//! The **talisman** autobuyer (Family 11, `buyTalismanLevelToRarityIncrease`)
-//! and the **tesseract** autobuyer (Family 12) are now wired.
+//! **All 13 `updateAll` autobuyer families are wired** — including the formerly
+//! deferred three: talisman (Family 11, `buyTalismanLevelToRarityIncrease`),
+//! tesseract (Family 12, AMOUNT mode + `calculate_tess_buildings_in_budget`),
+//! and ant-upgrades (Family 13, per-upgrade achievement / research / milestone
+//! gates). The PERCENTAGE-mode tesseract path (`autoBuyTesseracts`, on-ascension)
+//! is a separate call site, not part of this `updateAll` driver.
 
 use crate::events::{ProducerType, UpgradeTier};
 use crate::mechanics::accelerators::BuyAcceleratorInput;
@@ -161,6 +162,9 @@ pub(crate) fn run_auto_buy(state: &mut GameState, pre: &AutomationPre, output: &
 
     // ── Family 11: talismans (buyTalismanLevelToRarityIncrease) ──────
     talisman_autobuyer(state, output, ppg);
+
+    // ── Family 12: tesseract buildings (AMOUNT mode) ─────────────────
+    tesseract_autobuyer(state, output, ppg);
 
     // ── Family 13 (producers + masteries): ant autobuyers ────────────
     // Gated on the ant autobuy toggles + getAchievementReward('antAutobuyers').
@@ -570,6 +574,48 @@ fn talisman_level_cap_increase(state: &GameState, talisman: usize, universal: f6
     }
 }
 
+/// AMOUNT-mode tesseract-building autobuyer (`updateAll`, `Synergism.ts:4256`).
+/// Gated on `researches[190] > 0 && tesseract_auto_buyer_toggle && ascension_reset_mode == Amount`.
+/// Solves the cheapest-first distribution of `wow_tesseracts − reserve` across the
+/// auto-buy-enabled tiers ([`calculate_tess_buildings_in_budget`]) and dispatches
+/// the deltas highest-tier-first. The PERCENTAGE mode (on-ascension
+/// `autoBuyTesseracts`) is a separate call site and not driven here.
+fn tesseract_autobuyer(state: &mut GameState, output: &mut TickOutput, ppg: Decimal) {
+    use crate::mechanics::tesseract_buildings::{
+        calculate_tess_buildings_in_budget, BuyTesseractBuildingInput,
+    };
+    use crate::state::automation::AutoAscensionMode;
+
+    if state.researches.researches[190] <= 0.0
+        || !state.automation.tesseract_auto_buyer_toggle
+        || state.automation.ascension_reset_mode != AutoAscensionMode::Amount
+    {
+        return;
+    }
+    let owned: [Option<f64>; 5] = std::array::from_fn(|i| {
+        if state.automation.auto_tesseracts[i + 1] {
+            Some(state.tesseract_buildings.building((i + 1) as u8).owned)
+        } else {
+            None
+        }
+    });
+    let budget =
+        state.tesseract_buildings.wow_tesseracts - state.automation.tesseract_auto_buyer_amount;
+    let buy_to = calculate_tess_buildings_in_budget(owned, budget);
+    // Highest tier to lowest (matches the legacy order — guards float fuzz).
+    for i in (0..5).rev() {
+        if let (Some(from), Some(to)) = (owned[i], buy_to[i]) {
+            if to > from {
+                let req = BuyRequest::TesseractBuilding(BuyTesseractBuildingInput {
+                    index: (i + 1) as u8,
+                    amount: to - from,
+                });
+                output.events.extend(dispatch_buy(state, &req, ppg));
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,5 +673,30 @@ mod tests {
         let mut output = TickOutput::default();
         run_auto_buy(&mut state, &AutomationPre::default(), &mut output);
         assert!(state.ants.upgrades[0] > 0.0);
+    }
+
+    #[test]
+    fn tesseract_autobuyer_buys_within_budget() {
+        let mut state = GameState::default();
+        state.researches.researches[190] = 1.0;
+        state.automation.tesseract_auto_buyer_toggle = true; // ascension mode defaults Amount
+        state.automation.auto_tesseracts[1] = true; // enable tier 1
+        state.tesseract_buildings.wow_tesseracts = 1000.0;
+        let mut output = TickOutput::default();
+        tesseract_autobuyer(&mut state, &mut output, Decimal::zero());
+        assert!(state.tesseract_buildings.building(1).owned > 0.0);
+        assert!(!output.events.is_empty());
+    }
+
+    #[test]
+    fn tesseract_autobuyer_inert_without_toggle() {
+        let mut state = GameState::default();
+        state.researches.researches[190] = 1.0;
+        state.automation.auto_tesseracts[1] = true;
+        state.tesseract_buildings.wow_tesseracts = 1000.0;
+        let mut output = TickOutput::default();
+        tesseract_autobuyer(&mut state, &mut output, Decimal::zero());
+        assert_eq!(state.tesseract_buildings.building(1).owned, 0.0);
+        assert!(output.events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/tick/auto_buy.rs
+++ b/crates/synergismforkd_logic/src/tick/auto_buy.rs
@@ -15,12 +15,9 @@
 //!
 //! **Deferred families** (each needs an unported prerequisite, all dormant at
 //! default): the **ant-upgrade** autobuyer (its 16 per-upgrade `autobuy()`
-//! conditions are distinct unported achievement rewards / level milestones),
-//! the **talisman** autobuyer (`buyTalismanLevelToRarityIncrease` is a
-//! rarity-target purchase loop — `levelsUntilRarityIncrease` + the budget /
-//! affordability walk — not the single-level `buy_talisman_level`), and the
-//! **tesseract** autobuyer (needs the `resetToggleModes.ascension` mode, absent
-//! from the Rust schema, plus the budget-driven multi-building purchase).
+//! conditions are distinct unported achievement rewards / level milestones).
+//! The **talisman** autobuyer (Family 11, `buyTalismanLevelToRarityIncrease`)
+//! and the **tesseract** autobuyer (Family 12) are now wired.
 
 use crate::events::{ProducerType, UpgradeTier};
 use crate::mechanics::accelerators::BuyAcceleratorInput;
@@ -48,6 +45,7 @@ use crate::mechanics::rune_effects::{
 use crate::mechanics::upgrades::{buy_upgrades, BuyUpgradeInput};
 use crate::state::runes::{RUNE_PRISM, RUNE_THRIFT};
 use crate::state::{BuyAmount, GameState};
+use synergismforkd_bignum::Decimal;
 
 use super::{dispatch_buy, AutomationPre, BuyRequest, TickOutput};
 
@@ -160,6 +158,9 @@ pub(crate) fn run_auto_buy(state: &mut GameState, pre: &AutomationPre, output: &
             output.events.extend(dispatch_buy(state, &req, ppg));
         }
     }
+
+    // ── Family 11: talismans (buyTalismanLevelToRarityIncrease) ──────
+    talisman_autobuyer(state, output, ppg);
 
     // ── Family 13 (producers + masteries): ant autobuyers ────────────
     // Gated on the ant autobuy toggles + getAchievementReward('antAutobuyers').
@@ -417,5 +418,134 @@ fn multiplier_input(state: &GameState) -> BuyMultiplierInput {
         ),
         in_transcension_challenge_4: state.challenges.current_transcension_challenge == 4,
         in_reincarnation_challenge_8: state.challenges.current_reincarnation_challenge == 8,
+    }
+}
+
+/// `buyTalismanLevelToRarityIncrease(t, true)` for every talisman — updateAll's
+/// talisman autobuyer (`Synergism.ts:4286`). Gated on `auto_fortify_toggle` +
+/// (`researches[130] > 0 || researches[135] > 0`). For each talisman it buys
+/// single levels toward the next rarity tier
+/// ([`levels_until_talisman_rarity_increase`]) while affordable — `dispatch_buy`
+/// returns no events when a level is unaffordable or the cap binds, ending the
+/// loop. Inert at default (`auto_fortify_toggle` false).
+fn talisman_autobuyer(state: &mut GameState, output: &mut TickOutput, ppg: Decimal) {
+    use crate::mechanics::talisman_costs::talisman_costs_for_level;
+    use crate::mechanics::talisman_levels::{
+        levels_until_talisman_rarity_increase, BuyTalismanLevelInput,
+        LevelsUntilTalismanRarityIncreaseInput, TALISMAN_MAX_LEVELS,
+    };
+
+    if !state.automation.auto_fortify_toggle {
+        return;
+    }
+    if !(state.researches.researches[130] > 0.0 || state.researches.researches[135] > 0.0) {
+        return;
+    }
+    let universal = universal_talisman_level_cap_increase(state);
+    for (t, &max_level) in TALISMAN_MAX_LEVELS.iter().enumerate() {
+        let level_cap = max_level + talisman_level_cap_increase(state, t, universal);
+        let levels_to_buy =
+            levels_until_talisman_rarity_increase(&LevelsUntilTalismanRarityIncreaseInput {
+                level: state.talismans.talisman_levels[t],
+                max_level,
+                current_rarity: state.talismans.talisman_rarity[t],
+                level_cap,
+            });
+        if levels_to_buy <= 0.0 {
+            continue;
+        }
+        // Bound by levelsToBuy; the dispatch ends the loop early (no events)
+        // once a level is unaffordable or `level_cap` binds.
+        for _ in 0..(levels_to_buy as u64) {
+            let level = state.talismans.talisman_levels[t];
+            let req = BuyRequest::TalismanLevel(BuyTalismanLevelInput {
+                index: t,
+                costs: talisman_costs_for_level(t, level),
+                level_cap,
+            });
+            let events = dispatch_buy(state, &req, ppg);
+            if events.is_empty() {
+                break;
+            }
+            output.events.extend(events);
+        }
+    }
+}
+
+/// `universalTalismanMaxLevelIncreasers()` (`Talismans.ts`) — the talisman
+/// level-cap bonus shared by most talismans. `0` at the default state.
+/// (`taxmanLastStand` talismanFreeLevel is deferred — a singularity challenge,
+/// inert until entered.)
+fn universal_talisman_level_cap_increase(state: &GameState) -> f64 {
+    use crate::mechanics::octeracts::{
+        octeract_talisman_level_cap_1_effect, octeract_talisman_level_cap_2_effect,
+        octeract_talisman_level_cap_3_effect, octeract_talisman_level_cap_4_effect,
+    };
+    use crate::state::octeract_upgrades::{
+        OCTERACT_TALISMAN_LEVEL_CAP_1, OCTERACT_TALISMAN_LEVEL_CAP_2,
+        OCTERACT_TALISMAN_LEVEL_CAP_3, OCTERACT_TALISMAN_LEVEL_CAP_4,
+    };
+    let oct = |i: usize| {
+        state.octeract_upgrades.upgrades[i].level + state.octeract_upgrades.upgrades[i].free_level
+    };
+    6.0 * calc_ecc(
+        ChallengeType::Ascension,
+        state.challenges.challenge_completions[13],
+    ) + (state.researches.researches[200] / 400.0).floor()
+        + octeract_talisman_level_cap_1_effect(oct(OCTERACT_TALISMAN_LEVEL_CAP_1))
+        + octeract_talisman_level_cap_2_effect(oct(OCTERACT_TALISMAN_LEVEL_CAP_2))
+        + octeract_talisman_level_cap_3_effect(oct(OCTERACT_TALISMAN_LEVEL_CAP_3))
+        + octeract_talisman_level_cap_4_effect(oct(OCTERACT_TALISMAN_LEVEL_CAP_4))
+}
+
+/// Per-talisman `levelCapIncrease()` (`Talismans.ts`): cookieGrandma `+54` /
+/// horseShoe `+88` (constants), achievement = the `achievementTalismanEnhancement`
+/// level milestone, everything else the universal increaser. The
+/// metaphysics/plastic/mortuus custom extras are deferred (0/small at the
+/// reachable state).
+fn talisman_level_cap_increase(state: &GameState, talisman: usize, universal: f64) -> f64 {
+    use crate::state::{TALISMAN_ACHIEVEMENT, TALISMAN_COOKIE_GRANDMA, TALISMAN_HORSE_SHOE};
+    match talisman {
+        TALISMAN_COOKIE_GRANDMA => 54.0,
+        TALISMAN_HORSE_SHOE => 88.0,
+        TALISMAN_ACHIEVEMENT => get_level_milestone(
+            LevelMilestoneKey::AchievementTalismanEnhancement,
+            state.level.level,
+        ),
+        _ => universal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn talisman_autobuyer_levels_toward_rarity_target() {
+        let mut state = GameState::default();
+        state.automation.auto_fortify_toggle = true;
+        state.researches.researches[130] = 1.0; // gate
+                                                // Exemption (idx 0) at rarity 1 (recompute runs earlier in the real
+                                                // tick; set directly since we exercise the autobuyer in isolation).
+        state.talismans.talisman_rarity[0] = 1.0;
+        state.talismans.talisman_shards = 1e9;
+        state.talismans.common_fragments = 1e9;
+        let mut output = TickOutput::default();
+        talisman_autobuyer(&mut state, &mut output, Decimal::zero());
+        // rarity 1, maxLevel 180 ⇒ buys toward ceil(180/6)=30 levels.
+        assert!(state.talismans.talisman_levels[0] > 0.0);
+        assert!(!output.events.is_empty());
+    }
+
+    #[test]
+    fn talisman_autobuyer_inert_without_toggle() {
+        let mut state = GameState::default();
+        state.researches.researches[130] = 1.0;
+        state.talismans.talisman_rarity[0] = 1.0;
+        state.talismans.talisman_shards = 1e9;
+        let mut output = TickOutput::default();
+        talisman_autobuyer(&mut state, &mut output, Decimal::zero());
+        assert_eq!(state.talismans.talisman_levels[0], 0.0);
+        assert!(output.events.is_empty());
     }
 }

--- a/crates/synergismforkd_logic/src/tick/auto_buy.rs
+++ b/crates/synergismforkd_logic/src/tick/auto_buy.rs
@@ -25,7 +25,7 @@ use crate::mechanics::ant_masteries::{
     can_buy_ant_mastery, BuyAntMasteryInput, CanBuyAntMasteryInput, MAX_ANT_MASTERY_LEVEL,
 };
 use crate::mechanics::ant_producers::BuyAntProducerInput;
-use crate::mechanics::ant_upgrades::building_cost_scale_ant_upgrade_effect;
+use crate::mechanics::ant_upgrades::{building_cost_scale_ant_upgrade_effect, BuyAntUpgradeInput};
 use crate::mechanics::auto_upgrades::{
     buy_generator, click_upgrades, diamond_upgrade_reward, ClickUpgradesUnlocks,
     DIAMOND_UPGRADE_18_ACHIEVEMENT, DIAMOND_UPGRADE_19_ACHIEVEMENT, DIAMOND_UPGRADE_20_ACHIEVEMENT,
@@ -206,6 +206,60 @@ pub(crate) fn run_auto_buy(state: &mut GameState, pre: &AutomationPre, output: &
                 output.events.extend(events);
             }
         }
+    }
+
+    // ── Family 13 (upgrades): ant-upgrade autobuyer ──────────────────
+    // autobuyAntUpgrades — each of the 16 ant upgrades gates on its own
+    // `autobuy()` predicate (per-upgrade achievement reward / research /
+    // level milestone). `max_buy_upgrades` chooses single-vs-max.
+    if state.ants.toggles.autobuy_upgrades {
+        let max = state.ants.toggles.max_buy_upgrades;
+        for upgrade in 0..16u8 {
+            if ant_upgrade_autobuy_unlocked(state, upgrade) {
+                let req = BuyRequest::AntUpgrade(BuyAntUpgradeInput {
+                    index: upgrade,
+                    max,
+                });
+                output.events.extend(dispatch_buy(state, &req, ppg));
+            }
+        }
+    }
+}
+
+/// Per-ant-upgrade autobuy achievement index for upgrades 0-10 (the
+/// `getAchievementReward('<name>Autobuy')` gate, `AntUpgrades/data/data.ts`):
+/// AntSpeed/Coins→176, Taxes→177, AcceleratorBoosts/Multipliers→178,
+/// Offerings→179, BuildingCostScale→482, Salvage→174, FreeRunes→484,
+/// Obtainium→137, AntSacrifice→486 (verified against the antSacrificeUnlock=173
+/// anchor). Upgrades 11-15 use research / level-milestone gates instead.
+const ANT_UPGRADE_AUTOBUY_ACHIEVEMENTS: [usize; 11] =
+    [176, 176, 177, 178, 178, 179, 482, 174, 484, 137, 486];
+
+/// `antUpgradeData[upgrade].autobuy()` — whether ant upgrade `upgrade` (0-15)
+/// may autobuy. 0-10: the per-upgrade achievement reward; 11 (Mortuus):
+/// `researches[145] > 0`; 12-15 (AntELO/WowCubes/AscensionScore/Mortuus2): a
+/// level milestone.
+fn ant_upgrade_autobuy_unlocked(state: &GameState, upgrade: u8) -> bool {
+    match upgrade {
+        0..=10 => {
+            let idx = ANT_UPGRADE_AUTOBUY_ACHIEVEMENTS[upgrade as usize];
+            state
+                .achievements
+                .achievements
+                .get(idx)
+                .is_some_and(|&v| v != 0)
+        }
+        11 => state.researches.researches[145] > 0.0,
+        12 => get_level_milestone(LevelMilestoneKey::AntSpeed2Autobuyer, state.level.level) > 0.5,
+        13 => get_level_milestone(LevelMilestoneKey::WowCubesAutobuyer, state.level.level) > 0.5,
+        14 => {
+            get_level_milestone(
+                LevelMilestoneKey::AscensionScoreAutobuyer,
+                state.level.level,
+            ) > 0.5
+        }
+        15 => get_level_milestone(LevelMilestoneKey::Mortuus2Autobuyer, state.level.level) > 0.5,
+        _ => false,
     }
 }
 
@@ -547,5 +601,31 @@ mod tests {
         talisman_autobuyer(&mut state, &mut output, Decimal::zero());
         assert_eq!(state.talismans.talisman_levels[0], 0.0);
         assert!(output.events.is_empty());
+    }
+
+    #[test]
+    fn ant_upgrade_autobuy_gate_maps_correctly() {
+        let mut state = GameState::default();
+        assert!(!ant_upgrade_autobuy_unlocked(&state, 0));
+        // Achievement 176 (inceptus + fortunae) unlocks AntSpeed (0) + Coins (1).
+        state.achievements.achievements[176] = 1;
+        assert!(ant_upgrade_autobuy_unlocked(&state, 0));
+        assert!(ant_upgrade_autobuy_unlocked(&state, 1));
+        assert!(!ant_upgrade_autobuy_unlocked(&state, 2)); // Taxes needs 177
+                                                           // Mortuus (11) gates on research[145], not an achievement.
+        assert!(!ant_upgrade_autobuy_unlocked(&state, 11));
+        state.researches.researches[145] = 1.0;
+        assert!(ant_upgrade_autobuy_unlocked(&state, 11));
+    }
+
+    #[test]
+    fn ant_upgrade_autobuyer_buys_unlocked_upgrade() {
+        let mut state = GameState::default();
+        state.ants.toggles.autobuy_upgrades = true;
+        state.achievements.achievements[176] = 1; // unlock AntSpeed (0)
+        state.ants.crumbs = Decimal::from_mantissa_exponent(1.0, 20.0); // ample
+        let mut output = TickOutput::default();
+        run_auto_buy(&mut state, &AutomationPre::default(), &mut output);
+        assert!(state.ants.upgrades[0] > 0.0);
     }
 }

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1559,23 +1559,9 @@ fn talisman_is_unlocked(state: &GameState, t: usize) -> bool {
 /// bonus) read this tick's value. Locked talismans collapse to rarity 0; an
 /// unlocked talisman is at least rarity 1 even at level 0.
 fn recompute_talisman_rarities(state: &mut GameState) {
-    use crate::mechanics::talisman_levels::{compute_talisman_rarity, ComputeTalismanRarityInput};
-    /// Per-talisman raw `maxLevel` (the data-table constant, **not** the cap
-    /// with `levelCapIncrease`). Drives the rarity-tier ratios. From the
-    /// legacy `talismans` data table.
-    const TALISMAN_MAX_LEVELS: [f64; TALISMAN_COUNT] = [
-        180.0, // exemption
-        180.0, // chronos
-        180.0, // midas
-        180.0, // metaphysics
-        180.0, // polymath
-        180.0, // mortuus
-        180.0, // plastic
-        210.0, // wowSquare
-        40.0,  // achievement
-        6.0,   // cookieGrandma
-        12.0,  // horseShoe
-    ];
+    use crate::mechanics::talisman_levels::{
+        compute_talisman_rarity, ComputeTalismanRarityInput, TALISMAN_MAX_LEVELS,
+    };
     for (t, &max_level) in TALISMAN_MAX_LEVELS.iter().enumerate() {
         let is_unlocked = talisman_is_unlocked(state, t);
         state.talismans.talisman_rarity[t] =

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -642,10 +642,30 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
         input.dt * automation_pre.global_time_multiplier,
         &mut output,
     );
+    // Progress unlock flags that depend on finalized coins / prestige points
+    // (legacy per-tick checks, Synergism.ts:3976-3989 + Automation.ts:8).
+    update_progress_unlocks(state);
     phase_challenge_completion(state, &reset_gains, &mut output);
     phase_automation(state, &automation_pre, input, &mut output);
 
     output
+}
+
+/// Sticky per-tick progress-unlock flags that depend on finalized currencies:
+/// coin-producer gates (`coins` ≥ 500 / 1e4 / 1e5 / 4e6, Synergism.ts:3976-3989)
+/// and the generator gate (`prestigePoints` ≥ 1e12, Automation.ts:8). Each flag
+/// latches `true` and only resets on a singularity reset (Reset.ts:888). The
+/// `rrow1`-`rrow4` gates are singularity-milestone grants (handled by the
+/// singularity layer), so they are not set here.
+fn update_progress_unlocks(state: &mut GameState) {
+    let coins = state.upgrades.coins;
+    let prestige_points = state.upgrades.prestige_points;
+    let rc = &mut state.reset_counters;
+    rc.coin_one_unlocked |= coins >= Decimal::from_finite(500.0);
+    rc.coin_two_unlocked |= coins >= Decimal::from_finite(10_000.0);
+    rc.coin_three_unlocked |= coins >= Decimal::from_finite(100_000.0);
+    rc.coin_four_unlocked |= coins >= Decimal::from_finite(4e6);
+    rc.generation_unlocked |= prestige_points >= Decimal::from_finite(1e12);
 }
 
 /// Effective ant-upgrade level (legacy `calculateTrueAntLevel`): purchased
@@ -5970,14 +5990,17 @@ fn complete_active_challenge(
     {
         state.challenges.highest_challenge_completions[q_idx] += 1.0;
         // Ascension-challenge unlock side-effects fired on highest[i] first rise
-        // (Synergism.ts:3796-3808 — inside the `resetCheck` ascensionChallenge block).
+        // (Synergism.ts:3692-3700 — inside the `resetCheck` reincarnation block).
         match q_idx {
-            // Reincarnation challenge 10 unlocks ascensions (legacy
-            // `player.unlocks.ascensions = true`, Synergism.ts:3700) — the entry
-            // gate for ascension challenge 11. Without it the c11-c15 ladder is
-            // unreachable in normal play. (c8 anthill / c9 talismans+blessings
-            // still need new `unlocks` fields — deferred to the schema-gated
-            // follow-up.)
+            // Reincarnation challenge 8 unlocks the ant hill (anthill);
+            // challenge 9 unlocks talismans + cube blessings; challenge 10
+            // unlocks ascensions — the entry gate for ascension challenge 11
+            // (without it the c11-c15 ladder is unreachable in normal play).
+            8 => state.reset_counters.anthill_unlocked = true,
+            9 => {
+                state.reset_counters.talismans_unlocked = true;
+                state.reset_counters.blessings_unlocked = true;
+            }
             10 => state.reset_counters.ascension_unlocked = true,
             11 => state.reset_counters.tesseracts_unlocked = true,
             12 => state.reset_counters.spirits_unlocked = true,
@@ -8717,6 +8740,86 @@ mod tests {
             state.reset_counters.ascension_unlocked,
             "completing reincarnation challenge 10 must unlock ascensions"
         );
+    }
+
+    #[test]
+    fn completing_reincarnation_challenge_8_unlocks_anthill() {
+        // Synergism.ts:3692 — highest[8] > 0 sets unlocks.anthill.
+        let mut state = GameState::default();
+        state.challenges.current_reincarnation_challenge = 8;
+        let gains = crate::mechanics::reset_currency::ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        let requirement = |_challenge: u32, _comp: f64| Decimal::zero();
+        complete_active_challenge(
+            &mut state,
+            8,
+            Decimal::one(),
+            5.0,
+            1.0,
+            &requirement,
+            true,
+            &gains,
+            &mut output,
+        );
+        assert!(state.reset_counters.anthill_unlocked);
+    }
+
+    #[test]
+    fn completing_reincarnation_challenge_9_unlocks_talismans_and_blessings() {
+        // Synergism.ts:3695-3696 — highest[9] > 0 sets talismans + blessings.
+        let mut state = GameState::default();
+        state.challenges.current_reincarnation_challenge = 9;
+        let gains = crate::mechanics::reset_currency::ResetCurrencyResult {
+            prestige_point_gain: Decimal::zero(),
+            transcend_point_gain: Decimal::zero(),
+            reincarnation_point_gain: Decimal::zero(),
+        };
+        let mut output = TickOutput::default();
+        let requirement = |_challenge: u32, _comp: f64| Decimal::zero();
+        complete_active_challenge(
+            &mut state,
+            9,
+            Decimal::one(),
+            5.0,
+            1.0,
+            &requirement,
+            true,
+            &gains,
+            &mut output,
+        );
+        assert!(state.reset_counters.talismans_unlocked);
+        assert!(state.reset_counters.blessings_unlocked);
+    }
+
+    #[test]
+    fn coin_unlocks_latch_on_coin_thresholds() {
+        // Synergism.ts:3976-3989 — coinone..four latch as coins cross thresholds.
+        let mut state = GameState::default();
+        state.upgrades.coins = Decimal::from_finite(600.0);
+        update_progress_unlocks(&mut state);
+        assert!(state.reset_counters.coin_one_unlocked);
+        assert!(!state.reset_counters.coin_two_unlocked);
+        state.upgrades.coins = Decimal::from_finite(5e6);
+        update_progress_unlocks(&mut state);
+        assert!(state.reset_counters.coin_two_unlocked);
+        assert!(state.reset_counters.coin_three_unlocked);
+        assert!(state.reset_counters.coin_four_unlocked);
+    }
+
+    #[test]
+    fn generation_unlocks_at_prestige_threshold() {
+        // Automation.ts:8 — generation unlocks at prestige points >= 1e12.
+        let mut state = GameState::default();
+        state.upgrades.prestige_points = Decimal::from_finite(1e11);
+        update_progress_unlocks(&mut state);
+        assert!(!state.reset_counters.generation_unlocked);
+        state.upgrades.prestige_points = Decimal::from_finite(1e12);
+        update_progress_unlocks(&mut state);
+        assert!(state.reset_counters.generation_unlocked);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -507,6 +507,10 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     // (no caller bundle, no cross-mechanic cache). Built field-by-field below,
     // then handed to Phase 5.
     let mut automation_pre = AutomationPre::default();
+    // Refresh blueberry free levels (red-ambrosia `extraLevelCalc`) before the
+    // Phase 2 aggregators read `amb(i) = level + free_level` (cubes / luck /
+    // quark multipliers all depend on the effective level).
+    populate_ambrosia_free_levels(state);
     let aggregator_outputs = phase_global_state(state);
     // Quark multiplier (legacy `calculateQuarkMultiplier` / `allQuarkStats`):
     // cached as a percent so the `applyBonus` consumers (cube opening, challenge
@@ -2487,6 +2491,44 @@ fn compute_octeract_per_second(state: &GameState) -> f64 {
         shop_ex_ultra_effect(shop[SHOP_EX_ULTRA], lifetime_ambrosia),
         ascension_speed_line,
     ])
+}
+
+/// Populate each blueberry upgrade's `free_level` from the red-ambrosia
+/// `freeLevels` upgrades (legacy `BlueberryUpgrade.extraLevelCalc`). Row map:
+/// tutorial (0) → `freeTutorialLevels`; row 2 (1-3: quarks1/cubes1/luck1) →
+/// `freeLevelsRow2`; row 3 (4-9: the cross `*Cube1`/`*Quark1`/`*Luck1`) →
+/// `freeLevelsRow3`; row 4 (10-12: quarks2/cubes2/luck2) → `freeLevelsRow4`;
+/// row 5 (13-16: quarks3/cubes3/luck3/luck4) → `freeLevelsRow5`. Indices 17+
+/// have `extraLevelCalc: () => 0`. Recomputed each tick (the field is a cache),
+/// so it stays the identity `0` at the default state.
+fn populate_ambrosia_free_levels(state: &mut GameState) {
+    use crate::mechanics::red_ambrosia_upgrades::{
+        free_levels_row_2_effect, free_levels_row_3_effect, free_levels_row_4_effect,
+        free_levels_row_5_effect, free_tutorial_levels_effect,
+    };
+    use crate::state::red_ambrosia::{
+        RED_AMBROSIA_FREE_LEVELS_ROW_2, RED_AMBROSIA_FREE_LEVELS_ROW_3,
+        RED_AMBROSIA_FREE_LEVELS_ROW_4, RED_AMBROSIA_FREE_LEVELS_ROW_5,
+        RED_AMBROSIA_FREE_TUTORIAL_LEVELS,
+    };
+
+    let upgrades = &state.red_ambrosia.upgrades;
+    let tutorial = free_tutorial_levels_effect(upgrades[RED_AMBROSIA_FREE_TUTORIAL_LEVELS].level);
+    let row2 = free_levels_row_2_effect(upgrades[RED_AMBROSIA_FREE_LEVELS_ROW_2].level);
+    let row3 = free_levels_row_3_effect(upgrades[RED_AMBROSIA_FREE_LEVELS_ROW_3].level);
+    let row4 = free_levels_row_4_effect(upgrades[RED_AMBROSIA_FREE_LEVELS_ROW_4].level);
+    let row5 = free_levels_row_5_effect(upgrades[RED_AMBROSIA_FREE_LEVELS_ROW_5].level);
+
+    for (i, upgrade) in state.ambrosia.upgrades.iter_mut().enumerate() {
+        upgrade.free_level = match i {
+            0 => tutorial,
+            1..=3 => row2,
+            4..=9 => row3,
+            10..=12 => row4,
+            13..=16 => row5,
+            _ => 0.0,
+        };
+    }
 }
 
 /// `calculateQuarkMultiplier()` — the global quark-gain multiplier
@@ -6989,6 +7031,32 @@ mod tests {
         let mut state = GameState::default();
         let _ = tack(&mut state, &TackInput::default());
         assert!((state.quarks.quark_bonus - 25.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ambrosia_free_levels_populated_from_red_ambrosia() {
+        // Red-ambrosia freeLevelsRow2 grants free levels to blueberry row-2
+        // upgrades (quarks1/cubes1/luck1) only — not tutorial or row 4.
+        use crate::state::ambrosia::{AMBROSIA_QUARKS_1, AMBROSIA_QUARKS_2, AMBROSIA_TUTORIAL};
+        use crate::state::red_ambrosia::RED_AMBROSIA_FREE_LEVELS_ROW_2;
+        let mut state = GameState::default();
+        state.red_ambrosia.upgrades[RED_AMBROSIA_FREE_LEVELS_ROW_2].level = 5.0;
+        populate_ambrosia_free_levels(&mut state);
+        assert_eq!(state.ambrosia.upgrades[AMBROSIA_QUARKS_1].free_level, 5.0);
+        assert_eq!(state.ambrosia.upgrades[AMBROSIA_TUTORIAL].free_level, 0.0);
+        assert_eq!(state.ambrosia.upgrades[AMBROSIA_QUARKS_2].free_level, 0.0);
+    }
+
+    #[test]
+    fn ambrosia_free_levels_feed_quark_multiplier() {
+        // Red-ambrosia freeLevelsRow2 = 5 ⇒ ambrosiaQuarks1 effective level
+        // 0 + 5 ⇒ 1 + 0.01·5 = 1.05 (first-singularity bonus disabled).
+        use crate::state::red_ambrosia::RED_AMBROSIA_FREE_LEVELS_ROW_2;
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 1.0;
+        state.red_ambrosia.upgrades[RED_AMBROSIA_FREE_LEVELS_ROW_2].level = 5.0;
+        populate_ambrosia_free_levels(&mut state);
+        assert!((compute_quark_multiplier(&state) - 1.05).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -508,6 +508,12 @@ pub fn tack(state: &mut GameState, input: &TackInput) -> TickOutput {
     // then handed to Phase 5.
     let mut automation_pre = AutomationPre::default();
     let aggregator_outputs = phase_global_state(state);
+    // Quark multiplier (legacy `calculateQuarkMultiplier` / `allQuarkStats`):
+    // cached as a percent so the `applyBonus` consumers (cube opening, challenge
+    // rewards, achievement awards) credit the full multiplier. The field carries
+    // `(mult - 1) * 100`, so `1 + quark_bonus / 100 == calculateQuarkMultiplier()`.
+    let quark_multiplier = compute_quark_multiplier(state);
+    state.quarks.quark_bonus = (quark_multiplier - 1.0) * 100.0;
     // Phase 2b: coin production + tax. Mirrors the legacy `calculatetax()`
     // call slot — runs after the aggregators (it needs the fresh coin
     // multipliers), writes `g_cache.taxdivisor` for the *next* tick's
@@ -2480,6 +2486,186 @@ fn compute_octeract_per_second(state: &GameState) -> f64 {
         ),
         shop_ex_ultra_effect(shop[SHOP_EX_ULTRA], lifetime_ambrosia),
         ascension_speed_line,
+    ])
+}
+
+/// `calculateQuarkMultiplier()` — the global quark-gain multiplier
+/// (`allQuarkStats` product, original `Statistics.ts:1233` / `Calculate.ts:378`),
+/// self-derived from `&GameState`. Cached each tick into
+/// `state.quarks.quark_bonus` as `(mult - 1) * 100` (see [`tack`]) so the
+/// `applyBonus`-style consumers (cube opening, challenge rewards, achievement
+/// awards) credit the full multiplier — every such site reads
+/// `1 + quark_bonus / 100`, which equals this product.
+///
+/// Terms left at the multiplicative identity `1.0` are documented inline: the
+/// `quarkGain` achievement reward, the c15 quarks reward + quark-hepteract gate,
+/// `shopPanthema` / `infiniteAscent` (need their bonus-levels precompute /
+/// unlock gate), campaign bonus, and the UI/host-tier event + patreon
+/// (global / personal) bonuses. `favoriteUpgrade` passes a `0` maxed-sibling
+/// count (identity until that GQ upgrade is bought) and `ambrosiaCubeQuark1`
+/// passes a `0` `wow_cube_log_sum` — the same precedent as
+/// [`compute_ambrosia_luck_pre`]'s deferred cube-log terms.
+fn compute_quark_multiplier(state: &GameState) -> f64 {
+    use crate::mechanics::achievement_levels::achievement_level_from_points;
+    use crate::mechanics::ambrosia::{calculate_ambrosia_quark_mult, AmbrosiaMultInput};
+    use crate::mechanics::blueberry_upgrades::{
+        ambrosia_cube_quark_1_effect, ambrosia_luck_quark_1_effect, ambrosia_quarks_1_effect,
+        ambrosia_quarks_2_effect, ambrosia_quarks_3_effect, ambrosia_tutorial_effect,
+        AmbrosiaTutorialEffectKey,
+    };
+    use crate::mechanics::calculate::product_f64;
+    use crate::mechanics::golden_quark_upgrades::{
+        advanced_pack_effect, divine_pack_effect, expert_pack_effect, favorite_upgrade_effect,
+        intermediate_pack_effect, master_pack_effect, sing_quark_improver_1_effect,
+        AdvancedPackKey, DivinePackKey, ExpertPackKey, IntermediatePackKey, MasterPackKey,
+    };
+    use crate::mechanics::level_rewards::{get_level_reward, LevelRewardKey};
+    use crate::mechanics::octeract_bonuses::{
+        calculate_total_octeract_quark_bonus, CalculateTotalOcteractQuarkBonusInput,
+    };
+    use crate::mechanics::octeracts::{
+        octeract_quark_gain_2_effect, octeract_quark_gain_effect, octeract_starter_effect,
+        OcteractStarterKey,
+    };
+    use crate::mechanics::overflux_bonuses::calculate_quark_mult_from_powder;
+    use crate::mechanics::red_ambrosia_upgrades::{
+        viscount_effect, ViscountEffectKey, ViscountEffectValue,
+    };
+    use crate::mechanics::shop_upgrades::{shop_cash_grab_ultra_effect, ShopCashGrabUltraKey};
+    use crate::mechanics::singularity_challenges::{
+        limited_time_effect, sadistic_prequel_effect, LimitedTimeKey, SadisticPrequelKey,
+        SingularityEffectValue,
+    };
+    use crate::mechanics::singularity_milestones::calculate_singularity_quark_milestone_multiplier;
+    use crate::mechanics::talisman_effects::plastic_talisman_effects;
+
+    use crate::state::ambrosia::{
+        AMBROSIA_CUBE_QUARK_1, AMBROSIA_LUCK_QUARK_1, AMBROSIA_QUARKS_1, AMBROSIA_QUARKS_2,
+        AMBROSIA_QUARKS_3, AMBROSIA_TUTORIAL,
+    };
+    use crate::state::golden_quarks::{
+        GQ_ADVANCED_PACK, GQ_DIVINE_PACK, GQ_EXPERT_PACK, GQ_FAVORITE_UPGRADE,
+        GQ_INTERMEDIATE_PACK, GQ_MASTER_PACK, GQ_SING_QUARK_IMPROVER_1,
+    };
+    use crate::state::octeract_upgrades::{
+        OCTERACT_QUARK_GAIN, OCTERACT_QUARK_GAIN_2, OCTERACT_STARTER,
+    };
+    use crate::state::red_ambrosia::RED_AMBROSIA_VISCOUNT;
+    use crate::state::shop::SHOP_CASH_GRAB_ULTRA;
+    use crate::state::talismans::TALISMAN_PLASTIC;
+
+    // Legacy `player.cubeUpgrades[..]` indices (CookieUpgrade3 / CookieUpgrade18).
+    const CUBE_UPGRADE_QUARK_COOKIE_3: usize = 53;
+    const CUBE_UPGRADE_QUARK_COOKIE_18: usize = 68;
+
+    let sing = state.singularity.singularity_count;
+    let highest_sing = state.singularity.highest_singularity_count;
+    let shop = &state.shop.upgrades;
+    let cube = &state.cube_upgrade_levels.cube_upgrades;
+    let platonic = &state.cube_upgrade_levels.platonic_upgrades;
+    let achievement_level = achievement_level_from_points(state.achievements.achievement_points);
+    let lifetime_ambrosia = state.ambrosia.lifetime_ambrosia;
+    let ambrosia_luck = compute_ambrosia_luck_pre(state);
+    let gq = |i: usize| {
+        state.golden_quarks.upgrades[i].level + state.golden_quarks.upgrades[i].free_level
+    };
+    let oct = |i: usize| {
+        state.octeract_upgrades.upgrades[i].level + state.octeract_upgrades.upgrades[i].free_level
+    };
+    let amb = |i: usize| state.ambrosia.upgrades[i].level + state.ambrosia.upgrades[i].free_level;
+    let red = |i: usize| state.red_ambrosia.upgrades[i].level;
+
+    // Quark context → a missing singularity-challenge value is the multiplicative 1.
+    let scalar = |v: SingularityEffectValue| match v {
+        SingularityEffectValue::Scalar(s) => s,
+        SingularityEffectValue::Unlock(_) => 1.0,
+    };
+
+    // SingularityPacks: `1 + Σ packQuarkAdd` across the five GQ packs.
+    let singularity_packs = 1.0
+        + intermediate_pack_effect(gq(GQ_INTERMEDIATE_PACK), IntermediatePackKey::PackQuarkAdd)
+        + advanced_pack_effect(gq(GQ_ADVANCED_PACK), AdvancedPackKey::PackQuarkAdd)
+        + expert_pack_effect(gq(GQ_EXPERT_PACK), ExpertPackKey::PackQuarkAdd)
+        + master_pack_effect(gq(GQ_MASTER_PACK), MasterPackKey::PackQuarkAdd)
+        + divine_pack_effect(
+            gq(GQ_DIVINE_PACK),
+            DivinePackKey::PackQuarkAdd,
+            &state.corruptions.used.levels,
+        );
+
+    // Viscount red-ambrosia quark bonus → multiplicative scalar.
+    let viscount = match viscount_effect(red(RED_AMBROSIA_VISCOUNT), ViscountEffectKey::QuarkBonus)
+    {
+        ViscountEffectValue::Scalar(s) => s,
+        _ => 1.0,
+    };
+
+    product_f64(&[
+        1.0, // AchievementBonus — getAchievementReward('quarkGain') unported
+        get_level_reward(LevelRewardKey::Quarks, achievement_level),
+        plastic_talisman_effects(state.talismans.talisman_levels[TALISMAN_PLASTIC] as i32)
+            .quark_bonus,
+        if platonic[5] > 0.0 { 1.05 } else { 1.0 }, // PlatonicALPHA
+        if platonic[10] > 0.0 { 1.1 } else { 1.0 }, // PlatonicBETA
+        if platonic[15] > 0.0 { 1.15 } else { 1.0 }, // PlatonicOMEGA
+        1.0, // Jack (shopPanthema) — needs ShopPanthemaBonusLevels precompute
+        1.0, // Challenge15 — c15 quarks reward unported
+        1.0, // CampaignBonus — player.campaigns.quarkBonus unported
+        1.0, // InfiniteAscent — needs shop infiniteAscent unlock gate + rune
+        1.0, // QuarkHepteract — needs c15 hepteractsUnlocked gate + quark hepteract DR
+        calculate_quark_mult_from_powder(state.hepteracts.overflux_powder),
+        1.0 + sing / 10.0,                                     // SingularityCount
+        favorite_upgrade_effect(gq(GQ_FAVORITE_UPGRADE), 0.0), // siblings=0 until GQ bought
+        1.0 + 0.001 * cube[CUBE_UPGRADE_QUARK_COOKIE_3],       // CookieUpgrade3
+        1.0 + cube[CUBE_UPGRADE_QUARK_COOKIE_18] / 10_000.0
+            + 0.05 * (cube[CUBE_UPGRADE_QUARK_COOKIE_18] / 1_000.0).floor(), // CookieUpgrade18
+        calculate_singularity_quark_milestone_multiplier(sing),
+        if sing >= 200.0 {
+            (1.0 + (sing - 199.0) / 20.0).powi(2)
+        } else {
+            1.0
+        }, // skrauQ
+        calculate_total_octeract_quark_bonus(&CalculateTotalOcteractQuarkBonusInput {
+            exalt_4_enabled: state.singularity.no_octeracts.enabled,
+            total_wow_octeracts: state.cube_balances.total_wow_octeracts.to_number(),
+        }),
+        octeract_starter_effect(oct(OCTERACT_STARTER), OcteractStarterKey::QuarkMult),
+        octeract_quark_gain_effect(oct(OCTERACT_QUARK_GAIN)),
+        octeract_quark_gain_2_effect(
+            oct(OCTERACT_QUARK_GAIN_2),
+            oct(OCTERACT_QUARK_GAIN),
+            state.hepteracts.quark.bal,
+        ),
+        singularity_packs,
+        sing_quark_improver_1_effect(gq(GQ_SING_QUARK_IMPROVER_1)),
+        calculate_ambrosia_quark_mult(&AmbrosiaMultInput {
+            no_ambrosia_upgrades_enabled: state.singularity.no_ambrosia_upgrades.enabled,
+            lifetime_ambrosia,
+        }),
+        ambrosia_tutorial_effect(amb(AMBROSIA_TUTORIAL), AmbrosiaTutorialEffectKey::Quarks),
+        ambrosia_quarks_1_effect(amb(AMBROSIA_QUARKS_1)),
+        ambrosia_cube_quark_1_effect(amb(AMBROSIA_CUBE_QUARK_1), 0.0), // wow_cube_log_sum deferred
+        ambrosia_luck_quark_1_effect(amb(AMBROSIA_LUCK_QUARK_1), ambrosia_luck),
+        ambrosia_quarks_2_effect(amb(AMBROSIA_QUARKS_2), amb(AMBROSIA_QUARKS_1)),
+        ambrosia_quarks_3_effect(amb(AMBROSIA_QUARKS_3), amb(AMBROSIA_QUARKS_2)),
+        viscount,
+        shop_cash_grab_ultra_effect(
+            shop[SHOP_CASH_GRAB_ULTRA],
+            ShopCashGrabUltraKey::QuarkMult,
+            lifetime_ambrosia,
+        ),
+        scalar(limited_time_effect(
+            state.singularity.limited_time.completions,
+            LimitedTimeKey::QuarkMult,
+        )),
+        scalar(sadistic_prequel_effect(
+            state.singularity.sadistic_prequel.completions,
+            SadisticPrequelKey::QuarkMult,
+        )),
+        if highest_sing == 0.0 { 1.25 } else { 1.0 }, // FirstSingularityBonus
+        1.0,                                          // Event — UI-tier event calendar
+        1.0,                                          // GlobalSubscriber — patreon (host-tier)
+        1.0,                                          // AccountBonus — patreon (host-tier)
     ])
 }
 
@@ -6757,6 +6943,52 @@ mod tests {
     fn compute_offerings_default_is_base_floor() {
         // prestige_counter = 0 ⇒ time multiplier 0 ⇒ max(base 1, mult·0) = 1.
         assert_eq!(compute_offerings(&GameState::default()).to_number(), 1.0);
+    }
+
+    #[test]
+    fn quark_multiplier_default_is_first_singularity_bonus() {
+        // Fresh save: every term is the identity except FirstSingularityBonus
+        // (highestSingularityCount == 0 ⇒ ×1.25). Verbatim allQuarkStats product.
+        let state = GameState::default();
+        assert!((compute_quark_multiplier(&state) - 1.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quark_multiplier_neutral_after_first_singularity() {
+        // Once highestSingularityCount > 0 the first-singularity bonus drops and
+        // a fresh-otherwise state collapses to the identity 1.0.
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 1.0;
+        assert!((compute_quark_multiplier(&state) - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quark_multiplier_platonic_alpha_term() {
+        // PlatonicALPHA: platonicUpgrades[5] > 0 ⇒ ×1.05 (first-singularity off).
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 1.0;
+        state.cube_upgrade_levels.platonic_upgrades[5] = 1.0;
+        assert!((compute_quark_multiplier(&state) - 1.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quark_multiplier_includes_blueberry_quarks_1() {
+        // AmbrosiaQuarks1 (1 + 0.01n) is now wired into the product: level 10 ⇒
+        // ×1.10. Regression for the previously-uncalled blueberry quark effect.
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 1.0;
+        state.ambrosia.upgrades[crate::state::ambrosia::AMBROSIA_QUARKS_1].level = 10.0;
+        assert!((compute_quark_multiplier(&state) - 1.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tack_caches_quark_bonus_as_percent() {
+        // The tick caches `(calculateQuarkMultiplier() - 1) * 100` into
+        // quark_bonus, so applyBonus consumers see the full multiplier. Default
+        // multiplier 1.25 ⇒ quark_bonus 25.
+        let mut state = GameState::default();
+        let _ = tack(&mut state, &TackInput::default());
+        assert!((state.quarks.quark_bonus - 25.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -407,9 +407,9 @@ pub enum BuyRequest {
 
 /// Per-tier dispatcher for a manual reset, mirroring [`BuyRequest`].
 /// [`Self::Prestige`] / [`Self::Transcension`] / [`Self::Reincarnation`] /
-/// [`Self::Ascension`] are wired today; the singularity tier cascades on
-/// top and ports later.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// [`Self::Ascension`] / [`Self::Singularity`] are all wired. (`Eq` is not
+/// derived: [`Self::SingularityChallenge`] carries an `f64` target.)
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub enum ResetRequest {
     /// Manual prestige reset — the always-runs base reset
@@ -432,6 +432,18 @@ pub enum ResetRequest {
     /// `current_transcension/reincarnation_challenge` slots are zeroed as
     /// part of the shared ascension block in [`reset::perform_ascension_reset`].
     AscensionChallenge,
+    /// Manual singularity reset (`singularity(-1)`, `Reset.ts:1063`) — the
+    /// meta-reset above ascension. Grants golden quarks, advances the
+    /// singularity count (auto-climb), and rebuilds the player from a blank save
+    /// preserving meta-progression. Gated on the antiquities rune (level > 0).
+    Singularity,
+    /// Singularity challenge enter/exit (`singularity(setSingNumber)`). Same
+    /// reconstruction, but jumps the count to `set_sing_number` and skips the
+    /// antiquities gate (matching the legacy `setSingNumber !== -1` path).
+    SingularityChallenge {
+        /// The target `singularityCount` to jump to.
+        set_sing_number: f64,
+    },
 }
 
 /// `forcedDailyReset` (Calculate.ts:1638) — the once-per-real-day bookkeeping
@@ -3312,6 +3324,51 @@ fn compute_ascension_count(state: &GameState, effective_score: f64) -> f64 {
 
 /// `golden_quarks_multiplier_excluding_base` — self-derived from `&GameState`.
 ///
+/// `calculateGoldenQuarks()` (legacy `Calculate.ts`, granted on a singularity
+/// reset at `Reset.ts:1105`): the full `allGoldenQuarkMultiplierStats` product,
+/// i.e. `calculateBaseGoldenQuarks() × <the other 12 lines>`. The base reads
+/// quarks-this-singularity + the singularity / highest-singularity counts; the
+/// rest come from [`compute_golden_quarks_multiplier_excluding_base`].
+fn calculate_golden_quarks(state: &GameState) -> f64 {
+    use crate::mechanics::singularity_milestones::{
+        calculate_base_golden_quarks, CalculateBaseGoldenQuarksInput,
+    };
+    let base = calculate_base_golden_quarks(&CalculateBaseGoldenQuarksInput {
+        singularity: state.singularity.singularity_count,
+        quarks_this_singularity: state.golden_quarks.quarks_this_singularity,
+        highest_singularity_count: state.singularity.highest_singularity_count,
+    });
+    base * compute_golden_quarks_multiplier_excluding_base(state)
+}
+
+/// `calculateMaxSingularityLookahead(true)` — how many singularities the
+/// auto-climb advances per reset (legacy `Reset.ts:1108`). Self-derived from the
+/// fast-forward GQ / octeract upgrades; `1` at the default state.
+fn compute_singularity_lookahead(state: &GameState) -> f64 {
+    use crate::mechanics::golden_quark_upgrades::{
+        sing_fast_forward_2_effect, sing_fast_forward_effect,
+    };
+    use crate::mechanics::octeracts::octeract_fast_forward_effect;
+    use crate::mechanics::singularity_helpers::{
+        max_singularity_lookahead, MaxSingularityLookaheadInput,
+    };
+    use crate::state::golden_quarks::{GQ_SING_FAST_FORWARD, GQ_SING_FAST_FORWARD_2};
+    use crate::state::octeract_upgrades::OCTERACT_FAST_FORWARD;
+
+    let gq = |i: usize| {
+        state.golden_quarks.upgrades[i].level + state.golden_quarks.upgrades[i].free_level
+    };
+    let oct = |i: usize| {
+        state.octeract_upgrades.upgrades[i].level + state.octeract_upgrades.upgrades[i].free_level
+    };
+    max_singularity_lookahead(&MaxSingularityLookaheadInput {
+        non_zero: true,
+        sing_fast_forward_lookahead: sing_fast_forward_effect(gq(GQ_SING_FAST_FORWARD)),
+        sing_fast_forward_2_lookahead: sing_fast_forward_2_effect(gq(GQ_SING_FAST_FORWARD_2)),
+        octeract_fast_forward_lookahead: octeract_fast_forward_effect(oct(OCTERACT_FAST_FORWARD)),
+    })
+}
+
 /// Legacy Helper.ts `addTimers('goldenQuarks')` reduces
 /// `allGoldenQuarkMultiplierStats` (Statistics.ts:2337) but divides the `Base`
 /// line (`calculateBaseGoldenQuarks`) back out and applies it separately, so

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -117,6 +117,18 @@ pub(crate) fn perform_reset(
         ResetRequest::Reincarnation => perform_reincarnation_reset(state, gains),
         ResetRequest::Ascension => perform_ascension_reset(state, gains),
         ResetRequest::AscensionChallenge => perform_ascension_challenge_reset(state, gains),
+        ResetRequest::Singularity => {
+            // The antiquities-rune gate (Reset.ts:1064): the normal singularity
+            // path is a no-op without it (prevents the "double singularity bug").
+            if state.runes.rune_levels[crate::state::RUNE_ANTIQUITIES] > 0.0 {
+                perform_singularity_reset(state, -1.0)
+            } else {
+                SmallVec::new()
+            }
+        }
+        ResetRequest::SingularityChallenge { set_sing_number } => {
+            perform_singularity_reset(state, set_sing_number)
+        }
     }
 }
 
@@ -852,6 +864,166 @@ fn reset_talismans_ascension(talismans: &mut TalismansState) {
     talismans.mythical_fragments = 0.0;
 }
 
+/// `singularity(setSingNumber)` (`Reset.ts:1063-1285`) — the meta-reset above
+/// ascension. Grants golden quarks, advances the singularity count, and rebuilds
+/// the player from a blank save (`GameState::default()`) preserving only
+/// meta-progression. `set_sing_number < 0` is the normal auto-climb path;
+/// `>= 0` is the singularity-challenge enter/exit jump.
+///
+/// Survivors (the legacy `hold` copy, logic tier): achievements; golden quarks
+/// (balance + grant, all 80 upgrades, `total_quarks_ever`); the octeract /
+/// ambrosia-upgrade / red-ambrosia trees; shop; singularity challenge state +
+/// counts; automation prefs; the deterministic RNG and player level; the
+/// never-tier rune (horseShoe) and talismans (cookieGrandma, horseShoe); ant
+/// high-water marks (`highest_reborn_elo_ever`, per-mastery `highest_mastery`,
+/// `crumbs_ever_made`, sacrifice id); `cubeUpgrades[80]`; and the
+/// prestige/transcend/reincarnation counts once `highestSingularityCount >= 8`.
+/// Everything else resets to a fresh game.
+///
+/// Deferred (faithful for fresh saves): the elevator triad — the count advances
+/// `max(highest, count + lookahead)` (auto-climb), the only branch reachable
+/// while the elevator fields default to unlocked/non-slow. `worlds` (quarks)
+/// reset; the limitedTime `preserveQuarks` branch is inert until that
+/// singularity challenge is entered.
+pub(crate) fn perform_singularity_reset(
+    state: &mut GameState,
+    set_sing_number: f64,
+) -> SmallVec<[CoreEvent; 2]> {
+    use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+    use crate::state::{
+        RUNE_ANTIQUITIES, RUNE_HORSE_SHOE, TALISMAN_COOKIE_GRANDMA, TALISMAN_HORSE_SHOE,
+    };
+
+    // ── Grant + new counts (read pre-reset state) ──
+    let gq_grant = Decimal::from_finite(super::calculate_golden_quarks(state));
+    let old_count = state.singularity.singularity_count;
+    let old_highest = state.singularity.highest_singularity_count;
+    let antiquities = state.runes.rune_levels[RUNE_ANTIQUITIES] > 0.0;
+
+    let (new_count, new_highest, increment_highest) = if set_sing_number < 0.0 {
+        // Normal path — auto-climb (elevator unlocked, not slow-climb).
+        let increment = old_count == old_highest;
+        let lookahead = super::compute_singularity_lookahead(state);
+        (
+            old_highest.max(old_count + lookahead),
+            old_highest,
+            increment,
+        )
+    } else {
+        // Challenge enter/exit jump.
+        let increment = old_count == old_highest && set_sing_number > old_count && antiquities;
+        (set_sing_number, old_highest, increment)
+    };
+    let new_highest = if increment_highest {
+        new_highest + 1.0
+    } else {
+        new_highest
+    };
+    // goldenQuarks3 free-level milestone bumps at highest 5 / 10 (Reset.ts:1128).
+    let gq3_free_bonus = if increment_highest {
+        match new_highest as i64 {
+            5 => 1.0,
+            10 => 2.0,
+            _ => 0.0,
+        }
+    } else {
+        0.0
+    };
+    let total_quarks_ever =
+        state.golden_quarks.total_quarks_ever + state.golden_quarks.quarks_this_singularity;
+
+    // ── Capture survivors (before the blank-save reconstruction) ──
+    let achievements = state.achievements.clone();
+    let octeract_upgrades = state.octeract_upgrades.clone();
+    let red_ambrosia = state.red_ambrosia.clone();
+    let shop = state.shop.clone();
+    let automation = state.automation.clone();
+    let rng = state.rng.clone();
+    let level = state.level.clone();
+    let singularity = state.singularity; // Copy — keeps challenge state
+    let ambrosia_upgrades = state.ambrosia.upgrades;
+    let spent_blueberries = state.ambrosia.spent_blueberries;
+    let mut golden_quarks = state.golden_quarks.clone();
+    let prestige_count = state.reset_counters.prestige_count;
+    let transcend_count = state.reset_counters.transcend_count;
+    let reincarnation_count = state.reset_counters.reincarnation_count;
+    let cube_upgrade_80 = state.cube_upgrade_levels.cube_upgrades[80];
+    let horseshoe_level = state.runes.rune_levels[RUNE_HORSE_SHOE];
+    let horseshoe_exp = state.runes.rune_exp[RUNE_HORSE_SHOE];
+    let talisman_survivors = [TALISMAN_COOKIE_GRANDMA, TALISMAN_HORSE_SHOE].map(|i| {
+        (
+            i,
+            state.talismans.talisman_levels[i],
+            state.talismans.talisman_rarity[i],
+        )
+    });
+    let crumbs_ever_made = state.ants.crumbs_ever_made;
+    let highest_reborn_elo_ever = state.ants.highest_reborn_elo_ever.clone();
+    let ant_highest_masteries: [u8; 9] =
+        std::array::from_fn(|i| state.ants.masteries[i].highest_mastery);
+    let next_sacrifice_id = state.ants.current_sacrifice_id + 1;
+
+    // ── Blank-save reconstruction ──
+    *state = GameState::default();
+
+    // ── Restore survivors ──
+    state.achievements = achievements;
+    state.octeract_upgrades = octeract_upgrades;
+    state.red_ambrosia = red_ambrosia;
+    state.shop = shop;
+    state.automation = automation;
+    state.rng = rng;
+    state.level = level;
+
+    // Singularity: challenge state survives; counts set; counters zeroed.
+    state.singularity = singularity;
+    state.singularity.singularity_count = new_count;
+    state.singularity.highest_singularity_count = new_highest;
+    state.singularity.singularity_counter = 0.0;
+    state.singularity.sing_challenge_timer = 0.0;
+
+    // Golden quarks: grant added; upgrades survive; quarks-this-singularity reset.
+    golden_quarks.golden_quarks += gq_grant;
+    golden_quarks.quarks_this_singularity = 0.0;
+    golden_quarks.golden_quarks_timer = 0.0;
+    golden_quarks.total_quarks_ever = total_quarks_ever;
+    golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3].free_level += gq3_free_bonus;
+    state.golden_quarks = golden_quarks;
+
+    // Ambrosia: the upgrade tree + spent blueberries survive; currency resets.
+    state.ambrosia.upgrades = ambrosia_upgrades;
+    state.ambrosia.spent_blueberries = spent_blueberries;
+
+    // Prestige/transcend/reincarnation counts survive once highestSing >= 8.
+    if new_highest >= 8.0 {
+        state.reset_counters.prestige_count = prestige_count;
+        state.reset_counters.transcend_count = transcend_count;
+        state.reset_counters.reincarnation_count = reincarnation_count;
+    }
+    state.cube_upgrade_levels.cube_upgrades[80] = cube_upgrade_80;
+
+    // Never-tier runes / talismans.
+    state.runes.rune_levels[RUNE_HORSE_SHOE] = horseshoe_level;
+    state.runes.rune_exp[RUNE_HORSE_SHOE] = horseshoe_exp;
+    for (idx, lvl, rarity) in talisman_survivors {
+        state.talismans.talisman_levels[idx] = lvl;
+        state.talismans.talisman_rarity[idx] = rarity;
+    }
+
+    // Ant high-water marks.
+    state.ants.crumbs_ever_made = crumbs_ever_made;
+    state.ants.highest_reborn_elo_ever = highest_reborn_elo_ever;
+    for (mastery, highest) in state.ants.masteries.iter_mut().zip(ant_highest_masteries) {
+        mastery.highest_mastery = highest;
+    }
+    state.ants.current_sacrifice_id = next_sacrifice_id;
+
+    smallvec![CoreEvent::SingularityPerformed {
+        golden_quarks_gained: gq_grant,
+        singularity_count: new_count,
+    }]
+}
+
 /// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
 /// loops). Indices are the legacy 1-based positions, in range for the
 /// `[u8; UPGRADES_DEFAULT_LEN]` bitmap.
@@ -876,6 +1048,81 @@ mod tests {
             transcend_point_gain: Decimal::from_finite(transcend),
             reincarnation_point_gain: Decimal::from_finite(reincarnation),
         }
+    }
+
+    #[test]
+    fn singularity_reset_grants_gq_resets_economy_keeps_meta() {
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0; // gate open
+        state.upgrades.coins = Decimal::from_finite(1e50);
+        state.coin_producers.tiers[0].owned = 99.0;
+        state.reset_counters.ascension_count = 5.0;
+        state.cube_balances.wow_cubes = Decimal::from_finite(1e10);
+        state.achievements.achievement_points = 777.0; // meta — must survive
+        let events = perform_reset(&mut state, ResetRequest::Singularity, &gains(0.0, 0.0, 0.0));
+        // Golden quarks granted (default base 100), count auto-climbs 0 -> 1.
+        assert!(state.golden_quarks.golden_quarks.to_number() >= 100.0);
+        assert_eq!(state.singularity.singularity_count, 1.0);
+        // Economy rebuilt from a fresh save (GameState::default, == reset_save()).
+        assert_eq!(state.upgrades.coins, GameState::default().upgrades.coins);
+        assert_eq!(state.coin_producers.tiers[0].owned, 0.0);
+        assert_eq!(state.reset_counters.ascension_count, 0.0);
+        assert_eq!(state.cube_balances.wow_cubes.to_number(), 0.0);
+        // Meta-progression preserved.
+        assert_eq!(state.achievements.achievement_points, 777.0);
+        assert!(matches!(
+            events.first(),
+            Some(CoreEvent::SingularityPerformed { .. })
+        ));
+    }
+
+    #[test]
+    fn singularity_reset_no_op_without_antiquities() {
+        let mut state = GameState::default();
+        state.upgrades.coins = Decimal::from_finite(1e50);
+        let events = perform_reset(&mut state, ResetRequest::Singularity, &gains(0.0, 0.0, 0.0));
+        assert!(events.is_empty());
+        assert_eq!(state.singularity.singularity_count, 0.0);
+        assert_eq!(state.upgrades.coins.to_number(), 1e50); // untouched
+    }
+
+    #[test]
+    fn singularity_reset_preserves_gq_upgrades_and_accumulates_total_quarks() {
+        use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_1;
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.golden_quarks.golden_quarks = Decimal::from_finite(500.0);
+        state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_1].level = 5.0;
+        state.golden_quarks.quarks_this_singularity = 3e5;
+        perform_singularity_reset(&mut state, -1.0);
+        assert!(state.golden_quarks.golden_quarks.to_number() > 500.0); // balance + grant
+        assert_eq!(state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_1].level, 5.0); // survives
+        assert_eq!(state.golden_quarks.quarks_this_singularity, 0.0); // reset
+        assert_eq!(state.golden_quarks.total_quarks_ever, 3e5); // accumulated
+    }
+
+    #[test]
+    fn singularity_first_climb_increments_highest() {
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        perform_singularity_reset(&mut state, -1.0);
+        // count 0 == highest 0 ⇒ incrementHighest ⇒ highest 1.
+        assert_eq!(state.singularity.highest_singularity_count, 1.0);
+    }
+
+    #[test]
+    fn singularity_highest_five_grants_gq3_free_level() {
+        use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.singularity.singularity_count = 4.0;
+        state.singularity.highest_singularity_count = 4.0; // count == highest ⇒ increment
+        perform_singularity_reset(&mut state, -1.0);
+        assert_eq!(state.singularity.highest_singularity_count, 5.0);
+        assert_eq!(
+            state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3].free_level,
+            1.0
+        );
     }
 
     #[test]

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -29,10 +29,10 @@ porting notes.
 | Page | Covers | Overall |
 |---|---|---|
 | [reset-cascade.md](reset-cascade.md) | the prestige → … → singularity reset spine; what each tier grants / resets / unlocks | 🟩 mostly |
-| [core-economy.md](core-economy.md) | coins + the 4 building tiers, multipliers/accelerators, crystals, tax, research, obtainium | 🟨 (H1) |
-| [ascension-cubes.md](ascension-cubes.md) | ascension score hub, the 4 cube tiers, opening + blessings + upgrades, hepteracts/overflux | 🟨 |
+| [core-economy.md](core-economy.md) | coins + the 4 building tiers, multipliers/accelerators, crystals, tax, research, obtainium | 🟩 |
+| [ascension-cubes.md](ascension-cubes.md) | ascension score hub, the 4 cube tiers, opening + blessings + upgrades, hepteracts/overflux | 🟩 mostly |
 | [runes-talismans.md](runes-talismans.md) | offerings, the 10 runes, blessings, spirits, talismans, fragments | 🟩 |
-| [ants.md](ants.md) | ant producers / masteries / upgrades / sacrifice / crumbs / true-level | 🟩 (H2) |
+| [ants.md](ants.md) | ant producers / masteries / upgrades / sacrifice / crumbs / true-level | 🟩 |
 | [challenges-corruptions.md](challenges-corruptions.md) | challenges 1–15, corruptions, campaign, constants, auto-challenge | 🟩 |
 | [singularity-ambrosia.md](singularity-ambrosia.md) | singularity reset, golden quarks, octeracts, perks; ambrosia / blueberry / red-ambrosia | 🟧 / 🟨 |
 | [meta-economy.md](meta-economy.md) | quarks, shop, potions, purchases, codes, achievements, statistics/history | 🟩 mostly |
@@ -51,12 +51,12 @@ flowchart LR
   classDef bug fill:#f9a825,color:#000,stroke:#d50000,stroke-width:3px;
 
   infra["Infrastructure"]:::partial
-  coreEcon["Core economy"]:::bug
+  coreEcon["Core economy"]:::ported
   resets["Reset cascade"]:::ported
   research["Research / Obtainium"]:::ported
   offerings["Offerings"]:::ported
   runes["Runes / Talismans"]:::ported
-  ants["Ants"]:::bug
+  ants["Ants"]:::ported
   challenges["Challenges / Corruptions"]:::ported
   ascension["Ascension / Cubes"]:::partial
   hepteracts["Hepteracts / Overflux"]:::partial
@@ -86,23 +86,26 @@ flowchart LR
   achievements -->|"per-ach quarks"| meta
 ```
 
-## Open parity bugs (flagged on the pages)
+## Open parity bugs
 
-HIGH findings still open on `main` — full detail in [`PARITY_AUDIT.md`](../../PARITY_AUDIT.md):
-
-| Id | Where | One-liner |
-|---|---|---|
-| **H1** | [core-economy](core-economy.md) | crystals / `prestige_shards` read & write hit different slices → crystal coin-mult under-credited |
-| **H2** | [ants](ants.md) | `calculate_true_ant_level` called at 2/~14 sites → free levels + extinction divisor still bypassed at most sites |
+**None.** Every HIGH finding from the audit is now fixed in code, each verified against
+`crates/synergismforkd_logic/`. Full audit detail in [`PARITY_AUDIT.md`](../../PARITY_AUDIT.md).
 
 Fixed since the audit (shown green): **C1** global-speed mult, **C2** c10→ascension unlock,
-**H6** cube-opening, **H7** ant-sacrifice, via PR #265 **P1.4** C15 accrual / **H3** rune
-effective-level pipeline / **H4** rune-blessing power, and — via PR #269 — **H5** (achievement points
-now recompute on load + every award group feeds the total).
+**H6** cube-opening, **H7** ant-sacrifice; via PR #265 **P1.4** C15 accrual / **H3** rune
+effective-level pipeline / **H4** rune-blessing power; via PR #269 **H5** (achievement points
+recompute on load + every award group feeds the total); and now **H1** and **H2** — both already
+fixed in code, the map had simply gone stale:
 
-> **Baseline caveat.** This reflects `main` *after* PR #265 plus branch `claude/nifty-colden-ef7278`
-> (PR #269), which fixes **H5** (achievement points) and lands the autobuyers + save export/import.
-> Still-open: **H1**, **H2**.
+- **H1** — crystals / `prestige_shards` read *and* write the same `crystal_upgrades` slice; covered
+  by the regression test `prestige_shards_accumulate_across_ticks` (`tick/mod.rs`).
+- **H2** — a shared `true_ant_level()` wrapper (`tick/mod.rs:655`) threads the true level (free
+  levels + extinction divisor) through every ant-production site, not just two.
+
+> **Baseline caveat.** Reflects `main` *after* PR #265 + branch `claude/nifty-colden-ef7278`
+> (PR #269). **No HIGH parity bugs remain open.** Remaining porting work is feature breadth, not
+> bugs: the singularity layer, three deferred autobuyer families, and the `unlocks` schema keys
+> (tracked on their pages).
 
 ## Appendix: full single-canvas map
 

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -34,7 +34,7 @@ porting notes.
 | [runes-talismans.md](runes-talismans.md) | offerings, the 10 runes, blessings, spirits, talismans, fragments | 🟩 |
 | [ants.md](ants.md) | ant producers / masteries / upgrades / sacrifice / crumbs / true-level | 🟩 |
 | [challenges-corruptions.md](challenges-corruptions.md) | challenges 1–15, corruptions, campaign, constants, auto-challenge | 🟩 |
-| [singularity-ambrosia.md](singularity-ambrosia.md) | singularity reset, golden quarks, octeracts, perks; ambrosia / blueberry / red-ambrosia | 🟧 / 🟨 |
+| [singularity-ambrosia.md](singularity-ambrosia.md) | singularity reset, golden quarks, octeracts, perks; ambrosia / blueberry / red-ambrosia | 🟩 mostly |
 | [meta-economy.md](meta-economy.md) | quarks, shop, potions, purchases, codes, achievements, statistics/history | 🟩 mostly |
 | [infrastructure.md](infrastructure.md) | game loop, calculate engine, state schema, events, save, UI, automation, RNG | 🟨 |
 
@@ -60,8 +60,8 @@ flowchart LR
   challenges["Challenges / Corruptions"]:::ported
   ascension["Ascension / Cubes"]:::partial
   hepteracts["Hepteracts / Overflux"]:::partial
-  singularity["Singularity"]:::stub
-  ambrosia["Ambrosia"]:::partial
+  singularity["Singularity"]:::partial
+  ambrosia["Ambrosia"]:::ported
   meta["Quarks / Shop"]:::ported
   achievements["Achievements"]:::ported
 
@@ -103,9 +103,12 @@ fixed in code, the map had simply gone stale:
   levels + extinction divisor) through every ant-production site, not just two.
 
 > **Baseline caveat.** Reflects `main` *after* PR #265 + branch `claude/nifty-colden-ef7278`
-> (PR #269). **No HIGH parity bugs remain open.** Remaining porting work is feature breadth, not
-> bugs: the singularity layer, three deferred autobuyer families, and the `unlocks` schema keys
-> (tracked on their pages).
+> (PR #269), plus branch `claude/close-unmigrated-systems`: the quark multiplier
+> (`calculateQuarkMultiplier`) + blueberry quark/free-levels are ported, the 21 `unlocks` keys are
+> complete, and **the singularity layer is live** (reset + GQ grant + seeded metadata). **No HIGH
+> parity bugs remain open.** Remaining: the three deferred autobuyer families (talisman / ant-upgrade
+> / tesseract — each needs a prerequisite), the singularity elevator triad + challenge entry, and the
+> UI tree.
 
 ## Appendix: full single-canvas map
 

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -105,9 +105,9 @@ fixed in code, the map had simply gone stale:
 > **Baseline caveat.** Reflects `main` *after* PR #265 + branch `claude/nifty-colden-ef7278`
 > (PR #269), plus branch `claude/close-unmigrated-systems`: the quark multiplier
 > (`calculateQuarkMultiplier`) + blueberry quark/free-levels are ported, the 21 `unlocks` keys are
-> complete, and **the singularity layer is live** (reset + GQ grant + seeded metadata). **No HIGH
-> parity bugs remain open.** Remaining: the three deferred autobuyer families (talisman / ant-upgrade
-> / tesseract — each needs a prerequisite), the singularity elevator triad + challenge entry, and the
+> complete, **the singularity layer is live** (reset + GQ grant + seeded metadata), and **all 13
+> `updateAll` autobuyer families are wired** (incl. talisman / tesseract / ant-upgrade). **No HIGH
+> parity bugs remain open.** Remaining: the singularity elevator triad + challenge entry, and the
 > UI tree.
 
 ## Appendix: full single-canvas map

--- a/docs/systems/ants.md
+++ b/docs/systems/ants.md
@@ -17,7 +17,7 @@ flowchart LR
   antCrumbs["Crumbs"]:::ported
   antMastery["Ant masteries"]:::ported
   antUpg["Ant upgrades"]:::ported
-  antTrueLvl["Ant true-level ⚠H2"]:::bug
+  antTrueLvl["Ant true-level"]:::ported
   antSac["Ant sacrifice"]:::ported
 
   corr["Corruptions ↗ challenges"]:::ext
@@ -54,14 +54,17 @@ flowchart LR
 |---|---|---|
 | Producers, masteries, upgrades, crumbs | 🟩 Ported | `mechanics/ant_producers.rs`, `ant_masteries.rs`, `ant_upgrades.rs`, `state/ants.rs` |
 | Ant sacrifice | 🟩 Ported | `tick/mod.rs:5882`, `mechanics/ant_sacrifice.rs` (was audit **H7**) |
-| Ant true-level | 🟨 Partial ⚠**H2** | `mechanics/ant_upgrade_levels.rs::calculate_true_ant_level` |
+| Ant true-level | 🟩 Ported | shared `true_ant_level()` wrapper, `mechanics/ant_upgrade_levels.rs::calculate_true_ant_level` |
 
-## Porting notes / open bugs
+## Porting notes
 
-- ⚠ **H2 — true-level bypassed:** `calculate_true_ant_level` exists and is correct, but is called at
-  only **~2 of ~14** production sites (`tick/mod.rs:676`, `:2549`). Everywhere else the **raw** level is
-  fed to coin mult, multiplier mult, accelerator-boost mult, building power, tax reduction, etc., so
-  free levels and the extinction divisor are skipped. The correct calls prove the fix is mechanical —
-  it just needs threading to the remaining sites.
+- ✅ **H2 — true-level threaded (FIXED):** a shared `true_ant_level()` wrapper (`tick/mod.rs:655`)
+  computes the free-level pool + extinction divisor (with the four `exemptFromCorruption` upgrades) and
+  is called at **every** ant-production site — coin mult, multiplier mult, accelerator-boost mult,
+  building power, tax reduction, ascension-score base, etc. The audit's "~2 of ~14" snapshot is stale.
+- Two free-level *input* terms stay neutral-defaulted (identity at the default state): the
+  `freeAntUpgrades` achievement reward (→ 0) and the challenge-15 `bonusAntLevel` multiplier (→ 1.0).
+  These only diverge once those sources feed in; not a bypass. Wiring the now-ported achievement
+  reward is a small follow-up.
 - **Sacrifice** is wired and faithful (ELO, reborn-ELO, talisman tiers, offerings); some free-level
   inputs are neutral-defaulted pending the achievement/C15 sources that feed them.

--- a/docs/systems/ascension-cubes.md
+++ b/docs/systems/ascension-cubes.md
@@ -17,7 +17,7 @@ flowchart LR
   ascReset["Ascension reset"]:::ported
   ascShards["Ascend shards"]:::ported
   ascBldg["Ascend buildings ×5"]:::ported
-  ascScore["Ascension score"]:::partial
+  ascScore["Ascension score"]:::ported
   wowCubes["Wow cubes"]:::ported
   tesseracts["Tesseracts"]:::ported
   hypercubes["Hypercubes"]:::ported
@@ -74,7 +74,7 @@ flowchart LR
   classDef ext fill:#eceff1,color:#37474f,stroke:#90a4ae,stroke-dasharray:4 3;
 
   ch15["Challenge 15 ↗ challenges"]:::ported
-  hepteracts["Hepteracts ·6"]:::partial
+  hepteracts["Hepteracts ·6"]:::ported
   hepAutoCraft["Hepteract auto-craft"]:::ported
   overfluxPowder["Overflux powder"]:::ported
   overfluxOrbs["Overflux orbs"]:::ported
@@ -105,18 +105,22 @@ flowchart LR
 | System | Status | Rust |
 |---|---|---|
 | Ascension reset + award | 🟩 Ported | `tick/reset.rs:460-650` |
-| Ascension score | 🟨 Partial | under-credited by **H2** (ant true-level) and a c11 collapse |
+| Ascension score | 🟩 Ported | H2 fixed (routes `true_ant_level`); base arrays + c10 exponent + 1e23 softcap match TS |
 | Cube tiers + opening (RNG) | 🟩 Ported | `mechanics/cube_opening.rs` (was audit **H6**) |
 | Cube/platonic blessings + upgrades | 🟩 Ported | `cube_blessings.rs`, `platonic_blessings.rs`, `cube_upgrades.rs`, `platonic_upgrade_costs.rs` |
-| Hepteracts | 🟨 Partial | `mechanics/hepteract_values.rs`, `hepteract_effects.rs` |
+| Hepteracts | 🟩 Ported | `mechanics/hepteract_values.rs`, `hepteract_effects.rs` (DR softening on all 4 effects) |
 | Overflux orbs / powder | 🟩 Ported | `mechanics/overflux_bonuses.rs` |
 
 ## Porting notes / open bugs
 
 - **Cube opening** (audit **H6**) and **ascension reset/award** are done — this whole tree is largely
   faithful and is one of the more complete areas.
-- **Hepteracts:** raw `.bal` is fed to 4 effects (chronos/hyperrealism/accelerator/multiplier),
-  skipping the diminishing-returns softening past 1000 (medium finding). Challenge + acceleratorBoost
-  hepteracts correctly call `hepteract_effective()`.
-- **Score** is the main carrier of the **H2** ant-true-level shortfall — see [ants.md](ants.md).
-- Cube upgrades 4/5/6 regrant on ascension reset rather than immediately (medium: intra-ascension loss).
+- ✅ **Hepteracts (DR softening done):** all 4 effects (chronos/hyperrealism/accelerator/multiplier)
+  feed `hepteract_effective_bal()` (`tick/mod.rs:1283,1371,2140,2937`), applying the diminishing-returns
+  softening past 1000 — matches TS `Hepteracts.ts`. Chronos uses the `platonicUpgrades[19]/750` DR
+  increase.
+- ✅ **Score — H2 fixed:** ascension score routes ant-upgrade index 14 through `true_ant_level()`
+  like every other ant site (see [ants.md](ants.md)). c10→ascension unlock (audit **C2**) is also wired
+  in production (`tick/mod.rs:5753`).
+- Cube upgrades 4/5/6 regrant the just-cleared upgrade slots **on ascension reset**, matching TS
+  `Reset.ts:739-751` (faithful port — the TS regrants at the same point, not on purchase).

--- a/docs/systems/core-economy.md
+++ b/docs/systems/core-economy.md
@@ -88,7 +88,7 @@ flowchart LR
   `accelBoostCostDelay` now feeds the cost (the runes-page wire). The autobuyer path
   (`boostAccelerator(true)`) is now wired into the `updateAll` driver, and the `acceleratorBoosts`
   achievement group now awards.
-- **`updateAll` autobuyers now self-drive** (PR #269, `tick/auto_buy.rs`, Phase 5): producers
+- **`updateAll` autobuyers now self-drive** (`tick/auto_buy.rs`, Phase 5): producers
   (coin/diamond/mythos/particle), accelerator/multiplier/boost, crystal upgrades, the upgrade tab,
-  ascension constants, and ant producers/masteries — 10 of 13 families (ant-upgrades / talisman /
-  tesseract deferred behind prerequisites). A pure-idle Rust loop auto-buys once the toggles are on.
+  ascension constants, ant producers/masteries/upgrades, talismans, and tesseracts — **all 13
+  families**. A pure-idle Rust loop auto-buys once the toggles are on.

--- a/docs/systems/core-economy.md
+++ b/docs/systems/core-economy.md
@@ -17,13 +17,13 @@ flowchart LR
   coinBldg["Coin buildings ×5"]:::ported
   coins["Coins"]:::ported
   coinUpg["Coin upgrades"]:::ported
-  crystals["Crystals ⚠H1"]:::bug
+  crystals["Crystals"]:::ported
   crystalUpg["Crystal upgrades"]:::ported
   bldgPower["Building power"]:::ported
   tax["Tax · cost scaling"]:::ported
   mult["Multipliers"]:::ported
   accel["Accelerators"]:::ported
-  accelBoost["Accelerator boosts"]:::stub
+  accelBoost["Accelerator boosts"]:::ported
   globalSpeed["Global speed mult"]:::ported
   research["Research grid ·200"]:::ported
   obtainium["Obtainium"]:::ported
@@ -69,17 +69,20 @@ flowchart LR
 |---|---|---|
 | Coin/diamond/mythos/particle buildings + currencies | 🟩 Ported | `mechanics/coin_production.rs`, `producers.rs`, `particle_buildings.rs` |
 | Coin/prestige/transcend/reincarnation upgrades | 🟩 Ported | `mechanics/upgrades.rs`, `state/upgrades.rs` |
-| Crystals / `prestige_shards` | 🟨 Partial ⚠**H1** | `state/crystal_upgrades.rs`, `mechanics/resource_gain.rs` |
+| Crystals / `prestige_shards` | 🟩 Ported | `state/crystal_upgrades.rs`, `mechanics/resource_gain.rs` (H1 fixed) |
 | Multipliers / accelerators | 🟩 Ported | `mechanics/multipliers.rs`, `accelerators.rs` |
-| Accelerator boosts | 🟧 Stub | `mechanics/accelerator_boosts.rs` — cost ported, **no buy handler** → stays 0 |
+| Accelerator boosts | 🟩 Ported | `mechanics/accelerator_boosts.rs` — both buy paths + autobuyer wired |
 | Global speed mult | 🟩 Ported | fixed in `tick/mod.rs:585` (was audit **C1**) |
 | Research + Obtainium | 🟩 Ported | `mechanics/researches.rs`, `resource_gain.rs` |
 | Building power / tax | 🟩 Ported | `mechanics/crystal_and_building_power.rs` |
 
 ## Porting notes / open bugs
 
-- ⚠ **H1 — crystals desync:** `prestige_shards` is read from `crystal_upgrades.prestige_shards`
-  (seeded right) but written to a different slice, so the crystal coin-multiplier is under-credited.
+- ✅ **H1 — crystals desync (FIXED):** `prestige_shards` is read *and* written on the same
+  `crystal_upgrades.prestige_shards` slice (seed `resource_gain.rs:385`, writeback `tick/mod.rs:5954`,
+  multiplier `tick/mod.rs:1170`). Covered by the regression test
+  `prestige_shards_accumulate_across_ticks` (`tick/mod.rs`). The old `reset_counters.prestige_shards`
+  field is vestigial (only ever zeroed, never read) — a candidate for cleanup.
 - **Accelerator boosts** are ported — `BuyRequest::AcceleratorBoost` runs the classic
   single-boost+prestige-reset path and the bulk solver, and the thrift rune-blessing
   `accelBoostCostDelay` now feeds the cost (the runes-page wire). The autobuyer path

--- a/docs/systems/infrastructure.md
+++ b/docs/systems/infrastructure.md
@@ -57,7 +57,7 @@ flowchart LR
 |---|---|---|
 | Tick / game loop | 🟩 Mostly | `tick/mod.rs` + `tick/auto_buy.rs` (10/13 `updateAll` autobuyer families self-drive; ant-upgrades / talisman / tesseract deferred — each needs an unported prerequisite) |
 | Calculate engine | 🟩 Ported | `mechanics/calculate.rs`, `math/*` (leaf math faithful; golden-vector coverage thin) |
-| State schema | 🟨 Partial | `state/` (~80%; `unlocks` only 8/21 keys; some rune-blessing type divergence) |
+| State schema | 🟨 Partial | `state/` (~85%; `unlocks` now 21/21 keys; + `total_quarks_ever`; some rune-blessing type divergence) |
 | Events enum | 🟩 Ported | `events/mod.rs` |
 | Save / Import-Export | 🟨 Partial | `crates/synergismforkd_save/` (postcard round-trip + versioned envelope + base64 export/import string + on-load achievement recompute; persistent storage + save-on-tick are host-tier) |
 | UI render | 🟧 Stub | `synergismforkd_ui*` (scaffold) |

--- a/docs/systems/infrastructure.md
+++ b/docs/systems/infrastructure.md
@@ -55,7 +55,7 @@ flowchart LR
 
 | System | Status | Rust |
 |---|---|---|
-| Tick / game loop | 🟩 Mostly | `tick/mod.rs` + `tick/auto_buy.rs` (10/13 `updateAll` autobuyer families self-drive; ant-upgrades / talisman / tesseract deferred — each needs an unported prerequisite) |
+| Tick / game loop | 🟩 Ported | `tick/mod.rs` + `tick/auto_buy.rs` (all 13 `updateAll` autobuyer families self-drive) |
 | Calculate engine | 🟩 Ported | `mechanics/calculate.rs`, `math/*` (leaf math faithful; golden-vector coverage thin) |
 | State schema | 🟨 Partial | `state/` (~85%; `unlocks` now 21/21 keys; + `total_quarks_ever`; some rune-blessing type divergence) |
 | Events enum | 🟩 Ported | `events/mod.rs` |
@@ -67,15 +67,14 @@ flowchart LR
 ## Porting notes
 
 - The **logic core is healthy**. The remaining infrastructure gaps are the **UI** tree (still
-  scaffold), three deferred autobuyer families, and the host-tier slice of save (persistent storage,
-  save-on-tick).
-- The **`updateAll` autobuyers now self-drive** (`tick/auto_buy.rs`, run in Phase 5): autoUpgrades +
+  scaffold) and the host-tier slice of save (persistent storage, save-on-tick).
+- ✅ **All 13 `updateAll` autobuyer families self-drive** (`tick/auto_buy.rs`, Phase 5): autoUpgrades +
   coin/diamond/mythos/particle producers + accelerator/multiplier/boost + crystal upgrades + constant
-  upgrades + ant producers/masteries. Deferred (dormant at default, each needs an unported
-  prerequisite): the **ant-upgrade** autobuyer (16 per-upgrade `autobuy()` achievement-reward gates),
-  the **talisman** autobuyer (`buyTalismanLevelToRarityIncrease` rarity-loop wrapper), and the
-  **tesseract** autobuyer (`resetToggleModes.ascension` state + budget machinery). Inert on a fresh
-  save (`player.toggles[1..=26]` default false).
+  upgrades + ant producers/masteries + the formerly-deferred three — **talisman** (Family 11,
+  `buyTalismanLevelToRarityIncrease`), **tesseract** (Family 12, AMOUNT mode +
+  `calculate_tess_buildings_in_budget`), and **ant-upgrades** (Family 13, per-upgrade
+  achievement/research/milestone gates). Inert on a fresh save (`player.toggles[1..=26]` default
+  false). The PERCENTAGE-mode tesseract path (on-ascension) is a separate, non-`updateAll` call site.
 - **Save-load** gained a base64 export/import string API and an on-load **achievement-points
   recompute** (the full 509-entry `ACHIEVEMENT_POINT_VALUES` table → closes audit **H5**). The Rust
   save format is fresh (no TS-save compat); persistent storage + save-on-tick stay host-tier.

--- a/docs/systems/meta-economy.md
+++ b/docs/systems/meta-economy.md
@@ -61,7 +61,7 @@ flowchart LR
 
 | System | Status | Rust |
 |---|---|---|
-| Quarks (incl. per-achievement reward) | 🟩 Ported | `state/quarks.rs`, `mechanics/quarks.rs` |
+| Quarks (gain + `calculateQuarkMultiplier`) | 🟩 Ported | `state/quarks.rs`, `mechanics/quarks.rs`, `compute_quark_multiplier` (tick) |
 | Shop upgrades + costs | 🟩 Ported | `mechanics/shop_upgrades.rs`, `shop_costs.rs` |
 | Potions / consumables | 🟩 Ported | `state/shop.rs` |
 | Purchases / cosmetics / codes | ⬜ Absent | monetization + backend parked — see [`BACKEND_API_PLAN.md`](../../BACKEND_API_PLAN.md) |
@@ -80,17 +80,26 @@ flowchart LR
   reincarnation), accelerators/multipliers/acceleratorBoosts, speed-rune level/freeLevel/blessing/
   spirit, constant (ascendShards), antCrumbs, ascensionScore — on top of the pre-existing building /
   point-gain / challenge / sacrifice / no-reset groups.
+- ✅ **Quark multiplier ported.** `compute_quark_multiplier` now assembles `allQuarkStats`
+  (`Statistics.ts:1233`) and caches it into `quark_bonus` each tick as `(mult − 1)·100` — it was
+  **never written** (always `0` ⇒ every quark gain credited at ×1). ~28 terms ported (achievements
+  level, talisman, platonic, powder, singularity count, octeract bonuses, GQ packs, ambrosia incl. the
+  blueberry quark upgrades, viscount, cash-grab, first-singularity); ~7 left at identity and documented
+  (`quarkGain` achievement reward, c15 quark reward + quark-hepteract gate, shopPanthema, infiniteAscent,
+  campaign, patreon).
 - **Still blocked** (each needs an unported prerequisite): `campaignTokens` (the running token total
-  isn't a Rust state field), `singularityCount` (singularity paused), `addCodesUsed` (UI-tier code
-  array), progressive slots 8–11 (exalt rewardAP + upgrade `maxLevel` tracking unported). The
-  `getAchievementReward('quarkGain')` reward-reader is blocked on the unported quark-multiplier
-  assembler (`allQuarkStats` → `quark_bonus` is currently a static cache).
+  isn't a Rust state field), `addCodesUsed` (UI-tier code array), progressive slots 8–11 (exalt
+  rewardAP + upgrade `maxLevel` tracking unported). `singularityCount` now increments (the layer is
+  live — see [singularity-ambrosia](singularity-ambrosia.md)), so its award group is unblocked; the
+  `getAchievementReward('quarkGain')` term is the one quark-multiplier identity still pending a
+  per-reward port.
 - **Shop: ~50 of 83 effects are wired** (chronometer→ascension-speed, season-pass→cube-mults,
   offering/obtainium EX + cashGrab, the cube-blessing/quark-from-opening paths, costs + potions — all
   done). The remaining ~33 are mostly **blocked or out of reachable scope**: the quark-conversion
-  family (`cubeToQuark*`/`improveQuarkHept*` — the `allQuarkStats`/`quark_bonus` multiplier is
-  unported), the `calculator` family (UI add-codes), daily/powder/warp + `improved_daily` (host-tier
-  daily reset), `shop_singularity_*` (paused), `infinite_shop_upgrades` (unported shop-tablet sum).
+  family (`cubeToQuark*`/`improveQuarkHept*` feed the quark-hepteract term that
+  `compute_quark_multiplier` still leaves neutral pending its c15 gate), the `calculator` family (UI
+  add-codes), daily/powder/warp + `improved_daily` (host-tier daily reset), `shop_singularity_*`,
+  `infinite_shop_upgrades` (unported shop-tablet sum).
   `constant_ex` is now wired. A few minor reachable wires remain (`challenge_tome` needs its
   research + c10-gating component; `obtainium_auto`).
 - The **bonus-level composition** (effective shop level = raw `shopUpgrades[key]` + topHat-rune /

--- a/docs/systems/reset-cascade.md
+++ b/docs/systems/reset-cascade.md
@@ -20,7 +20,7 @@ flowchart LR
   transReset["Transcension reset"]:::ported
   reincReset["Reincarnation reset"]:::ported
   ascReset["Ascension reset"]:::ported
-  singReset["Singularity reset · paused"]:::stub
+  singReset["Singularity reset · live"]:::ported
 
   prestigePts["Prestige points"]:::ported
   transPts["Transcend pts · Mythos"]:::ported
@@ -55,7 +55,7 @@ flowchart LR
 | **Transcension** | Transcend points (Mythos) | the above + prestige layer | mythos buildings, crystals, challenges 1–5 |
 | **Reincarnation** | Reincarnation points (Particles) | + transcension layer | particle buildings, obtainium, research, runes, ants, challenges 6–10 |
 | **Ascension** | Wow cubes → platonic cubes, ascend shards, offerings | + reincarnation layer (coins…particles, runes, research) | ascend buildings, challenges 11–15, the whole cube tree |
-| **Singularity** | Golden quarks | essentially everything except persistent shop/GQ unlocks | golden-quark + octeract + ambrosia trees. **Paused in Rust** |
+| **Singularity** | Golden quarks | essentially everything except persistent shop/GQ unlocks | golden-quark + octeract + ambrosia trees. **Live in Rust** |
 
 ## Port status
 
@@ -63,12 +63,14 @@ flowchart LR
 |---|---|---|
 | Prestige / Transcension / Reincarnation | 🟩 Ported | `tick/reset.rs:117-460` |
 | Ascension (reset + `CalcCorruptionStuff` award) | 🟩 Ported | `tick/reset.rs:460-650` |
-| Singularity | 🟧 Stub (paused) | `tick/mod.rs:5600+` — `singularity_count` never increments, so the whole layer is inert |
+| Singularity | 🟩 Ported (live) | `tick/reset.rs::perform_singularity_reset` — increments `singularity_count`, grants golden quarks, rebuilds from a blank save preserving meta |
 
 ## Porting notes
 
 - The reset cascade through **ascension is complete and faithful**, including the corruption-effects
   and extinction divisor used by the ascension award.
-- **Singularity is paused by design**: golden-quark / octeract / perk machinery is ported but never
-  fires because nothing increments `singularity_count`. See [singularity-ambrosia.md](singularity-ambrosia.md).
+- ✅ **Singularity is live**: `perform_singularity_reset` (`ResetRequest::Singularity`, gated on the
+  antiquities rune) grants `calculateGoldenQuarks` and rebuilds the player from `GameState::default()`
+  preserving meta-progression. Auto-climb count advance; elevator triad + challenge entry deferred.
+  See [singularity-ambrosia.md](singularity-ambrosia.md).
 - Counts increment by a flat `+1` rather than `floor(multiplier)` (medium finding **P1.6**).

--- a/docs/systems/singularity-ambrosia.md
+++ b/docs/systems/singularity-ambrosia.md
@@ -5,24 +5,29 @@ golden-quark and **octeract** upgrades plus **perks**. **Ambrosia** (and its sib
 is a parallel idle currency spent on **blueberry** upgrades. Source: `singularity.ts`,
 `SingularityChallenges.ts`, `Octeracts.ts`, `BlueberryUpgrades.ts`, `RedAmbrosiaUpgrades.ts`.
 
-> **Whole layer is paused in Rust.** The pieces are ported but `singularity_count` never increments,
-> so nothing here actually fires yet. Colors reflect that: machinery 🟩/🟨 but the layer is 🟧 inert.
+> **The layer is now LIVE.** `perform_singularity_reset` (`tick/reset.rs`) increments
+> `singularity_count`, grants golden quarks (`calculateGoldenQuarks`), and rebuilds the player from a
+> blank save preserving meta-progression — triggered by `ResetRequest::Singularity` (gated on the
+> antiquities rune). The 80-entry GQ-upgrade metadata is seeded, so costs are real. Deferred: the
+> elevator triad (auto-climb only) and singularity-challenge *entry* (the challenge state + jump path
+> exist via `SingularityChallenge`, but auto/UI entry is unwired).
 
 ## Singularity
 
 ```mermaid
 flowchart LR
   classDef ported fill:#2e7d32,color:#fff,stroke:#1b5e20;
+  classDef partial fill:#f9a825,color:#000,stroke:#f57f17;
   classDef stub fill:#ef6c00,color:#fff,stroke:#bf360c;
   classDef ext fill:#eceff1,color:#37474f,stroke:#90a4ae,stroke-dasharray:4 3;
 
-  singReset["Singularity reset · paused"]:::stub
+  singReset["Singularity reset · live"]:::ported
   goldenQuarks["Golden quarks"]:::ported
   gqUpg["GQ upgrades"]:::ported
   octeracts["Octeracts"]:::ported
   octUpg["Octeract upgrades"]:::ported
-  singChal["Singularity challenges · inert"]:::stub
-  singPerks["Perks · milestones · inert"]:::stub
+  singChal["Singularity challenges · entry pending"]:::partial
+  singPerks["Perks · milestones"]:::partial
 
   asc["Ascension ↗ ascension-cubes"]:::ext
   quarks["Quarks ↗ meta-economy"]:::ext
@@ -53,7 +58,7 @@ flowchart LR
 
   ambrosia["Ambrosia"]:::ported
   blueberries["Blueberries · loadouts"]:::ported
-  blueberryUpg["Blueberry upgrades"]:::partial
+  blueberryUpg["Blueberry upgrades"]:::ported
   redAmbrosia["Red ambrosia"]:::ported
   redAmbUpg["Red ambrosia upgrades"]:::ported
 
@@ -75,20 +80,24 @@ flowchart LR
 
 | System | Status | Rust |
 |---|---|---|
-| Singularity reset / layer | 🟧 Stub (paused) | `state/singularity.rs`, `tick/mod.rs:5600+` |
-| Golden quarks + GQ upgrades | 🟩 Ported (inert) | `state/golden_quarks.rs`, `mechanics/golden_quark_upgrades.rs` |
-| Octeracts + upgrades | 🟩 Ported (inert) | `state/octeract_upgrades.rs`, `mechanics/octeracts.rs` |
-| Singularity challenges / perks | 🟧 Stub | ported but never entered/triggered |
+| Singularity reset / layer | 🟩 Ported (live) | `tick/reset.rs::perform_singularity_reset`, `calculate_golden_quarks` |
+| Golden quarks + GQ upgrades | 🟩 Ported | `state/golden_quarks.rs` (80-entry metadata seeded), `mechanics/golden_quark_upgrades.rs` |
+| Octeracts + upgrades | 🟩 Ported | `state/octeract_upgrades.rs`, `mechanics/octeracts.rs` |
+| Singularity challenges / perks | 🟨 Partial | machinery + `SingularityChallenge` jump ported; auto/UI *entry* unwired |
 | Ambrosia | 🟩 Ported | `state/ambrosia.rs`, `mechanics/ambrosia.rs` |
-| Blueberry upgrades | 🟨 Partial | `mechanics/blueberry_upgrades.rs` — `effective_levels` deferred to caller |
+| Blueberry upgrades | 🟩 Ported | `mechanics/blueberry_upgrades.rs`; effective levels populated (`populate_ambrosia_free_levels`), quark upgrades wired |
 | Red ambrosia + upgrades | 🟩 Ported | `state/red_ambrosia.rs`, `mechanics/red_ambrosia_*.rs` |
 
 ## Porting notes
 
-- This layer is **parked**, not broken: golden-quark / octeract / perk / challenge machinery is ported
-  but every reward is frozen at identity because the count never moves. Reviving it needs a production
-  path that increments `singularity_count`.
-- GQ per-slot metadata is zeroed at default (`cost_per_level=0`, `max_level=0`) — a free-unlimited-level
-  hazard if an unseeded buy ever runs (medium finding).
-- A few singularity reward fns have zero production callers (`no_quark_upgrades_effect`,
-  `sadistic_prequel`, `taxman_last_stand`).
+- ✅ **Revived.** `perform_singularity_reset` (`Reset.ts:1063-1285`) is the blankSave reconstruction:
+  reset to `GameState::default()` (== `reset_save`), restore the meta-progression survivors
+  (achievements, GQ balance + grant + all 80 upgrades + `total_quarks_ever`, octeract / ambrosia-upgrade
+  / red-ambrosia trees, shop, singularity challenge state + counts, automation prefs, RNG/level,
+  never-tier rune/talismans, ant high-water marks, `cubeUpgrades[80]`, and the prestige/transcend/
+  reincarnation counts once highest ≥ 8). Count auto-climbs `max(highest, count + lookahead)`.
+- ✅ **GQ metadata seeded** (`GQ_UPGRADE_SEEDS`, 80 rows) — `cost_per_level` / `max_level` / cost-form
+  now real, closing the free-unlimited-level hazard.
+- **Deferred:** the elevator triad (locked/slow-climb/target — auto-climb is faithful for fresh saves);
+  singularity-challenge auto/UI entry; `worlds` (quarks) reset has no `preserveQuarks` branch yet
+  (inert until that challenge is entered).


### PR DESCRIPTION
Closes out the remaining unmigrated **logic-tier** systems from the `docs/systems/` map. The UI tree is deliberately out of scope (its own epic).

## Key discovery: the docs were stale

Verifying the map against the code showed the two flagged HIGH parity bugs — **H1** (crystals/`prestige_shards` desync) and **H2** (ant true-level bypass) — are *already fixed in code* (H1 even has a regression test). Accelerator-boosts, hepteract-DR, and cube-4/5/6 timing were likewise done. So "close all unmigrated systems" was a sharper, smaller job than the map implied. The same theme recurred throughout: several "deferred" pieces turned out to be mostly ported and just unwired.

## What landed

| Area | Change |
|---|---|
| **Docs** | Re-statused 8 systems pages: H1/H2/accel/hepteract corrected to fixed; open-bugs table now empty. |
| **Quark multiplier** | Ported `calculateQuarkMultiplier` (`allQuarkStats`) — a real latent bug: `quark_bonus` was *never written* (always 0), so every quark gain was credited at ×1 (no achievement/platonic/singularity/octeract/ambrosia bonus). Now cached each tick as `(mult−1)·100`. |
| **Blueberry** | Wired the previously-uncalled quark upgrades into that product; populated `free_level` from the red-ambrosia `extraLevelCalc` upgrades (was always 0). |
| **Unlocks** | Added the 12 missing `player.unlocks` keys (21/21); closed the documented c8/c9 anthill·talismans·blessings gap. |
| **⭐ Singularity** | **Revived the paused layer** — seeded the 80-entry GQ-upgrade metadata table, the golden-quark grant formula, the full blankSave reset (`perform_singularity_reset`), and the `ResetRequest::Singularity` trigger (gated on the antiquities rune). |
| **Autobuyers** | Wired the 3 remaining `updateAll` families — **talisman**, **tesseract** (AMOUNT mode), **ant-upgrade** — so all 13 self-drive. |

## Schema additions (per CLAUDE.md)

All `player.*`-equivalent, plan-approved: `GoldenQuarksState.total_quarks_ever`, 12 `ResetCountersState` unlock bools, `AutomationState.ascension_reset_mode` (new `AutoAscensionMode` enum), plus the `CoreEvent::SingularityPerformed` event and two `ResetRequest` variants. `SaveV1` is `GameState`-verbatim, so all flow through the existing round-trip (verified).

## Testing

All green: full workspace tests (1332 in `synergismforkd_logic` + the save round-trip), `clippy --workspace --all-targets -D warnings`, `cargo fmt --all --check`, and the `wasm32-unknown-unknown` build. New unit + tack-level tests for every piece above; the headless sim runs clean. Everything is inert at the default state (toggles off / antiquities gate), so existing default-state invariants are preserved.

## Out of scope / remaining

The singularity elevator triad + singularity-challenge auto/UI entry (auto-climb is faithful for fresh saves), host-tier save wiring, and the UI tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
