### PR TITLE
Campaign runner, singularity perk table, export rewards, host save wiring, ant perks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -196,6 +221,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "postcard"
@@ -335,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +460,11 @@ name = "synergismforkd_ui_web"
 version = "0.1.0"
 dependencies = [
  "getrandom",
+ "js-sys",
+ "synergismforkd_logic",
+ "synergismforkd_save",
  "synergismforkd_ui",
+ "web-sys",
 ]
 
 [[package]]
@@ -553,6 +594,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/synergismforkd_logic/src/events/mod.rs
+++ b/crates/synergismforkd_logic/src/events/mod.rs
@@ -664,6 +664,15 @@ pub enum CoreEvent {
         /// The clamped new level written to `corruptions.next`.
         level: u32,
     },
+    /// A campaign was started (legacy start-campaign button →
+    /// `CampaignManager.set campaign`): the full ascension reset ran (its
+    /// own `ResetPerformed` precedes this event), `current_campaign` now
+    /// points at the chosen campaign, and its corruption loadout was applied
+    /// to `corruptions.used`.
+    CampaignStarted {
+        /// Campaign index (`campaignDatas` key order; `first` = 0).
+        campaign: usize,
+    },
     /// A challenge was entered (legacy `toggleChallenges`): the
     /// `current_*_challenge` slot was set and the tier reset ran. `challenge`
     /// is `0..=15` (`0` exits the transcension slot). The accompanying

--- a/crates/synergismforkd_logic/src/lib.rs
+++ b/crates/synergismforkd_logic/src/lib.rs
@@ -48,7 +48,10 @@ pub use currency::{Coins, Multiplier, PrestigePoints, ReincarnationPoints, Trans
 
 // ─── Tick orchestrator ───────────────────────────────────────────────────
 
-pub use tick::{daily_reset, tack, AutomationPre, BuyRequest, PlayerAction, TackInput, TickOutput};
+pub use tick::{
+    claim_export_rewards, daily_reset, tack, AutomationPre, BuyRequest, ExportRewardClaim,
+    PlayerAction, TackInput, TickOutput,
+};
 
 // Host seam: rebuild the achievement-points total from a loaded bitmap (H5).
 pub use mechanics::achievement_points::recompute_achievement_points;

--- a/crates/synergismforkd_logic/src/mechanics/campaigns.rs
+++ b/crates/synergismforkd_logic/src/mechanics/campaigns.rs
@@ -1,0 +1,270 @@
+//! Campaign runner data + helpers (`Campaign.ts`).
+//!
+//! The 50-entry `campaignDatas` const: per-campaign corruption loadouts and
+//! unlock requirements, in `campaignDatas` key order (`first` = 0 …
+//! `fiftieth` = 49). Token limits / meta flags already live in
+//! [`crate::mechanics::campaign_token_rewards`]; i18n names, descriptions
+//! and icons are UI-tier and not ported. Completion recording is the
+//! verbatim only-increase clamp of the `Campaign.c10Completions` setter
+//! (Campaign.ts:523-527).
+
+use crate::mechanics::campaign_token_rewards::CAMPAIGN_TOKEN_LIMITS;
+use crate::mechanics::corruptions::corruption_loadout_difficulty_score;
+pub use crate::state::campaigns::CAMPAIGNS_LEN;
+
+/// Per-campaign `campaignCorruptions` (Campaign.ts:562-1356), each row in
+/// corruption-index order (viscosity = 0, dilation = 1, hyperchallenge = 2,
+/// illiteracy = 3, deflation = 4, extinction = 5, drought = 6,
+/// recession = 7 — the `*_INDEX` constants in [`crate::state`]). Keys the
+/// legacy entry omits are `0` (the `corruptionsSchema` default).
+pub const CAMPAIGN_CORRUPTION_LOADOUTS: [[u32; 8]; CAMPAIGNS_LEN] = [
+    //  v  dil hyp ill def ext dro rec      cardinal
+    [1, 0, 0, 0, 0, 0, 0, 0],         // 1  first
+    [0, 0, 0, 0, 0, 0, 1, 0],         // 2  second
+    [1, 0, 0, 0, 0, 0, 1, 0],         // 3  third
+    [2, 0, 0, 0, 0, 0, 2, 0],         // 4  fourth
+    [3, 0, 0, 0, 0, 0, 3, 0],         // 5  fifth
+    [4, 0, 0, 0, 0, 0, 4, 0],         // 6  sixth
+    [5, 0, 0, 0, 0, 0, 5, 0],         // 7  seventh
+    [1, 0, 0, 0, 1, 0, 1, 0],         // 8  eighth
+    [3, 0, 0, 0, 1, 0, 1, 0],         // 9  ninth
+    [5, 0, 0, 0, 0, 1, 1, 0],         // 10 tenth
+    [7, 0, 0, 0, 0, 3, 1, 0],         // 11 eleventh
+    [7, 0, 0, 0, 3, 3, 1, 0],         // 12 twelfth
+    [7, 0, 0, 0, 3, 3, 3, 0],         // 13 thirteenth
+    [7, 0, 0, 0, 3, 3, 5, 0],         // 14 fourteenth
+    [7, 0, 0, 0, 3, 3, 7, 0],         // 15 fifteenth
+    [9, 0, 0, 1, 0, 0, 4, 1],         // 16 sixteenth
+    [9, 0, 0, 3, 0, 0, 4, 1],         // 17 seventeenth
+    [9, 0, 0, 3, 1, 3, 4, 1],         // 18 eighteenth
+    [9, 0, 0, 6, 1, 3, 4, 1],         // 19 nineteenth
+    [9, 0, 0, 9, 1, 3, 4, 1],         // 20 twentieth
+    [9, 0, 0, 3, 9, 3, 4, 1],         // 21 twentyFirst
+    [9, 0, 0, 6, 9, 3, 6, 1],         // 22 twentySecond
+    [9, 0, 0, 9, 9, 3, 6, 1],         // 23 twentyThird
+    [9, 0, 0, 9, 9, 3, 9, 1],         // 24 twentyFourth
+    [9, 0, 0, 9, 9, 5, 9, 3],         // 25 twentyFifth
+    [9, 1, 0, 9, 9, 3, 9, 3],         // 26 twentySixth
+    [9, 0, 1, 9, 9, 3, 9, 3],         // 27 twentySeventh
+    [9, 1, 1, 9, 9, 3, 9, 3],         // 28 twentyEighth
+    [9, 3, 3, 9, 9, 3, 9, 3],         // 29 twentyNinth
+    [0, 4, 1, 0, 4, 11, 5, 11],       // 30 thirtieth
+    [0, 4, 2, 0, 4, 11, 5, 11],       // 31 thirtyFirst
+    [1, 5, 3, 1, 4, 11, 5, 11],       // 32 thirtySecond
+    [1, 4, 3, 2, 4, 11, 5, 11],       // 33 thirtyThird
+    [1, 4, 5, 2, 4, 11, 9, 11],       // 34 thirtyFourth
+    [2, 4, 4, 2, 4, 11, 9, 11],       // 35 thirtyFifth
+    [2, 5, 5, 2, 4, 11, 9, 11],       // 36 thirtySixth
+    [2, 5, 5, 2, 4, 11, 10, 11],      // 37 thirtySeventh
+    [3, 5, 4, 2, 4, 11, 10, 11],      // 38 thirtyEighth
+    [0, 6, 9, 2, 4, 11, 10, 11],      // 39 thirtyNinth
+    [3, 6, 9, 11, 4, 11, 11, 11],     // 40 fortieth
+    [3, 7, 11, 11, 4, 11, 11, 11],    // 41 fortyFirst
+    [3, 9, 11, 12, 4, 12, 12, 12],    // 42 fortySecond
+    [5, 9, 11, 12, 4, 12, 12, 12],    // 43 fortyThird
+    [5, 11, 11, 12, 12, 12, 12, 12],  // 44 fortyFourth
+    [5, 11, 8, 13, 13, 12, 13, 13],   // 45 fortyFifth
+    [6, 12, 11, 13, 13, 13, 13, 13],  // 46 fortySixth
+    [6, 13, 7, 13, 13, 13, 13, 13],   // 47 fortySeventh
+    [6, 13, 11, 13, 13, 13, 13, 13],  // 48 fortyEighth
+    [11, 11, 11, 11, 11, 11, 11, 11], // 49 fortyNinth
+    [13, 13, 13, 13, 13, 13, 13, 13], // 50 fiftieth
+];
+
+/// A campaign's `unlockRequirement` closure, flattened to data — the legacy
+/// closures only ever test `maxCorruptionLevel()` thresholds or
+/// `player.cubeUpgrades[50] > 99999` (Campaign.ts:562-1356).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CampaignUnlock {
+    /// `() => true`.
+    Always,
+    /// `maxCorruptionLevel() >= n`.
+    MaxCorruption(u32),
+    /// `player.cubeUpgrades[50] > 99999` (campaigns 40-41).
+    CubeUpgrade50Over99999,
+}
+
+/// Per-campaign unlock gate, same key order as
+/// [`CAMPAIGN_CORRUPTION_LOADOUTS`].
+pub const CAMPAIGN_UNLOCK_REQUIREMENTS: [CampaignUnlock; CAMPAIGNS_LEN] = {
+    let mut reqs = [CampaignUnlock::Always; CAMPAIGNS_LEN];
+    let mut i = 7;
+    while i < 15 {
+        reqs[i] = CampaignUnlock::MaxCorruption(7); // 8-15
+        i += 1;
+    }
+    while i < 25 {
+        reqs[i] = CampaignUnlock::MaxCorruption(9); // 16-25
+        i += 1;
+    }
+    while i < 39 {
+        reqs[i] = CampaignUnlock::MaxCorruption(11); // 26-39
+        i += 1;
+    }
+    reqs[39] = CampaignUnlock::CubeUpgrade50Over99999; // 40
+    reqs[40] = CampaignUnlock::CubeUpgrade50Over99999; // 41
+    i = 41;
+    while i < 44 {
+        reqs[i] = CampaignUnlock::MaxCorruption(12); // 42-44
+        i += 1;
+    }
+    while i < 50 {
+        reqs[i] = CampaignUnlock::MaxCorruption(13); // 45-50
+        i += 1;
+    }
+    reqs
+};
+
+/// Evaluate a campaign's `unlockRequirement()` against the live inputs.
+#[must_use]
+pub fn campaign_unlocked(index: usize, max_corruption_level: f64, cube_upgrade_50: f64) -> bool {
+    match CAMPAIGN_UNLOCK_REQUIREMENTS[index] {
+        CampaignUnlock::Always => true,
+        CampaignUnlock::MaxCorruption(n) => max_corruption_level >= f64::from(n),
+        CampaignUnlock::CubeUpgrade50Over99999 => cube_upgrade_50 > 99999.0,
+    }
+}
+
+/// `usableLoadout.totalCorruptionDifficultyScore` for a campaign
+/// (Reset.ts:766-767): the difficulty of its stored loadout with the live
+/// `bonusLevels` added to every corruption. The legacy loadout is built
+/// straight from `campaignDatas` without clamping (the `CorruptionLoadout`
+/// constructor copies levels verbatim), so this is player-independent
+/// except for `bonus_levels`.
+#[must_use]
+pub fn campaign_loadout_difficulty(index: usize, bonus_levels: f64) -> f64 {
+    corruption_loadout_difficulty_score(&CAMPAIGN_CORRUPTION_LOADOUTS[index], bonus_levels)
+}
+
+/// `Campaign.c10Completions` setter (Campaign.ts:523-527) — only-increase,
+/// clamped to the campaign's `limit`. Used both by the singularity-4
+/// auto-complete (`setC10ToArbitrary`) and the active-campaign bank
+/// (`resetCampaign`), Reset.ts:762-784.
+pub fn record_campaign_completion(completions: &mut [f64; CAMPAIGNS_LEN], index: usize, c10: f64) {
+    if c10 > completions[index] {
+        completions[index] = c10.min(CAMPAIGN_TOKEN_LIMITS[index]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loadout_rows_match_legacy_spot_checks() {
+        // first: viscosity 1 only.
+        assert_eq!(CAMPAIGN_CORRUPTION_LOADOUTS[0], [1, 0, 0, 0, 0, 0, 0, 0]);
+        // second: drought 1 only (drought is index 6).
+        assert_eq!(CAMPAIGN_CORRUPTION_LOADOUTS[1], [0, 0, 0, 0, 0, 0, 1, 0]);
+        // eighteenth: v9 dr4 defl1 ext3 ill3 rec1.
+        assert_eq!(CAMPAIGN_CORRUPTION_LOADOUTS[17], [9, 0, 0, 3, 1, 3, 4, 1]);
+        // thirtieth drops viscosity/illiteracy to 0 (explicit zeros in TS).
+        assert_eq!(CAMPAIGN_CORRUPTION_LOADOUTS[29], [0, 4, 1, 0, 4, 11, 5, 11]);
+        // thirtyNinth has no viscosity key at all (schema default 0).
+        assert_eq!(
+            CAMPAIGN_CORRUPTION_LOADOUTS[38],
+            [0, 6, 9, 2, 4, 11, 10, 11]
+        );
+        // fiftieth: everything 13.
+        assert_eq!(CAMPAIGN_CORRUPTION_LOADOUTS[49], [13; 8]);
+    }
+
+    #[test]
+    fn unlock_table_matches_legacy_bands() {
+        assert_eq!(CAMPAIGN_UNLOCK_REQUIREMENTS[0], CampaignUnlock::Always);
+        assert_eq!(CAMPAIGN_UNLOCK_REQUIREMENTS[6], CampaignUnlock::Always);
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[7],
+            CampaignUnlock::MaxCorruption(7)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[14],
+            CampaignUnlock::MaxCorruption(7)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[15],
+            CampaignUnlock::MaxCorruption(9)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[24],
+            CampaignUnlock::MaxCorruption(9)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[25],
+            CampaignUnlock::MaxCorruption(11)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[38],
+            CampaignUnlock::MaxCorruption(11)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[39],
+            CampaignUnlock::CubeUpgrade50Over99999
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[40],
+            CampaignUnlock::CubeUpgrade50Over99999
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[41],
+            CampaignUnlock::MaxCorruption(12)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[43],
+            CampaignUnlock::MaxCorruption(12)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[44],
+            CampaignUnlock::MaxCorruption(13)
+        );
+        assert_eq!(
+            CAMPAIGN_UNLOCK_REQUIREMENTS[49],
+            CampaignUnlock::MaxCorruption(13)
+        );
+    }
+
+    #[test]
+    fn campaign_unlocked_evaluates_gates() {
+        assert!(campaign_unlocked(0, 0.0, 0.0));
+        assert!(!campaign_unlocked(7, 6.0, 0.0));
+        assert!(campaign_unlocked(7, 7.0, 0.0));
+        assert!(!campaign_unlocked(39, 14.0, 99999.0));
+        assert!(campaign_unlocked(39, 0.0, 100000.0));
+    }
+
+    #[test]
+    fn difficulty_matches_hand_computed_scores() {
+        // first at bonus 0: 400 + 16·1² over one level-1 corruption.
+        assert_eq!(campaign_loadout_difficulty(0, 0.0), 416.0);
+        // fiftieth at bonus 0: 400 + 8 · 16 · 13².
+        assert_eq!(
+            campaign_loadout_difficulty(49, 0.0),
+            400.0 + 8.0 * 16.0 * 169.0
+        );
+        // bonus levels are added to every one of the 8 corruptions, including
+        // the zero-level ones (first: 1+b plus seven at b each).
+        let b = 2.0;
+        let expected = 400.0 + 16.0 * (3.0_f64 * 3.0) + 7.0 * 16.0 * (b * b);
+        assert_eq!(campaign_loadout_difficulty(0, b), expected);
+    }
+
+    #[test]
+    fn record_completion_is_only_increase_and_clamped() {
+        let mut completions = [0.0; CAMPAIGNS_LEN];
+        // Plain increase.
+        record_campaign_completion(&mut completions, 0, 4.0);
+        assert_eq!(completions[0], 4.0);
+        // Never decreases.
+        record_campaign_completion(&mut completions, 0, 2.0);
+        assert_eq!(completions[0], 4.0);
+        // Clamps to the campaign limit (first: 10).
+        record_campaign_completion(&mut completions, 0, 25.0);
+        assert_eq!(completions[0], 10.0);
+        // Equal value is not an increase (verbatim `>` guard).
+        record_campaign_completion(&mut completions, 0, 10.0);
+        assert_eq!(completions[0], 10.0);
+        // fiftieth clamps at 140.
+        record_campaign_completion(&mut completions, 49, 500.0);
+        assert_eq!(completions[49], 140.0);
+    }
+}

--- a/crates/synergismforkd_logic/src/mechanics/corruptions.rs
+++ b/crates/synergismforkd_logic/src/mechanics/corruptions.rs
@@ -419,6 +419,19 @@ pub fn calculate_corruption_difficulty_score(total_levels: &[f64]) -> f64 {
     base_points
 }
 
+/// `CorruptionLoadout.totalCorruptionDifficultyScore` (Corruptions.ts:251-254)
+/// for a stored loadout: the difficulty over the 8 real corruptions at
+/// `level + bonusLevels` each (the bonus applies to every corruption,
+/// including zero-level ones).
+#[must_use]
+pub fn corruption_loadout_difficulty_score(levels: &[u32], bonus_levels: f64) -> f64 {
+    let mut totals = [0.0_f64; 8];
+    for (total, &level) in totals.iter_mut().zip(levels.iter().take(8)) {
+        *total = f64::from(level) + bonus_levels;
+    }
+    calculate_corruption_difficulty_score(&totals)
+}
+
 // ─── Level clipping / validation ───────────────────────────────────────────
 
 /// Clip a single corruption level to a valid stored value. Returns

--- a/crates/synergismforkd_logic/src/mechanics/mod.rs
+++ b/crates/synergismforkd_logic/src/mechanics/mod.rs
@@ -23,6 +23,7 @@ pub mod auto_upgrades;
 pub mod blueberry_upgrades;
 pub mod calculate;
 pub mod campaign_token_rewards;
+pub mod campaigns;
 pub mod challenge_15_rewards;
 pub mod challenges;
 pub mod coin_production;

--- a/crates/synergismforkd_logic/src/mechanics/mod.rs
+++ b/crates/synergismforkd_logic/src/mechanics/mod.rs
@@ -75,6 +75,7 @@ pub mod singularity_challenges;
 pub mod singularity_helpers;
 pub mod singularity_milestones;
 pub mod singularity_penalties;
+pub mod singularity_perks;
 pub mod talisman_costs;
 pub mod talisman_effects;
 pub mod talisman_levels;

--- a/crates/synergismforkd_logic/src/mechanics/singularity_perks.rs
+++ b/crates/synergismforkd_logic/src/mechanics/singularity_perks.rs
@@ -14,20 +14,26 @@
 //! its current Rust status:
 //!
 //! - **WIRED** — the effect is already ported at the cited site.
-//! - **DEFERRED(assembly)** — the perk's host stat-assembly is itself a neutral
-//!   placeholder in Rust (e.g. `calculateActualAntSpeedMult` → the tick's
-//!   `ant_speed_mult` input defaults to `1.0`), so the term has nowhere to land
-//!   yet. Not a dropped term — the whole assembly is unported.
 //! - **DEFERRED(export)** — GQ-per-second export generation, claimed in the
 //!   export/offline reward flow (the `goldenRevolution` family).
 //! - **UI** — display, automation-cadence, or unlock-gate only; no logic effect.
 //! - **EXTERNAL** — depends on a service outside the fork (PseudoCoins, add-codes).
+//! - **NONE** — the perk has a `description` but the TS source never applies a
+//!   mechanical effect for it anywhere (designed-but-unwired in the original).
+//!   The faithful port leaves it a no-op — adding an effect would *diverge*.
 //!
 //! The big multiplicative perks (`goldenCoins`, `skrauQ`, `goldenRevolution2`,
 //! `primalPower`, `derpSmithsCornucopia`, `immaculateAlchemy`, the salvage /
 //! token / ELO / blueberry perks) are all WIRED — most by the meta-economy
-//! sweep. What remains DEFERRED is gated on a *consumer* that isn't ported yet,
-//! not on the perk itself.
+//! sweep.
+//!
+//! The four ant-related perks resolved as: `antGodsCornucopia` is WIRED (the
+//! `SingularityPerk` term of `compute_ant_speed_mult`, tick); `forTheLoveOfTheAntGod`
+//! is WIRED (the `highestSingularityCount >= 10/15/20` producer/upgrade/crumb
+//! regrants that `apply_for_the_love_ant_regrants` runs at the tail of every ant
+//! reset — `Features/Ants/.../player/reset.ts`); and `irishAnt` / `irishAnt2` are
+//! **NONE** — they appear *only* in the `singularityPerks` table and have no
+//! mechanical consumer anywhere in the TS source, so they stay no-ops.
 
 /// A singularity perk, in `singularityPerks` declaration order
 /// (`welcometoSingularity` = 0 … `taxReduction` = 52). `ID` order is stable

--- a/crates/synergismforkd_logic/src/mechanics/singularity_perks.rs
+++ b/crates/synergismforkd_logic/src/mechanics/singularity_perks.rs
@@ -1,0 +1,383 @@
+//! Singularity perk table (`singularity.ts`, `singularityPerks`).
+//!
+//! The 53-perk roster: each perk's `levels` array — the singularity counts at
+//! which it unlocks and upgrades — plus the [`getLastUpgradeInfo`] level /
+//! next-threshold helper. This is the data model the singularity-perk panel
+//! renders from; the i18n `name` / `description` closures are UI-tier and not
+//! ported.
+//!
+//! ## Effect wiring
+//!
+//! A perk's *effect* is almost never applied at the perk record — it lives as a
+//! scattered `highestSingularityCount >= N` (occasionally `singularityCount >=
+//! N`) comparison inside the consuming system. Each perk below is tagged with
+//! its current Rust status:
+//!
+//! - **WIRED** — the effect is already ported at the cited site.
+//! - **DEFERRED(assembly)** — the perk's host stat-assembly is itself a neutral
+//!   placeholder in Rust (e.g. `calculateActualAntSpeedMult` → the tick's
+//!   `ant_speed_mult` input defaults to `1.0`), so the term has nowhere to land
+//!   yet. Not a dropped term — the whole assembly is unported.
+//! - **DEFERRED(export)** — GQ-per-second export generation, claimed in the
+//!   export/offline reward flow (the `goldenRevolution` family).
+//! - **UI** — display, automation-cadence, or unlock-gate only; no logic effect.
+//! - **EXTERNAL** — depends on a service outside the fork (PseudoCoins, add-codes).
+//!
+//! The big multiplicative perks (`goldenCoins`, `skrauQ`, `goldenRevolution2`,
+//! `primalPower`, `derpSmithsCornucopia`, `immaculateAlchemy`, the salvage /
+//! token / ELO / blueberry perks) are all WIRED — most by the meta-economy
+//! sweep. What remains DEFERRED is gated on a *consumer* that isn't ported yet,
+//! not on the perk itself.
+
+/// A singularity perk, in `singularityPerks` declaration order
+/// (`welcometoSingularity` = 0 … `taxReduction` = 52). `ID` order is stable
+/// and matches the legacy htmlID used for save/UI cross-reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(usize)]
+pub enum SingularityPerkId {
+    WelcomeToSingularity = 0,
+    UnlimitedGrowth = 1,
+    GoldenCoins = 2,
+    Xyz = 3,
+    GenerousOrbs = 4,
+    ResearchDummies = 5,
+    RecycledContent = 6,
+    AntGodsCornucopia = 7,
+    BringToLife = 8,
+    TokenInheritance = 9,
+    Sweepomatic = 10,
+    SuperStart = 11,
+    InvigoratedSpirits = 12,
+    EloBonus = 13,
+    NotSoChallenging = 14,
+    AutoCampaigns = 15,
+    AutomationUpgrades = 16,
+    EvenMoreQuarks = 17,
+    PotionAutogenerator = 18,
+    PersistentGlobalResets = 19,
+    ShopSpecialOffer = 20,
+    ForTheLoveOfTheAntGod = 21,
+    ItAllAddsUp = 22,
+    AutomagicalRunes = 23,
+    FirstClearTokens = 24,
+    DerpSmithsCornucopia = 25,
+    EternalAscensions = 26,
+    ExaltedAchievements = 27,
+    CoolQolCubes = 28,
+    InfiniteRecycling = 29,
+    IrishAnt = 30,
+    BonusTokens = 31,
+    ImmaculateAlchemy = 32,
+    Overclocked = 33,
+    WowCubeAutomatedShipping = 34,
+    PlatonicClones = 35,
+    CongealedBlueberries = 36,
+    LastClearTokens = 37,
+    RecyclistsDesktop = 38,
+    GoldenRevolution = 39,
+    GoldenRevolution2 = 40,
+    GoldenRevolution3 = 41,
+    IrishAnt2 = 42,
+    PlatSigma = 43,
+    PrimalPower = 44,
+    MidasMilleniumAgedGold = 45,
+    GoldenRevolution4 = 46,
+    OcteractMetagenesis = 47,
+    SkrauQ = 48,
+    DemeterHarvest = 49,
+    PermanentBenefaction = 50,
+    InfiniteShopUpgrades = 51,
+    TaxReduction = 52,
+}
+
+/// One perk record: its stable string ID (the legacy htmlID, used for
+/// save/UI cross-reference) and its monotonically-increasing `levels`
+/// thresholds.
+#[derive(Debug, Clone, Copy)]
+pub struct SingularityPerk {
+    /// The enum tag.
+    pub id: SingularityPerkId,
+    /// The legacy `ID` string (htmlID).
+    pub html_id: &'static str,
+    /// The singularity counts at which the perk unlocks (index 0) and each
+    /// subsequent level activates. Always non-empty and ascending.
+    pub levels: &'static [u32],
+}
+
+/// The full perk roster, in declaration order. Verified 1:1 against
+/// `singularityPerks` (53 perks; level arrays extracted mechanically).
+pub const SINGULARITY_PERKS: [SingularityPerk; 53] = {
+    use SingularityPerkId::*;
+    macro_rules! perk {
+        ($id:expr, $html:literal, $levels:expr) => {
+            SingularityPerk {
+                id: $id,
+                html_id: $html,
+                levels: &$levels,
+            }
+        };
+    }
+    [
+        perk!(WelcomeToSingularity, "welcometoSingularity", [1]),
+        perk!(UnlimitedGrowth, "unlimitedGrowth", [1]),
+        perk!(GoldenCoins, "goldenCoins", [1]),
+        perk!(Xyz, "xyz", [1, 20, 200]),
+        perk!(
+            GenerousOrbs,
+            "generousOrbs",
+            [1, 2, 5, 10, 15, 20, 25, 30, 35]
+        ),
+        perk!(ResearchDummies, "researchDummies", [1, 11]),
+        perk!(
+            RecycledContent,
+            "recycledContent",
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ),
+        perk!(AntGodsCornucopia, "antGodsCornucopia", [1, 30, 70, 100]),
+        perk!(
+            BringToLife,
+            "bringToLife",
+            [1, 9, 25, 49, 81, 121, 169, 196, 225, 256, 289]
+        ),
+        perk!(
+            TokenInheritance,
+            "tokenInheritance",
+            [2, 5, 10, 17, 26, 37, 50, 65, 82, 101, 220, 240, 260, 270, 277]
+        ),
+        perk!(Sweepomatic, "sweepomatic", [2, 101]),
+        perk!(SuperStart, "superStart", [2, 3, 4, 7, 15]),
+        perk!(
+            InvigoratedSpirits,
+            "invigoratedSpirits",
+            [2, 10, 26, 50, 82, 122, 170, 197, 226, 257, 290]
+        ),
+        perk!(
+            EloBonus,
+            "eloBonus",
+            [3, 11, 27, 51, 83, 123, 171, 198, 227, 258, 291]
+        ),
+        perk!(NotSoChallenging, "notSoChallenging", [4, 7, 10, 15, 20]),
+        perk!(AutoCampaigns, "autoCampaigns", [4]),
+        perk!(
+            AutomationUpgrades,
+            "automationUpgrades",
+            [5, 10, 15, 25, 30, 100]
+        ),
+        perk!(
+            EvenMoreQuarks,
+            "evenMoreQuarks",
+            [
+                5, 7, 10, 20, 35, 50, 65, 80, 90, 100, 121, 144, 150, 160, 166, 169, 170, 175, 180,
+                190, 196, 200, 201, 202, 203, 204, 205, 210, 213, 216, 219, 225, 228, 231, 234,
+                237, 240, 244, 248, 252, 256, 260, 264, 268, 272, 276, 280, 284, 288, 290
+            ]
+        ),
+        perk!(PotionAutogenerator, "potionAutogenerator", [6]),
+        perk!(PersistentGlobalResets, "persistentGlobalResets", [8]),
+        perk!(ShopSpecialOffer, "shopSpecialOffer", [10, 50]),
+        perk!(ForTheLoveOfTheAntGod, "forTheLoveOfTheAntGod", [10, 15, 20]),
+        perk!(
+            ItAllAddsUp,
+            "itAllAddsUp",
+            [10, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 235, 240]
+        ),
+        perk!(AutomagicalRunes, "automagicalRunes", [15, 30, 40, 50]),
+        perk!(FirstClearTokens, "firstClearTokens", [16]),
+        perk!(
+            DerpSmithsCornucopia,
+            "derpSmithsCornucopia",
+            [18, 38, 58, 78, 88, 98, 118, 148, 178, 188, 198, 208, 218, 228, 238, 248]
+        ),
+        perk!(EternalAscensions, "eternalAscensions", [25]),
+        perk!(ExaltedAchievements, "exaltedAchievements", [25]),
+        perk!(CoolQolCubes, "coolQOLCubes", [25, 35]),
+        perk!(
+            InfiniteRecycling,
+            "infiniteRecycling",
+            [30, 40, 61, 81, 111, 131, 161, 191, 236, 260]
+        ),
+        perk!(
+            IrishAnt,
+            "irishAnt",
+            [35, 42, 49, 56, 63, 70, 77, 135, 142, 149, 156, 163, 170, 177]
+        ),
+        perk!(BonusTokens, "bonusTokens", [41, 58, 113, 163, 229]),
+        perk!(ImmaculateAlchemy, "immaculateAlchemy", [50]),
+        perk!(
+            Overclocked,
+            "overclocked",
+            [50, 60, 75, 100, 125, 150, 175, 200, 225, 250]
+        ),
+        perk!(WowCubeAutomatedShipping, "wowCubeAutomatedShipping", [50]),
+        perk!(PlatonicClones, "platonicClones", [50]),
+        perk!(
+            CongealedBlueberries,
+            "congealedblueberries",
+            [64, 128, 192, 256, 270]
+        ),
+        perk!(LastClearTokens, "lastClearTokens", [69]),
+        perk!(
+            RecyclistsDesktop,
+            "recyclistsDesktop",
+            [75, 85, 105, 125, 155, 185, 215, 245, 260, 275]
+        ),
+        perk!(GoldenRevolution, "goldenRevolution", [100]),
+        perk!(GoldenRevolution2, "goldenRevolution2", [100]),
+        perk!(GoldenRevolution3, "goldenRevolution3", [100]),
+        perk!(
+            IrishAnt2,
+            "irishAnt2",
+            [100, 150, 200, 225, 250, 255, 260, 265, 269, 272]
+        ),
+        perk!(PlatSigma, "platSigma", [125, 200]),
+        perk!(PrimalPower, "primalPower", [131, 269]),
+        perk!(MidasMilleniumAgedGold, "midasMilleniumAgedGold", [150]),
+        perk!(
+            GoldenRevolution4,
+            "goldenRevolution4",
+            [160, 173, 185, 194, 204, 210, 219, 229, 240, 249]
+        ),
+        perk!(OcteractMetagenesis, "octeractMetagenesis", [200, 205]),
+        perk!(SkrauQ, "skrauQ", [200]),
+        perk!(DemeterHarvest, "demeterHarvest", [230, 245, 260, 275, 290]),
+        perk!(PermanentBenefaction, "permanentBenefaction", [244]),
+        perk!(InfiniteShopUpgrades, "infiniteShopUpgrades", [250, 280]),
+        perk!(TaxReduction, "taxReduction", [281]),
+    ]
+};
+
+impl SingularityPerkId {
+    /// This perk's record (its `html_id` + `levels`).
+    #[must_use]
+    pub fn def(self) -> &'static SingularityPerk {
+        &SINGULARITY_PERKS[self as usize]
+    }
+
+    /// This perk's `levels` thresholds.
+    #[must_use]
+    pub fn levels(self) -> &'static [u32] {
+        self.def().levels
+    }
+
+    /// The perk's current level at `count` singularities — the number of
+    /// thresholds crossed (`getLastUpgradeInfo(...).level`, `singularity.ts:
+    /// 3194-3204`). `0` until the first threshold is reached, then the count
+    /// of `levels[i] <= count`.
+    ///
+    /// Effects read `player.highestSingularityCount` (the all-time max), so
+    /// callers should pass that — *not* the current `singularityCount`, which
+    /// only the panel display uses.
+    #[must_use]
+    pub fn level_at(self, count: f64) -> u32 {
+        self.levels()
+            .iter()
+            .filter(|&&threshold| count >= f64::from(threshold))
+            .count() as u32
+    }
+
+    /// Whether the perk has unlocked at all (`level_at(count) >= 1`).
+    #[must_use]
+    pub fn is_active(self, count: f64) -> bool {
+        self.levels()
+            .first()
+            .is_some_and(|&first| count >= f64::from(first))
+    }
+
+    /// The next threshold strictly above `count` (`getLastUpgradeInfo(...).
+    /// next`), or `None` once the perk is maxed.
+    #[must_use]
+    pub fn next_threshold(self, count: f64) -> Option<u32> {
+        self.levels()
+            .iter()
+            .copied()
+            .find(|&threshold| f64::from(threshold) > count)
+    }
+}
+
+/// `getActivePerkCount` analogue — how many distinct perks have unlocked at
+/// `count` singularities (each perk counts once, regardless of level).
+#[must_use]
+pub fn active_perk_count(count: f64) -> usize {
+    SINGULARITY_PERKS
+        .iter()
+        .filter(|perk| count >= f64::from(perk.levels[0]))
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roster_is_53_perks_in_declaration_order() {
+        assert_eq!(SINGULARITY_PERKS.len(), 53);
+        // Tag index matches array slot for every entry.
+        for (i, perk) in SINGULARITY_PERKS.iter().enumerate() {
+            assert_eq!(perk.id as usize, i, "perk {} out of order", perk.html_id);
+        }
+        // Endpoints + a couple of mid-roster html IDs.
+        assert_eq!(SINGULARITY_PERKS[0].html_id, "welcometoSingularity");
+        assert_eq!(SINGULARITY_PERKS[7].html_id, "antGodsCornucopia");
+        assert_eq!(SINGULARITY_PERKS[48].html_id, "skrauQ");
+        assert_eq!(SINGULARITY_PERKS[52].html_id, "taxReduction");
+    }
+
+    #[test]
+    fn level_arrays_are_ascending_and_nonempty() {
+        for perk in &SINGULARITY_PERKS {
+            assert!(!perk.levels.is_empty(), "{} has no levels", perk.html_id);
+            assert!(
+                perk.levels.windows(2).all(|w| w[0] < w[1]),
+                "{} levels not strictly ascending",
+                perk.html_id
+            );
+        }
+    }
+
+    #[test]
+    fn evenmorequarks_has_the_full_50_entry_ladder() {
+        // The longest array — a transcription-risk row, asserted by length and
+        // endpoints against the mechanical extraction.
+        let levels = SingularityPerkId::EvenMoreQuarks.levels();
+        assert_eq!(levels.len(), 50);
+        assert_eq!(levels[0], 5);
+        assert_eq!(levels[49], 290);
+    }
+
+    #[test]
+    fn level_at_counts_crossed_thresholds() {
+        let generous = SingularityPerkId::GenerousOrbs; // [1,2,5,10,15,20,25,30,35]
+        assert_eq!(generous.level_at(0.0), 0);
+        assert_eq!(generous.level_at(1.0), 1);
+        assert_eq!(generous.level_at(5.0), 3); // 1,2,5 crossed
+        assert_eq!(generous.level_at(34.0), 8);
+        assert_eq!(generous.level_at(35.0), 9); // maxed
+        assert_eq!(generous.level_at(1000.0), 9); // can't exceed array length
+    }
+
+    #[test]
+    fn is_active_and_next_threshold_match_legacy_getlastupgradeinfo() {
+        let tax = SingularityPerkId::TaxReduction; // [281]
+        assert!(!tax.is_active(280.0));
+        assert!(tax.is_active(281.0));
+        assert_eq!(tax.next_threshold(0.0), Some(281));
+        assert_eq!(tax.next_threshold(281.0), None);
+
+        let coolqol = SingularityPerkId::CoolQolCubes; // [25,35]
+        assert_eq!(coolqol.next_threshold(25.0), Some(35));
+        assert_eq!(coolqol.next_threshold(34.9), Some(35));
+        assert_eq!(coolqol.next_threshold(35.0), None);
+    }
+
+    #[test]
+    fn active_perk_count_tracks_unlocks() {
+        // Below the first perk threshold (1) nothing is active.
+        assert_eq!(active_perk_count(0.0), 0);
+        // At sing 1 every perk whose levels[0] == 1 is active. From the roster:
+        // welcometoSingularity, unlimitedGrowth, goldenCoins, xyz, generousOrbs,
+        // researchDummies, recycledContent, antGodsCornucopia, bringToLife = 9.
+        assert_eq!(active_perk_count(1.0), 9);
+        // At a very high count, all 53 are active.
+        assert_eq!(active_perk_count(1000.0), 53);
+    }
+}

--- a/crates/synergismforkd_logic/src/state/campaigns.rs
+++ b/crates/synergismforkd_logic/src/state/campaigns.rs
@@ -24,12 +24,17 @@ pub const CONSTANT_UPGRADES_LEN: usize = 11;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct CampaignsState {
     /// Per-campaign `c10Completions` count, in `campaignDatas` key order
-    /// (`first` = 0 … `fiftieth` = 49). The campaign *runner* (choosing a
-    /// campaign, completing c10 under its corruptions) is UI-tier, so logic
-    /// only ever reads these; the token total derives from them via
-    /// [`crate::mechanics::campaign_token_rewards`].
+    /// (`first` = 0 … `fiftieth` = 49). Written by the ascension layer's
+    /// campaign sweep (auto-complete at `highestSingularityCount >= 4` +
+    /// the active-campaign bank, Reset.ts:762-784); the token total derives
+    /// from them via [`crate::mechanics::campaign_token_rewards`].
     #[serde(with = "BigArray")]
     pub campaign_completions: [f64; CAMPAIGNS_LEN],
+    /// `player.campaigns.currentCampaign` — the active campaign's index
+    /// (`campaignDatas` key order), or `None` outside a campaign. Set by
+    /// `PlayerAction::SelectCampaign`; cleared — after banking completions —
+    /// by the ascension layer (Reset.ts:782-784).
+    pub current_campaign: Option<u8>,
     /// `player.campaigns.tokensSpent` — total tokens spent across
     /// all campaigns.
     pub tokens_spent: f64,
@@ -47,6 +52,7 @@ impl Default for CampaignsState {
     fn default() -> Self {
         Self {
             campaign_completions: [0.0; CAMPAIGNS_LEN],
+            current_campaign: None,
             tokens_spent: 0.0,
             ascension_score_multiplier: 1.0,
             constant_upgrades: [0.0; CONSTANT_UPGRADES_LEN],

--- a/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
+++ b/crates/synergismforkd_logic/src/tick/ant_sacrifice.rs
@@ -377,9 +377,10 @@ pub(super) fn perform_ant_sacrifice(
 /// reborn-ELO leaderboards persist (they clear at singularity / save-reset).
 ///
 /// The `highestSingularityCount >= 10/15/20` crumb / producer / upgrade regrants
-/// and the `sacCount` group award + `antSacrificeToReincarnation` bump are
-/// omitted — the singularity layer is paused and the group awards belong to the
-/// achievement-awarding workstream. All are inert at every non-singularity state.
+/// (`forTheLoveOfTheAntGod`) run at the tail via
+/// [`super::reset::apply_for_the_love_ant_regrants`], reachable now that the
+/// singularity layer is live. The `antSacrificeToReincarnation` bump remains
+/// omitted (inert at every non-singularity state).
 fn reset_ants_for_sacrifice(state: &mut GameState) {
     // Ant upgrades whose `minimumResetTier` is `sacrifice` (0) — reset on every
     // sacrifice. Salvage(7) / Mortuus(11) / Mortuus2(13) / AscensionScore(14)
@@ -425,6 +426,10 @@ fn reset_ants_for_sacrifice(state: &mut GameState) {
     // Timers reset.
     state.ants.ant_sacrifice_timer = 0.0;
     state.ants.ant_sacrifice_timer_real = 0.0;
+
+    // forTheLoveOfTheAntGod regrants (the tier-independent tail of resetAnts).
+    let highest_singularity_count = state.singularity.highest_singularity_count;
+    super::reset::apply_for_the_love_ant_regrants(&mut state.ants, highest_singularity_count);
 }
 
 // ─── Reborn-ELO activation + leaderboard ──────────────────────────────────────

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -58,6 +58,7 @@ use crate::mechanics::particle_buildings::{buy_particle_building, BuyParticleBui
 use crate::mechanics::platonic_upgrade_costs::{buy_platonic_upgrade, BuyPlatonicUpgradeInput};
 use crate::mechanics::producers::{buy_max, buy_producer, BuyMaxInput, BuyProducerInput};
 use crate::mechanics::researches::{buy_research, BuyResearchInput};
+use crate::mechanics::reset_currency::ResetCurrencyResult;
 use crate::mechanics::resource_gain::{resource_gain, ResourceGainPre};
 use crate::mechanics::rune_levels::{buy_rune_levels, BuyRuneLevelsInput};
 use crate::mechanics::shop_costs::{buy_shop, BuyShopInput};
@@ -337,6 +338,14 @@ pub enum PlayerAction {
     /// singularity to the target; descending just sets the count — no reset.
     /// Gated on a valid target and on not being inside an Exalt.
     TeleportToSingularity,
+    /// Start a campaign (legacy start-campaign button): rejected while
+    /// inside an ascension challenge; otherwise runs a full ascension reset
+    /// (banking any active campaign's completions first) and applies the
+    /// chosen campaign's corruption loadout to `corruptions.used`.
+    SelectCampaign {
+        /// Campaign index (`campaignDatas` key order; `first` = 0).
+        campaign: usize,
+    },
 }
 
 /// Selects the automation flag a [`PlayerAction::ToggleAuto`] sets.
@@ -5862,6 +5871,11 @@ fn phase_player_input(
                     .events
                     .extend(reset::toggle_singularity_challenge(state, *challenge));
             }
+            PlayerAction::SelectCampaign { campaign } => {
+                output
+                    .events
+                    .extend(select_campaign(state, *campaign, reset_gains));
+            }
             PlayerAction::ConfigureSingularityElevator {
                 target,
                 locked,
@@ -6366,52 +6380,94 @@ fn set_automation_toggle(state: &mut GameState, target: AutoToggle, enabled: boo
     }
 }
 
-/// `CorruptionLoadout.setLevel` — set a single corruption's *next-ascension*
-/// level (clamped to `[0, maxCorruptionLevel]`) and recompute
-/// `corruptions.next.total_corruption_ascension_multiplier`
-/// (`updateCorruptionScoreMult`). Out-of-range slots (`>= 8`) are ignored.
-///
-/// Neutral-defaulted bonus contributions (faithful — unported / paused):
-/// `cookieGrandma` talisman free-corruption-levels (not among the 7 ported
-/// talismans), `corruptionFifteen` GQ + `oneChallengeCap` SC free levels and
-/// score-increase, and `advancedPack` GQ score-increase — all singularity-era
-/// and `0` at the current scope. finiteDescent rune free levels, `cubeUpgrades[74]`,
-/// and `platonicUpgrades[17]` are applied faithfully.
-fn set_corruption_level(
-    state: &mut GameState,
-    index: usize,
-    level: u32,
-) -> SmallVec<[CoreEvent; 1]> {
-    use crate::mechanics::corruptions::{
-        calculate_total_corruption_score_mult, max_corruption_level, MaxCorruptionLevelInput,
-        TotalCorruptionScoreMultInput,
-    };
-    use crate::mechanics::golden_quark_upgrades::{
-        platonic_tau_effect, PlatonicTauKey, PlatonicTauValue,
-    };
+/// `CorruptionLoadout.bonusLevels` (Corruptions.ts:239-246) — the flat free
+/// levels added to every corruption ahead of multiplier / difficulty
+/// lookups: GQ `corruptionFifteen` (identity) + the `oneChallengeCap` Exalt
+/// reward (`completions >= 12`) + the cookieGrandma talisman inscript + the
+/// finiteDescent rune.
+pub(crate) fn corruption_bonus_levels(state: &GameState) -> f64 {
+    use crate::mechanics::golden_quark_upgrades::corruption_fifteen_effect;
     use crate::mechanics::rune_effects::{finite_descent_rune_effects, FiniteDescentRuneKey};
-    use crate::state::golden_quarks::GQ_PLATONIC_TAU;
+    use crate::mechanics::singularity_challenges::{
+        one_challenge_cap_effect, OneChallengeCapKey, SingularityEffectValue,
+    };
+    use crate::mechanics::talisman_effects::cookie_grandma_talisman_effects;
+    use crate::state::golden_quarks::GQ_CORRUPTION_FIFTEEN;
+    use crate::state::talismans::TALISMAN_COOKIE_GRANDMA;
     use crate::state::RUNE_FINITE_DESCENT;
 
-    const CUBE_UPGRADE_74: usize = 74;
-    const PLATONIC_UPGRADE_17: usize = 17;
+    let gq15 = &state.golden_quarks.upgrades[GQ_CORRUPTION_FIFTEEN];
+    let exalt_free = match one_challenge_cap_effect(
+        state.singularity.one_challenge_cap.completions,
+        OneChallengeCapKey::FreeCorruptionLevel,
+    ) {
+        SingularityEffectValue::Scalar(s) => s,
+        SingularityEffectValue::Unlock(_) => 0.0,
+    };
+    corruption_fifteen_effect(gq15.level + gq15.free_level)
+        + exalt_free
+        + cookie_grandma_talisman_effects(
+            state.talismans.talisman_rarity[TALISMAN_COOKIE_GRANDMA] as i32,
+        )
+        .free_corruption_level
+        + finite_descent_rune_effects(
+            state.runes.rune_levels[RUNE_FINITE_DESCENT],
+            FiniteDescentRuneKey::CorruptionFreeLevels,
+        )
+}
 
-    // Only the 8 real corruptions (viscosity..recession) are settable.
-    if index >= 8 {
-        return smallvec![];
-    }
+/// `CorruptionLoadout` `bonusVal` (Corruptions.ts:140-143) — the additive
+/// score increase inside each corruption's raw-multiplier base: GQ
+/// `advancedPack` (flat `0.33` once owned) + `oneChallengeCap`
+/// `corrScoreIncrease` (`0.05`/completion) + `0.3 · cubeUpgrades[74]`.
+pub(crate) fn corruption_bonus_val(state: &GameState) -> f64 {
+    use crate::mechanics::golden_quark_upgrades::{advanced_pack_effect, AdvancedPackKey};
+    use crate::mechanics::singularity_challenges::{
+        one_challenge_cap_effect, OneChallengeCapKey, SingularityEffectValue,
+    };
+    use crate::state::golden_quarks::GQ_ADVANCED_PACK;
+
+    const CUBE_UPGRADE_74: usize = 74;
+
+    let gq_adv = &state.golden_quarks.upgrades[GQ_ADVANCED_PACK];
+    let exalt_score = match one_challenge_cap_effect(
+        state.singularity.one_challenge_cap.completions,
+        OneChallengeCapKey::CorrScoreIncrease,
+    ) {
+        SingularityEffectValue::Scalar(s) => s,
+        SingularityEffectValue::Unlock(_) => 0.0,
+    };
+    advanced_pack_effect(
+        gq_adv.level + gq_adv.free_level,
+        AdvancedPackKey::CorruptionScoreIncrease,
+    ) + exalt_score
+        + 0.3 * state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_74]
+}
+
+/// `maxCorruptionLevel()` (Corruptions.ts:388-400) with every input live,
+/// including the singularity-era GQ `corruptionFourteen` unlock and the
+/// `octeractCorruption` cap increase.
+pub(crate) fn current_max_corruption_level(state: &GameState) -> f64 {
+    use crate::mechanics::corruptions::{max_corruption_level, MaxCorruptionLevelInput};
+    use crate::mechanics::golden_quark_upgrades::{
+        corruption_fourteen_effect, platonic_tau_effect, PlatonicTauKey, PlatonicTauValue,
+    };
+    use crate::mechanics::octeracts::octeract_corruption_effect;
+    use crate::state::golden_quarks::{GQ_CORRUPTION_FOURTEEN, GQ_PLATONIC_TAU};
+    use crate::state::octeract_upgrades::OCTERACT_CORRUPTION;
 
     let cc = &state.challenges.challenge_completions;
     let platonic = &state.cube_upgrade_levels.platonic_upgrades;
+    let gq = &state.golden_quarks.upgrades;
     let platonic_tau_unlocked = matches!(
         platonic_tau_effect(
-            state.golden_quarks.upgrades[GQ_PLATONIC_TAU].level
-                + state.golden_quarks.upgrades[GQ_PLATONIC_TAU].free_level,
+            gq[GQ_PLATONIC_TAU].level + gq[GQ_PLATONIC_TAU].free_level,
             PlatonicTauKey::Unlocked,
         ),
         PlatonicTauValue::Unlock(true)
     );
-    let max = max_corruption_level(&MaxCorruptionLevelInput {
+    let oct_corruption = &state.octeract_upgrades.upgrades[OCTERACT_CORRUPTION];
+    max_corruption_level(&MaxCorruptionLevelInput {
         challenge_11_completions: cc[11],
         challenge_12_completions: cc[12],
         challenge_13_completions: cc[13],
@@ -6419,31 +6475,94 @@ fn set_corruption_level(
         platonic_upgrade_5: platonic[5],
         platonic_upgrade_10: platonic[10],
         platonic_tau_unlocked,
-        corruption_fourteen_unlocked: false, // GQ corruptionFourteen (singularity) → neutral
-        octeract_corruption_cap_increase: 0.0, // octeractCorruption (singularity) → neutral
-    });
+        corruption_fourteen_unlocked: corruption_fourteen_effect(
+            gq[GQ_CORRUPTION_FOURTEEN].level + gq[GQ_CORRUPTION_FOURTEEN].free_level,
+        ),
+        octeract_corruption_cap_increase: octeract_corruption_effect(
+            oct_corruption.level + oct_corruption.free_level,
+        ),
+    })
+}
 
+/// `updateCorruptionScoreMult` over an arbitrary loadout with the live bonus
+/// terms (the legacy lazy `totalCorruptionAscensionMultiplier` getter
+/// recomputes with exactly these on first read).
+pub(crate) fn corruption_score_mult_for(state: &GameState, levels: [u32; 14]) -> f64 {
+    use crate::mechanics::corruptions::{
+        calculate_total_corruption_score_mult, TotalCorruptionScoreMultInput,
+    };
+
+    const PLATONIC_UPGRADE_17: usize = 17;
+
+    calculate_total_corruption_score_mult(&TotalCorruptionScoreMultInput {
+        levels: &levels,
+        bonus_levels: corruption_bonus_levels(state),
+        bonus_val: corruption_bonus_val(state),
+        viscosity_platonic_17: state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_17],
+    })
+}
+
+/// `CorruptionLoadout.setLevel` — set a single corruption's *next-ascension*
+/// level (clamped to `[0, maxCorruptionLevel]`) and recompute
+/// `corruptions.next.total_corruption_ascension_multiplier`
+/// (`updateCorruptionScoreMult`). Out-of-range slots (`>= 8`) are ignored.
+/// Every bonus contribution is live: finiteDescent + cookieGrandma +
+/// `corruptionFifteen` + `oneChallengeCap` free levels, `advancedPack` +
+/// `oneChallengeCap` + `cubeUpgrades[74]` score increases, and the GQ /
+/// octeract corruption-cap raises.
+fn set_corruption_level(
+    state: &mut GameState,
+    index: usize,
+    level: u32,
+) -> SmallVec<[CoreEvent; 1]> {
+    // Only the 8 real corruptions (viscosity..recession) are settable.
+    if index >= 8 {
+        return smallvec![];
+    }
+
+    let max = current_max_corruption_level(state);
     let clamped = level.min(max as u32);
     state.corruptions.next.levels[index] = clamped;
 
-    // Recompute total_corruption_ascension_multiplier from the updated loadout.
-    let bonus_levels = finite_descent_rune_effects(
-        state.runes.rune_levels[RUNE_FINITE_DESCENT],
-        FiniteDescentRuneKey::CorruptionFreeLevels,
-    );
-    let bonus_val = 0.3 * state.cube_upgrade_levels.cube_upgrades[CUBE_UPGRADE_74];
+    let next_levels = state.corruptions.next.levels;
     state.corruptions.next.total_corruption_ascension_multiplier =
-        calculate_total_corruption_score_mult(&TotalCorruptionScoreMultInput {
-            levels: &state.corruptions.next.levels,
-            bonus_levels,
-            bonus_val,
-            viscosity_platonic_17: state.cube_upgrade_levels.platonic_upgrades[PLATONIC_UPGRADE_17],
-        });
+        corruption_score_mult_for(state, next_levels);
 
     smallvec![CoreEvent::CorruptionLevelSet {
         index,
         level: clamped,
     }]
+}
+
+/// Start a campaign (the legacy start-campaign button, Campaign.ts:1556-1564,
+/// then `CampaignManager.set campaign`, Campaign.ts:332-340): rejected while
+/// inside an ascension challenge; otherwise runs a full `reset('ascension')`
+/// — which banks + clears any currently-active campaign — then marks the
+/// chosen campaign current and applies its corruption loadout to
+/// `corruptions.used`. The fresh legacy `CorruptionLoadout`'s score mult
+/// re-derives lazily on first read; here the cache recomputes eagerly.
+fn select_campaign(
+    state: &mut GameState,
+    campaign: usize,
+    reset_gains: &ResetCurrencyResult,
+) -> SmallVec<[CoreEvent; 2]> {
+    use crate::mechanics::campaigns::{CAMPAIGNS_LEN, CAMPAIGN_CORRUPTION_LOADOUTS};
+
+    if campaign >= CAMPAIGNS_LEN || state.challenges.current_ascension_challenge != 0 {
+        return smallvec![];
+    }
+
+    let mut events = reset::perform_reset(state, ResetRequest::Ascension, reset_gains);
+
+    state.campaigns.current_campaign = Some(campaign as u8);
+    let mut levels = [0_u32; 14];
+    levels[..8].copy_from_slice(&CAMPAIGN_CORRUPTION_LOADOUTS[campaign]);
+    state.corruptions.used.levels = levels;
+    state.corruptions.used.total_corruption_ascension_multiplier =
+        corruption_score_mult_for(state, levels);
+
+    events.push(CoreEvent::CampaignStarted { campaign });
+    events
 }
 
 /// **Phase 4** — Resource generation + challenge auto-completion.
@@ -8529,6 +8648,75 @@ mod tests {
             output.events
         );
         assert_eq!(state.cube_upgrade_levels.cube_upgrades[1], 1.0);
+    }
+
+    #[test]
+    fn tack_dispatches_select_campaign_action() {
+        let mut state = GameState::default();
+        state.challenges.challenge_completions[10] = 3.0;
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::SelectCampaign { campaign: 4 });
+
+        let output = tack(&mut state, &input);
+
+        assert!(
+            output
+                .events
+                .iter()
+                .any(|e| matches!(e, CoreEvent::CampaignStarted { campaign: 4 })),
+            "expected CampaignStarted in events, got {:?}",
+            output.events
+        );
+        // The full ascension reset ran first (start button = reset('ascension')
+        // then the campaign setter)…
+        assert!(output.events.iter().any(|e| matches!(
+            e,
+            CoreEvent::ResetPerformed {
+                tier: crate::events::AutoResetTier::Ascension,
+                ..
+            }
+        )));
+        // …and the fifth campaign (viscosity 3 / drought 3) is now active on
+        // `corruptions.used`, with no completions banked (no campaign was
+        // active during the reset and singularity < 4).
+        assert_eq!(state.campaigns.current_campaign, Some(4));
+        assert_eq!(
+            state.corruptions.used.levels[crate::state::VISCOSITY_INDEX],
+            3
+        );
+        assert_eq!(
+            state.corruptions.used.levels[crate::state::DROUGHT_INDEX],
+            3
+        );
+        assert_eq!(state.campaigns.campaign_completions, [0.0; 50]);
+    }
+
+    #[test]
+    fn select_campaign_rejected_inside_ascension_challenge() {
+        let mut state = GameState::default();
+        state.challenges.current_ascension_challenge = 11;
+
+        let mut input = TackInput {
+            dt: 0.025,
+            ..TackInput::default()
+        };
+        input
+            .player_actions
+            .push(PlayerAction::SelectCampaign { campaign: 0 });
+
+        let output = tack(&mut state, &input);
+
+        assert!(!output
+            .events
+            .iter()
+            .any(|e| matches!(e, CoreEvent::CampaignStarted { .. })));
+        assert_eq!(state.campaigns.current_campaign, None);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/mod.rs
+++ b/crates/synergismforkd_logic/src/tick/mod.rs
@@ -3513,6 +3513,96 @@ fn compute_ascension_count(state: &GameState, effective_score: f64) -> f64 {
     })
 }
 
+/// The currencies banked by an export-reward claim (the return of
+/// [`claim_export_rewards`]). Both are post-multiplier amounts already added
+/// to the player's balances.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct ExportRewardClaim {
+    /// Golden quarks credited from the `goldenQuarksTimer` window.
+    pub golden_quarks: f64,
+    /// Quarks (worlds) credited from the `quarkstimer` window, after the
+    /// in-game quark multiplier.
+    pub quarks: f64,
+}
+
+/// `exportSynergism`'s reward claim (`ImportExport.ts:254-273`) — the
+/// timer→currency conversion run on a *real* export (the
+/// `shouldSetLastSaveSoWeStopFuckingBotheringPeople` branch). Triggered by an
+/// explicit player/host export, **not** the 5-second autosave: the host calls
+/// this before serializing an export. The `offlinetick` / `lastExportedSave`
+/// wall-clock stamps are host-tier (logic has no time-of-day) and live in the
+/// save envelope.
+///
+/// Golden quarks: when `goldenQuarks3` is owned (`exportGQPerHour > 0`), the
+/// whole-window count `floor(timer / (3600/perHour))` is credited times
+/// `bonusGQMultiplier` and the timer keeps its remainder. Quarks: when the
+/// `quarkHandler` gain is `>= 1`, `gain × calculateQuarkMultiplier()` is added
+/// to `worlds` and `quarksThisSingularity` and the timer keeps its remainder.
+///
+/// `bonusGQMultiplier`'s external subscriber term (`1 + getQuarkBonus()/100`)
+/// is neutral in the fork — the global/personal quark bonus is a parked RMT
+/// seam — so only the `highestSingularityCount >= 100` export bonus applies,
+/// matching how [`compute_quark_multiplier`] treats event/patreon as neutral.
+pub fn claim_export_rewards(state: &mut GameState) -> ExportRewardClaim {
+    use crate::mechanics::golden_quark_upgrades::golden_quarks_3_effect;
+    use crate::mechanics::octeracts::octeract_export_quarks_effect;
+    use crate::mechanics::quarks::{quark_handler, QuarkHandlerInput};
+    use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+    use crate::state::octeract_upgrades::OCTERACT_EXPORT_QUARKS;
+
+    let highest_sing = state.singularity.highest_singularity_count;
+
+    // bonusGQMultiplier: external subscriber bonus neutral (× 1) in the fork;
+    // only the highestSingularityCount >= 100 export bonus is live.
+    let bonus_gq_multiplier = if highest_sing >= 100.0 {
+        1.0 + highest_sing / 50.0
+    } else {
+        1.0
+    };
+
+    // Golden quarks: gated on the goldenQuarks3 upgrade's export rate.
+    let gq3 = &state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3];
+    let gq_per_hour = golden_quarks_3_effect(gq3.level + gq3.free_level);
+    let mut golden_quarks_awarded = 0.0;
+    if gq_per_hour > 0.0 {
+        let window = 3600.0 / gq_per_hour;
+        golden_quarks_awarded =
+            (state.golden_quarks.golden_quarks_timer / window).floor() * bonus_gq_multiplier;
+        state.golden_quarks.golden_quarks += Decimal::from_finite(golden_quarks_awarded);
+        state.golden_quarks.golden_quarks_timer %= window;
+    }
+
+    // Quarks (worlds): gated on a whole-quark gain. The award uses the full
+    // in-game quark multiplier (`worlds.add(gain, true, true)`).
+    let oct_export = &state.octeract_upgrades.upgrades[OCTERACT_EXPORT_QUARKS];
+    let researches = &state.researches.researches;
+    let quark = quark_handler(&QuarkHandlerInput {
+        research_195: researches[195],
+        researches_sum: researches[99]
+            + researches[100]
+            + researches[125]
+            + researches[180]
+            + researches[195],
+        export_quark_mult: octeract_export_quarks_effect(oct_export.level + oct_export.free_level),
+        quarks_timer: state.quarks.quarks_timer,
+        // cube_mult is a pass-through in `quark_handler` and does not enter the
+        // `gain` used here, so the `1.0` placeholder is faithful.
+        cube_mult: 1.0,
+    });
+    let mut quarks_awarded = 0.0;
+    if quark.gain >= 1.0 {
+        quarks_awarded = quark.gain * compute_quark_multiplier(state);
+        state.quarks.worlds += Decimal::from_finite(quarks_awarded);
+        state.golden_quarks.quarks_this_singularity += quarks_awarded;
+        state.quarks.quarks_timer %= 3600.0 / quark.per_hour;
+    }
+
+    ExportRewardClaim {
+        golden_quarks: golden_quarks_awarded,
+        quarks: quarks_awarded,
+    }
+}
+
 /// `golden_quarks_multiplier_excluding_base` — self-derived from `&GameState`.
 ///
 /// `calculateGoldenQuarks()` (legacy `Calculate.ts`, granted on a singularity
@@ -8695,6 +8785,72 @@ mod tests {
             3
         );
         assert_eq!(state.campaigns.campaign_completions, [0.0; 50]);
+    }
+
+    #[test]
+    fn claim_export_rewards_banks_golden_quarks_and_quarks() {
+        use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+        use crate::state::GoldenQuarkUpgrade;
+
+        let mut state = GameState::default();
+        // goldenQuarks3 level 1 → exportGQPerHour = 1·2/2 = 1/hr → window 3600s.
+        state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3] = GoldenQuarkUpgrade {
+            level: 1.0,
+            ..GoldenQuarkUpgrade::default()
+        };
+        state.golden_quarks.golden_quarks_timer = 7400.0; // 2 whole windows + 200s
+                                                          // Quark timer: base 5/hr (no researches). 7400s · 5/3600 = floor(10.27) = 10.
+        state.quarks.quarks_timer = 7400.0;
+
+        let claim = claim_export_rewards(&mut state);
+
+        // 2 golden quarks at the default (sing < 100 ⇒ bonus mult 1).
+        assert_eq!(claim.golden_quarks, 2.0);
+        assert_eq!(state.golden_quarks.golden_quarks.to_number(), 2.0);
+        assert_eq!(state.golden_quarks.golden_quarks_timer, 200.0); // remainder
+
+        // Quark gain 10 × quark multiplier (≥ 1). At default the multiplier is 1.
+        assert!(claim.quarks >= 10.0);
+        assert_eq!(state.quarks.worlds.to_number(), claim.quarks);
+        assert_eq!(state.golden_quarks.quarks_this_singularity, claim.quarks);
+        // quarkstimer keeps remainder of 7400 % (3600/5 = 720) = 7400 - 10·720.
+        assert!((state.quarks.quarks_timer - 200.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn claim_export_rewards_noop_without_goldenquarks3_or_quark_gain() {
+        let mut state = GameState::default();
+        // No goldenQuarks3 ⇒ exportGQPerHour 0 ⇒ GQ timer untouched.
+        state.golden_quarks.golden_quarks_timer = 5000.0;
+        // Sub-1-quark window: 600s · 5/3600 = floor(0.83) = 0 ⇒ no quark claim.
+        state.quarks.quarks_timer = 600.0;
+
+        let claim = claim_export_rewards(&mut state);
+
+        assert_eq!(claim, ExportRewardClaim::default());
+        assert_eq!(state.golden_quarks.golden_quarks_timer, 5000.0);
+        assert_eq!(state.quarks.quarks_timer, 600.0);
+        assert_eq!(state.quarks.worlds.to_number(), 0.0);
+    }
+
+    #[test]
+    fn claim_export_rewards_applies_sing100_export_bonus() {
+        use crate::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+        use crate::state::GoldenQuarkUpgrade;
+
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 200.0; // bonus = 1 + 200/50 = 5
+        state.golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3] = GoldenQuarkUpgrade {
+            level: 1.0,
+            ..GoldenQuarkUpgrade::default()
+        };
+        state.golden_quarks.golden_quarks_timer = 3600.0; // exactly one window
+
+        let claim = claim_export_rewards(&mut state);
+
+        // 1 whole window × bonus 5 = 5 golden quarks.
+        assert_eq!(claim.golden_quarks, 5.0);
+        assert_eq!(state.golden_quarks.golden_quarks.to_number(), 5.0);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -682,7 +682,8 @@ fn apply_ascension_layer(state: &mut GameState) -> Decimal {
     }
 
     // resetAnts(AntSacrificeTiers.ascension) (Reset.ts:650).
-    reset_ants_ascension(&mut state.ants);
+    let highest_singularity_count = state.singularity.highest_singularity_count;
+    reset_ants_ascension(&mut state.ants, highest_singularity_count);
 
     // resetTalismanData('ascension') (Reset.ts:651).
     reset_talismans_ascension(&mut state.talismans);
@@ -845,16 +846,51 @@ fn apply_ascension_layer(state: &mut GameState) -> Decimal {
     wow_cubes_gained
 }
 
+/// `forTheLoveOfTheAntGod` singularity-perk regrants — the tier-independent
+/// tail every `resetAnts` runs (`Features/Ants/{AntProducers,AntUpgrades,
+/// Crumbs}/player/reset.ts`, the `player.highestSingularityCount >= N` blocks
+/// outside the tier gate). Sequential `>=` so the producer grants stack
+/// (Workers `20 → 40`, Breeders, MetaBreeders) and the upgrade / crumb grants
+/// `max`-merge with whatever survived the reset. Inert below sing 10.
+pub(crate) fn apply_for_the_love_ant_regrants(
+    ants: &mut AntsState,
+    highest_singularity_count: f64,
+) {
+    // AntProducers enum: Workers = 0, Breeders = 1, MetaBreeders = 2.
+    const WORKERS: usize = 0;
+    const BREEDERS: usize = 1;
+    const META_BREEDERS: usize = 2;
+    // AntUpgrades enum: AntSpeed = 0, Mortuus = 11.
+    const ANT_UPGRADE_ANT_SPEED: usize = 0;
+    const ANT_UPGRADE_MORTUUS: usize = 11;
+
+    if highest_singularity_count >= 10.0 {
+        ants.producers[WORKERS].purchased = 20.0;
+        ants.upgrades[ANT_UPGRADE_ANT_SPEED] = ants.upgrades[ANT_UPGRADE_ANT_SPEED].max(10.0);
+    }
+    if highest_singularity_count >= 15.0 {
+        ants.producers[WORKERS].purchased = 40.0;
+        ants.producers[BREEDERS].purchased = 20.0;
+    }
+    if highest_singularity_count >= 20.0 {
+        ants.producers[META_BREEDERS].purchased = 25.0;
+        ants.upgrades[ANT_UPGRADE_MORTUUS] = ants.upgrades[ANT_UPGRADE_MORTUUS].max(1.0);
+        ants.upgrades[ANT_UPGRADE_ANT_SPEED] = ants.upgrades[ANT_UPGRADE_ANT_SPEED].max(25.0);
+        ants.crumbs = Decimal::from_finite(1e50);
+    }
+}
+
 /// `resetAnts(AntSacrificeTiers.ascension)`
 /// (`Features/Ants/player/reset.ts`) — the ant sub-reset an ascension runs.
 /// Tier ordering is `sacrifice=0 < ascension=1 < singularity=2 < never=3`;
-/// each ant feature resets when `ascension >= its minimum reset tier`.
+/// each ant feature resets when `ascension >= its minimum reset tier`. The
+/// `forTheLoveOfTheAntGod` regrants ([`apply_for_the_love_ant_regrants`]) run
+/// at the tail, reachable now that the singularity layer is live.
 ///
-/// Deferred (inert at default): the `highestSingularityCount >= 10/15/20`
-/// crumb / producer / upgrade regrants, and the `preserveAnthillCount`
-/// achievement that would keep `ant_sacrifice_count` (no achievement is held
-/// at default, so the count resets — faithful).
-fn reset_ants_ascension(ants: &mut AntsState) {
+/// Deferred (inert at default): the `preserveAnthillCount` achievement that
+/// would keep `ant_sacrifice_count` (no achievement is held at default, so the
+/// count resets — faithful).
+fn reset_ants_ascension(ants: &mut AntsState, highest_singularity_count: f64) {
     // Crumbs reset to their default `1`; `crumbs_ever_made` is never-tier and
     // survives (Crumbs/reset.ts).
     ants.crumbs = Decimal::from_finite(1.0);
@@ -893,6 +929,9 @@ fn reset_ants_ascension(ants: &mut AntsState) {
     // Sacrifice timers (the `resetAnts` wrapper, reset.ts).
     ants.ant_sacrifice_timer = 0.0;
     ants.ant_sacrifice_timer_real = 0.0;
+
+    // forTheLoveOfTheAntGod regrants (the tier-independent tail of resetAnts).
+    apply_for_the_love_ant_regrants(ants, highest_singularity_count);
 }
 
 /// `resetTalismanData('ascension')` (`Talismans.ts:1067-1086`): an ascension
@@ -1097,6 +1136,11 @@ pub(crate) fn perform_singularity_reset(
     }
     state.ants.current_sacrifice_id = next_sacrifice_id;
 
+    // `resetAnts(AntSacrificeTiers.singularity)` (Reset.ts:1103) runs *before*
+    // the count increment (1109+), so its `forTheLoveOfTheAntGod` regrants read
+    // the pre-singularity `old_highest`, not `new_highest`.
+    apply_for_the_love_ant_regrants(&mut state.ants, old_highest);
+
     // Quarks survive under the limitedTime `preserveQuarks` reward; the
     // default rebuild already mirrors `player.worlds.reset()` (→ 0).
     if preserve_quarks {
@@ -1287,6 +1331,79 @@ mod tests {
             transcend_point_gain: Decimal::from_finite(transcend),
             reincarnation_point_gain: Decimal::from_finite(reincarnation),
         }
+    }
+
+    #[test]
+    fn for_the_love_regrants_climb_the_singularity_staircase() {
+        // Below sing 10: nothing.
+        let mut ants = AntsState::default();
+        apply_for_the_love_ant_regrants(&mut ants, 9.0);
+        assert_eq!(ants.producers[0].purchased, 0.0);
+        assert_eq!(ants.upgrades[0], 0.0);
+
+        // Sing 10: Workers 20, AntSpeed ≥ 10; no Breeders yet.
+        let mut ants = AntsState::default();
+        apply_for_the_love_ant_regrants(&mut ants, 10.0);
+        assert_eq!(ants.producers[0].purchased, 20.0);
+        assert_eq!(ants.upgrades[0], 10.0);
+        assert_eq!(ants.producers[1].purchased, 0.0);
+
+        // Sing 15: Workers overwritten to 40, Breeders 20.
+        let mut ants = AntsState::default();
+        apply_for_the_love_ant_regrants(&mut ants, 15.0);
+        assert_eq!(ants.producers[0].purchased, 40.0);
+        assert_eq!(ants.producers[1].purchased, 20.0);
+
+        // Sing 20: + MetaBreeders 25, Mortuus ≥ 1, AntSpeed ≥ 25, crumbs 1e50.
+        let mut ants = AntsState::default();
+        apply_for_the_love_ant_regrants(&mut ants, 20.0);
+        assert_eq!(ants.producers[0].purchased, 40.0);
+        assert_eq!(ants.producers[1].purchased, 20.0);
+        assert_eq!(ants.producers[2].purchased, 25.0);
+        assert_eq!(ants.upgrades[11], 1.0); // Mortuus
+        assert_eq!(ants.upgrades[0], 25.0); // AntSpeed: max(10, 25) = 25
+        assert_eq!(ants.crumbs.to_number(), 1e50);
+    }
+
+    #[test]
+    fn for_the_love_regrants_max_merge_never_lowers_surviving_levels() {
+        let mut ants = AntsState::default();
+        ants.upgrades[0] = 30.0; // AntSpeed survived the reset above the grant
+        apply_for_the_love_ant_regrants(&mut ants, 20.0);
+        assert_eq!(ants.upgrades[0], 30.0); // max(30, 25) = 30, not lowered
+    }
+
+    #[test]
+    fn ascension_reset_applies_for_the_love_regrants() {
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 15.0;
+        // Producers/upgrades the ascension wipes are regranted at the tail.
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+        assert_eq!(state.ants.producers[0].purchased, 40.0);
+        assert_eq!(state.ants.producers[1].purchased, 20.0);
+    }
+
+    #[test]
+    fn singularity_reset_regrants_use_pre_increment_highest() {
+        // count === highest (19) forces the highest to climb to 20 this
+        // singularity. The regrant must read the PRE-increment 19 (Reset.ts:1103
+        // runs before the 1109+ bump): Workers 40 + Breeders (sing-15 tier) but
+        // NOT the sing-20 tier. If it wrongly used the post-climb 20, MetaBreeders
+        // would be 25 and crumbs 1e50 — so this distinguishes old vs new.
+        let mut state = GameState::default();
+        state.runes.rune_levels[RUNE_ANTIQUITIES] = 1.0; // gate open
+        state.singularity.singularity_count = 19.0;
+        state.singularity.highest_singularity_count = 19.0;
+        perform_reset(&mut state, ResetRequest::Singularity, &gains(0.0, 0.0, 0.0));
+        assert!(
+            state.singularity.highest_singularity_count >= 20.0,
+            "highest should climb past the pre-increment 19, got {}",
+            state.singularity.highest_singularity_count
+        );
+        assert_eq!(state.ants.producers[0].purchased, 40.0); // sing-15 tier
+        assert_eq!(state.ants.producers[1].purchased, 20.0);
+        assert_eq!(state.ants.producers[2].purchased, 0.0); // sing-20 tier NOT applied
+        assert_ne!(state.ants.crumbs.to_number(), 1e50);
     }
 
     #[test]

--- a/crates/synergismforkd_logic/src/tick/reset.rs
+++ b/crates/synergismforkd_logic/src/tick/reset.rs
@@ -599,8 +599,12 @@ pub(crate) fn perform_ascension_challenge_reset(
 /// - the `autoChallengeIndex` / `roombaResearchIndex` / `autoResearch` UI
 ///   cursors (no logic field / UI-tier);
 /// - the C15 corruption override (needs the `c15Corruptions` constant) and
-///   every `highestSingularityCount`-gated convenience (campaigns, hepteract
+///   the remaining `highestSingularityCount`-gated conveniences (hepteract
 ///   auto-craft, tesseract auto-buyer, auto-open) — inert at default.
+///
+/// The campaign sweep (Reset.ts:762-784) is **live**: the singularity-4
+/// auto-complete and the active-campaign bank both run just before the
+/// `used ← next` corruption swap.
 fn apply_ascension_layer(state: &mut GameState) -> Decimal {
     use crate::mechanics::calculate::{calc_corruption_stuff, CalcCorruptionStuffInput};
     use crate::mechanics::challenge_15_rewards;
@@ -648,6 +652,10 @@ fn apply_ascension_layer(state: &mut GameState) -> Decimal {
     } else {
         None
     };
+
+    // Campaign completion source (Reset.ts:684): captured before the
+    // challenge-completion wipe below zeroes it.
+    let c10_completions = state.challenges.challenge_completions[10];
 
     // Clear the lower auto-challenge gates (Reset.ts:633-634). The ascension
     // challenge gate itself is intentionally left untouched.
@@ -777,14 +785,62 @@ fn apply_ascension_layer(state: &mut GameState) -> Decimal {
         state.upgrades.upgrades[100] = 1;
     }
 
-    // Campaign reset (762-784) and the sing-gated conveniences block
-    // (796-877): DEFERRED — `highestSingularityCount`-gated, inert at default.
+    // Campaign sweep (Reset.ts:762-784) — runs before the `used ← next` swap,
+    // so the difficulty comparison reads the loadout of the ascension that
+    // just ended. Auto-complete (`highestSingularityCount >= 4`): every
+    // *unlocked* campaign whose loadout difficulty (live `bonusLevels` on
+    // both sides) is <= the used-loadout difficulty banks the captured c10
+    // (`setC10ToArbitrary`). Then an active campaign banks the same c10 and
+    // clears (`resetCampaign`). The legacy `updateTokens()` / HTML refresh
+    // have no logic mirror — tokens derive live in the tick.
+    {
+        use crate::mechanics::campaigns::{
+            campaign_loadout_difficulty, campaign_unlocked, record_campaign_completion,
+            CAMPAIGNS_LEN,
+        };
+        use crate::mechanics::corruptions::corruption_loadout_difficulty_score;
+
+        if state.singularity.highest_singularity_count >= 4.0 {
+            let bonus_levels = super::corruption_bonus_levels(state);
+            let current_difficulty =
+                corruption_loadout_difficulty_score(&state.corruptions.used.levels, bonus_levels);
+            let max_corruption = super::current_max_corruption_level(state);
+            let cube_50 = state.cube_upgrade_levels.cube_upgrades[50];
+            for index in 0..CAMPAIGNS_LEN {
+                if !campaign_unlocked(index, max_corruption, cube_50) {
+                    continue;
+                }
+                if campaign_loadout_difficulty(index, bonus_levels) <= current_difficulty {
+                    record_campaign_completion(
+                        &mut state.campaigns.campaign_completions,
+                        index,
+                        c10_completions,
+                    );
+                }
+            }
+        }
+        if let Some(active) = state.campaigns.current_campaign {
+            record_campaign_completion(
+                &mut state.campaigns.campaign_completions,
+                usize::from(active),
+                c10_completions,
+            );
+            state.campaigns.current_campaign = None;
+        }
+    }
 
     // Corruption loadout swap `used ← next` (Reset.ts:785). `CorruptionLoadout`
-    // is `Copy`, so this is a plain assignment. The C15 override (788-790) is
+    // is `Copy`, so this is a plain assignment; the fresh legacy loadout's
+    // score mult re-derives lazily on first read, so the cache recomputes
+    // eagerly here with the live bonus terms. The C15 override (788-790) is
     // deferred (needs `c15Corruptions`; inert unless inside ascension
-    // challenge 15).
+    // challenge 15). The sing-gated conveniences block (Reset.ts:796-877:
+    // hepteract auto-craft, tesseract auto-buyer, auto-open) stays DEFERRED —
+    // inert at default.
     state.corruptions.used = state.corruptions.next;
+    let used_levels = state.corruptions.used.levels;
+    state.corruptions.used.total_corruption_ascension_multiplier =
+        super::corruption_score_mult_for(state, used_levels);
 
     wow_cubes_gained
 }
@@ -1999,15 +2055,88 @@ mod tests {
         let mut state = GameState::default();
         state.corruptions.used.levels[2] = 1;
         state.corruptions.next.levels[2] = 7;
+        // Stale sentinel: the swap must NOT carry this cache. The legacy swap
+        // constructs a fresh `CorruptionLoadout`, whose score mult re-derives
+        // lazily on first read — the port recomputes it eagerly post-swap.
         state.corruptions.next.total_corruption_ascension_multiplier = 2.5;
 
         perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
 
         assert_eq!(state.corruptions.used.levels[2], 7);
+        let expected =
+            super::super::corruption_score_mult_for(&state, state.corruptions.used.levels);
         assert_eq!(
+            state.corruptions.used.total_corruption_ascension_multiplier,
+            expected
+        );
+        assert_ne!(
             state.corruptions.used.total_corruption_ascension_multiplier,
             2.5
         );
+    }
+
+    #[test]
+    fn ascension_reset_banks_active_campaign_and_clears_it() {
+        let mut state = GameState::default();
+        state.campaigns.current_campaign = Some(0);
+        state.challenges.challenge_completions[10] = 6.0;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        // `resetCampaign` (Reset.ts:782-784) runs at any singularity count.
+        assert_eq!(state.campaigns.campaign_completions[0], 6.0);
+        assert_eq!(state.campaigns.current_campaign, None);
+        // The c10 source itself is wiped by the reset.
+        assert_eq!(state.challenges.challenge_completions[10], 0.0);
+    }
+
+    #[test]
+    fn ascension_reset_campaign_bank_clamps_to_limit_and_never_decreases() {
+        let mut state = GameState::default();
+        state.campaigns.current_campaign = Some(0); // first: limit 10
+        state.campaigns.campaign_completions[0] = 4.0;
+        state.challenges.challenge_completions[10] = 25.0;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+        assert_eq!(state.campaigns.campaign_completions[0], 10.0);
+
+        // A later, lower-c10 run of the same campaign can't reduce the bank.
+        state.campaigns.current_campaign = Some(0);
+        state.challenges.challenge_completions[10] = 3.0;
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+        assert_eq!(state.campaigns.campaign_completions[0], 10.0);
+    }
+
+    #[test]
+    fn ascension_reset_auto_completes_easier_campaigns_at_singularity_4() {
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 4.0;
+        state.challenges.challenge_completions[10] = 8.0;
+        // Used loadout = the seventh campaign's exact corruptions
+        // (viscosity 5 / drought 5) — difficulty covers cardinals 1-7.
+        state.corruptions.used.levels[crate::state::VISCOSITY_INDEX] = 5;
+        state.corruptions.used.levels[crate::state::DROUGHT_INDEX] = 5;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        // first..=seventh auto-complete (their difficulty <= used difficulty).
+        assert_eq!(state.campaigns.campaign_completions[0], 8.0);
+        assert_eq!(state.campaigns.campaign_completions[6], 8.0);
+        // eighth needs maxCorruptionLevel() >= 7 — locked at default state.
+        assert_eq!(state.campaigns.campaign_completions[7], 0.0);
+    }
+
+    #[test]
+    fn ascension_reset_no_auto_complete_below_singularity_4() {
+        let mut state = GameState::default();
+        state.singularity.highest_singularity_count = 3.0;
+        state.challenges.challenge_completions[10] = 8.0;
+        state.corruptions.used.levels[crate::state::VISCOSITY_INDEX] = 5;
+        state.corruptions.used.levels[crate::state::DROUGHT_INDEX] = 5;
+
+        perform_ascension_reset(&mut state, &gains(0.0, 0.0, 0.0));
+
+        assert_eq!(state.campaigns.campaign_completions, [0.0; 50]);
     }
 
     #[test]

--- a/crates/synergismforkd_save/src/lib.rs
+++ b/crates/synergismforkd_save/src/lib.rs
@@ -44,10 +44,29 @@ pub const CURRENT_VERSION: u16 = 1;
 
 /// Wire-format envelope. The first thing serialized in every save; the
 /// `version` field is how a reader knows which `SaveV<N>` shape follows.
+///
+/// `saved_at_ms` is the host-stamped wall-clock (Unix epoch milliseconds) at
+/// save time — the Rust analogue of the legacy `player.offlinetick` /
+/// `lastExportedSave`. It lives on the envelope, not in [`GameState`], because
+/// the logic crate has no time-of-day: the host (which owns the clock) passes
+/// it in via [`save_at`] / [`export_to_string_at`] and reads it back via
+/// [`load_with_meta`] to compute offline-elapsed on load. `None` when the save
+/// was written without a timestamp (the plain [`save`] path).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SaveEnvelope {
     version: u16,
     payload: SaveV1,
+    saved_at_ms: Option<u64>,
+}
+
+/// Transport-level metadata recovered from a save, independent of the
+/// versioned [`GameState`] payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SaveMeta {
+    /// Host wall-clock at save time (Unix epoch milliseconds), or `None` if
+    /// the save was written without a timestamp. The host diffs this against
+    /// "now" to size offline progress.
+    pub saved_at_ms: Option<u64>,
 }
 
 /// Save schema version 1 — today, equal to [`GameState`] verbatim.
@@ -126,11 +145,25 @@ impl From<base64::DecodeError> for SaveError {
 /// `Serialize` impl on a state field — the happy-path GameState shape
 /// is always encodable.
 pub fn save(state: &GameState) -> Result<Vec<u8>, SaveError> {
+    save_at(state, None)
+}
+
+/// Encode a [`GameState`] with a host-stamped save timestamp (Unix epoch
+/// milliseconds). The timestamp rides on the envelope, not the state, and is
+/// recovered with [`load_with_meta`]. Use this on the host save path where the
+/// wall-clock is available; [`save`] is the `None`-timestamp shorthand.
+///
+/// # Errors
+///
+/// Returns [`SaveError::Postcard`] if the underlying postcard encoder fails
+/// (see [`save`]).
+pub fn save_at(state: &GameState, saved_at_ms: Option<u64>) -> Result<Vec<u8>, SaveError> {
     let envelope = SaveEnvelope {
         version: CURRENT_VERSION,
         payload: SaveV1 {
             state: state.clone(),
         },
+        saved_at_ms,
     };
     Ok(to_allocvec(&envelope)?)
 }
@@ -149,13 +182,30 @@ pub fn save(state: &GameState) -> Result<Vec<u8>, SaveError> {
 /// - [`SaveError::UnknownVersion`] if the header reports a version
 ///   greater than [`CURRENT_VERSION`] (a save written by a newer build).
 pub fn load(bytes: &[u8]) -> Result<GameState, SaveError> {
+    Ok(load_with_meta(bytes)?.0)
+}
+
+/// Decode a postcard byte stream into a [`GameState`] **and** its transport
+/// [`SaveMeta`] (the host-stamped save timestamp). The host uses the meta to
+/// compute offline-elapsed; [`load`] is the meta-dropping shorthand.
+///
+/// # Errors
+///
+/// - [`SaveError::Postcard`] if the bytes are not a well-formed postcard
+///   stream or the encoded shape does not match the current envelope.
+/// - [`SaveError::UnknownVersion`] if the header reports a version greater than
+///   [`CURRENT_VERSION`] (a save written by a newer build).
+pub fn load_with_meta(bytes: &[u8]) -> Result<(GameState, SaveMeta), SaveError> {
     let envelope: SaveEnvelope = from_bytes(bytes)?;
     if envelope.version > CURRENT_VERSION {
         return Err(SaveError::UnknownVersion(envelope.version));
     }
     // Single-arm dispatch today; the migration chain ladder lives here
     // when v2+ lands.
-    Ok(envelope.payload.state)
+    let meta = SaveMeta {
+        saved_at_ms: envelope.saved_at_ms,
+    };
+    Ok((envelope.payload.state, meta))
 }
 
 /// Encode a [`GameState`] to a portable base64 string — the user-facing export
@@ -170,6 +220,20 @@ pub fn export_to_string(state: &GameState) -> Result<String, SaveError> {
     Ok(BASE64_STANDARD.encode(save(state)?))
 }
 
+/// Like [`export_to_string`] but stamps the host wall-clock (Unix epoch
+/// milliseconds) into the envelope, recoverable with
+/// [`import_from_string_with_meta`].
+///
+/// # Errors
+///
+/// [`SaveError::Postcard`] if encoding the state fails (see [`save`]).
+pub fn export_to_string_at(
+    state: &GameState,
+    saved_at_ms: Option<u64>,
+) -> Result<String, SaveError> {
+    Ok(BASE64_STANDARD.encode(save_at(state, saved_at_ms)?))
+}
+
 /// Decode a base64 export blob back into a [`GameState`], then rebuild the
 /// achievement-points total from the loaded bitmap. A loaded save must not
 /// trust a possibly-drifted running points field, so
@@ -180,10 +244,23 @@ pub fn export_to_string(state: &GameState) -> Result<String, SaveError> {
 /// - [`SaveError::Base64`] if the string is not valid standard base64.
 /// - [`SaveError::Postcard`] / [`SaveError::UnknownVersion`] from [`load`].
 pub fn import_from_string(s: &str) -> Result<GameState, SaveError> {
+    Ok(import_from_string_with_meta(s)?.0)
+}
+
+/// Like [`import_from_string`] but also returns the transport [`SaveMeta`] (the
+/// host-stamped save timestamp), for offline-progress sizing on load. The
+/// achievement-points recompute (audit H5) runs here too.
+///
+/// # Errors
+///
+/// - [`SaveError::Base64`] if the string is not valid standard base64.
+/// - [`SaveError::Postcard`] / [`SaveError::UnknownVersion`] from
+///   [`load_with_meta`].
+pub fn import_from_string_with_meta(s: &str) -> Result<(GameState, SaveMeta), SaveError> {
     let bytes = BASE64_STANDARD.decode(s)?;
-    let mut state = load(&bytes)?;
+    let (mut state, meta) = load_with_meta(&bytes)?;
     recompute_achievement_points(&mut state);
-    Ok(state)
+    Ok((state, meta))
 }
 
 /// A fresh-start game state — the "reset save" operation (TS `resetGame`'s
@@ -304,6 +381,34 @@ mod tests {
 
         // The loaded total is rebuilt from the bitmap, discarding the drift.
         assert_eq!(restored.achievements.achievement_points, 30.0);
+    }
+
+    #[test]
+    fn save_timestamp_round_trips_through_envelope() {
+        let state = GameState::default();
+        // Stamped save carries the timestamp back out via the meta path.
+        let bytes = save_at(&state, Some(1_700_000_000_000)).expect("save_at");
+        let (_restored, meta) = load_with_meta(&bytes).expect("load_with_meta");
+        assert_eq!(meta.saved_at_ms, Some(1_700_000_000_000));
+
+        // The plain save path leaves the timestamp absent.
+        let plain = save(&state).expect("save");
+        let (_s, meta) = load_with_meta(&plain).expect("load_with_meta plain");
+        assert_eq!(meta.saved_at_ms, None);
+    }
+
+    #[test]
+    fn export_string_carries_timestamp_and_recomputes_points() {
+        let mut state = GameState::default();
+        state.achievements.achievements[0] = 1; // 5 pts
+        state.achievements.achievement_points = 999.0; // drift
+
+        let blob = export_to_string_at(&state, Some(42)).expect("export_at");
+        let (restored, meta) = import_from_string_with_meta(&blob).expect("import_with_meta");
+
+        assert_eq!(meta.saved_at_ms, Some(42));
+        // H5 recompute still runs on the meta import path.
+        assert_eq!(restored.achievements.achievement_points, 5.0);
     }
 
     #[test]

--- a/crates/synergismforkd_ui_web/Cargo.toml
+++ b/crates/synergismforkd_ui_web/Cargo.toml
@@ -13,6 +13,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 synergismforkd_ui = { path = "../synergismforkd_ui" }
+# Host-tier save wiring (localStorage persistence + the autosave loop) drives
+# the headless logic and the fresh save format directly. The `SaveHost`
+# orchestration is platform-agnostic and unit-tested on native; only the
+# localStorage backend + the wall-clock are wasm-gated below.
+synergismforkd_logic = { path = "../synergismforkd_logic" }
+synergismforkd_save = { path = "../synergismforkd_save" }
 
 # When this crate is built for wasm32-unknown-unknown, the transitive
 # `getrandom` dep (pulled in by `rand`'s `ThreadRng` inside
@@ -22,8 +28,13 @@ synergismforkd_ui = { path = "../synergismforkd_ui" }
 # Cargo-feature-unification fix; the `wasm_js` feature lives in the wasm
 # host crate (which already crosses the JS boundary) and stays out of
 # `synergismforkd_logic` per the crate-boundary rules.
+#
+# `web-sys` (localStorage) + `js-sys` (Date.now wall-clock) back the wasm-only
+# `SaveStorage` impl and `now_ms()`; both stay out of the native build.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["Window", "Storage"] }
 
 [lints]
 workspace = true

--- a/crates/synergismforkd_ui_web/src/lib.rs
+++ b/crates/synergismforkd_ui_web/src/lib.rs
@@ -3,6 +3,10 @@
 //! Built as `cdylib` for `wasm32-unknown-unknown`; mounts the
 //! `synergismforkd_ui` Dioxus root component into the page. Also built
 //! as `rlib` so the desktop crate can depend on it.
+//!
+//! Hosts the [`save_host`] seam: `localStorage` persistence + the autosave
+//! loop that drives the headless game logic and the fresh save format on the
+//! browser clock.
 
 use synergismforkd_ui as _;
 
@@ -13,5 +17,9 @@ use synergismforkd_ui as _;
 // so the silencer must match.
 #[cfg(target_arch = "wasm32")]
 use getrandom as _;
+
+pub mod save_host;
+
+pub use save_host::{BootOutcome, SaveHost, SaveStorage, AUTOSAVE_INTERVAL_S, SAVE_KEY};
 
 pub fn placeholder() {}

--- a/crates/synergismforkd_ui_web/src/save_host.rs
+++ b/crates/synergismforkd_ui_web/src/save_host.rs
@@ -1,0 +1,388 @@
+//! Host-tier save persistence + the autosave loop (the `Synergism.ts` save
+//! glue: `setNamedInterval('save', saveSynergy, 5000)` + load-on-boot +
+//! export-on-demand).
+//!
+//! The game logic and the save format are headless and time-free; this is the
+//! host seam that drives them on the browser's clock and parks the bytes in
+//! `localStorage`. The orchestration ([`SaveHost`]) is platform-agnostic and
+//! unit-tested on native; the only wasm-gated pieces are the [`SaveStorage`]
+//! backend ([`web::LocalStorageBackend`]) and the wall-clock ([`web::now_ms`]).
+
+use synergismforkd_logic::{
+    claim_export_rewards, tack, ExportRewardClaim, GameState, TackInput, TickOutput,
+};
+use synergismforkd_save::{export_to_string_at, import_from_string_with_meta, reset_save};
+
+/// `localStorage` key holding the base64 save blob. The legacy game used
+/// `Synergysave2`; the fork's save format is incompatible, so it gets its own
+/// key to avoid colliding with a legacy save on the same origin.
+pub const SAVE_KEY: &str = "SynergismForkdSave";
+
+/// Autosave cadence in seconds — the host saves at most this often, matching
+/// the legacy `setNamedInterval('save', saveSynergy, 5000)` (5 s).
+pub const AUTOSAVE_INTERVAL_S: f64 = 5.0;
+
+/// Where a [`SaveHost::boot`] state came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootOutcome {
+    /// No save present — started from a fresh [`reset_save`].
+    Fresh,
+    /// A stored save was loaded. `saved_at_ms` is the host wall-clock it was
+    /// written at (the offline-progress anchor), if it carried one.
+    Loaded {
+        /// Save-time wall-clock (Unix epoch ms), or `None` if unstamped.
+        saved_at_ms: Option<u64>,
+    },
+    /// A save was present but could not be decoded; started fresh instead.
+    /// The host should surface this rather than silently overwrite.
+    Corrupt,
+}
+
+/// Persistent-storage backend. Abstracted so the autosave orchestration is
+/// testable on native (with an in-memory fake) while the browser build wires
+/// `localStorage`.
+pub trait SaveStorage {
+    /// Read the stored blob, or `None` if absent / unreadable.
+    fn read(&self) -> Option<String>;
+    /// Write (overwrite) the stored blob. Failures are swallowed — a dropped
+    /// autosave is non-fatal and the next tick retries.
+    fn write(&self, blob: &str);
+    /// Remove the stored blob (the reset path).
+    fn clear(&self);
+}
+
+/// Owns the live [`GameState`], the autosave accumulator, and the storage
+/// backend. The browser app constructs one with [`SaveHost::boot`], calls
+/// [`SaveHost::tick`] each frame, [`SaveHost::export`] on a manual export, and
+/// [`SaveHost::reset`] on a hard reset.
+pub struct SaveHost<S: SaveStorage> {
+    state: GameState,
+    storage: S,
+    since_last_save_s: f64,
+}
+
+impl<S: SaveStorage> SaveHost<S> {
+    /// Load the persisted save (recomputing achievement points via
+    /// [`import_from_string_with_meta`]) or start fresh. Returns the host plus
+    /// a [`BootOutcome`] describing what happened.
+    pub fn boot(storage: S) -> (Self, BootOutcome) {
+        let (state, outcome) = match storage.read() {
+            None => (reset_save(), BootOutcome::Fresh),
+            Some(blob) => match import_from_string_with_meta(&blob) {
+                Ok((state, meta)) => (
+                    state,
+                    BootOutcome::Loaded {
+                        saved_at_ms: meta.saved_at_ms,
+                    },
+                ),
+                // A corrupt/foreign blob must not be clobbered blindly — start
+                // fresh in memory but leave the bytes for the host to inspect.
+                Err(_) => (reset_save(), BootOutcome::Corrupt),
+            },
+        };
+        (
+            Self {
+                state,
+                storage,
+                since_last_save_s: 0.0,
+            },
+            outcome,
+        )
+    }
+
+    /// Borrow the live game state (for the UI render).
+    pub fn state(&self) -> &GameState {
+        &self.state
+    }
+
+    /// Mutably borrow the live game state (rarely needed; prefer [`Self::tick`]).
+    pub fn state_mut(&mut self) -> &mut GameState {
+        &mut self.state
+    }
+
+    /// Advance the game by one tick, then autosave if at least
+    /// [`AUTOSAVE_INTERVAL_S`] of game time has elapsed since the last save.
+    /// `now_ms` is the host wall-clock used to stamp any save this tick.
+    /// Returns the tick's [`TickOutput`] event stream for the UI.
+    pub fn tick(&mut self, input: &TackInput, now_ms: u64) -> TickOutput {
+        let output = tack(&mut self.state, input);
+        self.since_last_save_s += input.dt;
+        if self.since_last_save_s >= AUTOSAVE_INTERVAL_S {
+            self.persist(now_ms);
+        }
+        output
+    }
+
+    /// Force a save now (e.g. on `visibilitychange` / `beforeunload`), stamping
+    /// the host clock and resetting the autosave accumulator.
+    pub fn persist(&mut self, now_ms: u64) {
+        self.since_last_save_s = 0.0;
+        if let Ok(blob) = export_to_string_at(&self.state, Some(now_ms)) {
+            self.storage.write(&blob);
+        }
+    }
+
+    /// A *real* export (the legacy `exportSynergism` happy path): claim the
+    /// accrued export rewards into the live state, persist, and hand back the
+    /// claim plus the export blob (for clipboard / download). `None` blob means
+    /// encoding failed.
+    pub fn export(&mut self, now_ms: u64) -> (ExportRewardClaim, Option<String>) {
+        let claim = claim_export_rewards(&mut self.state);
+        self.since_last_save_s = 0.0;
+        let blob = export_to_string_at(&self.state, Some(now_ms)).ok();
+        if let Some(blob) = &blob {
+            self.storage.write(blob);
+        }
+        (claim, blob)
+    }
+
+    /// Replace a foreign/clipboard save blob, recomputing on load. Returns the
+    /// [`BootOutcome`] (so the caller can reject a corrupt paste) and, on
+    /// success, persists it under [`SAVE_KEY`].
+    pub fn import(&mut self, blob: &str, now_ms: u64) -> BootOutcome {
+        match import_from_string_with_meta(blob) {
+            Ok((state, meta)) => {
+                self.state = state;
+                self.since_last_save_s = 0.0;
+                self.persist(now_ms);
+                BootOutcome::Loaded {
+                    saved_at_ms: meta.saved_at_ms,
+                }
+            }
+            Err(_) => BootOutcome::Corrupt,
+        }
+    }
+
+    /// Hard reset: fresh state + cleared storage (the legacy `resetGame`).
+    pub fn reset(&mut self) {
+        self.state = reset_save();
+        self.since_last_save_s = 0.0;
+        self.storage.clear();
+    }
+}
+
+/// Browser backend: `localStorage` + the `Date.now()` wall-clock. Wasm-only —
+/// `web-sys` / `js-sys` are not in the native dependency graph.
+#[cfg(target_arch = "wasm32")]
+pub mod web {
+    use super::SaveStorage;
+
+    /// `localStorage`-backed [`SaveStorage`]. Reads `window.localStorage`
+    /// lazily on each call so a host with storage disabled (private mode) just
+    /// degrades to no-persistence instead of panicking at construction.
+    pub struct LocalStorageBackend {
+        key: String,
+    }
+
+    impl LocalStorageBackend {
+        /// Back the given key (use [`super::SAVE_KEY`] for the main save).
+        #[must_use]
+        pub fn new(key: impl Into<String>) -> Self {
+            Self { key: key.into() }
+        }
+
+        fn storage() -> Option<web_sys::Storage> {
+            web_sys::window()?.local_storage().ok().flatten()
+        }
+    }
+
+    impl SaveStorage for LocalStorageBackend {
+        fn read(&self) -> Option<String> {
+            Self::storage()?.get_item(&self.key).ok().flatten()
+        }
+
+        fn write(&self, blob: &str) {
+            if let Some(storage) = Self::storage() {
+                // A quota / security failure is non-fatal — the next autosave
+                // retries.
+                let _ = storage.set_item(&self.key, blob);
+            }
+        }
+
+        fn clear(&self) {
+            if let Some(storage) = Self::storage() {
+                let _ = storage.remove_item(&self.key);
+            }
+        }
+    }
+
+    /// The host wall-clock (Unix epoch milliseconds) for stamping saves. The
+    /// Dioxus root passes this into [`super::SaveHost::tick`] /
+    /// [`super::SaveHost::export`].
+    #[must_use]
+    pub fn now_ms() -> u64 {
+        js_sys::Date::now() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// In-memory [`SaveStorage`] standing in for `localStorage` on native. The
+    /// slot is shared via `Rc` so a clone can be handed to the [`SaveHost`]
+    /// (which owns its storage) while the test keeps a handle to assert on.
+    #[derive(Default, Clone)]
+    struct MemStorage {
+        slot: Rc<RefCell<Option<String>>>,
+    }
+
+    impl MemStorage {
+        fn with(blob: &str) -> Self {
+            Self {
+                slot: Rc::new(RefCell::new(Some(blob.to_string()))),
+            }
+        }
+    }
+
+    impl SaveStorage for MemStorage {
+        fn read(&self) -> Option<String> {
+            self.slot.borrow().clone()
+        }
+        fn write(&self, blob: &str) {
+            *self.slot.borrow_mut() = Some(blob.to_string());
+        }
+        fn clear(&self) {
+            *self.slot.borrow_mut() = None;
+        }
+    }
+
+    fn tick_input(dt: f64) -> TackInput {
+        TackInput {
+            dt,
+            ..TackInput::default()
+        }
+    }
+
+    #[test]
+    fn boot_fresh_when_storage_empty() {
+        let store = MemStorage::default();
+        let (_host, outcome) = SaveHost::boot(store.clone());
+        assert_eq!(outcome, BootOutcome::Fresh);
+    }
+
+    #[test]
+    fn boot_loads_a_stamped_save_and_recovers_its_timestamp() {
+        // Write a stamped save through the host, then boot a second host over
+        // the same backing store.
+        let store = MemStorage::default();
+        {
+            let (mut host, _) = SaveHost::boot(store.clone());
+            host.state_mut().challenges.challenge_completions[5] = 4.0;
+            host.persist(1_700_000_000_000);
+        }
+        let (host, outcome) = SaveHost::boot(store.clone());
+        assert_eq!(
+            outcome,
+            BootOutcome::Loaded {
+                saved_at_ms: Some(1_700_000_000_000)
+            }
+        );
+        assert_eq!(host.state().challenges.challenge_completions[5], 4.0);
+    }
+
+    #[test]
+    fn corrupt_blob_boots_fresh_without_clobbering() {
+        let store = MemStorage::with("this is not a valid base64 postcard save !!!");
+        let (host, outcome) = SaveHost::boot(store.clone());
+        assert_eq!(outcome, BootOutcome::Corrupt);
+        // Fresh in memory…
+        assert_eq!(host.state().challenges.challenge_completions[5], 0.0);
+        // …and the original bytes are left untouched for the host to inspect.
+        assert_eq!(
+            store.slot.borrow().as_deref(),
+            Some("this is not a valid base64 postcard save !!!")
+        );
+    }
+
+    #[test]
+    fn autosave_only_fires_after_the_interval() {
+        let store = MemStorage::default();
+        let (mut host, _) = SaveHost::boot(store.clone());
+        assert!(store.read().is_none());
+
+        // Four 1s ticks: under the 5s threshold, nothing persisted yet.
+        for _ in 0..4 {
+            host.tick(&tick_input(1.0), 10);
+        }
+        assert!(store.read().is_none(), "no save before the 5s interval");
+
+        // The fifth crosses 5s → one autosave.
+        host.tick(&tick_input(1.0), 12345);
+        assert!(store.read().is_some(), "autosave at the interval");
+    }
+
+    #[test]
+    fn autosave_accumulator_resets_between_saves() {
+        let store = MemStorage::default();
+        let (mut host, _) = SaveHost::boot(store.clone());
+        // One big tick trips the save; clear the slot to detect the next one.
+        host.tick(&tick_input(6.0), 1);
+        assert!(store.read().is_some());
+        store.clear();
+        // A small follow-up tick must NOT immediately re-save (accumulator was
+        // reset, not left above threshold).
+        host.tick(&tick_input(1.0), 2);
+        assert!(store.read().is_none(), "accumulator reset after a save");
+    }
+
+    #[test]
+    fn export_claims_rewards_persists_and_returns_blob() {
+        use synergismforkd_logic::state::golden_quarks::GQ_GOLDEN_QUARKS_3;
+        use synergismforkd_logic::state::GoldenQuarkUpgrade;
+
+        let store = MemStorage::default();
+        let (mut host, _) = SaveHost::boot(store.clone());
+        // Arm an export reward: goldenQuarks3 lvl 1 + a full timer window.
+        host.state_mut().golden_quarks.upgrades[GQ_GOLDEN_QUARKS_3] = GoldenQuarkUpgrade {
+            level: 1.0,
+            ..GoldenQuarkUpgrade::default()
+        };
+        host.state_mut().golden_quarks.golden_quarks_timer = 3600.0;
+
+        let (claim, blob) = host.export(9_999);
+        assert_eq!(claim.golden_quarks, 1.0);
+        assert!(blob.is_some());
+        // The claim mutated the live state and the persisted blob reflects it.
+        assert_eq!(host.state().golden_quarks.golden_quarks.to_number(), 1.0);
+        assert!(store.read().is_some());
+    }
+
+    #[test]
+    fn import_replaces_state_and_persists() {
+        // Build a donor blob from one host…
+        let donor = MemStorage::default();
+        let donor_blob = {
+            let (mut host, _) = SaveHost::boot(donor.clone());
+            host.state_mut().challenges.challenge_completions[9] = 6.0;
+            host.export(1).1.expect("export blob")
+        };
+
+        // …and import it into a fresh host over a clean store.
+        let store = MemStorage::default();
+        let (mut host, _) = SaveHost::boot(store.clone());
+        let outcome = host.import(&donor_blob, 77);
+        assert!(matches!(outcome, BootOutcome::Loaded { .. }));
+        assert_eq!(host.state().challenges.challenge_completions[9], 6.0);
+        assert!(store.read().is_some());
+
+        // A garbage paste is rejected and leaves the state untouched.
+        assert_eq!(host.import("garbage!!!", 78), BootOutcome::Corrupt);
+        assert_eq!(host.state().challenges.challenge_completions[9], 6.0);
+    }
+
+    #[test]
+    fn reset_clears_state_and_storage() {
+        let store = MemStorage::default();
+        let (mut host, _) = SaveHost::boot(store.clone());
+        host.state_mut().challenges.challenge_completions[5] = 9.0;
+        host.persist(1);
+        assert!(store.read().is_some());
+
+        host.reset();
+        assert_eq!(host.state().challenges.challenge_completions[5], 0.0);
+        assert!(store.read().is_none(), "storage cleared on reset");
+    }
+}

--- a/docs/systems/README.md
+++ b/docs/systems/README.md
@@ -108,8 +108,13 @@ fixed in code, the map had simply gone stale:
 > complete, **the singularity layer is live** (reset + GQ grant + seeded metadata), and **all 13
 > `updateAll` autobuyer families are wired** (incl. talisman / tesseract / ant-upgrade). **No HIGH
 > parity bugs remain open.** Branch `claude/wrap-meta-economy-quarks` additionally lands the
-> campaign-token derivation, the exalt enter/exit loop, the elevator triad, and `preserveQuarks` —
-> remaining non-UI work is host-tier seams and the parked backend; otherwise the UI tree.
+> campaign-token derivation, the exalt enter/exit loop, the elevator triad, and `preserveQuarks`.
+> Branch `claude/campaign-perks-saveload` then lands the **campaign runner** (`SelectCampaign` +
+> the ascension completion sweep + de-neutralized corruption bonus terms), the **53-perk table**
+> (`singularity_perks.rs`), the **export-reward claim** (`claim_export_rewards`), and **host-tier
+> save wiring** (`ui_web::SaveHost`: localStorage + 5 s autosave + load-on-boot, over a
+> `saved_at_ms`-stamped envelope) — remaining non-UI work is offline-progress catch-up and the
+> parked backend; otherwise the UI tree.
 
 ## Appendix: full single-canvas map
 

--- a/docs/systems/challenges-corruptions.md
+++ b/docs/systems/challenges-corruptions.md
@@ -20,7 +20,7 @@ flowchart LR
   ch15["Challenge 15 exponent"]:::ported
   autoChal["Auto-challenge sweep"]:::ported
   corruptions["Corruptions ·8 · loadouts"]:::ported
-  campaign["Campaign · tokens"]:::partial
+  campaign["Campaign · tokens + runner"]:::ported
   constUpg["Constant upgrades"]:::ported
 
   reinc["Reincarnation ↗ reset-cascade"]:::ext
@@ -64,7 +64,7 @@ flowchart LR
 | Challenge 15 exponent | 🟩 Ported | `mechanics/challenge_15_rewards.rs`; accrual at `tick/mod.rs:5396` (PR #265) |
 | Corruptions (8 effects) | 🟩 Ported | `state/corruptions.rs`, `mechanics/corruptions.rs` |
 | Auto-challenge sweep | 🟩 Ported | `tick/challenge_sweep.rs` |
-| Campaign tokens / constant upgrades | 🟩 Mostly | `state/campaigns.rs` (50 campaigns), `mechanics/campaign_token_rewards.rs`, `compute_campaign_tokens` (tick) — the campaign *runner* (UI) remains |
+| Campaign tokens + runner / constant upgrades | 🟩 Ported | `state/campaigns.rs` (50 campaigns + `current_campaign`), `mechanics/campaigns.rs` (runner data + completion recording), `mechanics/campaign_token_rewards.rs`, `compute_campaign_tokens` (tick) — only the icon-grid UI remains |
 
 ## Porting notes / open bugs
 
@@ -76,5 +76,15 @@ flowchart LR
   ports `updateTokens()` as a pure derivation over the 50-campaign limit/isMeta table
   (`CAMPAIGNS_LEN` 10→50, a latent sizing bug), inheritance + the GQ/octeract bonus-token upgrades.
   Every `campaign_token_rewards` formula now feeds from it, and the `campaignTokens` achievement
-  group (426–435) awards in the per-tick sweep. Tokens flow from `highestSingularityCount ≥ 5`
-  without the UI-tier campaign runner (which writes `campaign_completions` once it exists).
+  group (426–435) awards in the per-tick sweep.
+- ✅ **Campaign runner — ported to the logic tier.** `mechanics/campaigns.rs` carries the 50-entry
+  `campaignDatas` tables (per-campaign corruption loadouts + the flattened `unlockRequirement` gates)
+  and the verbatim only-increase/clamped `c10Completions` recording. `PlayerAction::SelectCampaign`
+  runs a full `reset('ascension')` then applies the chosen loadout to `corruptions.used` (rejected
+  inside an ascension challenge), and the ascension layer now runs the **completion sweep**
+  (`Reset.ts:762-784`): the `highestSingularityCount ≥ 4` auto-complete (difficulty comparison with
+  live `bonusLevels` on both sides) plus the active-campaign bank, before the `used ← next` swap.
+  Only the campaign icon-grid HTML stays UI-tier. The corruption `bonusLevels` / `bonusVal` terms
+  (`corruptionFifteen` + `oneChallengeCap` + `cookieGrandma` + `finiteDescent`; `advancedPack` +
+  `oneChallengeCap` + `cube74`) and the `maxCorruptionLevel` GQ/octeract cap inputs were
+  de-neutralized at the same time.

--- a/docs/systems/infrastructure.md
+++ b/docs/systems/infrastructure.md
@@ -57,17 +57,18 @@ flowchart LR
 |---|---|---|
 | Tick / game loop | 🟩 Ported | `tick/mod.rs` + `tick/auto_buy.rs` (all 13 `updateAll` autobuyer families self-drive) |
 | Calculate engine | 🟩 Ported | `mechanics/calculate.rs`, `math/*` (leaf math faithful; golden-vector coverage thin) |
-| State schema | 🟨 Partial | `state/` (~85%; `unlocks` now 21/21 keys; + `total_quarks_ever`; some rune-blessing type divergence) |
+| State schema | 🟨 Partial | `state/` (~85%; `unlocks` 21/21 keys; + `total_quarks_ever`, `campaigns.current_campaign`; some rune-blessing type divergence) |
 | Events enum | 🟩 Ported | `events/mod.rs` |
-| Save / Import-Export | 🟨 Partial | `crates/synergismforkd_save/` (postcard round-trip + versioned envelope + base64 export/import string + on-load achievement recompute; persistent storage + save-on-tick are host-tier) |
-| UI render | 🟧 Stub | `synergismforkd_ui*` (scaffold) |
+| Save / Import-Export | 🟩 Mostly | `crates/synergismforkd_save/` (postcard round-trip + versioned envelope + base64 export/import string + on-load achievement recompute + host-stamped `saved_at_ms`) **+ host wiring** (`ui_web::SaveHost`: localStorage + 5 s autosave loop + load-on-boot + export claim) — only offline-progress catch-up remains |
+| UI render | 🟧 Stub | `synergismforkd_ui*` (scaffold; `ui_web` now also hosts the save seam) |
 | Automation overseer | 🟩 Ported | `tick/auto_reset.rs`, `auto_research.rs`, `challenge_sweep.rs`, `automatic_tools.rs` |
 | RNG | 🟩 Ported | deterministic Xoshiro, per-purpose seeding (used by cube opening) |
 
 ## Porting notes
 
-- The **logic core is healthy**. The remaining infrastructure gaps are the **UI** tree (still
-  scaffold) and the host-tier slice of save (persistent storage, save-on-tick).
+- The **logic core is healthy**. The remaining infrastructure gap is the **UI** tree (still
+  scaffold). The host-tier slice of save is now wired (`ui_web::SaveHost`); only offline-progress
+  catch-up on a stale `saved_at_ms` is unported.
 - ✅ **All 13 `updateAll` autobuyer families self-drive** (`tick/auto_buy.rs`, Phase 5): autoUpgrades +
   coin/diamond/mythos/particle producers + accelerator/multiplier/boost + crystal upgrades + constant
   upgrades + ant producers/masteries + the formerly-deferred three — **talisman** (Family 11,
@@ -77,6 +78,20 @@ flowchart LR
   false). The PERCENTAGE-mode tesseract path (on-ascension) is a separate, non-`updateAll` call site.
 - **Save-load** gained a base64 export/import string API and an on-load **achievement-points
   recompute** (the full 509-entry `ACHIEVEMENT_POINT_VALUES` table → closes audit **H5**). The Rust
-  save format is fresh (no TS-save compat); persistent storage + save-on-tick stay host-tier.
+  save format is fresh (no TS-save compat).
+- ✅ **Host-tier save wiring landed.** The envelope now carries a host-stamped `saved_at_ms` (the
+  `offlinetick`/`lastExportedSave` analogue, kept off `GameState` so logic stays time-free) recovered
+  via `load_with_meta` / `import_from_string_with_meta`. `ui_web::SaveHost<S: SaveStorage>` is the
+  `Synergism.ts` save glue: load-on-boot (recomputing points; reports `Loaded{saved_at_ms}` / `Fresh`
+  / `Corrupt`), a **5 s autosave loop** (`tick` accumulates game-time, matching
+  `setNamedInterval('save', saveSynergy, 5000)`), `export` (claims `claim_export_rewards` then writes
+  the blob — the `exportSynergism` happy path), `import`, and `reset`. Storage sits behind a
+  `SaveStorage` trait so the orchestration is unit-tested on native; the `localStorage` backend +
+  `Date.now` clock are wasm-gated (`web-sys`/`js-sys`). A corrupt blob boots fresh **without**
+  clobbering the stored bytes. Remaining: offline-progress catch-up + the rAF cadence (Dioxus root).
+- **Export-reward claim** (`synergismforkd_logic::claim_export_rewards`): the `goldenQuarksTimer` →
+  golden-quarks and `quarkstimer` → worlds conversions (`ImportExport.ts:254-273`), previously absent
+  so the timers accrued with nowhere to land. The host calls it on a real export, not the autosave.
 - State schema is the gating dependency for several features: adding fields requires explicit sign-off
-  (it affects save-file size) per the project rules.
+  (it affects save-file size) per the project rules. (`campaigns.current_campaign` was the one new
+  state field this batch; the `saved_at_ms` timestamp lives on the save envelope, not `GameState`.)

--- a/docs/systems/singularity-ambrosia.md
+++ b/docs/systems/singularity-ambrosia.md
@@ -121,11 +121,17 @@ flowchart LR
   not modeled" gap. The module header tags each perk's effect-wiring: the big multiplicative perks
   (`goldenCoins` / `skrauQ` / `goldenRevolution2` / `primalPower` / `derpSmiths` / `immaculateAlchemy`
   / salvage / token / ELO / blueberry) are already **WIRED** (mostly via the meta-economy sweep). The
-  remainder is **DEFERRED on a consumer**: the ant-production perks (`forTheLoveOfTheAntGod`,
-  `antGodsCornucopia`, `irishAnt`/`irishAnt2`) sit in `calculateActualAntSpeedMult`, whose Rust
-  `ant_speed_mult` input is still a neutral `1.0` placeholder — not dropped terms, an unported host
-  assembly. The `goldenRevolution` GQ-per-second family belongs to the export-reward flow; the rest
-  are UI/external.
+  four **ant** perks resolved as: `antGodsCornucopia` **WIRED** (the `SingularityPerk` term of the
+  fully-ported `compute_ant_speed_mult`); `forTheLoveOfTheAntGod` **WIRED** (reset-time regrants, see
+  below); `irishAnt` / `irishAnt2` are **NONE** — they exist only in the `singularityPerks` table with
+  no mechanical consumer anywhere in TS, so the faithful port leaves them no-ops. The
+  `goldenRevolution` GQ-per-second family belongs to the export-reward flow; the rest are UI/external.
+- ✅ **`forTheLoveOfTheAntGod` ported** (`apply_for_the_love_ant_regrants`): the
+  `highestSingularityCount >= 10/15/20` producer / upgrade / crumb regrants that run at the tail of
+  every ant reset (`Features/Ants/.../player/reset.ts`, outside the tier gate) — Workers 20→40 +
+  Breeders + MetaBreeders, AntSpeed/Mortuus `max`-merged, crumbs 1e50 at sing 20. Applied on all
+  three ant-reset paths (sacrifice / ascension / singularity); the singularity path uses the
+  pre-increment `old_highest` (`resetAnts(singularity)` runs at Reset.ts:1103, before the count bump).
 - ✅ **Export-reward claim ported** (`claim_export_rewards`, `ImportExport.ts:254-273`): the
   `goldenQuarksTimer` → golden-quarks (gated on `goldenQuarks3`, × the `highestSing ≥ 100` export
   bonus) and `quarkstimer` → `worlds` + `quarksThisSingularity` (× the full quark multiplier)

--- a/docs/systems/singularity-ambrosia.md
+++ b/docs/systems/singularity-ambrosia.md
@@ -28,7 +28,7 @@ flowchart LR
   octeracts["Octeracts"]:::ported
   octUpg["Octeract upgrades"]:::ported
   singChal["Singularity challenges"]:::ported
-  singPerks["Perks · milestones"]:::partial
+  singPerks["Perks · milestones · table"]:::ported
 
   asc["Ascension ↗ ascension-cubes"]:::ext
   quarks["Quarks ↗ meta-economy"]:::ext
@@ -85,7 +85,7 @@ flowchart LR
 | Golden quarks + GQ upgrades | 🟩 Ported | `state/golden_quarks.rs` (80-entry metadata seeded), `mechanics/golden_quark_upgrades.rs` |
 | Octeracts + upgrades | 🟩 Ported | `state/octeract_upgrades.rs`, `mechanics/octeracts.rs` |
 | Singularity challenges (Exalts) | 🟩 Ported | enter/exit loop (`reset.rs::toggle_singularity_challenge`), 9-row meta + requirement ladder (`mechanics/singularity_challenges.rs`), completions drive the effect readers + the exalt progressive |
-| Singularity perks / milestones | 🟨 Partial | milestone formulas ported (`singularity_milestones.rs`); the full perk list is not modeled |
+| Singularity perks / milestones | 🟩 Mostly | milestone formulas (`singularity_milestones.rs`) + the **53-perk table** (`singularity_perks.rs`: roster + `levels[]` ladders + `getLastUpgradeInfo` helpers). Effect-wiring documented per-perk: the multiplicative perks are WIRED; the rest are DEFERRED on an unported *consumer* (ant-speed stat product) or are export-flow / UI / external |
 | Ambrosia | 🟩 Ported | `state/ambrosia.rs`, `mechanics/ambrosia.rs` |
 | Blueberry upgrades | 🟩 Ported | `mechanics/blueberry_upgrades.rs`; effective levels populated (`populate_ambrosia_free_levels`), quark upgrades wired |
 | Red ambrosia + upgrades | 🟩 Ported | `state/red_ambrosia.rs`, `mechanics/red_ambrosia_*.rs` |
@@ -114,3 +114,20 @@ flowchart LR
   (verbatim quirk).
 - ✅ **`preserveQuarks` ported:** `worlds` resets with the rebuild unless the limitedTime reward is
   active, in which case the balance carries across (Reset.ts:1190).
+- ✅ **Perk table modeled.** `mechanics/singularity_perks.rs` ports `singularityPerks`
+  (`singularity.ts:2303-3156`) as data — the `SingularityPerkId` enum + the 53-row roster with each
+  perk's exact `levels[]` ladder (extracted mechanically) + the `getLastUpgradeInfo` helpers
+  (`level_at` / `is_active` / `next_threshold`) + `active_perk_count`. Closes the "full perk list is
+  not modeled" gap. The module header tags each perk's effect-wiring: the big multiplicative perks
+  (`goldenCoins` / `skrauQ` / `goldenRevolution2` / `primalPower` / `derpSmiths` / `immaculateAlchemy`
+  / salvage / token / ELO / blueberry) are already **WIRED** (mostly via the meta-economy sweep). The
+  remainder is **DEFERRED on a consumer**: the ant-production perks (`forTheLoveOfTheAntGod`,
+  `antGodsCornucopia`, `irishAnt`/`irishAnt2`) sit in `calculateActualAntSpeedMult`, whose Rust
+  `ant_speed_mult` input is still a neutral `1.0` placeholder — not dropped terms, an unported host
+  assembly. The `goldenRevolution` GQ-per-second family belongs to the export-reward flow; the rest
+  are UI/external.
+- ✅ **Export-reward claim ported** (`claim_export_rewards`, `ImportExport.ts:254-273`): the
+  `goldenQuarksTimer` → golden-quarks (gated on `goldenQuarks3`, × the `highestSing ≥ 100` export
+  bonus) and `quarkstimer` → `worlds` + `quarksThisSingularity` (× the full quark multiplier)
+  conversions, each keeping its window remainder. The host calls it on a real export; previously the
+  timers accrued with nowhere to land. The external subscriber term is a parked RMT seam → neutral.


### PR DESCRIPTION
Ports a batch of TS→Rust systems pulled from the `docs/systems/` maps: the campaign **runner**, the singularity **perk table**, the **export-reward** claim, **host-tier save** wiring, and the last wireable singularity **ant perk**. Every commit is gate-green (`cargo fmt`, `cargo clippy --workspace --all-targets -D warnings` on native **and** wasm32, all 16 test suites).

## Campaign runner → logic tier
- `mechanics/campaigns.rs`: the 50-entry `campaignDatas` tables (per-campaign corruption loadouts + the flattened `unlockRequirement` gates) and the verbatim only-increase/clamped `c10Completions` recording.
- New state field `CampaignsState.current_campaign`; new `PlayerAction::SelectCampaign` = `reset('ascension')` then apply the loadout to `corruptions.used` (rejected inside an ascension challenge), emitting `CoreEvent::CampaignStarted`.
- `apply_ascension_layer` now runs the **completion sweep** (`Reset.ts:762-784`): the `highestSingularityCount ≥ 4` auto-complete (difficulty comparison with live `bonusLevels` on both sides) + the active-campaign bank, before the `used ← next` swap (which now re-derives the score-mult cache for legacy lazy-getter parity).
- The corruption `bonusLevels` / `bonusVal` terms and the `maxCorruptionLevel` GQ/octeract cap inputs were de-neutralized (they were stale `0.0`/`false` placeholders).

## Singularity perk table
- `mechanics/singularity_perks.rs`: the `SingularityPerkId` enum + the 53-row roster with each perk's exact `levels[]` ladder (extracted mechanically, not hand-typed) + the `getLastUpgradeInfo` helpers + `active_perk_count`. Closes the docs' "full perk list is not modeled" gap.
- The perk *effects* were mostly already wired (the meta-economy sweep); the module header tags each perk WIRED / DEFERRED(export) / UI / EXTERNAL / NONE.

## Export-reward claim + save timestamp
- `synergismforkd_logic::claim_export_rewards` (`ImportExport.ts:254-273`): the `goldenQuarksTimer` → golden-quarks and `quarkstimer` → `worlds`/`quarksThisSingularity` conversions — **the** quark-claim path (the timers previously accrued with nowhere to land). The host calls it on a real export, not the autosave.
- The save envelope gained a host-stamped `saved_at_ms` (the `offlinetick`/`lastExportedSave` analogue, kept off `GameState` so the logic crate stays time-free), recovered via `load_with_meta` / `import_from_string_with_meta`.

## Host-tier save wiring (`ui_web`)
- `ui_web::SaveHost<S: SaveStorage>`: the `Synergism.ts` save glue — load-on-boot (recomputing achievement points; reports `Loaded{saved_at_ms}` / `Fresh` / `Corrupt`), a **5 s autosave loop** (`setNamedInterval('save', saveSynergy, 5000)` parity), `persist`, `export` (claim → blob), `import`, `reset`.
- Storage sits behind a `SaveStorage` trait so the orchestration is unit-tested on native; the `localStorage` backend + `Date.now` clock are wasm-gated (`web-sys`/`js-sys`, verified the wasm32 build + clippy are clean). A corrupt blob boots fresh **without** clobbering the stored bytes.

## Ant perks (`forTheLoveOfTheAntGod`)
- Resolves the four ant-related singularity perks. `antGodsCornucopia` was already wired in the fully-ported `compute_ant_speed_mult`; `irishAnt`/`irishAnt2` appear only in the perk table with no consumer in TS, so they stay no-ops (porting an effect would diverge).
- `forTheLoveOfTheAntGod` is a **reset-time grant** (not a multiplier): `apply_for_the_love_ant_regrants` tops up producers/upgrades/crumbs at the tail of every ant reset (sacrifice, ascension, singularity). The singularity path uses the pre-increment `old_highest` (`resetAnts(singularity)` runs at `Reset.ts:1103`, before the count bump at `:1109` — a test pins this off-by-one).

## Docs
- `docs/systems/{challenges-corruptions,infrastructure,singularity-ambrosia,README}.md` re-statused for all of the above.

## Notes
- The Rust save format is fresh (no TS-save compatibility). Remaining non-UI work after this batch: offline-progress catch-up, the rAF cadence (Dioxus root), and the parked backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
