### PR TITLE
Meta-economy wrap-up + singularity completion (quark terms, campaign tokens, exalts, elevator)

### DIFF
--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -515,6 +515,30 @@ pub enum CoreEvent {
         /// The new `singularityCount` after the reset.
         singularity_count: f64,
     },
+    /// A singularity (Exalt) challenge was entered
+    /// (`SingularityChallenge.enableChallenge`): the challenge flag is set and
+    /// a singularity reset jumped to the tier's required count. Accompanied by
+    /// the jump's [`Self::SingularityPerformed`].
+    SingularityChallengeEntered {
+        /// Which Exalt was entered.
+        challenge: SingularityChallengeId,
+        /// The singularity count the jump landed on
+        /// (`singularityRequirement(baseReq, completions)`).
+        target_singularity: f64,
+    },
+    /// A singularity (Exalt) challenge was exited
+    /// (`SingularityChallenge.exitChallenge`): the flag cleared and a
+    /// singularity reset returned to the held highest count. On success the
+    /// completion ladder was re-derived first.
+    SingularityChallengeExited {
+        /// Which Exalt was exited.
+        challenge: SingularityChallengeId,
+        /// Whether the tier was completed (the antiquities rune was purchased
+        /// inside the challenge).
+        success: bool,
+        /// The challenge's completion count after the exit.
+        completions: f64,
+    },
     /// One of the four `automaticTools()` branches fired this tick.
     ///
     /// Emitted by the auto-tool state machine (tick-side, not yet
@@ -692,6 +716,44 @@ pub enum CubeTier {
     /// Platonic Cubes.
     Platonic,
 }
+
+/// Identifies one of the nine singularity (Exalt) challenges — the keys of
+/// the legacy `player.singularityChallenges`, in `singularityChallengeData`
+/// order. Names match the `SingularityState` field names.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SingularityChallengeId {
+    /// `noSingularityUpgrades` (Exalt 1).
+    NoSingularityUpgrades,
+    /// `oneChallengeCap` (Exalt 2).
+    OneChallengeCap,
+    /// `noOcteracts` (Exalt 4).
+    NoOcteracts,
+    /// `limitedAscensions` (Exalt 3).
+    LimitedAscensions,
+    /// `noAmbrosiaUpgrades` (Exalt 5).
+    NoAmbrosiaUpgrades,
+    /// `noQuarkUpgrades`.
+    NoQuarkUpgrades,
+    /// `limitedTime` (Exalt 6).
+    LimitedTime,
+    /// `sadisticPrequel` (Exalt 7).
+    SadisticPrequel,
+    /// `taxmanLastStand` (Exalt 8).
+    TaxmanLastStand,
+}
+
+/// All nine Exalt challenges, in `singularityChallengeData` order.
+pub const SINGULARITY_CHALLENGE_IDS: [SingularityChallengeId; 9] = [
+    SingularityChallengeId::NoSingularityUpgrades,
+    SingularityChallengeId::OneChallengeCap,
+    SingularityChallengeId::NoOcteracts,
+    SingularityChallengeId::LimitedAscensions,
+    SingularityChallengeId::NoAmbrosiaUpgrades,
+    SingularityChallengeId::NoQuarkUpgrades,
+    SingularityChallengeId::LimitedTime,
+    SingularityChallengeId::SadisticPrequel,
+    SingularityChallengeId::TaxmanLastStand,
+];
 
 #[cfg(test)]
 mod tests {

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -798,6 +798,32 @@ pub fn singularity_achievement_check(
     award_threshold_group(ach, highest_singularity_count, SINGULARITY_COUNT)
 }
 
+// ─── Campaign-token group ───────────────────────────────────────────────────
+
+/// `campaignTokens` group — the derived campaign-token total (the legacy
+/// `updateTokens()` awards this group right after recomputing the total).
+const CAMPAIGN_TOKENS: &[ThresholdRow] = &[
+    (426, 10.0, 5.0),
+    (427, 20.0, 10.0),
+    (428, 40.0, 15.0),
+    (429, 80.0, 20.0),
+    (430, 160.0, 25.0),
+    (431, 320.0, 30.0),
+    (432, 1_000.0, 35.0),
+    (433, 2_000.0, 40.0),
+    (434, 4_000.0, 45.0),
+    (435, 9_000.0, 50.0),
+];
+
+/// `campaignTokens` achievement group — awarded from the campaign-token
+/// total (`compute_campaign_tokens`). Returns the count newly awarded.
+pub fn campaign_tokens_achievement_check(
+    ach: &mut AchievementsState,
+    campaign_tokens: f64,
+) -> usize {
+    award_threshold_group(ach, campaign_tokens, CAMPAIGN_TOKENS)
+}
+
 /// Per-run "didn't buy X this run" flags read by the ungrouped no-reset
 /// achievements (the `awardUngroupedAchievement` calls in the legacy
 /// `resetAchievementCheck`). Each starts `true`, is cleared on the matching

--- a/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_awards.rs
@@ -772,6 +772,32 @@ pub fn ascension_score_achievement_check(
     award_threshold_group(ach, effective_score, ASCENSION_SCORE)
 }
 
+// ─── Singularity-count group ────────────────────────────────────────────────
+
+/// `singularityCount` group — `player.highestSingularityCount`. Pure
+/// point-value achievements (no rewards). The seven indices sit between the
+/// `constant` group (…273) and the `firstOwnedCoin` second tier (281…). Now
+/// reachable: the singularity layer is live, so `highestSingularityCount`
+/// climbs in play.
+const SINGULARITY_COUNT: &[ThresholdRow] = &[
+    (274, 1.0, 10.0),
+    (275, 2.0, 20.0),
+    (276, 3.0, 30.0),
+    (277, 4.0, 40.0),
+    (278, 5.0, 50.0),
+    (279, 7.0, 60.0),
+    (280, 10.0, 70.0),
+];
+
+/// `singularityCount` achievement group — awarded from the highest singularity
+/// count reached. Returns the count newly awarded.
+pub fn singularity_achievement_check(
+    ach: &mut AchievementsState,
+    highest_singularity_count: f64,
+) -> usize {
+    award_threshold_group(ach, highest_singularity_count, SINGULARITY_COUNT)
+}
+
 /// Per-run "didn't buy X this run" flags read by the ungrouped no-reset
 /// achievements (the `awardUngroupedAchievement` calls in the legacy
 /// `resetAchievementCheck`). Each starts `true`, is cleared on the matching
@@ -1264,6 +1290,28 @@ mod tests {
         // Below the 1e5 floor → nothing.
         let mut low = AchievementsState::default();
         assert_eq!(ascension_score_achievement_check(&mut low, 9.9e4), 0);
+    }
+
+    #[test]
+    fn singularity_check_awards_by_highest_count_and_is_idempotent() {
+        let mut ach = AchievementsState::default();
+        // highestSingularityCount 5 → rows 274..=278 (thresholds 1/2/3/4/5);
+        // the threshold-7 row (279) stays unmet.
+        assert_eq!(singularity_achievement_check(&mut ach, 5.0), 5);
+        assert_eq!(ach.achievements[274], 1);
+        assert_eq!(ach.achievements[278], 1);
+        assert_eq!(ach.achievements[279], 0);
+        // Point values 10+20+30+40+50 = 150.
+        assert!((ach.achievement_points - 150.0).abs() < 1e-9);
+        // Monotonic + idempotent: re-checking the same count awards nothing.
+        assert_eq!(singularity_achievement_check(&mut ach, 5.0), 0);
+    }
+
+    #[test]
+    fn singularity_check_default_awards_nothing() {
+        let mut ach = AchievementsState::default();
+        assert_eq!(singularity_achievement_check(&mut ach, 0.0), 0);
+        assert_eq!(ach.achievement_points, 0.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/achievement_rewards.rs
@@ -208,6 +208,14 @@ const ASCENSION_COUNT_MULT_SCORE_INDEX: usize = 187;
 const ASCENSION_COUNT_MULT_FLAT_INDICES: [usize; 2] = [260, 261];
 const ASCENSION_COUNT_MULT_COUNTER_INDEX: usize = 474;
 
+/// `quarkGain` reward indices (multiplicative product; feeds the
+/// `AchievementBonus` line of the quark multiplier, `allQuarkStats`):
+/// #250 (Thousand Suns) and #251 (Thousand Moons) each grant flat `1.05`;
+/// #266 (group `ascensionCount`, `ascensionCount >= 1e14`) grants
+/// `1 + 0.1·min(ascensionCount/1e15, 1)`.
+const QUARK_GAIN_FLAT_INDICES: [usize; 2] = [250, 251];
+const QUARK_GAIN_ASC_COUNT_INDEX: usize = 266;
+
 #[inline]
 fn earned(achievements: &[u8; ACHIEVEMENTS_LEN], index: usize) -> bool {
     achievements[index] != 0
@@ -595,6 +603,28 @@ pub fn ascension_count_multiplier(
     prod
 }
 
+/// `getAchievementReward('quarkGain')` — multiplicative (base 1). Feeds the
+/// `AchievementBonus` line of `allQuarkStats` (the quark multiplier,
+/// [`crate::tick`]'s `compute_quark_multiplier`). Identity `1.0` at default.
+///
+/// `#250`/`#251` (Thousand Suns / Moons) are `ungrouped` achievements whose
+/// awarding is still deferred, so their `1.05` factors stay dormant; `#266` is
+/// in the ported `ascensionCount` group, so this reward goes live once
+/// `ascensionCount` reaches `1e14`.
+#[must_use]
+pub fn quark_gain(achievements: &[u8; ACHIEVEMENTS_LEN], ascension_count: f64) -> f64 {
+    let mut prod = 1.0;
+    for &index in &QUARK_GAIN_FLAT_INDICES {
+        if earned(achievements, index) {
+            prod *= 1.05;
+        }
+    }
+    if earned(achievements, QUARK_GAIN_ASC_COUNT_INDEX) {
+        prod *= 1.0 + 0.1 * (ascension_count / 1e15).min(1.0);
+    }
+    prod
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,6 +658,22 @@ mod tests {
     fn ascension_reward_scaling_tracks_achievement_204() {
         assert!(!ascension_reward_scaling(&earned_array(&[])));
         assert!(ascension_reward_scaling(&earned_array(&[204])));
+    }
+
+    #[test]
+    fn quark_gain_is_identity_at_default_and_compounds_when_earned() {
+        let none = earned_array(&[]);
+        assert_eq!(quark_gain(&none, 0.0), 1.0);
+        // Thousand Suns + Moons → 1.05 · 1.05.
+        assert!((quark_gain(&earned_array(&[250, 251]), 0.0) - 1.05 * 1.05).abs() < 1e-12);
+        // #266 alone, ascensionCount 5e14 → 1 + 0.1·min(0.5, 1) = 1.05.
+        assert!((quark_gain(&earned_array(&[266]), 5e14) - 1.05).abs() < 1e-12);
+        // #266 alone, ascensionCount ≥ 1e15 → the min saturates at 1 → 1.1.
+        assert!((quark_gain(&earned_array(&[266]), 1e16) - 1.1).abs() < 1e-12);
+        // All three earned at saturation → 1.05 · 1.05 · 1.1.
+        assert!(
+            (quark_gain(&earned_array(&[250, 251, 266]), 1e16) - 1.05 * 1.05 * 1.1).abs() < 1e-12
+        );
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/mechanics/campaign_token_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/campaign_token_rewards.rs
@@ -9,6 +9,13 @@
 //! return a scalar (or, for `tutorial_bonus`, a 3-field struct).
 //! All formulas are pure functions of `campaign_tokens` with no
 //! player or game-state reads.
+//!
+//! The token *total* (`updateTokens`) lives here too — the static
+//! per-campaign `limit`/`isMeta` table, [`campaign_token_value`], and the
+//! inheritance / singularity-multiplier grants. The `GameState` assembler
+//! (`compute_campaign_tokens`) composes them in the tick.
+
+use crate::state::campaigns::CAMPAIGNS_LEN;
 
 /// Result of [`tutorial_bonus`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -187,6 +194,140 @@ pub fn campaign_blueberry_speed_bonus(campaign_tokens: f64) -> f64 {
         + 0.03 * (1.0 - (-(campaign_tokens - 4_000.0).max(0.0) / 2_000.0).exp())
 }
 
+// ─── Token total (`updateTokens`) ──────────────────────────────────────────
+//
+// `campaignTokens` is a derived total in the legacy code (a module global
+// recomputed by `updateTokens()`): the sum of every campaign's
+// `computeTokenValue()` plus `inheritanceTokens()` plus the GQ
+// `singBonusTokens4` / octeract `octeractBonusTokens4` initial-token
+// bonuses. Logic derives it live from `campaign_completions` — no cached
+// state field.
+
+/// Per-campaign completion `limit`, in `campaignDatas` key order
+/// (`Campaign.ts`, `first` = 0 … `fiftieth` = 49; identical in both legacy
+/// snapshots).
+pub const CAMPAIGN_TOKEN_LIMITS: [f64; CAMPAIGNS_LEN] = [
+    10.0, 10.0, 10.0, 10.0, 10.0, // 0-4
+    15.0, 15.0, 15.0, 15.0, 15.0, // 5-9
+    20.0, 20.0, 20.0, 20.0, 20.0, // 10-14
+    25.0, 25.0, 25.0, 25.0, 25.0, // 15-19
+    30.0, 30.0, 30.0, 30.0, 30.0, // 20-24
+    35.0, 35.0, 35.0, 35.0, 35.0, // 25-29
+    40.0, 40.0, // 30-31
+    45.0, 45.0, // 32-33
+    50.0, 50.0, // 34-35
+    55.0, 55.0, // 36-37
+    60.0, 60.0, // 38-39
+    65.0, 70.0, 75.0, 80.0, 85.0, // 40-44
+    95.0, 105.0, 115.0, 125.0, 140.0, // 45-49
+];
+
+/// Per-campaign `isMeta` flag (meta campaigns earn doubled tokens), same
+/// key order as [`CAMPAIGN_TOKEN_LIMITS`].
+pub const CAMPAIGN_IS_META: [bool; CAMPAIGNS_LEN] = [
+    false, true, false, false, false, // 0-4
+    false, true, false, false, false, // 5-9
+    false, true, false, false, true, // 10-14
+    false, false, true, false, false, // 15-19
+    true, false, false, true, false, // 20-24
+    false, false, true, false, true, // 25-29
+    true, false, // 30-31
+    false, true, // 32-33
+    true, false, // 34-35
+    false, true, // 36-37
+    false, true, // 38-39
+    true, true, true, true, true, // 40-44
+    true, true, true, false, true, // 45-49
+];
+
+/// The cross-campaign bonus terms of `computeTokenValue` — identical for
+/// every campaign, so the caller assembles them once. Each folds the
+/// matching highest-singularity milestone with the GQ + octeract
+/// bonus-token upgrade effects.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct CampaignTokenBonuses {
+    /// Added once `completed >= 1`: `(highestSing >= 16 ? 5 : 0) +
+    /// singBonusTokens1 + octeractBonusTokens3`.
+    pub first_completion_bonus: f64,
+    /// Added once `completed == limit`: `(highestSing >= 69 ? 10 : 0) +
+    /// singBonusTokens3 + octeractBonusTokens1`.
+    pub last_completion_bonus: f64,
+    /// Shared multiplier: `singularityBonusTokenMult() × singBonusTokens2
+    /// × octeractBonusTokens2` (the per-campaign `isMeta` ×2 is applied
+    /// inside [`campaign_token_value`]).
+    pub token_multiplier: f64,
+}
+
+/// One campaign's token value — `Campaign.computeTokenValue()`
+/// (`Campaign.ts:538`). `completed = min(c10Completions, limit)` is the
+/// additive base; the first/last-completion bonuses join it, and the
+/// product of the shared multiplier with the meta ×2 is floored.
+#[must_use]
+pub fn campaign_token_value(
+    c10_completions: f64,
+    limit: f64,
+    is_meta: bool,
+    bonuses: &CampaignTokenBonuses,
+) -> f64 {
+    let completed = c10_completions.min(limit);
+    let mut additive = completed;
+    if completed >= 1.0 {
+        additive += bonuses.first_completion_bonus;
+    }
+    if completed == limit {
+        additive += bonuses.last_completion_bonus;
+    }
+    let multiplier = if is_meta { 2.0 } else { 1.0 } * bonuses.token_multiplier;
+    (additive * multiplier).floor()
+}
+
+/// `inheritanceLevels` — highest-singularity milestones for the
+/// inheritance token grant (`Calculate.ts:135`).
+const INHERITANCE_LEVELS: [f64; 15] = [
+    2.0, 5.0, 10.0, 17.0, 26.0, 37.0, 50.0, 65.0, 82.0, 101.0, 220.0, 240.0, 260.0, 270.0, 277.0,
+];
+
+/// `inheritanceTokenValues` — token grant per inheritance tier.
+const INHERITANCE_TOKEN_VALUES: [f64; 15] = [
+    1.0, 10.0, 25.0, 40.0, 75.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0, 500.0, 600.0,
+    750.0,
+];
+
+/// `inheritanceTokens()` (`Calculate.ts:1691`) — the flat token grant from
+/// the highest singularity reached.
+///
+/// Faithful quirk: the legacy loop runs `i = 15` down to `i = 1` over the
+/// 15-entry arrays — `i = 15` reads out of bounds (`>= undefined` is
+/// false, a no-op) and `i = 0` is never tested, so the `inheritanceLevels[0]
+/// = 2 → 1 token` tier is unreachable. The effective floor is singularity
+/// 5 → 10 tokens.
+#[must_use]
+pub fn inheritance_tokens(highest_singularity_count: f64) -> f64 {
+    for i in (1..=14).rev() {
+        if highest_singularity_count >= INHERITANCE_LEVELS[i] {
+            return INHERITANCE_TOKEN_VALUES[i];
+        }
+    }
+    0.0
+}
+
+/// `bonusTokenLevels` — highest-singularity milestones for the global
+/// token multiplier (`Calculate.ts:138`).
+const BONUS_TOKEN_LEVELS: [f64; 5] = [41.0, 58.0, 113.0, 163.0, 229.0];
+
+/// `singularityBonusTokenMult()` (`Calculate.ts:1701`) — `1 + 0.02·i` for
+/// the highest tier `i` (1-based) whose milestone the player has reached;
+/// `1` below singularity 41.
+#[must_use]
+pub fn singularity_bonus_token_mult(highest_singularity_count: f64) -> f64 {
+    for i in (1..=5).rev() {
+        if highest_singularity_count >= BONUS_TOKEN_LEVELS[i - 1] {
+            return 1.0 + 0.02 * i as f64;
+        }
+    }
+    1.0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,6 +338,68 @@ mod tests {
         assert_eq!(bonus.cube_bonus, 1.0);
         assert_eq!(bonus.obtainium_bonus, 1.0);
         assert_eq!(bonus.offering_bonus, 1.0);
+    }
+
+    #[test]
+    fn token_value_base_is_clamped_completions() {
+        let none = CampaignTokenBonuses {
+            token_multiplier: 1.0,
+            ..Default::default()
+        };
+        assert_eq!(campaign_token_value(0.0, 10.0, false, &none), 0.0);
+        assert_eq!(campaign_token_value(5.0, 10.0, false, &none), 5.0);
+        // Clamped to the limit.
+        assert_eq!(campaign_token_value(99.0, 10.0, false, &none), 10.0);
+    }
+
+    #[test]
+    fn token_value_applies_first_last_meta_and_floor() {
+        let bonuses = CampaignTokenBonuses {
+            first_completion_bonus: 5.0,
+            last_completion_bonus: 10.0,
+            token_multiplier: 1.02,
+        };
+        // 1 completion: (1 + 5)·1.02 = 6.12 → floor 6.
+        assert_eq!(campaign_token_value(1.0, 10.0, false, &bonuses), 6.0);
+        // Full completion: (10 + 5 + 10)·1.02 = 25.5 → floor 25.
+        assert_eq!(campaign_token_value(10.0, 10.0, false, &bonuses), 25.0);
+        // Meta doubles the multiplier: 25·2·1.02 = 51.
+        assert_eq!(campaign_token_value(10.0, 10.0, true, &bonuses), 51.0);
+    }
+
+    #[test]
+    fn inheritance_tokens_floor_is_singularity_5() {
+        // The legacy loop never tests index 0, so the level-2 → 1-token
+        // tier is unreachable — faithful quirk.
+        assert_eq!(inheritance_tokens(0.0), 0.0);
+        assert_eq!(inheritance_tokens(2.0), 0.0);
+        assert_eq!(inheritance_tokens(4.0), 0.0);
+        assert_eq!(inheritance_tokens(5.0), 10.0);
+        assert_eq!(inheritance_tokens(16.0), 25.0);
+        assert_eq!(inheritance_tokens(277.0), 750.0);
+    }
+
+    #[test]
+    fn singularity_bonus_token_mult_tiers() {
+        assert_eq!(singularity_bonus_token_mult(0.0), 1.0);
+        assert_eq!(singularity_bonus_token_mult(40.0), 1.0);
+        assert!((singularity_bonus_token_mult(41.0) - 1.02).abs() < 1e-12);
+        assert!((singularity_bonus_token_mult(229.0) - 1.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn campaign_tables_cover_all_fifty_campaigns() {
+        assert_eq!(CAMPAIGN_TOKEN_LIMITS.len(), CAMPAIGNS_LEN);
+        assert_eq!(CAMPAIGN_IS_META.len(), CAMPAIGNS_LEN);
+        // Spot anchors: first (10, not meta), second (10, meta),
+        // forty-ninth (125, not meta), fiftieth (140, meta).
+        assert_eq!(CAMPAIGN_TOKEN_LIMITS[0], 10.0);
+        assert!(!CAMPAIGN_IS_META[0]);
+        assert!(CAMPAIGN_IS_META[1]);
+        assert_eq!(CAMPAIGN_TOKEN_LIMITS[48], 125.0);
+        assert!(!CAMPAIGN_IS_META[48]);
+        assert_eq!(CAMPAIGN_TOKEN_LIMITS[49], 140.0);
+        assert!(CAMPAIGN_IS_META[49]);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
+++ b/crates/synergismforkd_logic/src/mechanics/challenge_15_rewards.rs
@@ -255,6 +255,19 @@ pub fn achievement_unlock(exponent: f64) -> f64 {
     }
 }
 
+/// `challenge15Rewards.quarks.value` — multiplied into the quark multiplier
+/// (`allQuarkStats`, the `Challenge15` line consumed by
+/// `compute_quark_multiplier`). Requirement `1e11`, `baseValue` `1`. Legacy
+/// formula `1 + (3/400)·log2(e·32 / 1e11)` (Variables.ts:298).
+#[must_use]
+pub fn quarks(exponent: f64) -> f64 {
+    if exponent >= 1e11 {
+        1.0 + (3.0 / 400.0) * (exponent * 32.0 / 1e11).log2()
+    } else {
+        1.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -283,6 +296,17 @@ mod tests {
         assert_eq!(score(9.9e9), 1.0);
         // Just under the ant-speed requirement → still identity.
         assert_eq!(ant_speed(1.99e5), 1.0);
+        // Just under the quarks requirement → still identity.
+        assert_eq!(quarks(9.9e10), 1.0);
+    }
+
+    #[test]
+    fn quarks_scales_above_requirement() {
+        // e = 1e11 → 1 + (3/400)·log2(1e11·32/1e11) = 1 + (3/400)·log2(32)
+        //          = 1 + (3/400)·5 = 1.0375.
+        assert!((quarks(1e11) - 1.0375).abs() < 1e-12);
+        // Monotonic increasing above the requirement.
+        assert!(quarks(1e12) > quarks(1e11));
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/mechanics/golden_quark_upgrades.rs
+++ b/crates/synergismforkd_logic/src/mechanics/golden_quark_upgrades.rs
@@ -787,6 +787,22 @@ pub fn favorite_upgrade_effect(n: f64, sum_of_maxed_sibling_upgrades: f64) -> f6
     1.0 + n / 5_000.0 * (sum_of_maxed_sibling_upgrades + 6.0)
 }
 
+/// Count of golden-quark upgrades whose **purchased** level has reached
+/// their `maxLevel` (the `singularityUpgrades` progressive-achievement
+/// closure: `maxLevel !== -1 && level >= maxLevel`; free levels don't
+/// count). Reads the seeded per-upgrade `max_level` metadata (`-1` =
+/// unlimited).
+#[must_use]
+pub fn count_maxed_golden_quark_upgrades(state: &crate::state::GoldenQuarksState) -> f64 {
+    let mut count = 0.0;
+    for upgrade in &state.upgrades {
+        if upgrade.max_level != -1.0 && upgrade.level >= upgrade.max_level {
+            count += 1.0;
+        }
+    }
+    count
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/synergismforkd_logic/src/mechanics/octeracts.rs
+++ b/crates/synergismforkd_logic/src/mechanics/octeracts.rs
@@ -843,6 +843,76 @@ pub fn octeract_talisman_level_cap_4_effect(n: f64) -> f64 {
     n
 }
 
+// ─── Max levels ────────────────────────────────────────────────────────────
+
+/// Per-upgrade `maxLevel`, in `octeractUpgrades` key order (`-1` =
+/// unlimited). Identical in both legacy snapshots. Static data the UI tier
+/// also owns — kept here (not in the state struct) since it never varies
+/// per player.
+pub const OCTERACT_MAX_LEVELS: [f64; OCTERACT_UPGRADES_LEN] = [
+    1.0,      // 0 octeractStarter
+    1e8,      // 1 octeractGain
+    -1.0,     // 2 octeractGain2
+    20_000.0, // 3 octeractQuarkGain
+    5.0,      // 4 octeractQuarkGain2
+    2.0,      // 5 octeractCorruption
+    50.0,     // 6 octeractGQCostReduce
+    100.0,    // 7 octeractExportQuarks
+    50.0,     // 8 octeractImprovedDaily
+    50.0,     // 9 octeractImprovedDaily2
+    -1.0,     // 10 octeractImprovedDaily3
+    25.0,     // 11 octeractImprovedQuarkHept
+    1_000.0,  // 12 octeractImprovedGlobalSpeed
+    100.0,    // 13 octeractImprovedAscensionSpeed
+    250.0,    // 14 octeractImprovedAscensionSpeed2
+    1.0,      // 15 octeractImprovedFree
+    1.0,      // 16 octeractImprovedFree2
+    1.0,      // 17 octeractImprovedFree3
+    40.0,     // 18 octeractImprovedFree4
+    10.0,     // 19 octeractSingUpgradeCap
+    -1.0,     // 20 octeractOfferings1
+    -1.0,     // 21 octeractObtainium1
+    1e6,      // 22 octeractAscensions
+    -1.0,     // 23 octeractAscensions2
+    -1.0,     // 24 octeractAscensionsOcteractGain
+    2.0,      // 25 octeractFastForward
+    -1.0,     // 26 octeractAutoPotionSpeed
+    100.0,    // 27 octeractAutoPotionEfficiency
+    20.0,     // 28 octeractOneMindImprover
+    -1.0,     // 29 octeractAmbrosiaLuck
+    30.0,     // 30 octeractAmbrosiaLuck2
+    30.0,     // 31 octeractAmbrosiaLuck3
+    50.0,     // 32 octeractAmbrosiaLuck4
+    -1.0,     // 33 octeractAmbrosiaGeneration
+    20.0,     // 34 octeractAmbrosiaGeneration2
+    35.0,     // 35 octeractAmbrosiaGeneration3
+    50.0,     // 36 octeractAmbrosiaGeneration4
+    10.0,     // 37 octeractBonusTokens1
+    5.0,      // 38 octeractBonusTokens2
+    5.0,      // 39 octeractBonusTokens3
+    50.0,     // 40 octeractBonusTokens4
+    6.0,      // 41 octeractBlueberries
+    80.0,     // 42 octeractInfiniteShopUpgrades
+    25.0,     // 43 octeractTalismanLevelCap1
+    35.0,     // 44 octeractTalismanLevelCap2
+    40.0,     // 45 octeractTalismanLevelCap3
+    -1.0,     // 46 octeractTalismanLevelCap4
+];
+
+/// Count of octeract upgrades whose **purchased** level has reached their
+/// `maxLevel` (the `octeractUpgrades` progressive-achievement closure:
+/// `maxLevel !== -1 && level >= maxLevel`; free levels don't count).
+#[must_use]
+pub fn count_maxed_octeract_upgrades(state: &OcteractUpgradesState) -> f64 {
+    let mut count = 0.0;
+    for (upgrade, max) in state.upgrades.iter().zip(OCTERACT_MAX_LEVELS) {
+        if max != -1.0 && upgrade.level >= max {
+            count += 1.0;
+        }
+    }
+    count
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/synergismforkd_logic/src/mechanics/red_ambrosia_upgrades.rs
+++ b/crates/synergismforkd_logic/src/mechanics/red_ambrosia_upgrades.rs
@@ -470,6 +470,58 @@ pub fn free_speed_upgrades_effect(n: f64) -> f64 {
     n
 }
 
+// ─── Max levels ────────────────────────────────────────────────────────────
+
+/// Per-upgrade `maxLevel`, in `redAmbrosiaUpgrades` key order (every red
+/// upgrade has a finite cap — no `-1` sentinel). Identical in both legacy
+/// snapshots. Static data the UI tier also owns — kept here (not in the
+/// state struct) since it never varies per player.
+pub const RED_AMBROSIA_MAX_LEVELS: [f64; crate::state::red_ambrosia::RED_AMBROSIA_UPGRADES_LEN] = [
+    100.0, // 0 tutorial
+    5.0,   // 1 conversionImprovement1
+    3.0,   // 2 conversionImprovement2
+    2.0,   // 3 conversionImprovement3
+    5.0,   // 4 freeTutorialLevels
+    5.0,   // 5 freeLevelsRow2
+    5.0,   // 6 freeLevelsRow3
+    5.0,   // 7 freeLevelsRow4
+    5.0,   // 8 freeLevelsRow5
+    100.0, // 9 blueberryGenerationSpeed
+    100.0, // 10 regularLuck
+    100.0, // 11 redGenerationSpeed
+    100.0, // 12 redLuck
+    1.0,   // 13 redAmbrosiaCube
+    1.0,   // 14 redAmbrosiaObtainium
+    1.0,   // 15 redAmbrosiaOffering
+    20.0,  // 16 redAmbrosiaCubeImprover
+    1.0,   // 17 viscount
+    40.0,  // 18 infiniteShopUpgrades
+    100.0, // 19 redAmbrosiaAccelerator
+    250.0, // 20 regularLuck2
+    250.0, // 21 blueberryGenerationSpeed2
+    100.0, // 22 salvageYinYang
+    5.0,   // 23 blueberries
+    10.0,  // 24 redAmbrosiaFreeAccumulator
+    5.0,   // 25 freeOfferingUpgrades
+    5.0,   // 26 freeObtainiumUpgrades
+    5.0,   // 27 freeCubeUpgrades
+    5.0,   // 28 freeSpeedUpgrades
+];
+
+/// Count of red-ambrosia upgrades whose level has reached their `maxLevel`
+/// (the `redAmbrosiaUpgrades` progressive-achievement closure:
+/// `level >= maxLevel`, no sentinel — every cap is finite).
+#[must_use]
+pub fn count_maxed_red_ambrosia_upgrades(state: &crate::state::RedAmbrosiaState) -> f64 {
+    let mut count = 0.0;
+    for (upgrade, max) in state.upgrades.iter().zip(RED_AMBROSIA_MAX_LEVELS) {
+        if upgrade.level >= max {
+            count += 1.0;
+        }
+    }
+    count
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/synergismforkd_logic/src/mechanics/singularity_challenges.rs
+++ b/crates/synergismforkd_logic/src/mechanics/singularity_challenges.rs
@@ -3,16 +3,21 @@
 //!
 //! Verbatim port of
 //! `legacy/core_split/packages/logic/src/mechanics/singularityChallenges.ts`.
-//! The UI tier still owns the `singularityChallengeData` table.
 //! This module owns the three pure-formula fields each challenge
-//! has: `singularity_requirement(base_req, completions)`,
-//! `achievement_point_value(n)`, and `effect(n, key)`.
+//! has — `singularity_requirement(base_req, completions)`,
+//! `achievement_point_value(n)`, and `effect(n, key)` — plus the
+//! static `singularityChallengeData` row each challenge keys
+//! ([`challenge_meta`]) and the enter/exit support math
+//! ([`challenge_singularity_requirement`],
+//! [`challenge_completions_from_highest`]).
 //!
 //! Effect functions return either booleans (for unlock keys) or
 //! `f64` scalars. To keep the dispatch clean while preserving
 //! variable return types, each challenge gets its own key enum and
 //! its own tagged-result enum (with an `Unlock(bool)` and
 //! `Scalar(f64)` variant). The caller pattern-matches the result.
+
+use crate::events::SingularityChallengeId;
 
 // ─── Per-challenge singularityRequirement formulas ────────────────────────
 
@@ -147,6 +152,145 @@ pub fn sadistic_prequel_achievement_point_value(n: f64) -> f64 {
 #[must_use]
 pub fn taxman_last_stand_achievement_point_value(n: f64) -> f64 {
     50.0 * n
+}
+
+// ─── Per-challenge static metadata + dispatch ──────────────────────────────
+
+/// One Exalt's static data-table row (`singularityChallengeData` —
+/// `baseReq` / `maxCompletions` / `unlockSingularity` / `resetTime`).
+/// Identical in both legacy snapshots. `reset_time` is `false` for every
+/// current challenge (the constructor's `data.resetTime ?? false`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SingularityChallengeMeta {
+    /// `baseReq` — the tier-0 singularity requirement.
+    pub base_req: f64,
+    /// `maxCompletions` — the completion cap.
+    pub max_completions: f64,
+    /// `unlockSingularity` — minimum `highestSingularityCount` to enter.
+    pub unlock_singularity: f64,
+    /// `resetTime` — whether entering zeroes `singularityCounter` (instead
+    /// of holding it across the jump).
+    pub reset_time: bool,
+}
+
+/// Static metadata for an Exalt challenge.
+#[must_use]
+pub const fn challenge_meta(id: SingularityChallengeId) -> SingularityChallengeMeta {
+    match id {
+        SingularityChallengeId::NoSingularityUpgrades => SingularityChallengeMeta {
+            base_req: 1.0,
+            max_completions: 15.0,
+            unlock_singularity: 25.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::OneChallengeCap => SingularityChallengeMeta {
+            base_req: 10.0,
+            max_completions: 15.0,
+            unlock_singularity: 40.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::NoOcteracts => SingularityChallengeMeta {
+            base_req: 75.0,
+            max_completions: 15.0,
+            unlock_singularity: 100.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::LimitedAscensions => SingularityChallengeMeta {
+            base_req: 7.0,
+            max_completions: 10.0,
+            unlock_singularity: 50.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::NoAmbrosiaUpgrades => SingularityChallengeMeta {
+            base_req: 150.0,
+            max_completions: 15.0,
+            unlock_singularity: 166.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::NoQuarkUpgrades => SingularityChallengeMeta {
+            base_req: 20.0,
+            max_completions: 10.0,
+            unlock_singularity: 66.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::LimitedTime => SingularityChallengeMeta {
+            base_req: 203.0,
+            max_completions: 15.0,
+            unlock_singularity: 216.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::SadisticPrequel => SingularityChallengeMeta {
+            base_req: 120.0,
+            max_completions: 15.0,
+            unlock_singularity: 256.0,
+            reset_time: false,
+        },
+        SingularityChallengeId::TaxmanLastStand => SingularityChallengeMeta {
+            base_req: 240.0,
+            max_completions: 10.0,
+            unlock_singularity: 281.0,
+            reset_time: false,
+        },
+    }
+}
+
+/// `computeSingularityRquirement()` — the singularity count tier
+/// `completions + 1` of this challenge requires, dispatching to the
+/// per-challenge `singularityRequirement` formula with its static
+/// `baseReq`.
+#[must_use]
+pub fn challenge_singularity_requirement(id: SingularityChallengeId, completions: f64) -> f64 {
+    let base_req = challenge_meta(id).base_req;
+    match id {
+        SingularityChallengeId::NoSingularityUpgrades => {
+            no_singularity_upgrades_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::OneChallengeCap => {
+            one_challenge_cap_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::NoOcteracts => {
+            no_octeracts_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::LimitedAscensions => {
+            limited_ascensions_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::NoAmbrosiaUpgrades => {
+            no_ambrosia_upgrades_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::NoQuarkUpgrades => {
+            no_quark_upgrades_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::LimitedTime => {
+            limited_time_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::SadisticPrequel => {
+            sadistic_prequel_singularity_requirement(base_req, completions)
+        }
+        SingularityChallengeId::TaxmanLastStand => {
+            taxman_last_stand_singularity_requirement(base_req, completions)
+        }
+    }
+}
+
+/// `updateChallengeCompletions()` — re-derive the completion count from the
+/// highest singularity this challenge was completed at: walk the
+/// requirement ladder while it stays within `highest_singularity_completed`,
+/// capped at `maxCompletions`. The legacy walk continues past the cap and
+/// clamps after; stopping at the cap is outcome-identical (the result is
+/// `min(walk, max)` either way) and bounds the loop.
+#[must_use]
+pub fn challenge_completions_from_highest(
+    id: SingularityChallengeId,
+    highest_singularity_completed: f64,
+) -> f64 {
+    let max_completions = challenge_meta(id).max_completions;
+    let mut completions = 0.0;
+    while completions < max_completions
+        && challenge_singularity_requirement(id, completions) <= highest_singularity_completed
+    {
+        completions += 1.0;
+    }
+    completions.min(max_completions)
 }
 
 // ─── Tagged result type ───────────────────────────────────────────────────
@@ -493,6 +637,41 @@ mod tests {
             no_singularity_upgrades_singularity_requirement(100.0, 5.0),
             180.0
         );
+    }
+
+    #[test]
+    fn challenge_meta_spot_anchors() {
+        let no_sing = challenge_meta(SingularityChallengeId::NoSingularityUpgrades);
+        assert_eq!(no_sing.base_req, 1.0);
+        assert_eq!(no_sing.max_completions, 15.0);
+        assert_eq!(no_sing.unlock_singularity, 25.0);
+        let taxman = challenge_meta(SingularityChallengeId::TaxmanLastStand);
+        assert_eq!(taxman.base_req, 240.0);
+        assert_eq!(taxman.max_completions, 10.0);
+        assert_eq!(taxman.unlock_singularity, 281.0);
+    }
+
+    #[test]
+    fn challenge_singularity_requirement_folds_base_req() {
+        // noSingularityUpgrades: base 1 → tier 1 sits at singularity 1,
+        // tier 6 at 1 + 16·5 = 81, tier 10 at 1 + 16·9 + 8 = 153.
+        let id = SingularityChallengeId::NoSingularityUpgrades;
+        assert_eq!(challenge_singularity_requirement(id, 0.0), 1.0);
+        assert_eq!(challenge_singularity_requirement(id, 5.0), 81.0);
+        assert_eq!(challenge_singularity_requirement(id, 9.0), 153.0);
+    }
+
+    #[test]
+    fn completions_ladder_walks_and_caps() {
+        let id = SingularityChallengeId::NoSingularityUpgrades;
+        // Nothing completed → 0.
+        assert_eq!(challenge_completions_from_highest(id, 0.0), 0.0);
+        // Completed at singularity 1 (the tier-1 requirement) → 1.
+        assert_eq!(challenge_completions_from_highest(id, 1.0), 1.0);
+        // Completed at 153 → tiers 1..=10 (the tier-10 rung is exactly 153).
+        assert_eq!(challenge_completions_from_highest(id, 153.0), 10.0);
+        // Far past every rung → capped at maxCompletions.
+        assert_eq!(challenge_completions_from_highest(id, 1e9), 15.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/state/campaigns.rs
+++ b/crates/synergismforkd_logic/src/state/campaigns.rs
@@ -5,11 +5,16 @@
 //! and the constant-upgrade reads scattered across the tick layer.
 
 use serde::{Deserialize, Serialize};
+use serde_big_array::BigArray;
 
 use synergismforkd_bignum::Decimal;
 
-/// Fixed cardinality of the campaign-completions array. Tier B item 12.
-pub const CAMPAIGNS_LEN: usize = 10;
+/// Fixed cardinality of the campaign-completions array — one slot per key
+/// of the legacy `campaignDatas` const (`Campaign.ts`, `first` through
+/// `fiftieth`), verified against both legacy snapshots (50 keys, identical
+/// order and `limit`/`isMeta` values). The earlier `10` was a latent sizing
+/// bug (the octeract-42→47 class).
+pub const CAMPAIGNS_LEN: usize = 50;
 
 /// Fixed cardinality of the constant-upgrade array — `10 + 1` for the
 /// legacy 1-indexed convention. Tier B item 12.
@@ -18,9 +23,12 @@ pub const CONSTANT_UPGRADES_LEN: usize = 11;
 /// Slice of `GameState` for campaigns + constant upgrades.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct CampaignsState {
-    /// Per-campaign completion count. UI maintains the name ↔
-    /// index mapping. Both arrays fit inside serde's default
-    /// 0..=32-length window so no `BigArray` attribute needed.
+    /// Per-campaign `c10Completions` count, in `campaignDatas` key order
+    /// (`first` = 0 … `fiftieth` = 49). The campaign *runner* (choosing a
+    /// campaign, completing c10 under its corruptions) is UI-tier, so logic
+    /// only ever reads these; the token total derives from them via
+    /// [`crate::mechanics::campaign_token_rewards`].
+    #[serde(with = "BigArray")]
     pub campaign_completions: [f64; CAMPAIGNS_LEN],
     /// `player.campaigns.tokensSpent` — total tokens spent across
     /// all campaigns.

--- a/crates/synergismforkd_logic/src/state/singularity.rs
+++ b/crates/synergismforkd_logic/src/state/singularity.rs
@@ -35,6 +35,17 @@ pub struct SingularityState {
     /// `player.singChallengeTimer` — time inside the current singularity
     /// challenge (accumulates while `enabled`, resets to 0 otherwise).
     pub sing_challenge_timer: f64,
+    /// `player.singularityElevatorTarget` — the elevator's chosen floor.
+    /// The configure action clamps it to
+    /// `[1, max(1, highest, count + lookahead if antiquities)]`.
+    pub elevator_target: f64,
+    /// `player.singularityElevatorSlowClimb` — when set (the blank-save
+    /// default), a normal singularity advances the count by exactly one
+    /// instead of jumping by the fast-forward lookahead.
+    pub elevator_slow_climb: bool,
+    /// `player.singularityElevatorLocked` — when set, a normal singularity
+    /// goes to [`Self::elevator_target`] instead of advancing.
+    pub elevator_locked: bool,
     /// `noSingularityUpgrades` Exalt 1.
     pub no_singularity_upgrades: SingularityChallengeState,
     /// `oneChallengeCap` Exalt 2.
@@ -62,6 +73,11 @@ impl Default for SingularityState {
             highest_singularity_count: 0.0,
             singularity_counter: 0.0,
             sing_challenge_timer: 0.0,
+            // blankSave: target 1, slowClimb TRUE, locked false
+            // (Synergism.ts:1076-1078).
+            elevator_target: 1.0,
+            elevator_slow_climb: true,
+            elevator_locked: false,
             no_singularity_upgrades: SingularityChallengeState::default(),
             one_challenge_cap: SingularityChallengeState::default(),
             no_octeracts: SingularityChallengeState::default(),

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -2557,13 +2557,14 @@ fn populate_ambrosia_free_levels(state: &mut GameState) {
 /// awards) credit the full multiplier — every such site reads
 /// `1 + quark_bonus / 100`, which equals this product.
 ///
-/// Terms left at the multiplicative identity `1.0` are documented inline: the
-/// `quarkGain` achievement reward, the c15 quarks reward + quark-hepteract gate,
-/// `shopPanthema` / `infiniteAscent` (need their bonus-levels precompute /
-/// unlock gate), campaign bonus, and the UI/host-tier event + patreon
-/// (global / personal) bonuses. `favoriteUpgrade` passes a `0` maxed-sibling
-/// count (identity until that GQ upgrade is bought) and `ambrosiaCubeQuark1`
-/// passes a `0` `wow_cube_log_sum` — the same precedent as
+/// The `quarkGain` achievement reward (#250/#251/#266), the Challenge-15
+/// `quarks` reward, and the quark-hepteract bonus are now wired (each identity
+/// at default). The terms still left at the multiplicative identity `1.0` are
+/// documented inline: `shopPanthema` / `infiniteAscent` (need their bonus-levels
+/// precompute / unlock gate), campaign bonus, and the UI/host-tier event +
+/// patreon (global / personal) bonuses. `favoriteUpgrade` passes a `0`
+/// maxed-sibling count (identity until that GQ upgrade is bought) and
+/// `ambrosiaCubeQuark1` passes a `0` `wow_cube_log_sum` — the same precedent as
 /// [`compute_ambrosia_luck_pre`]'s deferred cube-log terms.
 fn compute_quark_multiplier(state: &GameState) -> f64 {
     use crate::mechanics::achievement_levels::achievement_level_from_points;
@@ -2576,7 +2577,8 @@ fn compute_quark_multiplier(state: &GameState) -> f64 {
     use crate::mechanics::calculate::product_f64;
     use crate::mechanics::golden_quark_upgrades::{
         advanced_pack_effect, divine_pack_effect, expert_pack_effect, favorite_upgrade_effect,
-        intermediate_pack_effect, master_pack_effect, sing_quark_improver_1_effect,
+        intermediate_pack_effect, master_pack_effect, sing_quark_hepteract_2_effect,
+        sing_quark_hepteract_3_effect, sing_quark_hepteract_effect, sing_quark_improver_1_effect,
         AdvancedPackKey, DivinePackKey, ExpertPackKey, IntermediatePackKey, MasterPackKey,
     };
     use crate::mechanics::level_rewards::{get_level_reward, LevelRewardKey};
@@ -2605,7 +2607,8 @@ fn compute_quark_multiplier(state: &GameState) -> f64 {
     };
     use crate::state::golden_quarks::{
         GQ_ADVANCED_PACK, GQ_DIVINE_PACK, GQ_EXPERT_PACK, GQ_FAVORITE_UPGRADE,
-        GQ_INTERMEDIATE_PACK, GQ_MASTER_PACK, GQ_SING_QUARK_IMPROVER_1,
+        GQ_INTERMEDIATE_PACK, GQ_MASTER_PACK, GQ_SING_QUARK_HEPTERACT, GQ_SING_QUARK_HEPTERACT_2,
+        GQ_SING_QUARK_HEPTERACT_3, GQ_SING_QUARK_IMPROVER_1,
     };
     use crate::state::octeract_upgrades::{
         OCTERACT_QUARK_GAIN, OCTERACT_QUARK_GAIN_2, OCTERACT_STARTER,
@@ -2660,8 +2663,29 @@ fn compute_quark_multiplier(state: &GameState) -> f64 {
         _ => 1.0,
     };
 
+    // QuarkHepteract: once `challenge15Exponent` reaches the `hepteractsUnlocked`
+    // requirement (`1e15`), the quark hepteract's `quarkMultiplier` applies.
+    // `hepteractEffective('quark')` returns the raw `BAL` (the quark craft uses a
+    // custom non-polynomial formula — Hepteracts.ts:633), and the effect is
+    // `(1 + 0.2·log2(1 + bal/500))^(DR + DR_INCREASE)` (Hepteracts.ts:134) with
+    // `DR = 2` and `DR_INCREASE` the three `singQuarkHepteract` GQ upgrades'
+    // `quarkHeptExponent`. Identity at default (`bal = 0` → base `1`).
+    let quark_hepteract = if state.challenges.challenge15_exponent >= 1e15 {
+        let exponent = 2.0
+            + sing_quark_hepteract_effect(gq(GQ_SING_QUARK_HEPTERACT))
+            + sing_quark_hepteract_2_effect(gq(GQ_SING_QUARK_HEPTERACT_2))
+            + sing_quark_hepteract_3_effect(gq(GQ_SING_QUARK_HEPTERACT_3));
+        (1.0 + 0.2 * (1.0 + state.hepteracts.quark.bal / 500.0).log2()).powf(exponent)
+    } else {
+        1.0
+    };
+
     product_f64(&[
-        1.0, // AchievementBonus — getAchievementReward('quarkGain') unported
+        // AchievementBonus — getAchievementReward('quarkGain') (#250/#251/#266).
+        crate::mechanics::achievement_rewards::quark_gain(
+            &state.achievements.achievements,
+            state.reset_counters.ascension_count,
+        ),
         get_level_reward(LevelRewardKey::Quarks, achievement_level),
         plastic_talisman_effects(state.talismans.talisman_levels[TALISMAN_PLASTIC] as i32)
             .quark_bonus,
@@ -2669,10 +2693,11 @@ fn compute_quark_multiplier(state: &GameState) -> f64 {
         if platonic[10] > 0.0 { 1.1 } else { 1.0 }, // PlatonicBETA
         if platonic[15] > 0.0 { 1.15 } else { 1.0 }, // PlatonicOMEGA
         1.0, // Jack (shopPanthema) — needs ShopPanthemaBonusLevels precompute
-        1.0, // Challenge15 — c15 quarks reward unported
+        // Challenge15 — c15 `quarks` reward, gated on `challenge15Exponent`.
+        crate::mechanics::challenge_15_rewards::quarks(state.challenges.challenge15_exponent),
         1.0, // CampaignBonus — player.campaigns.quarkBonus unported
         1.0, // InfiniteAscent — needs shop infiniteAscent unlock gate + rune
-        1.0, // QuarkHepteract — needs c15 hepteractsUnlocked gate + quark hepteract DR
+        quark_hepteract,
         calculate_quark_mult_from_powder(state.hepteracts.overflux_powder),
         1.0 + sing / 10.0,                                     // SingularityCount
         favorite_upgrade_effect(gq(GQ_FAVORITE_UPGRADE), 0.0), // siblings=0 until GQ bought
@@ -7087,6 +7112,43 @@ mod tests {
         state.singularity.highest_singularity_count = 1.0;
         state.ambrosia.upgrades[crate::state::ambrosia::AMBROSIA_QUARKS_1].level = 10.0;
         assert!((compute_quark_multiplier(&state) - 1.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quark_multiplier_includes_quark_gain_achievement_reward() {
+        // getAchievementReward('quarkGain'): achievement #266 (ascensionCount
+        // group) earned with ascensionCount ≥ 1e15 ⇒ ×(1 + 0.1·1) = ×1.1
+        // (first-singularity bonus disabled).
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 1.0;
+        state.achievements.achievements[266] = 1;
+        state.reset_counters.ascension_count = 1e16;
+        assert!((compute_quark_multiplier(&state) - 1.1).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quark_multiplier_includes_challenge15_quarks_reward() {
+        // The c15 `quarks` reward at exponent 1e11 (its requirement, below the
+        // 1e15 quark-hepteract gate) ⇒ 1 + (3/400)·log2(32) = 1.0375.
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 1.0;
+        state.challenges.challenge15_exponent = 1e11;
+        assert!((compute_quark_multiplier(&state) - 1.0375).abs() < 1e-9);
+    }
+
+    #[test]
+    fn quark_multiplier_includes_quark_hepteract() {
+        // QuarkHepteract activates at challenge15Exponent ≥ 1e15. Isolate its
+        // factor by holding the exponent fixed and varying only the quark
+        // hepteract balance: with no GQ DR upgrades the exponent is 2, so
+        // (1 + 0.2·log2(1 + 1500/500))^2 = (1 + 0.2·log2(4))^2 = 1.4^2 = 1.96.
+        let mut base = GameState::default();
+        base.singularity.highest_singularity_count = 1.0;
+        base.challenges.challenge15_exponent = 1e15;
+        let mut with_hept = base.clone();
+        with_hept.hepteracts.quark.bal = 1500.0;
+        let ratio = compute_quark_multiplier(&with_hept) / compute_quark_multiplier(&base);
+        assert!((ratio - 1.96).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1679,6 +1679,7 @@ fn phase_global_state(state: &mut GameState) -> AggregatorOutputs {
     } else {
         0.0
     };
+    let campaign_tokens = compute_campaign_tokens(state);
     let awarded = crate::mechanics::achievement_awards::reset_count_achievement_check(
         &mut state.achievements,
         state.reset_counters.prestige_count,
@@ -1706,6 +1707,9 @@ fn phase_global_state(state: &mut GameState) -> AggregatorOutputs {
     ) + crate::mechanics::achievement_awards::singularity_achievement_check(
         &mut state.achievements,
         state.singularity.highest_singularity_count,
+    ) + crate::mechanics::achievement_awards::campaign_tokens_achievement_check(
+        &mut state.achievements,
+        campaign_tokens,
     )
         // thousandSuns (#250) / thousandMoons (#251) — ungrouped, checked at
         // updateAll cadence in the legacy tick (Synergism.ts:3994). The legacy
@@ -1905,9 +1909,9 @@ fn phase_tax(state: &mut GameState, agg: &AggregatorOutputs) -> TaxOutputs {
         )
         .tax_reduction,
         challenge_15_taxes_reward: challenge_15_rewards::taxes(challenges.challenge15_exponent),
-        // Campaign-token subsystem unported → 0 tokens → multiplier 1
-        // (`campaignTaxMultiplier` returns 1 below 250 tokens).
-        campaign_tax_multiplier: campaign_token_rewards::campaign_tax_multiplier(0.0),
+        campaign_tax_multiplier: campaign_token_rewards::campaign_tax_multiplier(
+            compute_campaign_tokens(state),
+        ),
         ascend_shards: state.campaigns.ascend_shards,
         rare_fragments: Decimal::from_finite(state.talismans.rare_fragments),
         fortunae_formicidae_coin_multiplier: coins_ant.coin_multiplier,
@@ -2244,8 +2248,9 @@ fn compute_ascension_speed_mult_raw(state: &GameState) -> f64 {
 /// (each `AscensionScore` line), and the ascension cube award
 /// (`calc_corruption_stuff`).
 ///
-/// Bonus-subsystem neutral-defaults (faithful): campaign mult (campaign
-/// subsystem unported → 1) and event buff (UI-tier calendar → 0).
+/// The campaign multiplier is wired (`campaign_ascension_score_multiplier`
+/// of the derived token total); the event buff stays a faithful neutral 0
+/// (UI-tier calendar).
 fn compute_ascension_score_result(
     state: &GameState,
 ) -> crate::mechanics::calculate::CalculateAscensionScoreResult {
@@ -2287,7 +2292,10 @@ fn compute_ascension_score_result(
             platonic_blessing_mult: calculate_ascension_score_platonic_blessing(
                 &state.platonic_blessings,
             ),
-            campaign_ascension_score_mult: 1.0, // campaign subsystem unported → neutral
+            campaign_ascension_score_mult:
+                crate::mechanics::campaign_token_rewards::campaign_ascension_score_multiplier(
+                    compute_campaign_tokens(state),
+                ),
             finite_descent_ascension_score: finite_descent_rune_effects(
                 state.runes.rune_levels[RUNE_FINITE_DESCENT],
                 FiniteDescentRuneKey::AscensionScore,
@@ -2460,7 +2468,9 @@ fn compute_octeract_per_second(state: &GameState) -> f64 {
         ascension_score_line,
         1.0, // PseudoCoins — PCoin meta layer (unported)
         get_level_reward(LevelRewardKey::WowOcteracts, achievement_level),
-        1.0, // Campaign — player.campaigns.octeractBonus (unported)
+        crate::mechanics::campaign_token_rewards::campaign_octeract_bonus(compute_campaign_tokens(
+            state,
+        )), // Campaign — player.campaigns.octeractBonus
         season_pass_3_effect(shop[SHOP_SEASON_PASS_3]),
         season_pass_y_effect(shop[SHOP_SEASON_PASS_Y]),
         season_pass_z_effect(shop[SHOP_SEASON_PASS_Z], sing),
@@ -2569,6 +2579,80 @@ fn populate_ambrosia_free_levels(state: &mut GameState) {
     }
 }
 
+/// `updateTokens()` — the campaign-token total (`Campaign.ts:489`),
+/// self-derived from `&GameState`: every campaign's `computeTokenValue()`
+/// summed, plus `inheritanceTokens()` and the GQ `singBonusTokens4` /
+/// octeract `octeractBonusTokens4` initial-token grants. The legacy keeps
+/// this in a module global recomputed on campaign/upgrade changes; logic
+/// derives it live wherever a `campaign_token_rewards::*` bonus needs it.
+///
+/// `0` at default state (no completions, no singularity), so every
+/// token-derived bonus stays at its identity. Tokens flow without the
+/// campaign runner once `highestSingularityCount ≥ 5` (the inheritance
+/// floor) — the runner itself (picking a campaign, completing c10 under
+/// its corruptions) is UI-tier and writes `campaign_completions`.
+fn compute_campaign_tokens(state: &GameState) -> f64 {
+    use crate::mechanics::campaign_token_rewards::{
+        campaign_token_value, inheritance_tokens, singularity_bonus_token_mult,
+        CampaignTokenBonuses, CAMPAIGN_IS_META, CAMPAIGN_TOKEN_LIMITS,
+    };
+    use crate::mechanics::golden_quark_upgrades::{
+        sing_bonus_tokens_1_effect, sing_bonus_tokens_2_effect, sing_bonus_tokens_3_effect,
+        sing_bonus_tokens_4_effect,
+    };
+    use crate::mechanics::octeracts::{
+        octeract_bonus_tokens_1_effect, octeract_bonus_tokens_2_effect,
+        octeract_bonus_tokens_3_effect, octeract_bonus_tokens_4_effect,
+    };
+    use crate::state::campaigns::CAMPAIGNS_LEN;
+    use crate::state::golden_quarks::{
+        GQ_SING_BONUS_TOKENS_1, GQ_SING_BONUS_TOKENS_2, GQ_SING_BONUS_TOKENS_3,
+        GQ_SING_BONUS_TOKENS_4,
+    };
+    use crate::state::octeract_upgrades::{
+        OCTERACT_BONUS_TOKENS_1, OCTERACT_BONUS_TOKENS_2, OCTERACT_BONUS_TOKENS_3,
+        OCTERACT_BONUS_TOKENS_4,
+    };
+
+    let highest_sing = state.singularity.highest_singularity_count;
+    let gq = |i: usize| {
+        state.golden_quarks.upgrades[i].level + state.golden_quarks.upgrades[i].free_level
+    };
+    let oct = |i: usize| {
+        state.octeract_upgrades.upgrades[i].level + state.octeract_upgrades.upgrades[i].free_level
+    };
+
+    let first_milestone = if highest_sing >= 16.0 { 5.0 } else { 0.0 };
+    let last_milestone = if highest_sing >= 69.0 { 10.0 } else { 0.0 };
+    let bonuses = CampaignTokenBonuses {
+        first_completion_bonus: first_milestone
+            + sing_bonus_tokens_1_effect(gq(GQ_SING_BONUS_TOKENS_1))
+            + octeract_bonus_tokens_3_effect(oct(OCTERACT_BONUS_TOKENS_3)),
+        last_completion_bonus: last_milestone
+            + sing_bonus_tokens_3_effect(gq(GQ_SING_BONUS_TOKENS_3))
+            + octeract_bonus_tokens_1_effect(oct(OCTERACT_BONUS_TOKENS_1)),
+        token_multiplier: singularity_bonus_token_mult(highest_sing)
+            * sing_bonus_tokens_2_effect(gq(GQ_SING_BONUS_TOKENS_2))
+            * octeract_bonus_tokens_2_effect(oct(OCTERACT_BONUS_TOKENS_2)),
+    };
+
+    let campaign_sum: f64 = (0..CAMPAIGNS_LEN)
+        .map(|i| {
+            campaign_token_value(
+                state.campaigns.campaign_completions[i],
+                CAMPAIGN_TOKEN_LIMITS[i],
+                CAMPAIGN_IS_META[i],
+                &bonuses,
+            )
+        })
+        .sum();
+
+    campaign_sum
+        + inheritance_tokens(highest_sing)
+        + sing_bonus_tokens_4_effect(gq(GQ_SING_BONUS_TOKENS_4))
+        + octeract_bonus_tokens_4_effect(oct(OCTERACT_BONUS_TOKENS_4))
+}
+
 /// `calculateQuarkMultiplier()` — the global quark-gain multiplier
 /// (`allQuarkStats` product, original `Statistics.ts:1233` / `Calculate.ts:378`),
 /// self-derived from `&GameState`. Cached each tick into
@@ -2578,10 +2662,11 @@ fn populate_ambrosia_free_levels(state: &mut GameState) {
 /// `1 + quark_bonus / 100`, which equals this product.
 ///
 /// The `quarkGain` achievement reward (#250/#251/#266), the Challenge-15
-/// `quarks` reward, and the quark-hepteract bonus are now wired (each identity
-/// at default). The terms still left at the multiplicative identity `1.0` are
-/// documented inline: `shopPanthema` / `infiniteAscent` (need their bonus-levels
-/// precompute / unlock gate), campaign bonus, and the UI/host-tier event +
+/// `quarks` reward, the quark-hepteract bonus, and the campaign bonus (of the
+/// derived token total) are now wired (each identity at default). The terms
+/// still left at the multiplicative identity `1.0` are documented inline:
+/// `shopPanthema` / `infiniteAscent` (need their bonus-levels precompute /
+/// unlock gate) and the UI/host-tier event +
 /// patreon (global / personal) bonuses. `favoriteUpgrade` passes a `0`
 /// maxed-sibling count (identity until that GQ upgrade is bought) and
 /// `ambrosiaCubeQuark1` passes a `0` `wow_cube_log_sum` — the same precedent as
@@ -2715,7 +2800,9 @@ fn compute_quark_multiplier(state: &GameState) -> f64 {
         1.0, // Jack (shopPanthema) — needs ShopPanthemaBonusLevels precompute
         // Challenge15 — c15 `quarks` reward, gated on `challenge15Exponent`.
         crate::mechanics::challenge_15_rewards::quarks(state.challenges.challenge15_exponent),
-        1.0, // CampaignBonus — player.campaigns.quarkBonus unported
+        crate::mechanics::campaign_token_rewards::campaign_quark_bonus(compute_campaign_tokens(
+            state,
+        )), // CampaignBonus — player.campaigns.quarkBonus
         1.0, // InfiniteAscent — needs shop infiniteAscent unlock gate + rune
         quark_hepteract,
         calculate_quark_mult_from_powder(state.hepteracts.overflux_powder),
@@ -2785,9 +2872,9 @@ fn compute_quark_multiplier(state: &GameState) -> f64 {
 /// zeroes it; the award block in `apply_ascension_layer` therefore calls this
 /// before the counter reset (Reset.ts ordering).
 ///
-/// Neutral-defaulted lines (faithful — unported / paused / UI-tier):
-/// PseudoCoins (PCoin meta), CampaignTutorial + Campaign (campaign subsystem
-/// unported), InfiniteAscent (the infiniteAscent rune is outside the 7-rune
+/// CampaignTutorial + Campaign are wired to the derived campaign-token
+/// total. Neutral-defaulted lines (faithful — unported / paused / UI-tier):
+/// PseudoCoins (PCoin meta), InfiniteAscent (the infiniteAscent rune is outside the 7-rune
 /// `rune_levels` model → level 0 → `1 + 0/100`), SingDebuff
 /// (`1 / calculateSingularityDebuff('Cubes')` — the singularity layer is paused
 /// and has no production debuff-input builder; `= 1` at `singularityCount 0`,
@@ -2868,10 +2955,15 @@ fn compute_all_cube_multiplier(state: &GameState) -> f64 {
     let amb = |i: usize| state.ambrosia.upgrades[i].level + state.ambrosia.upgrades[i].free_level;
     let red = |i: usize| state.red_ambrosia.upgrades[i].level;
 
+    let campaign_tokens = compute_campaign_tokens(state);
+
     // AscensionTime: `min(1, counter/threshold)^2`, times `(1 + overflow)` once
     // the `ascensionRewardScaling` achievement (#204) is earned.
     let reset_threshold = reset_time_threshold(&ResetTimeThresholdInput {
-        campaign_time_threshold_reduction: 0.0, // campaign subsystem unported → 0
+        campaign_time_threshold_reduction:
+            crate::mechanics::campaign_token_rewards::campaign_time_threshold_reduction(
+                campaign_tokens,
+            ),
     });
     let frac = state.reset_counters.ascension_counter / reset_threshold;
     let ascension_time_base = frac.min(1.0).powi(2);
@@ -2933,8 +3025,8 @@ fn compute_all_cube_multiplier(state: &GameState) -> f64 {
     product_f64(&[
         1.0, // PseudoCoins — PCoin meta layer (unported)
         ascension_time,
-        1.0, // CampaignTutorial — campaign subsystem (unported)
-        1.0, // Campaign — campaign subsystem (unported)
+        crate::mechanics::campaign_token_rewards::tutorial_bonus(campaign_tokens).cube_bonus, // CampaignTutorial
+        crate::mechanics::campaign_token_rewards::campaign_cube_bonus(campaign_tokens), // Campaign
         challenge_15_cubes,
         1.0, // InfiniteAscent — rune outside the 7-rune model → level 0 → 1
         1.0 + platonic[PLATONIC_UPGRADE_BETA], // Beta
@@ -3468,7 +3560,9 @@ fn compute_golden_quarks_multiplier_excluding_base(state: &GameState) -> f64 {
 
     product_f64(&[
         1.0, // PseudoCoins — PCoin meta layer (unported)
-        1.0, // Campaign — player.campaigns.goldenQuarkBonus (unported)
+        crate::mechanics::campaign_token_rewards::campaign_golden_quark_bonus(
+            compute_campaign_tokens(state),
+        ), // Campaign — player.campaigns.goldenQuarkBonus
         // Challenge15: 1 + max(0, log10(challenge15Exponent + 1) − 20) / 2.
         1.0 + 0.0_f64.max((state.challenges.challenge15_exponent + 1.0).log10() - 20.0) / 2.0,
         golden_quarks_1_effect(gq(GQ_GOLDEN_QUARKS_1)),
@@ -3546,9 +3640,9 @@ fn compute_base_obtainium(state: &GameState) -> f64 {
 /// blessing also appears as the `CubeBonus` line, so it is applied twice,
 /// verbatim with the legacy `calculateObtainiumDecimal`.
 ///
-/// Neutral-defaulted lines (faithful — no logic state source / inert at the
-/// current state): campaign `TutorialBonus`/`CampaignBonus` (campaign
-/// subsystem unported → 1), `Event` (UI-tier event calendar → 1),
+/// `TutorialBonus`/`CampaignBonus` are wired to the derived campaign-token
+/// total. Neutral-defaulted lines (faithful — no logic state source / inert
+/// at the current state): `Event` (UI-tier event calendar → 1),
 /// `ReincarnationUpgrade14` (reads `maxOfferings`, untracked → 1; its branch
 /// is `1` at `maxOfferings 0` anyway), `Jack`/`shopPanthema` (needs the
 /// unported `ShopPanthemaBonusLevels` → 1), `SpiritPower` (effective
@@ -3682,18 +3776,20 @@ fn compute_obtainium(
     // CubeUpgradeCx21 — `1.04 ^ (cubeUpgrades[71] · ΣtalismanRarities)`.
     let talisman_rarities = state.talismans.talisman_rarity.map(|r| r as u8);
 
+    let campaign_tokens = compute_campaign_tokens(state);
+
     // immaculate = Π allObtainiumIgnoreDRStats (line 1 = calculateBaseObtainium).
     let immaculate = product_f64(&[
-        base_obtainium,                                                         // Base
-        1.0 + 0.04 * cube[42],                                                  // CubeUpgrade4x2
-        1.0 + 0.03 * cube[43],                                                  // CubeUpgrade4x3
-        1.0, // TutorialBonus — campaign subsystem unported → 1
-        1.0, // CampaignBonus — campaign subsystem unported → 1
+        base_obtainium,        // Base
+        1.0 + 0.04 * cube[42], // CubeUpgrade4x2
+        1.0 + 0.03 * cube[43], // CubeUpgrade4x3
+        crate::mechanics::campaign_token_rewards::tutorial_bonus(campaign_tokens).obtainium_bonus, // TutorialBonus
+        crate::mechanics::campaign_token_rewards::campaign_obtainium_bonus(campaign_tokens), // CampaignBonus
         challenge_15_rewards::obtainium(state.challenges.challenge15_exponent), // ChallengeBonus
-        1.0 + platonic[5], // PlatonicALPHA
-        1.0 + 1.5 * platonic[9], // PlatonicUpgrade9
-        1.0 + 2.5 * platonic[10], // PlatonicBETA
-        1.0 + 5.0 * platonic[15], // PlatonicOMEGA
+        1.0 + platonic[5],                                                      // PlatonicALPHA
+        1.0 + 1.5 * platonic[9],                                                // PlatonicUpgrade9
+        1.0 + 2.5 * platonic[10],                                               // PlatonicBETA
+        1.0 + 5.0 * platonic[15],                                               // PlatonicOMEGA
         10.0_f64.powf(antiquities_rune_effects(
             state.runes.rune_levels[RUNE_ANTIQUITIES],
             AntiquitiesRuneKey::ObtainiumLog10,
@@ -3701,7 +3797,7 @@ fn compute_obtainium(
                 singularity_count: sing,
             },
         )), // Antiquities
-        1.0 + cube[55] / 100.0, // CubeUpgradeCx5
+        1.0 + cube[55] / 100.0,                                                 // CubeUpgradeCx5
         if cube[62] > 0.0 && state.challenges.current_ascension_challenge == 15 {
             8.0
         } else {
@@ -3725,7 +3821,7 @@ fn compute_obtainium(
         } else {
             1.0
         }, // Exalt6Penalty
-        1.0, // Event — UI-tier event calendar → 1 + 0
+        1.0,                                             // Event — UI-tier event calendar → 1 + 0
     ]);
 
     // base_mults = Π allObtainiumStats × calculateObtainiumCubeBlessing(),
@@ -3862,8 +3958,8 @@ fn compute_obtainium(
 /// resets faster than the threshold), `TimeMultiplier` (`max(1, t/threshold)`
 /// when `time_mult_check`, else 1, rewarding longer resets), and `HalfMind`
 /// (`globalSpeedMult / 10` when the half-mind GQ upgrade is unlocked, else 1).
-/// `threshold` uses `campaignTimeThresholdReduction = 0` (campaign subsystem
-/// unported → threshold 10).
+/// `threshold` folds the campaign time-threshold reduction of the derived
+/// token total (10 at zero tokens).
 fn offering_obtainium_time_multiplier(state: &GameState, time: f64, time_mult_check: bool) -> f64 {
     use crate::mechanics::golden_quark_upgrades::half_mind_effect;
     use crate::mechanics::reset_time_and_auto_obtainium::{
@@ -3872,7 +3968,10 @@ fn offering_obtainium_time_multiplier(state: &GameState, time: f64, time_mult_ch
     use crate::state::golden_quarks::GQ_HALF_MIND;
 
     let threshold = reset_time_threshold(&ResetTimeThresholdInput {
-        campaign_time_threshold_reduction: 0.0,
+        campaign_time_threshold_reduction:
+            crate::mechanics::campaign_token_rewards::campaign_time_threshold_reduction(
+                compute_campaign_tokens(state),
+            ),
     });
     let ratio = time / threshold;
 
@@ -3984,13 +4083,13 @@ fn compute_base_offerings(state: &GameState) -> f64 {
 /// caller's `calculateBaseOfferings()` (the `Base` line). Reduced in Decimal
 /// space to survive the 1e300 cap.
 ///
-/// Neutral-defaulted lines (faithful — no logic-state source / inert at the
-/// current state): `AchievementBonus` (achievement awarding unported, P3.1/H5
-/// → 1.0; the lone contributor is the `prestigeCount ≥ 1000` achievement),
-/// `ParticleUpgrade3x5` (`maxObtainium` untracked → the `min(maxObtainium, …)`
-/// term is 0, so the line is 1.0), `TutorialBonus`/`CampaignBonus` (campaign
-/// subsystem unported → 1.0), `ThriftSpirit` (rune-spirit power chain unported
-/// → 1.0), `Jack`/`shopPanthema` (needs the unported `ShopPanthemaBonusLevels`
+/// `TutorialBonus`/`CampaignBonus` are wired to the derived campaign-token
+/// total. Neutral-defaulted lines (faithful — no logic-state source / inert
+/// at the current state): `AchievementBonus` (the `offeringBonus` reward
+/// *reader* is unported → 1.0; its lone contributor is the
+/// `prestigeCount ≥ 1000` achievement), `ParticleUpgrade3x5` (`maxObtainium`
+/// untracked → the `min(maxObtainium, …)` term is 0, so the line is 1.0),
+/// `Jack`/`shopPanthema` (needs the unported `ShopPanthemaBonusLevels`
 /// → 1.0), `SingularityDebuff` (`1/calculateSingularityDebuff`; singularity
 /// layer paused → 1.0), and `Event` (UI-tier event calendar → 1.0).
 fn compute_offering_mult(state: &GameState, base_offerings: f64) -> Decimal {
@@ -4142,8 +4241,11 @@ fn compute_offering_mult(state: &GameState, base_offerings: f64) -> Decimal {
         1.0 + 0.02 * state.campaigns.constant_upgrades[3], // ConstantUpgrade3
         // ResearchTalismans — 1 + 0.0003·midas·research[149] + 0.0004·midas·research[179].
         1.0 + 0.0003 * midas_level * researches[149] + 0.0004 * midas_level * researches[179],
-        1.0, // TutorialBonus — campaign subsystem unported → 1.0
-        1.0, // CampaignBonus — campaign subsystem unported → 1.0
+        crate::mechanics::campaign_token_rewards::tutorial_bonus(compute_campaign_tokens(state))
+            .offering_bonus, // TutorialBonus
+        crate::mechanics::campaign_token_rewards::campaign_offering_bonus(compute_campaign_tokens(
+            state,
+        )), // CampaignBonus
         1.0 + 0.12 * calc_ecc(ChallengeType::Ascension, cc[12]), // Challenge12
         // ThriftSpirit — getRuneSpiritEffect('thrift').offerings.
         crate::mechanics::rune_spirit_effects::thrift_rune_spirit_effects(rune_spirit_power(
@@ -4253,8 +4355,8 @@ fn compute_offerings(state: &GameState) -> Decimal {
 /// ant-sacrifice obtainium source (a `max()` alternative gated by
 /// `cubeUpgrades[47] > 0`) is now wired to `calculateAntSacrificeObtainium` via
 /// the ported `ant_sacrifice::compute_ant_sacrifice_multiplier`; it stays inert
-/// at the current state (`cubeUpgrades[47] == 0`). The reset-time divisor uses
-/// `campaignTimeThresholdReduction = 0` (campaign subsystem unported).
+/// at the current state (`cubeUpgrades[47] == 0`). The reset-time divisor folds
+/// the campaign time-threshold reduction of the derived token total.
 fn compute_obtainium_gain(
     state: &GameState,
     dt: f64,
@@ -4270,7 +4372,10 @@ fn compute_obtainium_gain(
     // Auto-research path: legacy `calculateObtainium(false)` ⇒ timeMult 1.0.
     let resource_mult = compute_obtainium(state, base_obtainium, reincarnation_point_gain, 1.0);
     let reset_time_divisor = reset_time_threshold(&ResetTimeThresholdInput {
-        campaign_time_threshold_reduction: 0.0, // campaign subsystem unported → 0
+        campaign_time_threshold_reduction:
+            crate::mechanics::campaign_token_rewards::campaign_time_threshold_reduction(
+                compute_campaign_tokens(state),
+            ),
     });
 
     // Ant-sacrifice obtainium alternative source (gated by cubeUpgrades[47]):
@@ -5174,7 +5279,9 @@ fn compute_ambrosia_luck_pre(state: &GameState) -> f64 {
             LevelRewardKey::AmbrosiaLuck,
             achievement_level_from_points(state.achievements.achievement_points),
         ),
-        0.0, // Campaign — player.campaigns.ambrosiaLuckBonus (unported)
+        crate::mechanics::campaign_token_rewards::campaign_ambrosia_luck_bonus(
+            compute_campaign_tokens(state),
+        ), // Campaign — player.campaigns.ambrosiaLuckBonus
         calculate_singularity_ambrosia_luck_milestone_bonus(highest_sing),
         shop_ambrosia_luck_1_effect(shop[SHOP_AMBROSIA_LUCK_1]),
         shop_ambrosia_luck_2_effect(shop[SHOP_AMBROSIA_LUCK_2]),
@@ -5259,10 +5366,11 @@ fn compute_ambrosia_luck_pre(state: &GameState) -> f64 {
 /// so this is exactly `0` at the default state (ambrosia locked) — matching
 /// the old default.
 ///
+/// The campaign blueberry-speed bonus is wired to the derived token total.
 /// Multiplicative lines whose context is unported are neutral `1.0`
-/// (planar-coin, campaign bonus [campaign-token total not tracked], shop
-/// `panthema`, patreon [quark-bonus arg], event); the additive blueberry
-/// lines neutral `0`. All are inert at the current play state.
+/// (planar-coin, shop `panthema`, patreon [quark-bonus arg], event); the
+/// additive blueberry lines neutral `0`. All are inert at the current play
+/// state.
 fn compute_ambrosia_generation_speed_pre(state: &GameState) -> f64 {
     use crate::mechanics::ambrosia::{
         calculate_number_of_thresholds, calculate_singularity_milestone_blueberries,
@@ -5332,7 +5440,9 @@ fn compute_ambrosia_generation_speed_pre(state: &GameState) -> f64 {
     let raw_speed = product_f64(&[
         if no_sing > 0.0 { 1.0 } else { 0.0 }, // Default gate
         1.0,                                   // PseudoCoins (planar, unported)
-        1.0,                                   // Campaign (token total not tracked)
+        crate::mechanics::campaign_token_rewards::campaign_blueberry_speed_bonus(
+            compute_campaign_tokens(state),
+        ), // Campaign — player.campaigns.blueberrySpeedBonus
         shop_ambrosia_generation_1_effect(shop[SHOP_AMBROSIA_GENERATION_1]),
         shop_ambrosia_generation_2_effect(shop[SHOP_AMBROSIA_GENERATION_2]),
         shop_ambrosia_generation_3_effect(shop[SHOP_AMBROSIA_GENERATION_3]),
@@ -5980,9 +6090,9 @@ fn phase_challenge_completion(
     if qa == 15 && state.shop.upgrades[SHOP_CHALLENGE_15_AUTO] > 0.0 {
         // challenge15ScoreMultiplier(): campaign · challenge-hepteract · OMEGA.
         let c15_sm = challenge_15_score_multiplier(&Challenge15ScoreMultiplierInput {
-            // Campaign subsystem unported → neutral (mirrors the `campaign_*` legs
-            // elsewhere in the tick, e.g. `campaign_ascension_score_mult`).
-            c15_bonus: 1.0,
+            c15_bonus: crate::mechanics::campaign_token_rewards::campaign_c15_bonus(
+                compute_campaign_tokens(state),
+            ),
             // `hepteractEffective('challenge')` — challenge craft LIMIT 1000, DR 1/6,
             // DR_INCREASE 0 (Hepteracts.ts:190-192).
             challenge_hepteract_effective: hepteract_effective_bal(
@@ -7169,6 +7279,54 @@ mod tests {
         with_hept.hepteracts.quark.bal = 1500.0;
         let ratio = compute_quark_multiplier(&with_hept) / compute_quark_multiplier(&base);
         assert!((ratio - 1.96).abs() < 1e-9);
+    }
+
+    #[test]
+    fn campaign_tokens_default_is_zero() {
+        assert_eq!(compute_campaign_tokens(&GameState::default()), 0.0);
+    }
+
+    #[test]
+    fn campaign_tokens_flow_from_inheritance_and_completions() {
+        // Inheritance alone: highestSingularityCount 16 sits in the
+        // `levels[2] = 10` tier → 25 tokens.
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 16.0;
+        assert_eq!(compute_campaign_tokens(&state), 25.0);
+
+        // One full campaign (first: limit 10, not meta): additive
+        // 10 + 5 (first-completion, sing ≥ 16) + 0 (last needs sing ≥ 69),
+        // multiplier 1 → 15. Total 25 + 15 = 40.
+        state.campaigns.campaign_completions[0] = 10.0;
+        assert_eq!(compute_campaign_tokens(&state), 40.0);
+
+        // A meta campaign doubles its own value: second (limit 10, meta)
+        // at 1 completion → (1 + 5)·2 = 12. Total 52.
+        state.campaigns.campaign_completions[1] = 1.0;
+        assert_eq!(compute_campaign_tokens(&state), 52.0);
+    }
+
+    #[test]
+    fn phase_global_state_awards_campaign_token_achievements() {
+        // 40 tokens (sing 16 + a full first campaign) crosses the 10/20/40
+        // gates (#426/#427/#428) but not 80 (#429).
+        let mut s = GameState::default();
+        s.singularity.highest_singularity_count = 16.0;
+        s.campaigns.campaign_completions[0] = 10.0;
+        let _ = phase_global_state(&mut s);
+        assert_eq!(s.achievements.achievements[426], 1);
+        assert_eq!(s.achievements.achievements[428], 1);
+        assert_eq!(s.achievements.achievements[429], 0);
+    }
+
+    #[test]
+    fn quark_multiplier_includes_campaign_bonus() {
+        // highestSingularityCount 50 → inheritance 150 tokens →
+        // campaignQuarkBonus = 1 + 0.05·min(50, 100)/100 = 1.025. Every
+        // other term stays identity (singularityCount itself is 0).
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 50.0;
+        assert!((compute_quark_multiplier(&state) - 1.025).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -312,6 +312,14 @@ pub enum PlayerAction {
         /// Open the entire balance.
         max: bool,
     },
+    /// Toggle a singularity (Exalt) challenge (legacy
+    /// `SingularityChallenge.challengeEntryHandler`): enter it when its flag
+    /// is clear (jumping to the tier's required singularity), otherwise exit —
+    /// succeeding iff the antiquities rune was purchased inside.
+    ToggleSingularityChallenge {
+        /// Which Exalt to toggle.
+        challenge: crate::events::SingularityChallengeId,
+    },
 }
 
 /// Selects the automation flag a [`PlayerAction::ToggleAuto`] sets.
@@ -5832,6 +5840,11 @@ fn phase_player_input(
                     state, *tier, *value, *max,
                 ));
             }
+            PlayerAction::ToggleSingularityChallenge { challenge } => {
+                output
+                    .events
+                    .extend(reset::toggle_singularity_challenge(state, *challenge));
+            }
         }
     }
 }
@@ -7353,6 +7366,42 @@ mod tests {
             assert_eq!(s.achievements.progressive[slot].cached_points, 0.0);
         }
         assert_eq!(s.achievements.achievement_points, 0.0);
+    }
+
+    #[test]
+    fn exalt_toggle_dispatches_through_tack_and_lights_the_progressive() {
+        use crate::events::SingularityChallengeId as Id;
+        // Enter via the player action…
+        let mut s = GameState::default();
+        s.singularity.highest_singularity_count = 25.0;
+        s.singularity.singularity_count = 25.0;
+        let mut input = TackInput::default();
+        input
+            .player_actions
+            .push(PlayerAction::ToggleSingularityChallenge {
+                challenge: Id::NoSingularityUpgrades,
+            });
+        let out = tack(&mut s, &input);
+        assert!(s.singularity.no_singularity_upgrades.enabled);
+        assert_eq!(s.singularity.singularity_count, 1.0);
+        assert!(out
+            .events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::SingularityChallengeEntered { .. })));
+
+        // …complete it (antiquities re-acquired) and exit via the same action.
+        s.runes.rune_levels[crate::state::RUNE_ANTIQUITIES] = 1.0;
+        let out = tack(&mut s, &input);
+        assert!(!s.singularity.no_singularity_upgrades.enabled);
+        assert_eq!(s.singularity.no_singularity_upgrades.completions, 1.0);
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            CoreEvent::SingularityChallengeExited { success: true, .. }
+        )));
+        // The exalt progressive (slot 8) sees the completion on the next tick:
+        // noSingularityUpgrades rewardAP = 15·1.
+        let _ = tack(&mut s, &TackInput::default());
+        assert_eq!(s.achievements.progressive[8].cached_points, 15.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1706,7 +1706,24 @@ fn phase_global_state(state: &mut GameState) -> AggregatorOutputs {
     ) + crate::mechanics::achievement_awards::singularity_achievement_check(
         &mut state.achievements,
         state.singularity.highest_singularity_count,
-    );
+    )
+        // thousandSuns (#250) / thousandMoons (#251) — ungrouped, checked at
+        // updateAll cadence in the legacy tick (Synergism.ts:3994). The legacy
+        // `=== 1e5` gates are `>= 1e5` here: both levels cap at exactly 1e5
+        // (research 8x25 / cube w5x10), so the forms are equivalent and `>=`
+        // stays monotonic.
+        + crate::mechanics::achievement_awards::award_ungrouped_achievement(
+            &mut state.achievements,
+            250,
+            100.0,
+            state.researches.researches[200] >= 1e5,
+        )
+        + crate::mechanics::achievement_awards::award_ungrouped_achievement(
+            &mut state.achievements,
+            251,
+            150.0,
+            state.cube_upgrade_levels.cube_upgrades[50] >= 1e5,
+        );
     credit_achievement_quarks(state, awarded);
     recompute_talisman_rarities(state);
     let total_accelerator_boost = compute_total_accelerator_boost(state);
@@ -10153,6 +10170,30 @@ mod tests {
         assert_eq!(s.achievements.achievements[274], 1);
         assert_eq!(s.achievements.achievements[276], 1);
         assert_eq!(s.achievements.achievements[277], 0);
+    }
+
+    #[test]
+    fn phase_global_state_awards_thousand_suns_and_moons() {
+        // thousandSuns (#250): research 8x25 maxed at 1e5. thousandMoons
+        // (#251): cube upgrade w5x10 maxed at 1e5. Each then feeds the
+        // quarkGain achievement reward (×1.05 apiece).
+        let mut s = GameState::default();
+        s.singularity.highest_singularity_count = 1.0; // drop the ×1.25 default
+        let _ = phase_global_state(&mut s);
+        assert_eq!(s.achievements.achievements[250], 0);
+
+        s.researches.researches[200] = 1e5;
+        s.cube_upgrade_levels.cube_upgrades[50] = 1e5;
+        let _ = phase_global_state(&mut s);
+        assert_eq!(s.achievements.achievements[250], 1);
+        assert_eq!(s.achievements.achievements[251], 1);
+        // The newly-awarded bits light the quarkGain reward in the multiplier.
+        assert!((compute_quark_multiplier(&s) - 1.05 * 1.05).abs() < 1e-9);
+        // One level short → not awarded.
+        let mut below = GameState::default();
+        below.researches.researches[200] = 1e5 - 1.0;
+        let _ = phase_global_state(&mut below);
+        assert_eq!(below.achievements.achievements[250], 0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1472,14 +1472,21 @@ fn compute_update_all_tick_pre(
 /// live state. Runs first in [`phase_global_state`] so the crystal/mythos
 /// exponents (which read `achievement_points`) see the fresh total.
 ///
-/// Neutral-defaulted to `0` (faithful — input not in logic / subsystem inert):
-/// `exalts` (singularity-challenge `rewardAP`, singularity paused) and the
-/// three maxed-upgrade families (`maxLevel` is UI-tier data, `0` in logic, so
-/// "maxed" can't be told apart). They contribute once that data lands.
+/// All 12 slots are live. The `exalts` slot derives each singularity
+/// challenge's `rewardAP` (= `achievementPointValue(completions)`, a getter
+/// in the legacy class) from the tracked completion counts; the three
+/// maxed-upgrade families count `level >= maxLevel` against the seeded GQ
+/// metadata / the static octeract + red-ambrosia max-level tables. Their
+/// legacy `updateValue()` closures return `0`, so the cached value stays `0`
+/// and the points come entirely from live state (`useCachedValue: false`).
 fn update_progressive_achievements(state: &mut GameState) {
     use crate::mechanics::achievement_awards::update_progressive_slot;
     use crate::mechanics::achievement_points as ap;
     use crate::mechanics::ant_reborn_elo::calculate_leaderboard_value;
+    use crate::mechanics::golden_quark_upgrades::count_maxed_golden_quark_upgrades;
+    use crate::mechanics::octeracts::count_maxed_octeract_upgrades;
+    use crate::mechanics::red_ambrosia_upgrades::count_maxed_red_ambrosia_upgrades;
+    use crate::mechanics::singularity_challenges as sc;
     use crate::state::runes::RUNE_COUNT;
 
     // Gather every live value that needs a state read before the `&mut` borrow.
@@ -1500,6 +1507,31 @@ fn update_progressive_achievements(state: &mut GameState) {
     let lifetime_ambrosia = state.ambrosia.lifetime_ambrosia;
     let lifetime_red = state.red_ambrosia.lifetime_red_ambrosia;
     let rarity_sum: f64 = state.talismans.talisman_rarity.iter().sum();
+    // exalts: Σ rewardAP = Σ achievementPointValue(completions) per challenge.
+    let s = &state.singularity;
+    let exalt_ap = ap::exalt_points(&[
+        sc::no_singularity_upgrades_achievement_point_value(s.no_singularity_upgrades.completions),
+        sc::one_challenge_cap_achievement_point_value(s.one_challenge_cap.completions),
+        sc::no_octeracts_achievement_point_value(s.no_octeracts.completions),
+        sc::limited_ascensions_achievement_point_value(s.limited_ascensions.completions),
+        sc::no_ambrosia_upgrades_achievement_point_value(s.no_ambrosia_upgrades.completions),
+        sc::no_quark_upgrades_achievement_point_value(s.no_quark_upgrades.completions),
+        sc::limited_time_achievement_point_value(s.limited_time.completions),
+        sc::sadistic_prequel_achievement_point_value(s.sadistic_prequel.completions),
+        sc::taxman_last_stand_achievement_point_value(s.taxman_last_stand.completions),
+    ]);
+    let gq_maxed_points = ap::maxed_upgrade_family_points(
+        count_maxed_golden_quark_upgrades(&state.golden_quarks),
+        5.0,
+    );
+    let oct_maxed_points = ap::maxed_upgrade_family_points(
+        count_maxed_octeract_upgrades(&state.octeract_upgrades),
+        8.0,
+    );
+    let red_maxed_points = ap::maxed_upgrade_family_points(
+        count_maxed_red_ambrosia_upgrades(&state.red_ambrosia),
+        10.0,
+    );
 
     let ach = &mut state.achievements;
     // useCachedValue: true → score from the cached Math.max value.
@@ -1514,10 +1546,12 @@ fn update_progressive_achievements(state: &mut GameState) {
         ap::reborn_elo_points(leaderboard_elo)
     });
     update_progressive_slot(ach, 4, sing, |_| ap::singularity_count_points(sing));
-    update_progressive_slot(ach, 8, 0.0, |_| 0.0); // exalts — rewardAP untracked (sing paused)
-    update_progressive_slot(ach, 9, 0.0, |_| 0.0); // singularityUpgrades — maxLevel UI-tier
-    update_progressive_slot(ach, 10, 0.0, |_| 0.0); // octeractUpgrades — maxLevel UI-tier
-    update_progressive_slot(ach, 11, 0.0, |_| 0.0); // redAmbrosiaUpgrades — maxLevel UI-tier
+    // Slots 8-11 mirror the legacy `updateValue: () => 0` — live value 0,
+    // points from live state.
+    update_progressive_slot(ach, 8, 0.0, |_| exalt_ap);
+    update_progressive_slot(ach, 9, 0.0, |_| gq_maxed_points);
+    update_progressive_slot(ach, 10, 0.0, |_| oct_maxed_points);
+    update_progressive_slot(ach, 11, 0.0, |_| red_maxed_points);
 }
 
 /// `talismans[t].isUnlocked()` — the per-talisman unlock predicate
@@ -7279,6 +7313,46 @@ mod tests {
         with_hept.hepteracts.quark.bal = 1500.0;
         let ratio = compute_quark_multiplier(&with_hept) / compute_quark_multiplier(&base);
         assert!((ratio - 1.96).abs() < 1e-9);
+    }
+
+    #[test]
+    fn progressive_slots_8_to_11_score_from_live_state() {
+        // Slot 8 (exalts): noSingularityUpgrades rewardAP = 15·completions.
+        let mut s = GameState::default();
+        s.singularity.no_singularity_upgrades.completions = 2.0;
+        // Slot 9 (singularityUpgrades): max one capped GQ upgrade → +5.
+        // GQ_GOLDEN_QUARKS_1 has max_level 15 (seeded metadata).
+        let gq1 = crate::state::golden_quarks::GQ_GOLDEN_QUARKS_1;
+        s.golden_quarks.upgrades[gq1].level = s.golden_quarks.upgrades[gq1].max_level;
+        // Slot 10 (octeractUpgrades): octeractStarter caps at 1 → +8.
+        s.octeract_upgrades.upgrades[crate::state::octeract_upgrades::OCTERACT_STARTER].level = 1.0;
+        // Slot 11 (redAmbrosiaUpgrades): viscount caps at 1 → +10.
+        s.red_ambrosia.upgrades[crate::state::red_ambrosia::RED_AMBROSIA_VISCOUNT].level = 1.0;
+
+        update_progressive_achievements(&mut s);
+        assert_eq!(s.achievements.progressive[8].cached_points, 30.0);
+        assert_eq!(s.achievements.progressive[9].cached_points, 5.0);
+        assert_eq!(s.achievements.progressive[10].cached_points, 8.0);
+        assert_eq!(s.achievements.progressive[11].cached_points, 10.0);
+        assert_eq!(s.achievements.achievement_points, 53.0);
+
+        // Free levels alone don't count a GQ upgrade as maxed (purchased
+        // level only, mirroring `upgrade.level >= upgrade.maxLevel`).
+        let mut free_only = GameState::default();
+        let max = free_only.golden_quarks.upgrades[gq1].max_level;
+        free_only.golden_quarks.upgrades[gq1].free_level = max;
+        update_progressive_achievements(&mut free_only);
+        assert_eq!(free_only.achievements.progressive[9].cached_points, 0.0);
+    }
+
+    #[test]
+    fn progressive_slots_8_to_11_inert_at_default() {
+        let mut s = GameState::default();
+        update_progressive_achievements(&mut s);
+        for slot in 8..=11 {
+            assert_eq!(s.achievements.progressive[slot].cached_points, 0.0);
+        }
+        assert_eq!(s.achievements.achievement_points, 0.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -1703,6 +1703,9 @@ fn phase_global_state(state: &mut GameState) -> AggregatorOutputs {
     ) + crate::mechanics::achievement_awards::ascension_score_achievement_check(
         &mut state.achievements,
         ascension_score,
+    ) + crate::mechanics::achievement_awards::singularity_achievement_check(
+        &mut state.achievements,
+        state.singularity.highest_singularity_count,
     );
     credit_achievement_quarks(state, awarded);
     recompute_talisman_rarities(state);
@@ -10136,6 +10139,20 @@ mod tests {
         let _ = phase_global_state(&mut s);
         // The per-tick recompute runs inside phase_global_state.
         assert_eq!(s.talismans.talisman_rarity[TALISMAN_EXEMPTION], 1.0);
+    }
+
+    #[test]
+    fn phase_global_state_awards_singularity_count_achievements() {
+        // The singularityCount group is swept every tick from
+        // highestSingularityCount; the layer is live so this fires in play.
+        let mut s = GameState::default();
+        assert_eq!(s.achievements.achievements[274], 0);
+        s.singularity.highest_singularity_count = 3.0;
+        let _ = phase_global_state(&mut s);
+        // Rows 274/275/276 (thresholds 1/2/3) awarded; 277 (threshold 4) not.
+        assert_eq!(s.achievements.achievements[274], 1);
+        assert_eq!(s.achievements.achievements[276], 1);
+        assert_eq!(s.achievements.achievements[277], 0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -320,6 +320,23 @@ pub enum PlayerAction {
         /// Which Exalt to toggle.
         challenge: crate::events::SingularityChallengeId,
     },
+    /// Configure the singularity elevator (the legacy elevator panel inputs):
+    /// set the target floor (clamped like the input listener, to
+    /// `[1, max(1, highest, count + lookahead if antiquities)]`) and the
+    /// locked / slow-climb toggles. Pure config — no event.
+    ConfigureSingularityElevator {
+        /// Requested elevator floor.
+        target: f64,
+        /// Lock a normal singularity to the target floor.
+        locked: bool,
+        /// Advance by exactly one singularity instead of the lookahead jump.
+        slow_climb: bool,
+    },
+    /// Ride the elevator to its target floor now (legacy
+    /// `teleportToSingularity`): ascending (count ≤ target) performs a full
+    /// singularity to the target; descending just sets the count — no reset.
+    /// Gated on a valid target and on not being inside an Exalt.
+    TeleportToSingularity,
 }
 
 /// Selects the automation flag a [`PlayerAction::ToggleAuto`] sets.
@@ -5845,6 +5862,20 @@ fn phase_player_input(
                     .events
                     .extend(reset::toggle_singularity_challenge(state, *challenge));
             }
+            PlayerAction::ConfigureSingularityElevator {
+                target,
+                locked,
+                slow_climb,
+            } => {
+                let requested = if target.is_finite() { *target } else { 1.0 };
+                let max_target = elevator_max_target(state);
+                state.singularity.elevator_target = requested.clamp(1.0, max_target);
+                state.singularity.elevator_locked = *locked;
+                state.singularity.elevator_slow_climb = *slow_climb;
+            }
+            PlayerAction::TeleportToSingularity => {
+                output.events.extend(reset::teleport_to_singularity(state));
+            }
         }
     }
 }
@@ -6950,6 +6981,20 @@ fn inside_singularity_challenge(s: &crate::state::SingularityState) -> bool {
         || s.taxman_last_stand.enabled
 }
 
+/// The elevator's highest reachable floor — `max(1, highestSingularityCount,
+/// count + lookahead)`, the lookahead leg only with the antiquities rune
+/// purchased (the legacy input listener / `teleportToSingularity` rule).
+fn elevator_max_target(state: &GameState) -> f64 {
+    let sing_look = if state.runes.rune_levels[crate::state::RUNE_ANTIQUITIES] > 0.0 {
+        state.singularity.singularity_count + compute_singularity_lookahead(state)
+    } else {
+        0.0
+    };
+    1.0_f64
+        .max(state.singularity.highest_singularity_count)
+        .max(sing_look)
+}
+
 // ─── Dispatch helpers ────────────────────────────────────────────────────
 
 /// `buildingAchievementCheck()` — run after a coin-producer buy to award the
@@ -7366,6 +7411,36 @@ mod tests {
             assert_eq!(s.achievements.progressive[slot].cached_points, 0.0);
         }
         assert_eq!(s.achievements.achievement_points, 0.0);
+    }
+
+    #[test]
+    fn configure_elevator_clamps_target_and_sets_toggles() {
+        let mut s = GameState::default();
+        s.singularity.highest_singularity_count = 10.0;
+        let mut input = TackInput::default();
+        input
+            .player_actions
+            .push(PlayerAction::ConfigureSingularityElevator {
+                target: 50.0, // above the reachable max (no antiquities) → clamps to highest
+                locked: true,
+                slow_climb: false,
+            });
+        let _ = tack(&mut s, &input);
+        assert_eq!(s.singularity.elevator_target, 10.0);
+        assert!(s.singularity.elevator_locked);
+        assert!(!s.singularity.elevator_slow_climb);
+
+        // Below the floor → clamps to 1.
+        let mut input = TackInput::default();
+        input
+            .player_actions
+            .push(PlayerAction::ConfigureSingularityElevator {
+                target: 0.0,
+                locked: false,
+                slow_climb: true,
+            });
+        let _ = tack(&mut s, &input);
+        assert_eq!(s.singularity.elevator_target, 1.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -1024,6 +1024,125 @@ pub(crate) fn perform_singularity_reset(
     }]
 }
 
+/// The mutable per-challenge tracker for an Exalt id (the
+/// `player.singularityChallenges[key]` lookup).
+pub(crate) fn challenge_state_mut(
+    state: &mut GameState,
+    id: crate::events::SingularityChallengeId,
+) -> &mut crate::state::singularity::SingularityChallengeState {
+    use crate::events::SingularityChallengeId as Id;
+    let s = &mut state.singularity;
+    match id {
+        Id::NoSingularityUpgrades => &mut s.no_singularity_upgrades,
+        Id::OneChallengeCap => &mut s.one_challenge_cap,
+        Id::NoOcteracts => &mut s.no_octeracts,
+        Id::LimitedAscensions => &mut s.limited_ascensions,
+        Id::NoAmbrosiaUpgrades => &mut s.no_ambrosia_upgrades,
+        Id::NoQuarkUpgrades => &mut s.no_quark_upgrades,
+        Id::LimitedTime => &mut s.limited_time,
+        Id::SadisticPrequel => &mut s.sadistic_prequel,
+        Id::TaxmanLastStand => &mut s.taxman_last_stand,
+    }
+}
+
+/// `SingularityChallenge.challengeEntryHandler()` — toggle an Exalt: enter
+/// it when its flag is clear, otherwise exit (success iff the antiquities
+/// rune was purchased inside — the legacy
+/// `exitChallenge(runes.antiquities.level > 0)`).
+///
+/// **Enter** (`enableChallenge`, sans the UI confirm — the action carries
+/// intent): gated on `highestSingularityCount ≥ unlockSingularity` and on
+/// not already being inside an Exalt. Holds the singularity counter and the
+/// quark / golden-quark export timers across a singularity jump to
+/// `singularityRequirement(baseReq, completions)`; the golden-quark grant is
+/// credited by the jump itself (the legacy capture-then-overwrite nets the
+/// same single grant).
+///
+/// **Exit** (`exitChallenge`): clears the flag, then on success sets
+/// `highestSingularityCompleted` to the *current* count and re-derives the
+/// completion ladder **before** the return jump (so the jump's golden-quark
+/// grant already sees the new completions, mirroring the legacy ordering).
+/// Jumps back to the held highest count. The singularity counter is restored
+/// either way; the quark / golden-quark export timers only on failure
+/// (success forfeits them, verbatim).
+pub(crate) fn toggle_singularity_challenge(
+    state: &mut GameState,
+    id: crate::events::SingularityChallengeId,
+) -> SmallVec<[CoreEvent; 4]> {
+    use crate::mechanics::singularity_challenges::{
+        challenge_completions_from_highest, challenge_meta, challenge_singularity_requirement,
+    };
+    use crate::state::RUNE_ANTIQUITIES;
+
+    let inside_any = super::inside_singularity_challenge(&state.singularity);
+
+    if !challenge_state_mut(state, id).enabled {
+        // ── Enter ──
+        let meta = challenge_meta(id);
+        if state.singularity.highest_singularity_count < meta.unlock_singularity || inside_any {
+            return SmallVec::new();
+        }
+        let completions = challenge_state_mut(state, id).completions;
+        let target = challenge_singularity_requirement(id, completions);
+        let hold_sing_counter = state.singularity.singularity_counter;
+        let hold_quark_timer = state.quarks.quarks_timer;
+        let hold_gq_timer = state.golden_quarks.golden_quarks_timer;
+
+        // The flag survives the jump (the whole singularity slice does).
+        challenge_state_mut(state, id).enabled = true;
+        let mut events: SmallVec<[CoreEvent; 4]> = perform_singularity_reset(state, target)
+            .into_iter()
+            .collect();
+
+        state.singularity.singularity_counter = if meta.reset_time {
+            0.0
+        } else {
+            hold_sing_counter
+        };
+        state.quarks.quarks_timer = hold_quark_timer;
+        state.golden_quarks.golden_quarks_timer = hold_gq_timer;
+
+        events.push(CoreEvent::SingularityChallengeEntered {
+            challenge: id,
+            target_singularity: target,
+        });
+        events
+    } else {
+        // ── Exit ──
+        let success = state.runes.rune_levels[RUNE_ANTIQUITIES] > 0.0;
+        let hold_highest = state.singularity.highest_singularity_count;
+        let hold_sing_counter = state.singularity.singularity_counter;
+        let hold_quark_timer = state.quarks.quarks_timer;
+        let hold_gq_timer = state.golden_quarks.golden_quarks_timer;
+        let current_count = state.singularity.singularity_count;
+
+        let ch = challenge_state_mut(state, id);
+        ch.enabled = false;
+        if success {
+            ch.highest_singularity_completed = current_count;
+            ch.completions = challenge_completions_from_highest(id, current_count);
+        }
+        let completions = ch.completions;
+
+        let mut events: SmallVec<[CoreEvent; 4]> = perform_singularity_reset(state, hold_highest)
+            .into_iter()
+            .collect();
+
+        state.singularity.singularity_counter = hold_sing_counter;
+        if !success {
+            state.quarks.quarks_timer = hold_quark_timer;
+            state.golden_quarks.golden_quarks_timer = hold_gq_timer;
+        }
+
+        events.push(CoreEvent::SingularityChallengeExited {
+            challenge: id,
+            success,
+            completions,
+        });
+        events
+    }
+}
+
 /// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
 /// loops). Indices are the legacy 1-based positions, in range for the
 /// `[u8; UPGRADES_DEFAULT_LEN]` bitmap.
@@ -1099,6 +1218,111 @@ mod tests {
         assert_eq!(state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_1].level, 5.0); // survives
         assert_eq!(state.golden_quarks.quarks_this_singularity, 0.0); // reset
         assert_eq!(state.golden_quarks.total_quarks_ever, 3e5); // accumulated
+    }
+
+    #[test]
+    fn exalt_enter_gates_on_unlock_singularity_and_inside_flag() {
+        use crate::events::SingularityChallengeId as Id;
+        // Below unlockSingularity (25) → no-op.
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 24.0;
+        let events = toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+        assert!(events.is_empty());
+        assert!(!state.singularity.no_singularity_upgrades.enabled);
+
+        // Already inside another Exalt → no-op.
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 100.0;
+        state.singularity.one_challenge_cap.enabled = true;
+        let events = toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+        assert!(events.is_empty());
+        assert!(!state.singularity.no_singularity_upgrades.enabled);
+    }
+
+    #[test]
+    fn exalt_enter_jumps_to_tier_requirement_and_holds_timers() {
+        use crate::events::SingularityChallengeId as Id;
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 25.0;
+        state.singularity.singularity_count = 25.0;
+        state.singularity.singularity_counter = 77.0;
+        state.quarks.quarks_timer = 55.0;
+        state.golden_quarks.golden_quarks_timer = 33.0;
+
+        let events = toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+        // Tier 1 of noSingularityUpgrades sits at singularity 1 (baseReq 1).
+        assert!(state.singularity.no_singularity_upgrades.enabled);
+        assert_eq!(state.singularity.singularity_count, 1.0);
+        assert_eq!(state.singularity.highest_singularity_count, 25.0);
+        // Timers held across the jump (resetTime is false).
+        assert_eq!(state.singularity.singularity_counter, 77.0);
+        assert_eq!(state.quarks.quarks_timer, 55.0);
+        assert_eq!(state.golden_quarks.golden_quarks_timer, 33.0);
+        // The golden-quark grant was credited by the jump.
+        assert!(state.golden_quarks.golden_quarks.to_number() >= 100.0);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::SingularityChallengeEntered { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::SingularityPerformed { .. })));
+    }
+
+    #[test]
+    fn exalt_exit_success_derives_completions_and_returns_to_highest() {
+        use crate::events::SingularityChallengeId as Id;
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 25.0;
+        state.singularity.singularity_count = 25.0;
+        toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+        assert_eq!(state.singularity.singularity_count, 1.0);
+
+        // Re-acquire antiquities inside the challenge → the exit succeeds.
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.quarks.quarks_timer = 41.0;
+        let events = toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+        let ch = state.singularity.no_singularity_upgrades;
+        assert!(!ch.enabled);
+        // Completed at singularity 1 = the tier-1 rung → 1 completion.
+        assert_eq!(ch.highest_singularity_completed, 1.0);
+        assert_eq!(ch.completions, 1.0);
+        // Returned to the held highest.
+        assert_eq!(state.singularity.singularity_count, 25.0);
+        // Success forfeits the quark export timer (only failure restores it).
+        assert_eq!(state.quarks.quarks_timer, 0.0);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            CoreEvent::SingularityChallengeExited {
+                success: true,
+                completions,
+                ..
+            } if *completions == 1.0
+        )));
+    }
+
+    #[test]
+    fn exalt_exit_failure_keeps_completions_and_restores_timers() {
+        use crate::events::SingularityChallengeId as Id;
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 25.0;
+        state.singularity.singularity_count = 25.0;
+        toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+
+        // No antiquities inside → the exit fails.
+        state.quarks.quarks_timer = 41.0;
+        state.golden_quarks.golden_quarks_timer = 13.0;
+        let events = toggle_singularity_challenge(&mut state, Id::NoSingularityUpgrades);
+        let ch = state.singularity.no_singularity_upgrades;
+        assert!(!ch.enabled);
+        assert_eq!(ch.completions, 0.0);
+        assert_eq!(state.singularity.singularity_count, 25.0);
+        // Failure restores the export timers.
+        assert_eq!(state.quarks.quarks_timer, 41.0);
+        assert_eq!(state.golden_quarks.golden_quarks_timer, 13.0);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            CoreEvent::SingularityChallengeExited { success: false, .. }
+        )));
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -903,14 +903,19 @@ pub(crate) fn perform_singularity_reset(
     let antiquities = state.runes.rune_levels[RUNE_ANTIQUITIES] > 0.0;
 
     let (new_count, new_highest, increment_highest) = if set_sing_number < 0.0 {
-        // Normal path — auto-climb (elevator unlocked, not slow-climb).
+        // Normal path — the elevator triad (Reset.ts:1112-1123): locked goes
+        // to the chosen floor, slow-climb advances by one, otherwise
+        // auto-climb by the fast-forward lookahead.
         let increment = old_count == old_highest;
-        let lookahead = super::compute_singularity_lookahead(state);
-        (
-            old_highest.max(old_count + lookahead),
-            old_highest,
-            increment,
-        )
+        let count = if state.singularity.elevator_locked {
+            state.singularity.elevator_target
+        } else if state.singularity.elevator_slow_climb {
+            old_count + 1.0
+        } else {
+            let lookahead = super::compute_singularity_lookahead(state);
+            old_highest.max(old_count + lookahead)
+        };
+        (count, old_highest, increment)
     } else {
         // Challenge enter/exit jump.
         let increment = old_count == old_highest && set_sing_number > old_count && antiquities;
@@ -1167,6 +1172,41 @@ pub(crate) fn toggle_singularity_challenge(
     }
 }
 
+/// `teleportToSingularity()` (`singularity.ts:3898`) — ride the elevator to
+/// its target floor. Gated on a valid target (`[1, max(1, highest,
+/// count + lookahead if antiquities)]`) and on not being inside an Exalt.
+///
+/// Ascending (`count <= target`) performs a full singularity to the target —
+/// and when the antiquities rune was *not* purchased, the singularity
+/// counter is held across it (the legacy `antiquitiesLevel === 0` branch).
+/// Descending just sets the count: **no reset** (verbatim — dropping floors
+/// is free).
+pub(crate) fn teleport_to_singularity(state: &mut GameState) -> SmallVec<[CoreEvent; 2]> {
+    use crate::state::RUNE_ANTIQUITIES;
+
+    let target = state.singularity.elevator_target;
+    let max_target = super::elevator_max_target(state);
+    if target < 1.0
+        || target > max_target
+        || super::inside_singularity_challenge(&state.singularity)
+    {
+        return SmallVec::new();
+    }
+
+    if state.singularity.singularity_count <= target {
+        let antiquities_level = state.runes.rune_levels[RUNE_ANTIQUITIES];
+        let held_counter = state.singularity.singularity_counter;
+        let events = perform_singularity_reset(state, target);
+        if antiquities_level == 0.0 {
+            state.singularity.singularity_counter = held_counter;
+        }
+        events
+    } else {
+        state.singularity.singularity_count = target;
+        SmallVec::new()
+    }
+}
+
 /// Zero a contiguous run of `player.upgrades` slots (the `resetUpgrades`
 /// loops). Indices are the legacy 1-based positions, in range for the
 /// `[u8; UPGRADES_DEFAULT_LEN]` bitmap.
@@ -1347,6 +1387,83 @@ mod tests {
             e,
             CoreEvent::SingularityChallengeExited { success: false, .. }
         )));
+    }
+
+    #[test]
+    fn elevator_branches_choose_the_next_floor() {
+        // Slow climb (the blank-save default): +1 even from below highest.
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.singularity.singularity_count = 3.0;
+        state.singularity.highest_singularity_count = 10.0;
+        perform_singularity_reset(&mut state, -1.0);
+        assert_eq!(state.singularity.singularity_count, 4.0);
+        assert_eq!(state.singularity.highest_singularity_count, 10.0);
+
+        // Auto-climb (slow climb off): jump to max(highest, count + lookahead).
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.singularity.elevator_slow_climb = false;
+        state.singularity.singularity_count = 3.0;
+        state.singularity.highest_singularity_count = 10.0;
+        perform_singularity_reset(&mut state, -1.0);
+        assert_eq!(state.singularity.singularity_count, 10.0);
+
+        // Locked: go to the chosen floor, even downward.
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.singularity.elevator_locked = true;
+        state.singularity.elevator_target = 2.0;
+        state.singularity.singularity_count = 10.0;
+        state.singularity.highest_singularity_count = 10.0;
+        perform_singularity_reset(&mut state, -1.0);
+        assert_eq!(state.singularity.singularity_count, 2.0);
+        // The was-at-highest +1 bump applies regardless of branch
+        // (Reset.ts:1125 sits outside the elevator if/else).
+        assert_eq!(state.singularity.highest_singularity_count, 11.0);
+    }
+
+    #[test]
+    fn teleport_descends_without_reset_and_ascends_with_one() {
+        // Descending: count drops to the target, nothing else moves.
+        let mut state = GameState::default();
+        state.singularity.singularity_count = 10.0;
+        state.singularity.highest_singularity_count = 10.0;
+        state.singularity.elevator_target = 3.0;
+        state.upgrades.coins = Decimal::from_finite(1e50);
+        let events = teleport_to_singularity(&mut state);
+        assert!(events.is_empty());
+        assert_eq!(state.singularity.singularity_count, 3.0);
+        assert_eq!(state.upgrades.coins.to_number(), 1e50); // no reset
+
+        // Ascending (count <= target, within highest): a full singularity to
+        // the floor; without antiquities the singularity counter is held.
+        state.singularity.elevator_target = 10.0;
+        state.singularity.singularity_counter = 99.0;
+        let events = teleport_to_singularity(&mut state);
+        assert_eq!(state.singularity.singularity_count, 10.0);
+        assert_eq!(state.upgrades.coins, GameState::default().upgrades.coins);
+        assert_eq!(state.singularity.singularity_counter, 99.0);
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::SingularityPerformed { .. })));
+    }
+
+    #[test]
+    fn teleport_gates_on_target_range_and_exalt() {
+        // Target above the reachable max (highest 10, no antiquities) → no-op.
+        let mut state = GameState::default();
+        state.singularity.singularity_count = 10.0;
+        state.singularity.highest_singularity_count = 10.0;
+        state.singularity.elevator_target = 11.0;
+        assert!(teleport_to_singularity(&mut state).is_empty());
+        assert_eq!(state.singularity.singularity_count, 10.0);
+
+        // Inside an Exalt → no-op.
+        state.singularity.elevator_target = 3.0;
+        state.singularity.limited_time.enabled = true;
+        assert!(teleport_to_singularity(&mut state).is_empty());
+        assert_eq!(state.singularity.singularity_count, 10.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -880,11 +880,13 @@ fn reset_talismans_ascension(talismans: &mut TalismansState) {
 /// prestige/transcend/reincarnation counts once `highestSingularityCount >= 8`.
 /// Everything else resets to a fresh game.
 ///
+/// `worlds` (quarks) resets with the rebuild unless the limitedTime
+/// `preserveQuarks` reward is active (Reset.ts:1190), in which case the
+/// balance carries across.
+///
 /// Deferred (faithful for fresh saves): the elevator triad — the count advances
 /// `max(highest, count + lookahead)` (auto-climb), the only branch reachable
-/// while the elevator fields default to unlocked/non-slow. `worlds` (quarks)
-/// reset; the limitedTime `preserveQuarks` branch is inert until that
-/// singularity challenge is entered.
+/// while the elevator fields default to unlocked/non-slow.
 pub(crate) fn perform_singularity_reset(
     state: &mut GameState,
     set_sing_number: f64,
@@ -931,6 +933,22 @@ pub(crate) fn perform_singularity_reset(
     };
     let total_quarks_ever =
         state.golden_quarks.total_quarks_ever + state.golden_quarks.quarks_this_singularity;
+
+    // limitedTime `preserveQuarks` (Reset.ts:1190): while the effect is
+    // active, `worlds` (quarks) survives the singularity instead of resetting.
+    let preserve_quarks = {
+        use crate::mechanics::singularity_challenges::{
+            limited_time_effect, LimitedTimeKey, SingularityEffectValue,
+        };
+        matches!(
+            limited_time_effect(
+                state.singularity.limited_time.completions,
+                LimitedTimeKey::PreserveQuarks,
+            ),
+            SingularityEffectValue::Scalar(s) if s > 0.0
+        )
+    };
+    let held_worlds = state.quarks.worlds;
 
     // ── Capture survivors (before the blank-save reconstruction) ──
     let achievements = state.achievements.clone();
@@ -1017,6 +1035,12 @@ pub(crate) fn perform_singularity_reset(
         mastery.highest_mastery = highest;
     }
     state.ants.current_sacrifice_id = next_sacrifice_id;
+
+    // Quarks survive under the limitedTime `preserveQuarks` reward; the
+    // default rebuild already mirrors `player.worlds.reset()` (→ 0).
+    if preserve_quarks {
+        state.quarks.worlds = held_worlds;
+    }
 
     smallvec![CoreEvent::SingularityPerformed {
         golden_quarks_gained: gq_grant,
@@ -1323,6 +1347,24 @@ mod tests {
             e,
             CoreEvent::SingularityChallengeExited { success: false, .. }
         )));
+    }
+
+    #[test]
+    fn singularity_resets_quarks_unless_preserved_by_limited_time() {
+        // Without the limitedTime reward, quarks reset with the rebuild.
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.quarks.worlds = Decimal::from_finite(1234.0);
+        perform_singularity_reset(&mut state, -1.0);
+        assert_eq!(state.quarks.worlds.to_number(), 0.0);
+
+        // With a limitedTime completion the preserveQuarks reward holds them.
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0;
+        state.singularity.limited_time.completions = 1.0;
+        state.quarks.worlds = Decimal::from_finite(1234.0);
+        perform_singularity_reset(&mut state, -1.0);
+        assert_eq!(state.quarks.worlds.to_number(), 1234.0);
     }
 
     #[test]

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -107,8 +107,9 @@ fixed in code, the map had simply gone stale:
 > (`calculateQuarkMultiplier`) + blueberry quark/free-levels are ported, the 21 `unlocks` keys are
 > complete, **the singularity layer is live** (reset + GQ grant + seeded metadata), and **all 13
 > `updateAll` autobuyer families are wired** (incl. talisman / tesseract / ant-upgrade). **No HIGH
-> parity bugs remain open.** Remaining: the singularity elevator triad + challenge entry, and the
-> UI tree.
+> parity bugs remain open.** Branch `claude/wrap-meta-economy-quarks` additionally lands the
+> campaign-token derivation, the exalt enter/exit loop, the elevator triad, and `preserveQuarks` —
+> remaining non-UI work is host-tier seams and the parked backend; otherwise the UI tree.
 
 ## Appendix: full single-canvas map
 

--- a/docs/systems/challenges-corruptions.md
+++ b/docs/systems/challenges-corruptions.md
@@ -64,7 +64,7 @@ flowchart LR
 | Challenge 15 exponent | 🟩 Ported | `mechanics/challenge_15_rewards.rs`; accrual at `tick/mod.rs:5396` (PR #265) |
 | Corruptions (8 effects) | 🟩 Ported | `state/corruptions.rs`, `mechanics/corruptions.rs` |
 | Auto-challenge sweep | 🟩 Ported | `tick/challenge_sweep.rs` |
-| Campaign / constant upgrades | 🟨 Partial | `state/campaigns.rs`, `mechanics/campaign_token_rewards.rs` |
+| Campaign tokens / constant upgrades | 🟩 Mostly | `state/campaigns.rs` (50 campaigns), `mechanics/campaign_token_rewards.rs`, `compute_campaign_tokens` (tick) — the campaign *runner* (UI) remains |
 
 ## Porting notes / open bugs
 
@@ -72,5 +72,9 @@ flowchart LR
   (commit `ff7683e9`), so the C15 reward cascade lights up and hepteracts are reachable via the C15
   path. (It was open at this map's first draft, cut before #265 merged.)
 - Audit **C1** (global-speed mult dropped in c1) and **C2** (c10→ascension unlock dead) are **fixed**.
-- **Campaign tokens:** the token count is never tracked, leaving ~14 dormant reward consumers at
-  identity (UI-tier concern).
+- ✅ **Campaign tokens — derived + all 14 reward consumers fed.** `compute_campaign_tokens` (tick)
+  ports `updateTokens()` as a pure derivation over the 50-campaign limit/isMeta table
+  (`CAMPAIGNS_LEN` 10→50, a latent sizing bug), inheritance + the GQ/octeract bonus-token upgrades.
+  Every `campaign_token_rewards` formula now feeds from it, and the `campaignTokens` achievement
+  group (426–435) awards in the per-tick sweep. Tokens flow from `highestSingularityCount ≥ 5`
+  without the UI-tier campaign runner (which writes `campaign_completions` once it exists).

--- a/docs/systems/meta-economy.md
+++ b/docs/systems/meta-economy.md
@@ -23,7 +23,7 @@ flowchart LR
   codes["Promo codes"]:::absent
   achievements["Achievements ·509"]:::ported
   achPoints["Achievement points/levels"]:::ported
-  progAch["Progressive achievements"]:::partial
+  progAch["Progressive achievements"]:::ported
   statistics["Statistics"]:::stub
   history["History"]:::stub
 
@@ -79,8 +79,24 @@ flowchart LR
   reusing `award_threshold_group`/`award_log10_group`): reset counts (ascension/prestige/transcend/
   reincarnation), accelerators/multipliers/acceleratorBoosts, speed-rune level/freeLevel/blessing/
   spirit, constant (ascendShards), antCrumbs, ascensionScore, **singularityCount** (indices 274–280,
-  `highestSingularityCount` ≥ 1/2/3/4/5/7/10 — now reachable since the singularity layer is live) — on
+  `highestSingularityCount` ≥ 1/2/3/4/5/7/10 — now reachable since the singularity layer is live),
+  **campaignTokens** (indices 426–435, thresholds 10–9000 over the derived token total), and the
+  ungrouped **thousandSuns/thousandMoons** (#250/#251, research-8x25 / cube-w5x10 maxed at 1e5) — on
   top of the pre-existing building / point-gain / challenge / sacrifice / no-reset groups.
+- ✅ **Campaign tokens derived — every token bonus feeds.** `compute_campaign_tokens` ports
+  `updateTokens()` as a pure derivation (no cached state): Σ per-campaign `computeTokenValue`
+  (`campaign_token_rewards::campaign_token_value` over the 50-campaign limit/isMeta table —
+  `CAMPAIGNS_LEN` was 10, a latent sizing bug) + `inheritance_tokens` (verbatim incl. the legacy
+  loop quirk that dead-letters the level-2 tier) + the GQ/octeract bonus-token upgrades. All 14
+  `campaign_token_rewards` formulas now feed from it: tax, ascension-score, octeract/s, quark,
+  cube (tutorial + campaign), golden-quark, offering/obtainium pairs, the 3 reset-time-threshold
+  reductions, ambrosia-luck, blueberry speed, and the c15 score multiplier. Tokens flow without
+  the UI-tier campaign *runner* once `highestSingularityCount ≥ 5` (inheritance floor); the runner
+  (picking campaigns, completing c10 under their corruptions) writes `campaign_completions` later.
+- ✅ **Progressive achievements — all 12 slots live.** Slots 8–11 were the neutral tail: exalts
+  (Σ `achievementPointValue(completions)` — a legacy getter, derivable from the tracked per-challenge
+  counts), and the three maxed-upgrade families (`count_maxed_*` against the seeded GQ `max_level`
+  metadata / new static `OCTERACT_MAX_LEVELS`/`RED_AMBROSIA_MAX_LEVELS` tables; ×5/×8/×10 points).
 - ✅ **Quark multiplier ported — all reachable terms now wired.** `compute_quark_multiplier` assembles
   `allQuarkStats` (`Statistics.ts:1233`) and caches it into `quark_bonus` each tick as `(mult − 1)·100`
   — it was **never written** (always `0` ⇒ every quark gain credited at ×1). The three terms that were
@@ -88,15 +104,12 @@ flowchart LR
   (`achievement_rewards::quark_gain` — #250/#251 ×1.05, #266 ×(1+0.1·min(ascCount/1e15,1))), the
   Challenge-15 `quarks` reward (`challenge_15_rewards::quarks`, req 1e11), and the quark-hepteract bonus
   (gated on `challenge15Exponent ≥ 1e15`, the custom `(1+0.2·log2(1+bal/500))^(2+singQuarkHepteract1/2/3)`).
-  Only **4 terms remain at identity**, all genuinely UI/external-blocked: `shopPanthema` /
-  `infiniteAscent` (bonus-level precompute / shop unlock gate), campaign bonus, and the host-tier event +
-  patreon bonuses.
-- **Still blocked** (each needs an unported prerequisite): `campaignTokens` (the running token total
-  isn't a Rust state field), `addCodesUsed` (UI-tier code array), progressive slots 8–11 (exalt
-  rewardAP + upgrade `maxLevel` tracking unported). Awarding of the two `ungrouped` quarkGain
-  achievements #250/#251 (`researches[200]`/`cubeUpgrades[50]` maxed) awaits the ungrouped-award path;
-  the reader is faithful regardless (those two ×1.05 factors stay dormant until the bits are set, while
-  #266 fires from the ported `ascensionCount` group).
+  The campaign bonus now also feeds (from the derived token total). Only **3 terms remain at
+  identity**, all genuinely UI/external-blocked: `shopPanthema` / `infiniteAscent` (bonus-level
+  precompute / shop unlock gate) and the host-tier event + patreon bonuses.
+- **Still blocked** (genuinely UI/external): `addCodesUsed` (UI-tier code array; its 15 achievements
+  are the only unported award group left), the campaign *runner* (UI-tier — token math is fully
+  ported), and Statistics/History.
 - **Shop: ~50 of 83 effects are wired** (chronometer→ascension-speed, season-pass→cube-mults,
   offering/obtainium EX + cashGrab, the cube-blessing/quark-from-opening paths, costs + potions — all
   done). The remaining ~33 are mostly **blocked or out of reachable scope**: the quark-conversion

--- a/docs/systems/meta-economy.md
+++ b/docs/systems/meta-economy.md
@@ -78,28 +78,33 @@ flowchart LR
 - ✅ **Award groups — all portable ones ported** (a per-tick monotonic sweep in `phase_global_state`,
   reusing `award_threshold_group`/`award_log10_group`): reset counts (ascension/prestige/transcend/
   reincarnation), accelerators/multipliers/acceleratorBoosts, speed-rune level/freeLevel/blessing/
-  spirit, constant (ascendShards), antCrumbs, ascensionScore — on top of the pre-existing building /
-  point-gain / challenge / sacrifice / no-reset groups.
-- ✅ **Quark multiplier ported.** `compute_quark_multiplier` now assembles `allQuarkStats`
-  (`Statistics.ts:1233`) and caches it into `quark_bonus` each tick as `(mult − 1)·100` — it was
-  **never written** (always `0` ⇒ every quark gain credited at ×1). ~28 terms ported (achievements
-  level, talisman, platonic, powder, singularity count, octeract bonuses, GQ packs, ambrosia incl. the
-  blueberry quark upgrades, viscount, cash-grab, first-singularity); ~7 left at identity and documented
-  (`quarkGain` achievement reward, c15 quark reward + quark-hepteract gate, shopPanthema, infiniteAscent,
-  campaign, patreon).
+  spirit, constant (ascendShards), antCrumbs, ascensionScore, **singularityCount** (indices 274–280,
+  `highestSingularityCount` ≥ 1/2/3/4/5/7/10 — now reachable since the singularity layer is live) — on
+  top of the pre-existing building / point-gain / challenge / sacrifice / no-reset groups.
+- ✅ **Quark multiplier ported — all reachable terms now wired.** `compute_quark_multiplier` assembles
+  `allQuarkStats` (`Statistics.ts:1233`) and caches it into `quark_bonus` each tick as `(mult − 1)·100`
+  — it was **never written** (always `0` ⇒ every quark gain credited at ×1). The three terms that were
+  left neutral by the close-unmigrated push are now ported: `getAchievementReward('quarkGain')`
+  (`achievement_rewards::quark_gain` — #250/#251 ×1.05, #266 ×(1+0.1·min(ascCount/1e15,1))), the
+  Challenge-15 `quarks` reward (`challenge_15_rewards::quarks`, req 1e11), and the quark-hepteract bonus
+  (gated on `challenge15Exponent ≥ 1e15`, the custom `(1+0.2·log2(1+bal/500))^(2+singQuarkHepteract1/2/3)`).
+  Only **4 terms remain at identity**, all genuinely UI/external-blocked: `shopPanthema` /
+  `infiniteAscent` (bonus-level precompute / shop unlock gate), campaign bonus, and the host-tier event +
+  patreon bonuses.
 - **Still blocked** (each needs an unported prerequisite): `campaignTokens` (the running token total
   isn't a Rust state field), `addCodesUsed` (UI-tier code array), progressive slots 8–11 (exalt
-  rewardAP + upgrade `maxLevel` tracking unported). `singularityCount` now increments (the layer is
-  live — see [singularity-ambrosia](singularity-ambrosia.md)), so its award group is unblocked; the
-  `getAchievementReward('quarkGain')` term is the one quark-multiplier identity still pending a
-  per-reward port.
+  rewardAP + upgrade `maxLevel` tracking unported). Awarding of the two `ungrouped` quarkGain
+  achievements #250/#251 (`researches[200]`/`cubeUpgrades[50]` maxed) awaits the ungrouped-award path;
+  the reader is faithful regardless (those two ×1.05 factors stay dormant until the bits are set, while
+  #266 fires from the ported `ascensionCount` group).
 - **Shop: ~50 of 83 effects are wired** (chronometer→ascension-speed, season-pass→cube-mults,
   offering/obtainium EX + cashGrab, the cube-blessing/quark-from-opening paths, costs + potions — all
   done). The remaining ~33 are mostly **blocked or out of reachable scope**: the quark-conversion
-  family (`cubeToQuark*`/`improveQuarkHept*` feed the quark-hepteract term that
-  `compute_quark_multiplier` still leaves neutral pending its c15 gate), the `calculator` family (UI
-  add-codes), daily/powder/warp + `improved_daily` (host-tier daily reset), `shop_singularity_*`,
-  `infinite_shop_upgrades` (unported shop-tablet sum).
+  family (`cubeToQuark*`/`improveQuarkHept*` — these shop upgrades *amplify* the quark-hepteract craft;
+  the quark-hepteract multiplier term itself is now wired, but these amplifiers await the hepteract
+  crafting / cube-to-quark surface), the `calculator` family (UI add-codes), daily/powder/warp +
+  `improved_daily` (host-tier daily reset), `shop_singularity_*`, `infinite_shop_upgrades` (unported
+  shop-tablet sum).
   `constant_ex` is now wired. A few minor reachable wires remain (`challenge_tome` needs its
   research + c10-gating component; `obtainium_auto`).
 - The **bonus-level composition** (effective shop level = raw `shopUpgrades[key]` + topHat-rune /

--- a/docs/systems/reset-cascade.md
+++ b/docs/systems/reset-cascade.md
@@ -69,8 +69,10 @@ flowchart LR
 
 - The reset cascade through **ascension is complete and faithful**, including the corruption-effects
   and extinction divisor used by the ascension award.
-- ✅ **Singularity is live**: `perform_singularity_reset` (`ResetRequest::Singularity`, gated on the
-  antiquities rune) grants `calculateGoldenQuarks` and rebuilds the player from `GameState::default()`
-  preserving meta-progression. Auto-climb count advance; elevator triad + challenge entry deferred.
-  See [singularity-ambrosia.md](singularity-ambrosia.md).
+- ✅ **Singularity is live — nothing deferred**: `perform_singularity_reset`
+  (`ResetRequest::Singularity`, gated on the antiquities rune) grants `calculateGoldenQuarks` and
+  rebuilds the player from `GameState::default()` preserving meta-progression. The elevator triad
+  drives the count advance (locked / slow-climb / auto-climb; slowClimb is the blankSave default),
+  the exalt enter/exit loop and the teleport ride the explicit-jump path, and quarks survive under
+  the limitedTime `preserveQuarks` reward. See [singularity-ambrosia.md](singularity-ambrosia.md).
 - Counts increment by a flat `+1` rather than `floor(multiplier)` (medium finding **P1.6**).

--- a/docs/systems/singularity-ambrosia.md
+++ b/docs/systems/singularity-ambrosia.md
@@ -5,12 +5,13 @@ golden-quark and **octeract** upgrades plus **perks**. **Ambrosia** (and its sib
 is a parallel idle currency spent on **blueberry** upgrades. Source: `singularity.ts`,
 `SingularityChallenges.ts`, `Octeracts.ts`, `BlueberryUpgrades.ts`, `RedAmbrosiaUpgrades.ts`.
 
-> **The layer is now LIVE.** `perform_singularity_reset` (`tick/reset.rs`) increments
-> `singularity_count`, grants golden quarks (`calculateGoldenQuarks`), and rebuilds the player from a
-> blank save preserving meta-progression — triggered by `ResetRequest::Singularity` (gated on the
-> antiquities rune). The 80-entry GQ-upgrade metadata is seeded, so costs are real. Deferred: the
-> elevator triad (auto-climb only) and singularity-challenge *entry* (the challenge state + jump path
-> exist via `SingularityChallenge`, but auto/UI entry is unwired).
+> **The layer is now LIVE — with nothing deferred.** `perform_singularity_reset` (`tick/reset.rs`)
+> increments `singularity_count`, grants golden quarks (`calculateGoldenQuarks`), and rebuilds the
+> player from a blank save preserving meta-progression — triggered by `ResetRequest::Singularity`
+> (gated on the antiquities rune). The 80-entry GQ-upgrade metadata is seeded, so costs are real.
+> The **exalt enter/exit loop** (`PlayerAction::ToggleSingularityChallenge`), the **elevator triad**
+> (locked / slow-climb / teleport, `ConfigureSingularityElevator` + `TeleportToSingularity`), and the
+> limitedTime **preserveQuarks** branch are all ported.
 
 ## Singularity
 
@@ -26,7 +27,7 @@ flowchart LR
   gqUpg["GQ upgrades"]:::ported
   octeracts["Octeracts"]:::ported
   octUpg["Octeract upgrades"]:::ported
-  singChal["Singularity challenges · entry pending"]:::partial
+  singChal["Singularity challenges"]:::ported
   singPerks["Perks · milestones"]:::partial
 
   asc["Ascension ↗ ascension-cubes"]:::ext
@@ -83,7 +84,8 @@ flowchart LR
 | Singularity reset / layer | 🟩 Ported (live) | `tick/reset.rs::perform_singularity_reset`, `calculate_golden_quarks` |
 | Golden quarks + GQ upgrades | 🟩 Ported | `state/golden_quarks.rs` (80-entry metadata seeded), `mechanics/golden_quark_upgrades.rs` |
 | Octeracts + upgrades | 🟩 Ported | `state/octeract_upgrades.rs`, `mechanics/octeracts.rs` |
-| Singularity challenges / perks | 🟨 Partial | machinery + `SingularityChallenge` jump ported; auto/UI *entry* unwired |
+| Singularity challenges (Exalts) | 🟩 Ported | enter/exit loop (`reset.rs::toggle_singularity_challenge`), 9-row meta + requirement ladder (`mechanics/singularity_challenges.rs`), completions drive the effect readers + the exalt progressive |
+| Singularity perks / milestones | 🟨 Partial | milestone formulas ported (`singularity_milestones.rs`); the full perk list is not modeled |
 | Ambrosia | 🟩 Ported | `state/ambrosia.rs`, `mechanics/ambrosia.rs` |
 | Blueberry upgrades | 🟩 Ported | `mechanics/blueberry_upgrades.rs`; effective levels populated (`populate_ambrosia_free_levels`), quark upgrades wired |
 | Red ambrosia + upgrades | 🟩 Ported | `state/red_ambrosia.rs`, `mechanics/red_ambrosia_*.rs` |
@@ -98,6 +100,17 @@ flowchart LR
   reincarnation counts once highest ≥ 8). Count auto-climbs `max(highest, count + lookahead)`.
 - ✅ **GQ metadata seeded** (`GQ_UPGRADE_SEEDS`, 80 rows) — `cost_per_level` / `max_level` / cost-form
   now real, closing the free-unlimited-level hazard.
-- **Deferred:** the elevator triad (locked/slow-climb/target — auto-climb is faithful for fresh saves);
-  singularity-challenge auto/UI entry; `worlds` (quarks) reset has no `preserveQuarks` branch yet
-  (inert until that challenge is entered).
+- ✅ **Exalt enter/exit loop ported** (`PlayerAction::ToggleSingularityChallenge`): enter gates on
+  `unlockSingularity` + not-inside-an-Exalt, holds the singularity counter and quark/GQ export timers
+  across a jump to `singularityRequirement(baseReq, completions)`; exit succeeds iff antiquities was
+  re-purchased inside — completions re-derive from the requirement ladder *before* the return jump
+  (legacy ordering), then back to the held highest. Export timers restore only on failure (verbatim).
+  Completions now grow in play, lighting the exalt effect readers and the progressive exalt slot.
+- ✅ **Elevator triad ported** (3 new `SingularityState` fields; slowClimb defaults *true* per
+  blankSave): locked → the target floor (the was-at-highest +1 bump applies regardless, verbatim),
+  slow-climb → `count + 1`, else the lookahead auto-climb. `ConfigureSingularityElevator` clamps the
+  target like the legacy input listener; `TeleportToSingularity` ascends via a full singularity
+  (counter held when antiquities is unpurchased) and **descends by just setting the count — no reset**
+  (verbatim quirk).
+- ✅ **`preserveQuarks` ported:** `worlds` resets with the rebuild unless the limitedTime reward is
+  active, in which case the balance carries across (Reset.ts:1190).


### PR DESCRIPTION
Closes out the meta-economy node's portable gaps and empties the singularity-ambrosia deferred list. 11 commits, ~1.8k insertions, **1365 logic tests** (+25), all four gates green (test/clippy/fmt/wasm), sim quiescent at default state.

## Quark multiplier — every reachable term now wired

- `getAchievementReward('quarkGain')` → `achievement_rewards::quark_gain` (#250/#251 ×1.05, #266 ×(1+0.1·min(ascCount/1e15,1)))
- Challenge-15 `quarks` reward → `challenge_15_rewards::quarks` (req 1e11)
- quark-hepteract bonus — gated on `challenge15Exponent ≥ 1e15`; `hepteractEffective('quark')` returns the **raw** balance (custom non-polynomial craft), so `(1+0.2·log2(1+bal/500))^(2+singQuarkHepteract1/2/3)`
- campaign bonus (see below)

Only 3 terms remain at identity, all UI/external: shopPanthema, infiniteAscent, event+patreon.

## Achievement awarding — only `addCodesUsed` left unported

- **singularityCount** group (idx 274–280) — unblocked by the live singularity layer
- **thousandSuns/thousandMoons** (#250/#251, research-8x25 / cube-w5x10 maxed) — their awarding lights the quarkGain ×1.05² factors end-to-end
- **campaignTokens** group (idx 426–435)

## Campaign tokens — derived, all 14 bonus consumers fed

`compute_campaign_tokens` ports `updateTokens()` as a pure derivation (no cached state): Σ per-campaign `computeTokenValue` over the 50-campaign limit/isMeta table + `inheritanceTokens` (verbatim incl. the legacy loop quirk that dead-letters the level-2 tier) + the GQ/octeract bonus-token upgrades. **Fixes a latent sizing bug: `CAMPAIGNS_LEN` was 10; both legacy snapshots have 50 campaigns.** Every dormant `campaign_token_rewards` formula now feeds from it: tax, ascension score, octeract/s, quark, cube (tutorial+campaign), golden-quark, offering/obtainium pairs, 3× reset-time-threshold reductions, ambrosia luck, blueberry speed, and the c15 score multiplier. Tokens flow from `highestSingularityCount ≥ 5` without the UI-tier campaign runner.

## Progressive achievement slots 8–11 — all 12 slots live

- **exalts**: rewardAP is a getter (`achievementPointValue(completions)`) — derived from tracked completion counts via the already-ported 9 AP formulas
- **singularityUpgrades / octeractUpgrades / redAmbrosiaUpgrades**: maxed-count ×5/×8/×10 against the seeded GQ `max_level` metadata + new static `OCTERACT_MAX_LEVELS` (47) / `RED_AMBROSIA_MAX_LEVELS` (29) tables

## Singularity — deferred list emptied

- **Exalt enter/exit loop** (`PlayerAction::ToggleSingularityChallenge`): enter gates on `unlockSingularity` + not-inside, holds the singularity counter and quark/GQ export timers across a jump to `singularityRequirement(baseReq, completions)`; exit succeeds iff antiquities was re-purchased inside — completions re-derive from the requirement ladder *before* the return jump (legacy ordering), export timers restore only on failure (verbatim). Completions now grow in play, lighting the exalt effect readers and the progressive exalt slot.
- **preserveQuarks**: quarks survive the singularity under the limitedTime reward (Reset.ts:1190).
- **Elevator triad**: 3 new `SingularityState` fields — `elevator_target` (1), `elevator_slow_climb` (**true** — the blankSave default; the previous unconditional auto-climb was the slowClimb=false behavior), `elevator_locked` (false). Locked → target floor (the was-at-highest +1 bump applies regardless of branch, verbatim); slow-climb → +1; else lookahead auto-climb. `ConfigureSingularityElevator` clamps like the legacy input listener; `TeleportToSingularity` ascends via a full singularity (counter held when antiquities is unpurchased) and **descends by just setting the count — no reset** (verbatim quirk).

## State changes (player.* standing-OK)

- `CAMPAIGNS_LEN` 10 → 50 (sizing-bug fix, count-bump precedent; + BigArray attr)
- `SingularityState.{elevator_target, elevator_slow_climb, elevator_locked}`

Everything else is zero new state; all changes identity/inert at default. Docs re-statused (meta-economy, challenges-corruptions, singularity-ambrosia, reset-cascade, README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)