### PR TITLE
ci(claude): migrate claude-code-action to v1 input schema

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -23,12 +23,13 @@ jobs:
           persist-credentials: false
 
       - name: Automatic PR Review
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # beta
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          timeout_minutes: "60"
           use_sticky_comment: "true"
-          direct_prompt: |
+          # Supplying `prompt` runs the action automatically (no @claude trigger
+          # phrase needed). This is the v1 replacement for the old `direct_prompt`.
+          prompt: |
             Please review this pull request and provide comprehensive feedback.
 
             Focus on:
@@ -41,4 +42,7 @@ jobs:
 
             Provide constructive feedback with specific suggestions for improvement.
             Use inline comments to highlight specific areas of concern.
-          # allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          # v1 moves CLI-level options (timeout, max turns, tool allowlist, model)
+          # into `claude_args`. See https://github.com/anthropics/claude-code-action
+          claude_args: |
+            --max-turns 30

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,13 +31,15 @@ jobs:
           persist-credentials: false
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # beta
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          timeout_minutes: "60"
-          # mode: tag  # Default: responds to @claude mentions
+          # Default (no `prompt`) = tag mode: responds to @claude mentions.
+          # v1 moves CLI-level options into `claude_args`, e.g.:
+          # claude_args: |
+          #   --max-turns 30
           # Optional: Restrict network access to specific domains only
           # experimental_allowed_domains: |
           #   .anthropic.com


### PR DESCRIPTION
## Problem

Claude autoreview was silently broken. The `# beta` action pin rolled forward to **claude-code-action v1.x**, which renamed its inputs. The auto-review job kept using the v0 names, so the runs reported "success" in ~20s without ever reviewing anything.

Run log evidence:

```
##[warning]Unexpected input(s) 'timeout_minutes', 'direct_prompt'
...
No trigger found, skipping remaining steps
```

`direct_prompt` was ignored → no `prompt` → action fell back to trigger-phrase mode → found no `@claude` → exited green without reviewing.

## Fix

- **claude-auto-review.yml**: `direct_prompt` → `prompt` (in v1, presence of `prompt` is what runs the action automatically); dropped `timeout_minutes` in favor of `claude_args: --max-turns 30`.
- **claude.yml**: dropped the now-invalid `timeout_minutes` input.
- Relabeled the stale `# beta` pin comments as `# v1`.

## Note

The auto-review job **on this PR** may still report `401 Workflow validation failed` — that's GitHub requiring the workflow to match the default branch, expected for any PR that edits a workflow file. The fix goes live for subsequent PRs once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)